### PR TITLE
Additional fixes for "parameterless" CLI options on vllm-benchmark

### DIFF
--- a/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
+++ b/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
@@ -2,7 +2,7 @@
 mkdir -p "$LLMDBENCH_HARNESS_RESULTS_DIR"
 cd /workspace/vllm-benchmark/
 en=$(cat /workspace/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r .executable)
-python benchmarks/${en} --$(cat /workspace/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g')  --seed $(date +%s) --save-result > >(tee -a $LLMDBENCH_HARNESS_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_HARNESS_RESULTS_DIR/stderr.log >&2)
+python benchmarks/${en} --$(cat /workspace/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g' -e 's^=none$^^g')  --seed $(date +%s) --save-result > >(tee -a $LLMDBENCH_HARNESS_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_HARNESS_RESULTS_DIR/stderr.log >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
 find /workspace -name '*.json' -exec mv -t "$LLMDBENCH_HARNESS_RESULTS_DIR"/ {} +
 exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC

--- a/workload/profiles/vllm-benchmark/random_1k_concurrent_10-1_ISL-OSL.yaml.in
+++ b/workload/profiles/vllm-benchmark/random_1k_concurrent_10-1_ISL-OSL.yaml.in
@@ -1,0 +1,11 @@
+executable: benchmark_serving.py
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+dataset-name: random
+random-input-len: 10000
+random-output-len: 1000
+max-concurrency: REPLACE_ENV_LLMDBENCH_RUN_EXPERIMENT_PARAMETER_MAX_CONCURRENCY
+num-prompts: 32
+percentile-metrics: "ttft,tpot,itl,e2el"
+metric-percentiles: "90,95,99"
+ignore-eos: none


### PR DESCRIPTION
Additionally added an example workload (vllm-benchmark) which allows "parameter sweep"