### PR TITLE
[143] Enhancement to Step 4 of Model Namespace Preparation 

### DIFF
--- a/setup/steps/04_ensure_model_namespace_prepared.sh
+++ b/setup/steps/04_ensure_model_namespace_prepared.sh
@@ -1,44 +1,70 @@
 #!/usr/bin/env bash
-source ${LLMDBENCH_CONTROL_DIR}/env.sh
+source "${LLMDBENCH_CONTROL_DIR}/env.sh"
 
-announce "🔍 Checking if \"${LLMDBENCH_VLLM_COMMON_NAMESPACE}\" is prepared."
-check_storage_class_and_affinity
-llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} --namespace ${LLMDBENCH_VLLM_COMMON_NAMESPACE} delete job download-model --ignore-not-found" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+main() {
+  announce "🔍 Checking if \"${LLMDBENCH_VLLM_COMMON_NAMESPACE}\" is prepared."
+  check_storage_class_and_affinity
+  if [[ $? -ne 0 ]]
+  then
+    announce "❌ Failed to check storage class and affinity"
+    exit 1
+  fi
 
-for model in ${LLMDBENCH_DEPLOY_MODEL_LIST//,/ }; do
-  modelfn=$(echo ${model} | ${LLMDBENCH_CONTROL_SCMD} 's^/^___^g' )
-  cat << EOF > $LLMDBENCH_CONTROL_WORK_DIR/setup/yamls/${LLMDBENCH_CURRENT_STEP}_prepare_namespace_${modelfn}.yaml
-sampleApplication:
-  enabled: true
-  baseConfigMapRefName: basic-gpu-with-nixl-and-redis-lookup-preset
-  model:
-    modelArtifactURI: pvc://$LLMDBENCH_VLLM_COMMON_PVC_NAME/models/$(model_attribute $model model)
-    modelName: "$(model_attribute $model model)"
-EOF
+  for model in ${LLMDBENCH_DEPLOY_MODEL_LIST//,/ }; do
+    llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} --namespace "${LLMDBENCH_VLLM_COMMON_NAMESPACE}" delete job download-model --ignore-not-found" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
 
-  llmd_opts="--namespace ${LLMDBENCH_VLLM_COMMON_NAMESPACE} --skip-infra --download-pvc-only --storage-class ${LLMDBENCH_VLLM_COMMON_PVC_STORAGE_CLASS} --storage-size ${LLMDBENCH_VLLM_COMMON_PVC_MODEL_CACHE_SIZE} --download-model $(model_attribute $model model) --download-timeout ${LLMDBENCH_VLLM_COMMON_PVC_DOWNLOAD_TIMEOUT} --values-file $LLMDBENCH_CONTROL_WORK_DIR/setup/yamls/${LLMDBENCH_CURRENT_STEP}_prepare_namespace_${modelfn}.yaml --context $LLMDBENCH_CONTROL_WORK_DIR/environment/context.ctx"
-  announce "🚀 Calling llm-d-deployer with options \"${llmd_opts}\"..."
-  pushd $LLMDBENCH_DEPLOYER_DIR/llm-d-deployer/quickstart &>/dev/null
-  llmdbench_execute_cmd "cd $LLMDBENCH_DEPLOYER_DIR/llm-d-deployer/quickstart; export HF_TOKEN=$LLMDBENCH_HF_TOKEN; ./llmd-installer.sh $llmd_opts" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE} 0 3
-  popd &>/dev/null
-  announce "✅ llm-d-deployer prepared namespace"
-done
+    local MODEL_ARTIFACT_URI="pvc://${LLMDBENCH_VLLM_COMMON_PVC_NAME}/models/$(model_attribute "${model}" model)"
+    local PROTOCOL="${MODEL_ARTIFACT_URI%%://*}"
+    local DOWNLOAD_MODEL="$(model_attribute "${model}" model)"
 
