### PR TITLE
A few relevant bugfixes

### DIFF
--- a/.github/workflows/benchmark1.yaml
+++ b/.github/workflows/benchmark1.yaml
@@ -130,7 +130,6 @@ jobs:
           LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
         run: ./setup/teardown.sh -c cicd -t deployer -d
 
-
       - name: Install AWS CLI
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/setup/env.sh
+++ b/setup/env.sh
@@ -125,7 +125,14 @@ export LLMDBENCH_CONTROL_WARNING_DISPLAYED=${LLMDBENCH_CONTROL_WARNING_DISPLAYED
 export LLMDBENCH_CONTROL_WAIT_TIMEOUT=${LLMDBENCH_CONTROL_WAIT_TIMEOUT:-900}
 export LLMDBENCH_CONTROL_CHECK_CLUSTER_AUTHORIZATIONS=${LLMDBENCH_CONTROL_CHECK_CLUSTER_AUTHORIZATIONS:-0}
 export LLMDBENCH_CONTROL_RESOURCE_LIST=deployment,httproute,route,service,gateway,gatewayparameters,inferencepool,inferencemodel,cm,ing,pod,job
-export LLMDBENCH_CONTROL_KCMD=${LLMDBENCH_CONTROL_KCMD:-oc}
+
+is_oc=$(which oc || true)
+if [[ -z $is_oc ]]; then
+  export LLMDBENCH_CONTROL_KCMD=${LLMDBENCH_CONTROL_KCMD:-kubectl}
+else
+  export LLMDBENCH_CONTROL_KCMD=${LLMDBENCH_CONTROL_KCMD:-oc}
+fi
+
 export LLMDBENCH_CONTROL_HCMD=helm
 export LLMDBENCH_CONTROL_CLI_OPTS_PROCESSED=${LLMDBENCH_CONTROL_CLI_OPTS_PROCESSED:-0}
 
@@ -306,7 +313,7 @@ not_admin=$($LLMDBENCH_CONTROL_KCMD get crds 2>&1 | grep -i Forbidden || true)
 if [[ ! -z ${not_admin} ]]; then
   export LLMDBENCH_USER_IS_ADMIN=0
 else
-  is_ns=$($LLMDBENCH_CONTROL_KCMD get namespace | grep ${LLMDBENCH_VLLM_COMMON_NAMESPACE} || true)
+  is_ns=$($LLMDBENCH_CONTROL_KCMD get namespace -o name| grep -E "namespace/${LLMDBENCH_VLLM_COMMON_NAMESPACE}$" || true)
   if [[ ! -z ${is_ns} ]]; then
     export LLMDBENCH_CONTROL_PROXY_UID=$($LLMDBENCH_CONTROL_KCMD get namespace ${LLMDBENCH_VLLM_COMMON_NAMESPACE} -o json | jq -e -r '.metadata.annotations["openshift.io/sa.scc.uid-range"]' | perl -F'/' -lane 'print $F[0]+1');
   fi
@@ -520,15 +527,40 @@ function check_storage_class_and_affinity {
     return 1
   fi
 
-  local annotation=$(echo $LLMDBENCH_VLLM_COMMON_AFFINITY | cut -d ':' -f 1)
-  local has_affinity=$($LLMDBENCH_CONTROL_KCMD get nodes -o json | jq -r '.items[].metadata.annotations[]' | grep $annotation || true)
+  local annotation1=$(echo $LLMDBENCH_VLLM_COMMON_AFFINITY | cut -d ':' -f 1)
+  local annotation2=$(echo $LLMDBENCH_VLLM_COMMON_AFFINITY | cut -d ':' -f 2)
+  local has_affinity=$($LLMDBENCH_CONTROL_KCMD get nodes -o json | jq -r '.items[].metadata.labels' | grep -E "$annotation1.*$annotation2" || true)
   if [[ -z $has_affinity ]]; then
-    echo "ERROR. There are no nodes on this cluster with the annotation \"${annotation}\" (environment variable LLMDBENCH_VLLM_COMMON_AFFINITY)"
+    echo "ERROR. There are no nodes on this cluster with the label \"${annotation1}:${annotation2}\" (environment variable LLMDBENCH_VLLM_COMMON_AFFINITY)"
     return 1
   fi
 
 }
 export -f check_storage_class_and_affinity
+
+function not_valid_ip {
+
+    local  ip=$1
+    local  stat=1
+
+    echo ${ip} | grep -q '/'
+    if [[ $? -eq 0 ]]; then
+        local ip=$(echo $ip | cut -d '/' -f 1)
+    fi
+
+    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        OIFS=$IFS
+        IFS='.'
+        ip=($ip)
+        IFS=$OIFS
+        [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]
+        stat=$?
+    fi
+    if [[ $stat -eq 0 ]]; then
+      echo $ip
+    fi
+}
+export -f not_valid_ip
 
 function announce {
     # 1 - MESSAGE

--- a/setup/steps/04_ensure_model_namespace_prepared.sh
+++ b/setup/steps/04_ensure_model_namespace_prepared.sh
@@ -19,7 +19,7 @@ EOF
   llmd_opts="--namespace ${LLMDBENCH_VLLM_COMMON_NAMESPACE} --skip-infra --download-pvc-only --storage-class ${LLMDBENCH_VLLM_COMMON_PVC_STORAGE_CLASS} --storage-size ${LLMDBENCH_VLLM_COMMON_PVC_MODEL_CACHE_SIZE} --download-model $(model_attribute $model model) --download-timeout ${LLMDBENCH_VLLM_COMMON_PVC_DOWNLOAD_TIMEOUT} --values-file $LLMDBENCH_CONTROL_WORK_DIR/setup/yamls/${LLMDBENCH_CURRENT_STEP}_prepare_namespace_${modelfn}.yaml --context $LLMDBENCH_CONTROL_WORK_DIR/environment/context.ctx"
   announce "🚀 Calling llm-d-deployer with options \"${llmd_opts}\"..."
   pushd $LLMDBENCH_DEPLOYER_DIR/llm-d-deployer/quickstart &>/dev/null
-  llmdbench_execute_cmd "cd $LLMDBENCH_DEPLOYER_DIR/llm-d-deployer/quickstart; export HF_TOKEN=$LLMDBENCH_HF_TOKEN; ./llmd-installer.sh $llmd_opts" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE} 0
+  llmdbench_execute_cmd "cd $LLMDBENCH_DEPLOYER_DIR/llm-d-deployer/quickstart; export HF_TOKEN=$LLMDBENCH_HF_TOKEN; ./llmd-installer.sh $llmd_opts" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE} 0 3
   popd &>/dev/null
   announce "✅ llm-d-deployer prepared namespace"
 done


### PR DESCRIPTION
1) Allow step 4 to be retried (should solve CI/CD) issues 
2) Allow deployment from a workstation without `oc` (only with `kubectl`)
3) Relevant improvements for messages displayed on step 8  (`08_smoketest.sh`), which should improve debuggabillity
4) Solved a "false positive" bug when a pre-existing namespace that was  a superset of the target namespace already existed (e.g., `llmdbench2` should not be taken as `llmdbench`)