### PR TITLE
quickstart: fix perms in jobs, set default env llm-d

### DIFF
--- a/quickstart-existing-stack-benchmark/analysis-job.yaml
+++ b/quickstart-existing-stack-benchmark/analysis-job.yaml
@@ -12,7 +12,6 @@ spec:
     spec:
       serviceAccountName: benchmark-runner
       securityContext:
-        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -25,7 +24,6 @@ spec:
           capabilities:
             drop:
               - ALL
-          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
         command: ["sh"]

--- a/quickstart-existing-stack-benchmark/benchmark-job.yaml
+++ b/quickstart-existing-stack-benchmark/benchmark-job.yaml
@@ -12,7 +12,6 @@ spec:
     spec:
       serviceAccountName: benchmark-runner
       securityContext:
-        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -21,13 +20,12 @@ spec:
         image: quay.io/sallyom/llm-d-benchmark:quickstart
         imagePullPolicy: Always
         securityContext:
+          seccompProfile:
+            type: RuntimeDefault
           allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
         command: ["sh"]
         args: ["-c", "ln -sf /workspace/config/llmdbench_workload.yaml /workspace/llmdbench_workload.yaml && python3 /workspace/workload/harnesses/llm-d-benchmark.py"]
         envFrom:

--- a/quickstart-existing-stack-benchmark/compare-stacks/benchmark-job.yaml
+++ b/quickstart-existing-stack-benchmark/compare-stacks/benchmark-job.yaml
@@ -12,7 +12,6 @@ spec:
     spec:
       serviceAccountName: benchmark-runner
       securityContext:
-        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -25,7 +24,6 @@ spec:
           capabilities:
             drop:
               - ALL
-          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
         command: ["sh"]
@@ -62,7 +60,6 @@ spec:
     spec:
       serviceAccountName: benchmark-runner
       securityContext:
-        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -75,7 +72,6 @@ spec:
           capabilities:
             drop:
               - ALL
-          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
         command: ["sh"]

--- a/quickstart-existing-stack-benchmark/compare-stacks/compare-analysis-job.yaml
+++ b/quickstart-existing-stack-benchmark/compare-stacks/compare-analysis-job.yaml
@@ -12,7 +12,6 @@ spec:
     spec:
       serviceAccountName: benchmark-runner
       securityContext:
-        runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       containers:
@@ -25,7 +24,6 @@ spec:
           capabilities:
             drop:
               - ALL
-          runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
         command: ["sh"]

--- a/quickstart-existing-stack-benchmark/compare-stacks/retrieve-compare.yaml
+++ b/quickstart-existing-stack-benchmark/compare-stacks/retrieve-compare.yaml
@@ -14,7 +14,6 @@ spec:
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-      runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
     command: ["/bin/sh", "-c"]

--- a/quickstart-existing-stack-benchmark/resources/benchmark-env.yaml
+++ b/quickstart-existing-stack-benchmark/resources/benchmark-env.yaml
@@ -7,9 +7,9 @@ data:
   # UPDATE TO MATCH YOUR CLUSTER & DEPLOYMENT
   # Core benchmark configuration
   LLMDBENCH_FMPERF_NAMESPACE: "llm-d-benchmark"
-  LLMDBENCH_FMPERF_STACK_TYPE: "vllm-prod"
-  LLMDBENCH_FMPERF_ENDPOINT_URL: "https://vllm-service.vllm-namespace.cluster.local.svc"
-  LLMDBENCH_FMPERF_STACK_NAME: "standalone-vllm-llama-3b"
+  LLMDBENCH_FMPERF_STACK_TYPE: "llm-d"
+  LLMDBENCH_FMPERF_ENDPOINT_URL: "http://llm-d-inference-gateway.llm-d.svc.cluster.local:80"
+  LLMDBENCH_FMPERF_STACK_NAME: "llm-d-3b"
   LLMDBENCH_FMPERF_WORKLOAD_FILE: "llmdbench_workload.yaml"
   LLMDBENCH_FMPERF_REPETITION: "1"
   LLMDBENCH_FMPERF_RESULTS_DIR: "/requests"

