### PR TITLE
[Run] feat: add guidellm as a new harness.

### DIFF
--- a/analysis/guidellm-analyze_results.sh
+++ b/analysis/guidellm-analyze_results.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis"
+result_start=$(grep -nr "Benchmarks Stats:" $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | cut -d ':' -f 1)
+total_file_lenght=$(cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | wc -l)
+cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | sed "$result_start,$total_file_lenght!d" > $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/summary.txt
+exit $?

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -65,6 +65,16 @@ ARG VLLM_BENCHMARK_BRANCH=main
 RUN git clone --branch ${VLLM_BENCHMARK_BRANCH} ${VLLM_BENCHMARK_REPO}
 RUN cd vllm; pip install vllm; cd ..; mv -f vllm vllm-benchmark
 
+ARG GUIDELLM_REPO=https://github.com/vllm-project/guidellm.git
+ARG GUIDELLM_BRANCH=main
+RUN git clone --branch ${GUIDELLM_BRANCH} ${GUIDELLM_REPO}
+RUN cd guidellm; pip install guidellm
+
+RUN echo "fmperf: ${FM_PERF_REPO}" > /workspace/repos.txt; \
+    echo "inference-perf: ${INFERENCE_PERF_REPO}" >> /workspace/repos.txt; \
+    echo "vllm-benchmark: ${VLLM_BENCHMARK_REPO}" >> /workspace/repos.txt; \
+    echo "guidellm: ${GUIDELLM_REPO}" >> /workspace/repos.txt
+
 RUN ln -s /usr/bin/sleep /usr/local/bin/sleep
 
 ADD workload/harnesses/ /usr/local/bin/
@@ -72,12 +82,14 @@ COPY analysis/fmperf-analyze_results.py /usr/local/bin/fmperf-analyze_results.py
 COPY analysis/inference-perf-analyze_results.sh /usr/local/bin/inference-perf-analyze_results.sh
 COPY analysis/nop-analyze_results.py /usr/local/bin/nop-analyze_results.py
 COPY analysis/vllm-benchmark-analyze_results.sh /usr/local/bin/vllm-benchmark-analyze_results.sh
+COPY analysis/guidellm-analyze_results.sh /usr/local/bin/guidellm-analyze_results.sh
 
 RUN echo "#!/usr/bin/env bash" > /usr/local/bin/llm-d-benchmark.sh; echo -e "\
 
 if [[ ! -z \$1 ]]; then\n\
   export LLMDBENCH_RUN_EXPERIMENT_HARNESS=\$(find /usr/local/bin | grep \${1}.*-llm-d-benchmark | rev | cut -d '/' -f 1 | rev)\n\
   export LLMDBENCH_RUN_EXPERIMENT_ANALYZER=\$(find /usr/local/bin | grep \${1}.*-analyze_results | rev | cut -d '/' -f 1 | rev)\n\