-if [[ $LLMDBENCH_CONTROL_DEPLOY_IS_OPENSHIFT -eq 1 ]]; then
-  llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} \
-adm \
-policy \
-add-scc-to-user \
-anyuid \
--z ${LLMDBENCH_VLLM_COMMON_SERVICE_ACCOUNT} \
--n $LLMDBENCH_VLLM_COMMON_NAMESPACE" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+    local PVC_AND_MODEL_PATH="${MODEL_ARTIFACT_URI#*://}"
+    local PVC_NAME="${PVC_AND_MODEL_PATH%%/*}"
+    local MODEL_PATH="${PVC_AND_MODEL_PATH#*/}"
 
-  llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} \
-adm \
-policy \
-add-scc-to-user \
-privileged \
--z ${LLMDBENCH_VLLM_COMMON_SERVICE_ACCOUNT} \
--n $LLMDBENCH_VLLM_COMMON_NAMESPACE" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
-fi
-announce "✅ Namespace \"${LLMDBENCH_VLLM_COMMON_NAMESPACE}\" prepared."
+    create_namespace "${LLMDBENCH_CONTROL_KCMD}" "${LLMDBENCH_VLLM_COMMON_NAMESPACE}"
+    create_or_update_hf_secret "${LLMDBENCH_CONTROL_KCMD}" "${LLMDBENCH_VLLM_COMMON_NAMESPACE}" "${LLMDBENCH_VLLM_COMMON_HF_TOKEN_NAME}" ${LLMDBENCH_VLLM_COMMON_HF_TOKEN_KEY} "${LLMDBENCH_HF_TOKEN}"
+
+    validate_and_create_pvc \
+      "${LLMDBENCH_CONTROL_KCMD}" \
+      "${LLMDBENCH_VLLM_COMMON_NAMESPACE}" \
+      "${DOWNLOAD_MODEL}" \
+      "${PVC_NAME}" \
+      "${LLMDBENCH_VLLM_COMMON_PVC_MODEL_CACHE_SIZE}" \
+      "${LLMDBENCH_VLLM_COMMON_PVC_STORAGE_CLASS}"
+
+    launch_download_job \
+      "${LLMDBENCH_CONTROL_KCMD}" \
+      "${LLMDBENCH_VLLM_COMMON_NAMESPACE}" \
+      "${LLMDBENCH_VLLM_COMMON_HF_TOKEN_NAME}" \
+      "${DOWNLOAD_MODEL}" \
+      "${MODEL_PATH}" \
+      "${PVC_NAME}"
+
+    wait_for_download_job \
+      "${LLMDBENCH_CONTROL_KCMD}" \
+      "${LLMDBENCH_VLLM_COMMON_NAMESPACE}" \
+      "${LLMDBENCH_VLLM_COMMON_PVC_DOWNLOAD_TIMEOUT}"
+
+    announce "✅ llm-d-deployer prepared namespace"
+
+    if [[ "${LLMDBENCH_CONTROL_DEPLOY_IS_OPENSHIFT}" -eq 1 ]]; then
+      llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} \
+        adm policy add-scc-to-user anyuid \
+        -z ${LLMDBENCH_VLLM_COMMON_SERVICE_ACCOUNT} \
+        -n ${LLMDBENCH_VLLM_COMMON_NAMESPACE}" \
+        "${LLMDBENCH_CONTROL_DRY_RUN}" "${LLMDBENCH_CONTROL_VERBOSE}" 1 1 1
+
+      llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} \
+        adm policy add-scc-to-user privileged \
+        -z ${LLMDBENCH_VLLM_COMMON_SERVICE_ACCOUNT} \
+        -n ${LLMDBENCH_VLLM_COMMON_NAMESPACE}" \
+        "${LLMDBENCH_CONTROL_DRY_RUN}" "${LLMDBENCH_CONTROL_VERBOSE}" 1 1 1
+    fi
+
+    announce "✅ Namespace \"${LLMDBENCH_VLLM_COMMON_NAMESPACE}\" prepared."
+  done
+
+  return 0
+}
+
+main


### PR DESCRIPTION
# Summary

- This addresses the issue #143 by refactoring and improving the model namespace lifecycle

## Details

