### PR TITLE
jq and affinity typo

### DIFF
--- a/setup/env.sh
+++ b/setup/env.sh
@@ -504,8 +504,8 @@ function check_storage_class_and_affinity {
   fi
 
   local annotation=$(echo $LLMDBENCH_VLLM_COMMON_AFFINITY | cut -d ':' -f 1)
-  local has_affinity=$($LLMDBENCH_CONTROL_KCMD get nodes -o json | jq -r '.items[].metadata.annotations.[]' | grep $annotation || true)
-  if [[ -z $has_sc ]]; then
+  local has_affinity=$($LLMDBENCH_CONTROL_KCMD get nodes -o json | jq -r '.items[].metadata.annotations[]' | grep $annotation || true)
+  if [[ -z $has_affinity ]]; then
     echo "ERROR. There are no nodes on this cluster with the annotation \"${annotation}\" (environment variable LLMDBENCH_VLLM_COMMON_AFFINITY)"
     return 1
   fi


### PR DESCRIPTION
`oc get nodes -o json | jq -C -r '.items[].metadata.annotations.[]' | grep nvidia.com/gpu.product`
```
jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 1:
.items[].metadata.annotations.[]
jq: 1 compile error
```
