### PR TITLE
[Run] feat: ensure all harnesses work properly and output the same data

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /workspace
 
 # Install harnesses
 
-# Required by fmperf
+# Required by our fmperf benchmark harness
 RUN pip install kubernetes_asyncio
 
 ARG FM_PERF_REPO=https://github.com/fmperf-project/fmperf.git

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,6 +31,10 @@ sed -i 's^\-e^^' /etc/rsyncd.conf
 WORKDIR /workspace
 
 # Install harnesses
+
+# Required by fmperf
+RUN pip install kubernetes_asyncio
+
 ARG FM_PERF_REPO=https://github.com/fmperf-project/fmperf.git
 ARG FM_PERF_BRANCH=main
 ARG FM_PERF_COMMIT=0b1f63acdafcc815847a22332c0e478cc41ebed2

--- a/build/llm-d-benchmark.sh
+++ b/build/llm-d-benchmark.sh
@@ -5,6 +5,7 @@ export LLMDBENCH_RUN_EXPERIMENT_HARNESS_EC=1
   export LLMDBENCH_RUN_EXPERIMENT_HARNESS=$(find /usr/local/bin | grep ${1}.*-llm-d-benchmark | rev | cut -d '/' -f 1 | rev)
   export LLMDBENCH_RUN_EXPERIMENT_ANALYZER=$(find /usr/local/bin | grep ${1}.*-analyze_results | rev | cut -d '/' -f 1 | rev)
   export LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR=/requests/$(echo $LLMDBENCH_RUN_EXPERIMENT_HARNESS | sed "s^-llm-d-benchmark^^g" | cut -d '.' -f 1)_${LLMDBENCH_RUN_EXPERIMENT_ID}_${LLMDBENCH_HARNESS_STACK_NAME}
+  export LLMDBENCH_CONTROL_WORK_DIR=$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR
 fi
 if [[ ! -z $2 ]]; then
   export LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME=$2

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -901,3 +901,24 @@ function validate_model_name {
   done
 }
 export -f validate_model_name
+
+function backup_work_dir {
+if [[ $LLMDBENCH_CONTROL_WORK_DIR_BACKEDUP -eq 1 ]]; then
+  return 0
+fi
+
+if [[ $LLMDBENCH_CONTROL_WORK_DIR_SET -eq 1 && $LLMDBENCH_CONTROL_STANDUP_ALL_STEPS -eq 1 ]]; then
+  if [[ $LLMDBENCH_CURRENT_STEP == "00" && ${LLMDBENCH_CONTROL_CALLER} != "standup.sh" || ${LLMDBENCH_CONTROL_CALLER} != "e2s.sh" ]]; then
+    backup_suffix=$(date +"%Y-%m-%d_%H.%M.%S")
+    backup_target=$(echo $LLMDBENCH_CONTROL_WORK_DIR | $LLMDBENCH_CONTROL_SCMD 's^/$^^').$backup_suffix
+    announce "🗑️  Environment Variable \"LLMDBENCH_CONTROL_WORK_DIR\" was set outside \"setup/env.sh\", all steps were selected on \"setup/standup.sh\" and this is the first step on standup. Moving \"$LLMDBENCH_CONTROL_WORK_DIR\" to \"$backup_target\"..."
+    llmdbench_execute_cmd "mv -f $LLMDBENCH_CONTROL_WORK_DIR $backup_target" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+    export LLMDBENCH_CONTROL_WORK_DIR_BACKEDUP=1
+    prepare_work_dir
+    if [[ -f $backup_target/environment/context.ctx ]]; then
+      llmdbench_execute_cmd "cp -f $backup_target/environment/context.ctx $LLMDBENCH_CONTROL_WORK_DIR/environment/context.ctx" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+    fi
+  fi
+fi
+}
+export -f backup_work_dir

--- a/setup/teardown.sh
+++ b/setup/teardown.sh
@@ -147,15 +147,17 @@ for tgtns in ${LLMDBENCH_VLLM_COMMON_NAMESPACE} ${LLMDBENCH_HARNESS_NAMESPACE}; 
     llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} delete --namespace $tgtns --ignore-not-found=true job download-model" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
     done
 
-    for crot in ClusterRoleBinding ClusterRole; do
-      for cro in $(${LLMDBENCH_CONTROL_KCMD} get $crot | grep ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE} | awk '{ print $1}'); do
-        llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} delete --ignore-not-found=true $crot $cro" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+    if [[ $LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_MODELSERVICE_ACTIVE -eq 1 ]]; then
+      for crot in ClusterRoleBinding ClusterRole; do
+        for cro in $(${LLMDBENCH_CONTROL_KCMD} get $crot | grep ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE} | awk '{ print $1}'); do
+          llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} delete --ignore-not-found=true $crot $cro" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+        done
       done
-    done
 
-    for cr in ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-endpoint-picker ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-epp-metrics-scrape ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-manager ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-metrics-auth ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-admin ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-editor ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-viewer; do
-      llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} delete --ignore-not-found=true ClusterRole $cr" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
-    done
+      for cr in ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-endpoint-picker ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-epp-metrics-scrape ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-manager ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-metrics-auth ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-admin ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-editor ${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-modelservice-viewer; do
+        llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} delete --ignore-not-found=true ClusterRole $cr" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE}
+      done
+    fi
   done
 
 for workload_type in ${LLMDBENCH_HARNESS_PROFILE_HARNESS_LIST}; do

--- a/workload/harnesses/guidellm-llm-d-benchmark.sh
+++ b/workload/harnesses/guidellm-llm-d-benchmark.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
 cd /workspace/guidellm/
-guidellm benchmark --$(cat /workspace/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g' -e 's^=none$^^g') --output-path=$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/results.json > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+cp -f /workspace/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
+guidellm benchmark --$(cat /workspace/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g' -e 's^=none$^^g') --output-path=$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/results.json > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
 exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC

--- a/workload/harnesses/nop-llm-d-benchmark.py
+++ b/workload/harnesses/nop-llm-d-benchmark.py
@@ -19,13 +19,14 @@ from urllib.parse import urljoin, urlparse
 import pandas
 import requests
 
+from pathlib import Path
 from kubernetes import client, config
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 
 REQUEST_TIMEOUT = 60.0  # time (seconds) to wait for request
 MAX_VLLM_WAIT = 15.0 * 60.0  # time (seconds) to wait for vllm to respond
@@ -742,6 +743,20 @@ def main():
     endpoint_url = envs[1]
     control_work_dir = envs[2]
     requests_dir = control_work_dir
+
+    Path(requests_dir).mkdir(parents=True, exist_ok=True)
+
+    file_handler = logging.FileHandler(f"{requests_dir}/stdout.log")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    console_handler.setFormatter(formatter)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+
     domain = urlparse(endpoint_url).netloc
     arr = domain.split(".")
     if len(arr) == 0:

--- a/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
+++ b/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
 cd /workspace/vllm-benchmark/
+cp -f /workspace/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
 en=$(cat /workspace/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r .executable)
 python benchmarks/${en} --$(cat /workspace/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g' -e 's^=none$^^g')  --seed $(date +%s) --save-result > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?


### PR DESCRIPTION
With this PR all harnesses, whether python or bash, will add the used workload profile (an `yaml` file) and a `stdout.log` to the results directory.

Also, fixed a longstanding bug with the moving of the `LLMDBENCH_CONTROL_WORK_DIR` when `./setup/standup.sh` was called with all the steps