- Removes the dependency `llm-d-deployer` git repo.
- Adds several new functions to `env.sh` for convenience
- Cleans up the flow of `04_ensure_model_namespace_prepared.sh` and handles error cases efficiently by leveraging `llmdbench_execute_cmd`

## Sample Run

```
llm-d-benchmark git:(model-download-issue-143) ./setup/standup.sh -m meta-llama/Llama-3.1-8B-Instruct -t standalone
==> Thu Jul 17 18:06:32 EDT 2025 - ./setup/standup.sh - === Running step: 00_ensure_llm-d-deployer.sh ===
==> Thu Jul 17 18:06:36 EDT 2025 - ./setup/standup.sh - 💾 Cloning and setting up llm-d-deployer...
==> Thu Jul 17 18:06:36 EDT 2025 - ./setup/standup.sh - ✅ llm-d-deployer is present at "/tmp"

==> Thu Jul 17 18:06:36 EDT 2025 - ./setup/standup.sh - === Running step: 01_ensure_local_conda.sh ===
==> Thu Jul 17 18:06:39 EDT 2025 - ./setup/standup.sh - ⏭️ Environment variable "LLMDBENCH_RUN_EXPERIMENT_ANALYZE_LOCALLY" is set to 0, skipping local setup of conda environment

==> Thu Jul 17 18:06:39 EDT 2025 - ./setup/standup.sh - === Running step: 02_ensure_gateway_provider.sh ===
==> Thu Jul 17 18:06:43 EDT 2025 - ./setup/standup.sh - 🔍 Checking if Gateway Provider is setup...
==> Thu Jul 17 18:06:43 EDT 2025 - ./setup/standup.sh - ⏭️  Gateway Provider is already setup, skipping installation
==> Thu Jul 17 18:06:49 EDT 2025 - ./setup/standup.sh - ⏭️  The CRDs from istio present are recent enough, skipping application of newer CRDs

==> Thu Jul 17 18:06:49 EDT 2025 - ./setup/standup.sh - === Running step: 03_ensure_user_workload_monitoring_configuration.sh ===
==> Thu Jul 17 18:06:52 EDT 2025 - ./setup/standup.sh - 🔍 Checking for OpenShift user workload monitoring enablement...
==> Thu Jul 17 18:06:53 EDT 2025 - ./setup/standup.sh - ✅ OpenShift user workload monitoring enabled

==> Thu Jul 17 18:06:53 EDT 2025 - ./setup/standup.sh - === Running step: 04_ensure_model_namespace_prepared.sh ===
==> Thu Jul 17 18:06:55 EDT 2025 - ./setup/standup.sh - 🔍 Checking if "llmdbench" is prepared.
==> Thu Jul 17 18:06:57 EDT 2025 - ./setup/standup.sh - 📦 Creating namespace llmdbench...
==> Thu Jul 17 18:06:58 EDT 2025 - ./setup/standup.sh - ✅ Namespace ready
==> Thu Jul 17 18:06:58 EDT 2025 - ./setup/standup.sh - 🔐 Creating/updating HF token secret...
==> Thu Jul 17 18:06:59 EDT 2025 - ./setup/standup.sh - ✅ HF token secret created
==> Thu Jul 17 18:06:59 EDT 2025 - ./setup/standup.sh - 💾 Provisioning model storage…
==> Thu Jul 17 18:06:59 EDT 2025 - ./setup/standup.sh - 🔍 Checking storage class 'nfs-client-simplenfs'...
==> Thu Jul 17 18:07:00 EDT 2025 - ./setup/standup.sh - 🚀 Launching model download job...
==> Thu Jul 17 18:07:01 EDT 2025 - ./setup/standup.sh - ⏳ Waiting for pod to start model download job ...
==> Thu Jul 17 18:07:03 EDT 2025 - ./setup/standup.sh - ⏳ Waiting up to 2400s for job to complete...
==> Thu Jul 17 18:08:03 EDT 2025 - ./setup/standup.sh - ✅ Model downloaded
==> Thu Jul 17 18:08:03 EDT 2025 - ./setup/standup.sh - ✅ llm-d-deployer prepared namespace
==> Thu Jul 17 18:08:05 EDT 2025 - ./setup/standup.sh - ✅ Namespace "llmdbench" prepared.

==> Thu Jul 17 18:08:05 EDT 2025 - ./setup/standup.sh - === Running step: 05_ensure_harness_namespace_prepared.sh ===
==> Thu Jul 17 18:08:08 EDT 2025 - ./setup/standup.sh - ⏭️ Environment variable "LLMDBENCH_RUN_EXPERIMENT_ANALYZE_LOCALLY" is set to 0, skipping local setup of harness
==> Thu Jul 17 18:08:08 EDT 2025 - ./setup/standup.sh - 🔄 Creating namespace (llmdbench), service account (vllm-benchmark-runner) and rbac for harness...
==> Thu Jul 17 18:08:11 EDT 2025 - ./setup/standup.sh - ✅ Namespace (llmdbench), service account (vllm-benchmark-runner) and rbac for harness created
==> Thu Jul 17 18:08:11 EDT 2025 - ./setup/standup.sh - ✅ PVC "workload-pvc" for harness data storage created
==> Thu Jul 17 18:08:11 EDT 2025 - ./setup/standup.sh - 🔄 Starting pod "access-to-harness-data-workload-pvc" to provide access to PVC workload-pvc (harness data storage)...
==> Thu Jul 17 18:08:13 EDT 2025 - ./setup/standup.sh - ✅ Pod "access-to-harness-data-workload-pvc" started, providing access to PVC workload-pvc

==> Thu Jul 17 18:08:15 EDT 2025 - ./setup/standup.sh - === Running step: 06_deploy_vllm_standalone_models.sh ===
==> Thu Jul 17 18:08:18 EDT 2025 - ./setup/standup.sh - 🚚 Deploying model "meta-llama/Llama-3.1-8B-Instruct" and associated service (from files located at /var/folders/pj/7679q1l50672dgqrzp26fxdh0000gn/T/pokprod007-standupXXX.x6YdCXf0Ii)...
==> Thu Jul 17 18:08:20 EDT 2025 - ./setup/standup.sh - ✅ Model "meta-llama/Llama-3.1-8B-Instruct" and associated service deployed.
==> Thu Jul 17 18:08:20 EDT 2025 - ./setup/standup.sh - ⏳ Waiting for (standalone) pods serving model meta-llama/Llama-3.1-8B-Instruct to be in "Running" state (timeout=3600s)...
==> Thu Jul 17 18:08:28 EDT 2025 - ./setup/standup.sh - 🚀 (standalone) pods serving model meta-llama/Llama-3.1-8B-Instruct running
==> Thu Jul 17 18:08:29 EDT 2025 - ./setup/standup.sh - ⏳ Waiting for (standalone) pods serving meta-llama/Llama-3.1-8B-Instruct to be Ready (timeout=3600s)...
==> Thu Jul 17 18:12:57 EDT 2025 - ./setup/standup.sh - 🚀 (standalone) pods serving model meta-llama/Llama-3.1-8B-Instruct ready
==> Thu Jul 17 18:12:57 EDT 2025 - ./setup/standup.sh - 📜 Exposing pods serving model meta-llama/Llama-3.1-8B-Instruct as service...
==> Thu Jul 17 18:12:58 EDT 2025 - ./setup/standup.sh - ✅ Service for pods service model meta-llama/Llama-3.1-8B-Instruct created
==> Thu Jul 17 18:12:58 EDT 2025 - ./setup/standup.sh - ✅ Model "meta-llama/Llama-3.1-8B-Instruct" and associated service deployed.
==> Thu Jul 17 18:12:58 EDT 2025 - ./setup/standup.sh - ℹ️ A snapshot of the relevant (model-specific) resources on namespace "llmdbench":
NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/vllm-standalone-granite-3-2b   1/1     1            1           13m
deployment.apps/vllm-standalone-llama-3-8b     1/1     1            1           4m40s

NAME                                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
service/llm-d-benchmark-harness        ClusterIP   REDACT    <none>        20873/TCP   44h
service/vllm-standalone-granite-3-2b   ClusterIP   REDACT  <none>        80/TCP      13m
service/vllm-standalone-llama-3-8b     ClusterIP   REDACT   <none>        80/TCP      4m39s

NAME                                                          HOST/PORT                                                                        PATH   SERVICES                       PORT   TERMINATION   WILDCARD
route.route.openshift.io/vllm-standalone-granite-3-2b-route   vllm-standalone-granite-3-2b-route-llmdbench.apps.REDACT          vllm-standalone-granite-3-2b   http                 None
route.route.openshift.io/vllm-standalone-llama-3-8b-route     vllm-standalone-llama-3-8b-route-llmdbench.apps.REDACT            vllm-standalone-llama-3-8b     http                 None

NAME                                                READY   STATUS      RESTARTS   AGE
pod/access-to-harness-data-workload-pvc             0/1     Pending     0          44h
pod/download-model-tfm5j                            0/1     Completed   0          5m59s
pod/vllm-standalone-granite-3-2b-79c669d8b4-g4vfz   1/1     Running     0          13m
pod/vllm-standalone-llama-3-8b-775477ffdf-bqkcc     1/1     Running     0          4m41s

NAME                    TYPE     DATA   AGE
secret/llm-d-hf-token   Opaque   1      6m2s

==> Thu Jul 17 18:13:01 EDT 2025 - ./setup/standup.sh - === Running step: 07_invoke_llm-d-deployer.sh ===
==> Thu Jul 17 18:13:04 EDT 2025 - ./setup/standup.sh - ⏭️ Environment types are "standalone". Skipping this step.

==> Thu Jul 17 18:13:05 EDT 2025 - ./setup/standup.sh - === Running step: 08_smoketest.sh ===
==> Thu Jul 17 18:13:08 EDT 2025 - ./setup/standup.sh - 🔍 Checking if current deployment was successfull...
==> Thu Jul 17 18:13:09 EDT 2025 - ./setup/standup.sh - 🚀 Testing all pods "standalone" (port 8000)...
==> Thu Jul 17 18:13:09 EDT 2025 - ./setup/standup.sh -        🚀 Testing pod ip "REDACT" ...
==> Thu Jul 17 18:13:17 EDT 2025 - ./setup/standup.sh -        ✅ Pod ip "REDACT" responds successfully
==> Thu Jul 17 18:13:17 EDT 2025 - ./setup/standup.sh -        🚀 Testing pod ip "REDACT" ...
==> Thu Jul 17 18:13:21 EDT 2025 - ./setup/standup.sh -        ✅ Pod ip "REDACT" responds successfully
==> Thu Jul 17 18:13:21 EDT 2025 - ./setup/standup.sh - ✅ All pods respond successfully
==> Thu Jul 17 18:13:21 EDT 2025 - ./setup/standup.sh - 🚀 Testing service/gateway "vllm-standalone-granite-3-2b vllm-standalone-llama-3-8b" ("REDACT") (port 80)...
==> Thu Jul 17 18:13:26 EDT 2025 - ./setup/standup.sh - ✅ Service responds successfully
==> Thu Jul 17 18:13:26 EDT 2025 - ./setup/standup.sh - 🚀 Testing external route "vllm-standalone-granite-3-2b-route-llmdbench.apps.REDACT vllm-standalone-llama-3-8b-route-llmdbench.apps.REDACT"...
==> Thu Jul 17 18:13:27 EDT 2025 - ./setup/standup.sh - ✅ External route responds successfully

==> Thu Jul 17 18:13:27 EDT 2025 - ./setup/standup.sh - ℹ️  The current work dir is "/var/folders/pj/7679q1l50672dgqrzp26fxdh0000gn/T/REDACT-standupXXX.x6YdCXf0Ii". Run "export LLMDBENCH_CONTROL_WORK_DIR=/var/folders/pj/7679q1l50672dgqrzp26fxdh0000gn/T/REDACT-standupXXX.x6YdCXf0Ii" if you wish subsequent executions use the same diretory
==> Thu Jul 17 18:13:27 EDT 2025 - ./setup/standup.sh - ✅ All steps complete.
```