--- a/quickstart-existing-stack-benchmark/retrieve.yaml
+++ b/quickstart-existing-stack-benchmark/retrieve.yaml
@@ -8,13 +8,12 @@ spec:
   serviceAccountName: benchmark-runner
   containers:
   - name: results-retriever
-    image: registry.redhat.io/ubi9/ubi:latest
+    image: registry.access.redhat.com/ubi9/ubi:latest
     imagePullPolicy: IfNotPresent
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-      runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
     command: ["/bin/sh", "-c"]

--- a/util/patches/fmperf.patch
+++ b/util/patches/fmperf.patch
@@ -2,17 +2,16 @@ diff --git a/fmperf/Cluster.py b/fmperf/Cluster.py
 index 5a398f9..fb616af 100644
 --- a/fmperf/Cluster.py
 +++ b/fmperf/Cluster.py
-@@ -40,8 +40,7 @@ def __init__(
+@@ -40,8 +40,6 @@ def __init__(
          self.security_context = {
              "allowPrivilegeEscalation": False,
              "capabilities": {"drop": ["ALL"]},
 -            "runAsNonRoot": False,
 -            "runAsUser": 0,
-+            "runAsNonRoot": True,
              "seccompProfile": {"type": "RuntimeDefault"},
          }
  
-@@ -412,6 +411,26 @@ def evaluate(
+@@ -412,6 +410,26 @@ def evaluate(
              # Add OUTPUT_PATH based on the volume mount and job name
              env.append({"name": "OUTPUT_PATH", "value": f"/requests/{job_name}"})
  
@@ -39,7 +38,7 @@ index 5a398f9..fb616af 100644
              # Add Hugging Face cache environment variables
              env.extend(
                  [
-@@ -423,6 +442,12 @@ def evaluate(
+@@ -423,6 +441,12 @@ def evaluate(
                      },
                  ]
              )
@@ -52,7 +51,7 @@ index 5a398f9..fb616af 100644
  
              # Add HF_TOKEN from host environment if available
              hf_token = (
-@@ -433,14 +458,17 @@ def evaluate(
+@@ -433,14 +457,17 @@ def evaluate(
              )
              if hf_token:
                  env.append({"name": "HF_TOKEN", "value": hf_token})
@@ -78,7 +77,7 @@ index 5a398f9..fb616af 100644
              # Add Hugging Face cache environment variables
              env.extend(
                  [
-@@ -452,23 +480,15 @@ def evaluate(
+@@ -452,23 +479,15 @@ def evaluate(
                      },
                  ]
              )
@@ -106,7 +105,7 @@ index 5a398f9..fb616af 100644
          else:
              env = [
                  {"name": "MODEL_ID", "value": model_name},
-@@ -524,16 +544,17 @@ def evaluate(
+@@ -524,16 +543,17 @@ def evaluate(
                          "initContainers": [
                              {
                                  "name": "init-cache-dirs",
@@ -126,7 +125,7 @@ index 5a398f9..fb616af 100644
                              }
                          ],
                          "containers": [
-@@ -547,10 +568,7 @@ def evaluate(
+@@ -547,10 +567,7 @@ def evaluate(
                                  ),
                                  "args": container_args,
                                  "volumeMounts": volume_mounts,
@@ -138,7 +137,7 @@ index 5a398f9..fb616af 100644
                              }
                          ],
                          "restartPolicy": "Never",
-@@ -642,6 +660,6 @@ def evaluate(
+@@ -642,6 +659,6 @@ def evaluate(
          else:
              perf_out, energy_out = None, None
  


### PR DESCRIPTION
Quickstart was failing in Kubernetes due to runAsNonRoot being set.
OpenShift runs as non-root by default, no need to set this - setting `runAsNonRoot` causes an error in Kubernetes `"Error: container has runAsNonRoot and image will run as root"`. The correct way to run as non-root that is compatible with OpenShift and Kubernetes is to set non-root user in the Dockerfile. OpenShift will ignore the UID and run with an arbitrary non-root UID. Kubernetes will honor the UID and run as what's set in the Dockerfile. 