### PR TITLE
Use RUN_EXPERIMENT_RESULTS_DIR as storage path

### DIFF
--- a/workload/harnesses/inference-perf-llm-d-benchmark.sh
+++ b/workload/harnesses/inference-perf-llm-d-benchmark.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+echo Using experiment result dir: "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
-inference-perf --config_file /workspace/profiles/inference-perf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+pushd "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
+yq '.storage["local_storage"]["path"] = '\"${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}\" <"/workspace/profiles/inference-perf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}" -y >${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
+inference-perf --config_file "$(realpath ./${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME})" > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
-find /workspace -maxdepth 1 -mindepth 1 -name '*.json' -exec mv -t "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"/ {} +
 exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC


### PR DESCRIPTION
Override the storage configuration in the `yaml` file: 
```
...
storage:
  local_storage:
    path: /workspace
```
Currently you must have `/workspace` as your storage configuration. Anything else would fail to copy the results.
Sets the location directly to `${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}`. 
No need to copy the `json` files anymore. 
Also saves the profile with the results.