## Functional Test

```
curl -v -k "http://vllm-standalone-llama-3-8b-route-llmdbench.apps.REDACT/v1/chat/completions" \
  -H "Content-Type: application/json" \
  --data '{
    "model": "meta-llama/Llama-3.1-8B-Instruct",
    "messages": [
      {
        "role": "user",
        "content": "What can I do in NYC in 8 hours?"
      }
    ]
}'

*   Trying 1REDACT:80...
* Connected to vllm-standalone-llama-3-8b-route-llmdbench.apps.REDACT (REDACT) port 80
> POST /v1/chat/completions HTTP/1.1
> Host: vllm-standalone-llama-3-8b-route-llmdbench.apps.REDACT
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 170
>
< HTTP/1.1 200 OK
< date: Thu, 17 Jul 2025 22:25:49 GMT
< server: uvicorn
< content-length: 2813
< content-type: application/json
< set-cookie: REDACT; path=/; HttpOnly
<
* Connection #0 to host vllm-standalone-llama-3-8b-route-llmdbench.apps.REDACT left intact
{"id":"chatcmpl-REDACT","object":"chat.completion","created":1752791151,"model":"meta-llama/Llama-3.1-8B-Instruct","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":"With 8 hours in NYC, you can experience a mix of iconic landmarks, cultural attractions, and a taste of the city's diverse neighborhoods. Here's a suggested itinerary:\n\n**Stop 1: Iconic Landmarks (1 hour)**\n\n- Start at Times Square (9:00 am - 9:30 am), the heart of New York's entertainment district.\n- Walk to the nearby TKTS Booth in Duffy Square to grab a same-day ticket for a Broadway show (if available).\n- Visit the New Year's Eve Ball at Times Square (if you're visiting in December).\n\n**Stop 2: Central Park (1 hour)**\n\n- Head to Central Park (9:30 am - 10:30 am), an 843-acre green oasis in the middle of Manhattan.\n- Take a stroll through the park, visit the Bethesda Fountain, or rent a bike and explore the park.\n\n**Stop 3: The Metropolitan Museum of Art (1.5 hours)**\n\n- Visit the Metropolitan Museum of Art (10:30 am - 12:00 pm), one of the world's largest and most famous museums.\n- Explore the museum's vast collections, from ancient Egyptian artifacts to modern art.\n\n**Stop 4: Lunch in a Classic NYC Restaurant (1 hour)**\n\n- Grab lunch at a classic NYC eatery like Katz's Delicatessen (12:00 pm - 1:00 pm) or Carbone (1:00 pm - 2:00 pm).\n- Try a classic NYC dish like pastrami on rye or a plate of pasta.\n\n**Stop 5: Walk across the Brooklyn Bridge (1 hour)**\n\n- Take a walk across the iconic Brooklyn Bridge (2:00 pm - 3:00 pm) for spectacular views of the Manhattan skyline and the East River.\n- Explore the trendy DUMBO neighborhood in Brooklyn.\n\n**Stop 6: Explore a NYC Neighborhood (1.5 hours)**\n\n- Visit the historic Greenwich Village neighborhood (3:00 pm - 4:30 pm), known for its charming streets, boutique shops, and lively nightlife.\n- Explore the trendy boutiques and galleries in the Meatpacking District.\n\n**Stop 7: Catch a Broadway Show (1.5 hours)**\n\n- If you were able to grab a same-day ticket, catch a Broadway show (5:00 pm - 6:30 pm).\n- Alternatively, visit the TKTS Booth to grab a ticket for a same-day show.\n\n**Stop 8: End the Day with a Sunset View (1 hour)**\n\n- End your day with a stunning sunset view from the Top of the Rock Observation Deck (6:30 pm - 7:30 pm) or the Empire State Building.\n- Reflect on your amazing day in NYC!\n\nRemember, this itinerary is just a suggestion, and you can customize it to fit your interests and preferences. Enjoy your time in NYC!","tool_calls":[]},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":46,"total_tokens":641,"completion_tokens":595,"prompt_tokens_details":null},"prompt_logprobs":null,"kv_transfer_params":null}%
```
