### PR TITLE
fix broken links in quickstart templates & docs typo

### DIFF
--- a/.github/actions/markdown-link-checker/action.yaml
+++ b/.github/actions/markdown-link-checker/action.yaml
@@ -38,7 +38,7 @@ runs:
           else
             echo "✅ No broken links in $file"
           fi
-        done < <(find . -type f -name "*.md" -print0)
+        done < <(find . -type f -name "*.md" -not -name "*-template.md" -print0)
 
         echo "------------------------------------------------------------"
         if [ "$failed" -ne 0 ]; then

--- a/README.md
+++ b/README.md
@@ -141,6 +141,6 @@ For a simplified workflow that includes automated analysis of benchmark results,
    - See [Single Model Quickstart](quickstart-k8s/README.md) for details
 
 2. **Multi-Model Comparison**: Compare performance across multiple LLM models
-   - See [Multi-Model Comparison Quickstart](quickstart-k8s/compare-baseline-llmd/README.md) for details
+   - See [Multi-Model Comparison Quickstart](quickstart-k8s/Compare-README.md) for details
 
 To get started, navigate to the quickstart-k8s directory and follow the instructions in the respective README files.

--- a/quickstart-k8s/README.md
+++ b/quickstart-k8s/README.md
@@ -123,7 +123,7 @@ The benchmark results can be analyzed using the provided Python script in the `a
 
 2. Run the analysis script:
    ```bash
-   python analyze-results/analyze_results.py --results-dir fmperf-results
+   python analyze_results.py --results-dir fmperf-results
    ```
 
 The script will create a `plots` directory and generate:
@@ -139,7 +139,7 @@ The script will create a `plots` directory and generate:
 # Install grip if needed
 pip install grip
 
-cd ./compare-results/analysis/plots
+cd ./fmperf-results/plots
 
 # Generate HTML and view in browser (--browser opens it automatically)
 grip README.md --browser

--- a/quickstart-k8s/analyze_results.py
+++ b/quickstart-k8s/analyze_results.py
@@ -49,9 +49,10 @@ def create_plots_readme(plots_dir):
     script_dir = os.path.dirname(os.path.abspath(__file__))
     template_path = os.path.join(script_dir, 'readme-analyze-template.md')
     readme_path = os.path.join(plots_dir, 'README.md')
+
     if os.path.exists(template_path):
         shutil.copyfile(template_path, readme_path)
-        print(f"Copied template to: {readme_path}")
+        print(f"Created README.md at: {readme_path}")
     else:
         print(f"Warning: Template file not found at {template_path}, using default content")
         readme_content = """# Benchmark Analysis Plots


### PR DESCRIPTION
@maugustosilva ptal, ty! This fixes the templates to remove broken links and fixes paths in README