+  export LLMDBENCH_HARNESS_GIT_REPO=\$(cat /workspace/repos.txt | grep ^\${1}: | cut -d \":\" -f 2,3 | tr -d ' ')\n\
   export LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR=/requests/\$(echo \$LLMDBENCH_RUN_EXPERIMENT_HARNESS | sed \"s^-llm-d-benchmark^^g\" | cut -d '.' -f 1)_\${LLMDBENCH_RUN_EXPERIMENT_ID}_\${LLMDBENCH_HARNESS_STACK_NAME}\n\
 fi\n\
 if [[ ! -z \$2 ]]; then\n\

--- a/setup/steps/10_smoketest.sh
+++ b/setup/steps/10_smoketest.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+source ${LLMDBENCH_CONTROL_DIR}/env.sh
+
+announce "🔍 Checking if current deployment was successfull..."
+if [[ $LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_STANDALONE_ACTIVE -eq 1 ]]; then
+  pod_string=standalone
+  route_string=standalone
+  service=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get service --no-headers | grep ${pod_string})
+  service_name=$(echo "${service}" | awk '{print $1}')
+  service_ip=$(echo "${service}" | awk '{print $3}')
+else
+  pod_string=decode
+  route_string=${LLMDBENCH_VLLM_DEPLOYER_RELEASE}-inference-gateway
+  service=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get gateway --no-headers | grep ^${LLMDBENCH_VLLM_DEPLOYER_RELEASE}-inference-gateway)
+  service_name=$(echo "${service}" | awk '{print $1}')
+  service_ip=$(echo "${service}" | awk '{print $3}')
+fi
+
+for model in ${LLMDBENCH_DEPLOY_MODEL_LIST//,/ }; do
+  if [[ $LLMDBENCH_CONTROL_DRY_RUN -ne 0 ]]; then
+    pod_ip_list="127.0.0.4"
+    service_ip="127.0.0.8"
+  else
+    pod_ip_list=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get pods -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.podIP}{"\n"}{end}' | grep ${pod_string} | awk '{print $2}')
+  fi
+
+  if [[ -z $pod_ip_list ]]; then
+    announce "❌ Unable to find IPs for pods \"${pod_string}\"!"
+    exit 1
+  fi
+
+  announce "🚀 Testing all pods \"${pod_string}\" (port ${LLMDBENCH_VLLM_COMMON_INFERENCE_PORT})..."
+  for pod_ip in $pod_ip_list; do
+    announce "       🚀 Testing pod ip \"${pod_ip}\" ..."
+    llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} run testinference-pod -n ${LLMDBENCH_VLLM_COMMON_NAMESPACE} --attach --restart=Never --rm --image=$(get_image ${LLMDBENCH_IMAGE_REGISTRY} ${LLMDBENCH_IMAGE_REPO} ${LLMDBENCH_IMAGE_NAME} ${LLMDBENCH_IMAGE_TAG}) --quiet --command -- bash -c \"curl --no-progress-meter http://${pod_ip}:${LLMDBENCH_VLLM_COMMON_INFERENCE_PORT}/v1/models\" | jq .object | grep list" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE} 1 2
+    announce "       ✅ Pod ip \"${pod_ip}\" responds successfully"
+  done
+  announce "✅ All pods respond successfully"
+
+  if [[ -z $service_ip ]]; then
+    announce "❌ Unable to find IP for service/gateway \"${service}\"!"
+    exit 1
+  fi
+
+  if [[ -z $(not_valid_ip ${service_ip}) ]]; then
+    announce "❌ Invalid IP (\"${service_ip}\") for service/gateway \"${service_name}\"!"
+    exit 1
+  fi
+
+  announce "🚀 Testing service/gateway \"${service_name}\" (\"${service_ip}\") (port 80)..."
+  llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} run testinference-gateway -n ${LLMDBENCH_VLLM_COMMON_NAMESPACE} --attach --restart=Never --rm --image=$(get_image ${LLMDBENCH_IMAGE_REGISTRY} ${LLMDBENCH_IMAGE_REPO} ${LLMDBENCH_IMAGE_NAME} ${LLMDBENCH_IMAGE_TAG}) --quiet --command -- bash -c \"curl --no-progress-meter http://${service_ip}:80/v1/models\" | jq .object | grep list" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE} 1 2
+  announce "✅ Service responds successfully"
+
+  route_url=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get route --no-headers --ignore-not-found | grep ${route_string} | awk '{print $2}'  || true)
+  if [[ ! -z $route_url ]]; then
+    announce "🚀 Testing external route \"${route_url}\"..."
+    llmdbench_execute_cmd "curl --no-progress-meter http://${route_url}:80/v1/models | jq .object | grep list" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE} 1 2
+    announce "✅ External route responds successfully"
+  fi
+done

--- a/workload/harnesses/guidellm-llm-d-benchmark.sh
+++ b/workload/harnesses/guidellm-llm-d-benchmark.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
+cd /workspace/guidellm/
+guidellm benchmark --$(cat /workspace/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g' -e 's^=none$^^g') --output-path=$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/results.json > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
+exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC

--- a/workload/profiles/guidellm/simple-concurrent.yaml.in
+++ b/workload/profiles/guidellm/simple-concurrent.yaml.in
@@ -1,0 +1,5 @@
+target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+rate-type: concurrent
+rate: 2
+max-seconds: 30
+data: prompt_tokens=256,output_tokens=128


### PR DESCRIPTION
Added GuideLLM (https://github.com/vllm-project/guidellm), now part of VLLM as yet anoter possible harness.

At this point, only one, very simple workload profile was added.

Additionally fixed a few bugs on the functions `create_namespace` and `create_namespace
create_or_update_hf_secret`

Finally, also included the (wrongly removed)
`setup/steps/10_smoketest.sh`