### PR TITLE
Fix typo in inference-perf config path

### DIFF
--- a/workload/harnesses/inference-perf-llm-d-benchmark.sh
+++ b/workload/harnesses/inference-perf-llm-d-benchmark.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
-inference-perf --config_file /workspace/profiles/inferenece-perf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+inference-perf --config_file /workspace/profiles/inference-perf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
 find /workspace -maxdepth 1 -mindepth 1 -name '*.json' -exec mv -t "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"/ {} +
 exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC


### PR DESCRIPTION
Fix typo in path to inference-perf config directory (inferenece-perf → inference-perf)