### PR TITLE
Allow different conda root locations

### DIFF
--- a/setup/run.sh
+++ b/setup/run.sh
@@ -368,10 +368,14 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
 
     if [[ $LLMDBENCH_RUN_EXPERIMENT_ANALYZE_LOCALLY -eq 1 ]]; then
       announce "🔍 Analyzing collected data..."
-      if [ "$LLMDBENCH_CONTROL_DEPLOY_HOST_OS" = "mac" ] && [ -f "/opt/homebrew/Caskroom/miniforge/base/etc/profile.d/conda.sh" ]; then
-        llmdbench_execute_cmd "source \"/opt/homebrew/Caskroom/miniforge/base/etc/profile.d/conda.sh\"" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
-      elif [ "$LLMDBENCH_CONTROL_DEPLOY_HOST_OS" = "linux" ] && [ -f "/opt/miniconda/etc/profile.d/conda.sh" ]; then
-        llmdbench_execute_cmd "source \"/opt/miniconda/etc/profile.d/conda.sh\"" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+      conda_root="$(conda info --all --json | jq -r '.root_prefix'  2>/dev/null)"
+      if [ "$LLMDBENCH_CONTROL_DEPLOY_HOST_OS" = "mac" ]; then
+        conda_sh="${conda_root}/base/etc/profile.d/conda.sh"
+      else
+        conda_sh="${conda_root}/etc/profile.d/conda.sh"
+      fi
+      if [ -f "${conda_sh}" ]; then
+        llmdbench_execute_cmd "source \"${conda_sh}\"" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
       else
         announce "❌ Could not find conda.sh for $LLMDBENCH_CONTROL_DEPLOY_HOST_OS. Please verify your Anaconda installation."
         exit 1


### PR DESCRIPTION
Detect conda root location (e.g., when installed on user's home)

- need to verify on mac
- consider calling step 01 to install conda if missing. (maybe just add to failure notification)  