### PR TITLE
[Run] feat: add support for `vllm` benchmarks as a harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Once llm-d is fully deployed, an experiment can be run. This script takes in dif
 
 ```
 ./run.sh
-./run.sh --harness inference-perf --workload chatbot_synthetic.yaml 
+./run.sh --harness inference-perf --workload chatbot_synthetic.yaml
 ```
 
 > [!IMPORTANT]

--- a/analysis/vllm-benchmark-analyze_results.sh
+++ b/analysis/vllm-benchmark-analyze_results.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Placeholder, to be populated later.
+
+exit 0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update; \
     rsync \
     patch \
     curl \
+    yq \
     && apt-get clean && rm -rf /var/cache/apt
 
 RUN OC_FILE_NAME=openshift-client-$(uname -s | sed -e "s/Linux/linux/g" -e "s/Darwin/apple-darwin/g")$(echo "-$(uname -m)" | sed -e 's/-x86_64//g' -e 's/-amd64//g' -e 's/aarch64/arm64-rhel9/g').tar.gz; \
@@ -45,22 +46,68 @@ list = yes\n\
 " >> /etc/rsyncd.conf; \
 sed -i 's^\-e^^' /etc/rsyncd.conf
 
+WORKDIR /workspace
+
+ARG FM_PERF_REPO=https://github.com/fmperf-project/fmperf.git
+ARG FM_PERF_BRANCH=main
+RUN git clone --branch ${FM_PERF_BRANCH} ${FM_PERF_REPO}
+RUN cd fmperf; \
+    pip install --no-cache-dir -r requirements.txt && \
+    python3 setup.py install
+
+ARG INFERENCE_PERF_REPO=https://github.com/kubernetes-sigs/inference-perf.git
+ARG INFERENCE_PERF_BRANCH=main
+RUN git clone --branch ${INFERENCE_PERF_BRANCH} ${INFERENCE_PERF_REPO}
+RUN cd inference-perf; pip install .
+
+ARG VLLM_BENCHMARK_REPO=https://github.com/vllm-project/vllm.git
+ARG VLLM_BENCHMARK_BRANCH=main
+RUN git clone --branch ${VLLM_BENCHMARK_BRANCH} ${VLLM_BENCHMARK_REPO}
+RUN cd vllm; pip install vllm; cd ..; mv -f vllm vllm-benchmark
+
+RUN ln -s /usr/bin/sleep /usr/local/bin/sleep
+
+ADD workload/harnesses/ /usr/local/bin/
+COPY analysis/fmperf-analyze_results.py /usr/local/bin/fmperf-analyze_results.py
+COPY analysis/inference-perf-analyze_results.sh /usr/local/bin/inference-perf-analyze_results.sh
+COPY analysis/nop-analyze_results.py /usr/local/bin/nop-analyze_results.py
+COPY analysis/vllm-benchmark-analyze_results.sh /usr/local/bin/vllm-benchmark-analyze_results.sh
+
 RUN echo "#!/usr/bin/env bash" > /usr/local/bin/llm-d-benchmark.sh; echo -e "\
+
+if [[ ! -z \$1 ]]; then\n\
+  export LLMDBENCH_RUN_EXPERIMENT_HARNESS=\$(find /usr/local/bin | grep \${1}.*-llm-d-benchmark | rev | cut -d '/' -f 1 | rev)\n\
+fi\n\
+if [[ ! -z \$2 ]]; then\n\
+  export LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME=\$(echo \$2\".yaml\" | sed \"s^.yaml.yaml^.yaml^g\")\n\
+else \n\
+  if [[ ! -z \${LLMDBENCH_BASE64_HARNESS_WORKLOAD_CONTENTS} ]]; then\n\
+    echo \${LLMDBENCH_BASE64_HARNESS_WORKLOAD_CONTENTS} | base64 -d > /workspace/\${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}\n\
+  fi\n\
+fi\n\
+export LLMDBENCH_RUN_EXPERIMENT_HARNESS_DIR=\$(echo \$LLMDBENCH_RUN_EXPERIMENT_HARNESS | sed \"s^-llm-d-benchmark^^g\" | cut -d '.' -f 1)\n\
 mkdir -p ~/.kube\n\
-if [[ ! -z \${LLMDBENCH_BASE64_CONTEXT} ]]; then\n\
-  echo \${LLMDBENCH_BASE64_CONTEXT} | base64 -d > ~/.kube/config\n\
+if [[ ! -z \${LLMDBENCH_BASE64_CONTEXT_CONTENTS} ]]; then\n\
+  echo \${LLMDBENCH_BASE64_CONTEXT_CONTENTS} | base64 -d > ~/.kube/config\n\
 fi\n\
-if [[ ! -z \${LLMDBENCH_BASE64_HARNESS_WORKLOAD} ]]; then\n\
-  echo \${LLMDBENCH_BASE64_HARNESS_WORKLOAD} | base64 -d > /workspace/llmdbench_workload.yaml\n\
-fi\n\
-mv -f ~/.bashrc ~/fixbashrc\n\
+if [[ -f ~/.bashrc ]]; then \n\
+  mv -f ~/.bashrc ~/fixbashrc\n\
+fi \n\
+if [[ -d \$LLMDBENCH_RUN_EXPERIMENT_HARNESS_DIR ]]; then \n\
+  pushd /workspace/\$LLMDBENCH_RUN_EXPERIMENT_HARNESS_DIR \n\
+  git fetch \n\
+  git checkout \$LLMDBENCH_HARNESS_GIT_BRANCH \n\
+  popd \n\
+fi \n\
 /usr/local/bin/\${LLMDBENCH_RUN_EXPERIMENT_HARNESS}\n\
 ec=\$?\n\
 if [[ \$ec -ne 0 ]]; then\n\
   echo \"execution of /usr/local/bin/\${LLMDBENCH_RUN_EXPERIMENT_HARNESS} failed, wating 30 seconds and trying again\"\n\
   sleep 30\n\
 fi\n\
-mv -f ~/fixbashrc ~/.bashrc\n\
+if [[ -f ~/fixbashrc ]]; then \n\
+  mv -f ~/fixbashrc ~/.bashrc\n\
+fi \n\
 /usr/local/bin/\${LLMDBENCH_RUN_EXPERIMENT_ANALYZER}\n\
 ec=\$?\n\
 if [[ \$ec -ne 0 ]]; then\n\
@@ -72,27 +119,6 @@ exit \$ec\n\
 sed -i 's^\-e^^' /usr/local/bin/llm-d-benchmark.sh; \
 chmod +x /usr/local/bin/llm-d-benchmark.sh
 
-WORKDIR /workspace
-
-ARG FM_PERF_REPO=https://github.com/fmperf-project/fmperf.git
-ARG FM_PERF_BRANCH=main
-RUN git clone --branch ${FM_PERF_BRANCH} ${FM_PERF_REPO}
-
-ARG INFERENCE_PERF_REPO=https://github.com/kubernetes-sigs/inference-perf.git
-ARG INFERENCE_PERF_BRANCH=main
-RUN git clone --branch ${INFERENCE_PERF_BRANCH} ${INFERENCE_PERF_REPO}
-RUN cd inference-perf; pip install .
-
-RUN cd fmperf; \
-    pip install --no-cache-dir -r requirements.txt && \
-    python3 setup.py install
-
-RUN ln -s /usr/bin/sleep /usr/local/bin/sleep
-
-ADD workload/harnesses/ /usr/local/bin/
-COPY analysis/fmperf-analyze_results.py /usr/local/bin/fmperf-analyze_results.py
-COPY analysis/inference-perf-analyze_results.sh /usr/local/bin/inference-perf-analyze_results.sh
-COPY analysis/nop-analyze_results.py /usr/local/bin/nop-analyze_results.py
 
 #RUN mkdir /root/.kube
 #RUN touch /root/.llmdbench_dependencies_checked

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -5,3 +5,4 @@ numpy>=1.22.0
 seaborn>=0.12.0
 kubernetes>=28.0.0
 requests
+pybase64

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -41,7 +41,7 @@ export LLMDBENCH_HARNESS_SKIP_RUN=0
 export LLMDBENCH_HARNESS_DEBUG=0
 
 function get_harness_list {
-  ls ${LLMDBENCH_MAIN_DIR}/workload/harnesses | $LLMDBENCH_CONTROL_SCMD 's^inference-perf^inference_perf^' | cut -d '-' -f 1 | $LLMDBENCH_CONTROL_SCMD -n -e 's^inference_perf^inference-perf^' -e 'H;${x;s/\n/,/g;s/^,//;p;}'
+  ls ${LLMDBENCH_MAIN_DIR}/workload/harnesses | $LLMDBENCH_CONTROL_SCMD -e 's^inference-perf^inference_perf^' -e 's^vllm-benchmark^vllm_benchmark^' | cut -d '-' -f 1 | $LLMDBENCH_CONTROL_SCMD -n -e 's^inference_perf^inference-perf^' -e 's^vllm_benchmark^vllm-benchmark^' -e 'H;${x;s/\n/,/g;s/^,//;p;}'
 }
 
 function show_usage {
@@ -168,7 +168,7 @@ source ${LLMDBENCH_CONTROL_DIR}/env.sh
 
 export LLMDBENCH_EXPERIMENT_ID=${LLMDBENCH_EXPERIMENT_ID:-"default"}
 
-export LLMDBENCH_BASE64_CONTEXT=$(cat $LLMDBENCH_CONTROL_WORK_DIR/environment/context.ctx | base64 $LLMDBENCH_BASE64_ARGS)
+export LLMDBENCH_BASE64_CONTEXT_CONTENTS=$(cat $LLMDBENCH_CONTROL_WORK_DIR/environment/context.ctx | base64 $LLMDBENCH_BASE64_ARGS)
 
 create_harness_pod() {
   cat <<EOF > $LLMDBENCH_CONTROL_WORK_DIR/setup/yamls/pod_benchmark-launcher.yaml
@@ -193,16 +193,20 @@ spec:
       value: "1"
     - name: LLMDBENCH_RUN_EXPERIMENT_ANALYZE_LOCALLY
       value: "${LLMDBENCH_RUN_EXPERIMENT_ANALYZE_LOCALLY}"
+    - name: LLMDBENCH_HARNESS_GIT_BRANCH
+      value: "${LLMDBENCH_HARNESS_GIT_BRANCH}"
     - name: LLMDBENCH_RUN_EXPERIMENT_HARNESS
       value: "${LLMDBENCH_RUN_EXPERIMENT_HARNESS}"
     - name: LLMDBENCH_RUN_EXPERIMENT_ANALYZER
       value: "${LLMDBENCH_RUN_EXPERIMENT_ANALYZER}"
     - name: LLMDBENCH_CONTROL_WORK_DIR
       value: "/requests/${LLMDBENCH_HARNESS_STACK_NAME}/"
-    - name: LLMDBENCH_BASE64_CONTEXT
-      value: "$LLMDBENCH_BASE64_CONTEXT"
-    - name: LLMDBENCH_BASE64_HARNESS_WORKLOAD
-      value: "${LLMDBENCH_BASE64_HARNESS_WORKLOAD}"
+    - name: LLMDBENCH_BASE64_CONTEXT_CONTENTS
+      value: "$LLMDBENCH_BASE64_CONTEXT_CONTENTS"
+    - name: LLMDBENCH_BASE64_HARNESS_WORKLOAD_CONTENTS
+      value: "${LLMDBENCH_BASE64_HARNESS_WORKLOAD_CONTENTS}"
+    - name: LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME
+      value: "llmdbench_workload.yaml"
     - name: LLMDBENCH_HARNESS_NAMESPACE
       value: "${LLMDBENCH_HARNESS_NAMESPACE}"
     - name: LLMDBENCH_HARNESS_STACK_TYPE
@@ -323,7 +327,7 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
 
       announce "ℹ️ Selected workload profile is \"$workload_template_file_name\""
       render_template $workload_template_full_path ${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/$workload_template_file_name
-      export LLMDBENCH_BASE64_HARNESS_WORKLOAD=$(cat ${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/$workload_template_file_name | base64 $LLMDBENCH_BASE64_ARGS)
+      export LLMDBENCH_BASE64_HARNESS_WORKLOAD_CONTENTS=$(cat ${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/$workload_template_file_name | base64 $LLMDBENCH_BASE64_ARGS)
 
       create_harness_pod
 
@@ -361,7 +365,7 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
         announce "ℹ️ To collect results after an execution, \"$copy_results_cmd && $copy_analisys_cmd"
       else
         announce "ℹ️ Harness was started in \"debug mode\". The pod can be accessed through \"${LLMDBENCH_CONTROL_KCMD} --namespace ${LLMDBENCH_HARNESS_NAMESPACE} exec -it pod/${LLMDBENCH_RUN_HARNESS_LAUNCHER_NAME} -- bash\""
-        announce "ℹ️ In order to execute a given workload profile, change the value of env var \"LLMDBENCH_RUN_EXPERIMENT_HARNESS\" and \"LLMDBENCH_RUN_EXPERIMENT_ANALYZER\", follwing by running \"llm-d-benchmark.sh\" (all inside the pod \"${LLMDBENCH_RUN_HARNESS_LAUNCHER_NAME}\")"
+        announce "ℹ️ In order to execute a given workload profile, run \"llm-d-benchmark.sh <[$(get_harness_list)]> [WORKLOAD FILE NAME]\" (all inside the pod \"${LLMDBENCH_RUN_HARNESS_LAUNCHER_NAME}\")"
         announce "ℹ️ To collect results after an execution, \"$copy_results_cmd && $copy_analisys_cmd"
       fi
     fi

--- a/workload/harnesses/inference-perf-llm-d-benchmark.sh
+++ b/workload/harnesses/inference-perf-llm-d-benchmark.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-inference-perf --config_file /workspace/llmdbench_workload.yaml
 mkdir -p "/requests/$LLMDBENCH_HARNESS_STACK_NAME"
+inference-perf --config_file /workspace/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} > >(tee -a /requests/$LLMDBENCH_HARNESS_STACK_NAME/stdout.log) 2> >(tee -a /requests/$LLMDBENCH_HARNESS_STACK_NAME/stderr.log >&2)
+export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
 find /workspace -name '*.json' -exec mv -t "/requests/$LLMDBENCH_HARNESS_STACK_NAME"/ {} +
-exit 0
+exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC

--- a/workload/harnesses/nop-llm-d-benchmark.sh
+++ b/workload/harnesses/nop-llm-d-benchmark.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 # Placeholder, to be populated later.
-
-exit 0
+true
+export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
+exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC

--- a/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
+++ b/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+mkdir -p "/requests/$LLMDBENCH_HARNESS_STACK_NAME"
+cd /workspace/vllm-benchmark/
+en=$(cat /workspace/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r .executable)
+python benchmarks/${en} --$(cat /workspace/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")')  --seed $(date +%s) --save-result > >(tee -a /requests/$LLMDBENCH_HARNESS_STACK_NAME/stdout.log) 2> >(tee -a /requests/$LLMDBENCH_HARNESS_STACK_NAME/stderr.log >&2)
+export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
+exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC

--- a/workload/profiles/vllm-benchmark/simple-random.yaml.in
+++ b/workload/profiles/vllm-benchmark/simple-random.yaml.in
@@ -1,0 +1,4 @@
+executable: benchmark_serving.py
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+dataset-name: random


### PR DESCRIPTION
A new harness type, `vllm-benchmark` can be specified. The rendered yaml file is, internally, converted into a list CLI options, with the parameter `executable` specifying the load generator (e.g., `benchmark_serving.py`)

During this process, a small refactor on `llm-d-benchmark.sh` made it simpler to call with different harnesses (and workloads) when the parameter `-d` is used on `run.sh`