### PR TITLE
[Setup][Run] feat: automatically detected the served model name

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -829,6 +829,38 @@ EOF
 }
 export -f create_harness_pod
 
+function get_model_name_from_pod {
+    local namespace=$1
+    local image=$2
+    local url=$3
+    local port=$4
+
+    has_protocol=$(echo $url | grep "http://" || true)
+    if [[ -z $has_protocol ]]; then
+      local url="http://$url"
+    fi
+
+    has_port=$(echo $url | grep  ":$port" || true)
+    if [[ -z $has_port ]]; then
+      local url="$url:$port"
+    fi
+
+    local url=$url/v1/models
+
+    local response=$(llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} run testinference-pod-$(get_rand_string) -n $namespace --attach --restart=Never --rm --image=$image --quiet --command -- bash -c \"curl --no-progress-meter $url\"" ${LLMDBENCH_CONTROL_DRY_RUN} ${LLMDBENCH_CONTROL_VERBOSE} 0 2)
+    is_jq=$(echo $response | jq -r . || true)
+
+    if [[ -z $is_jq ]]; then
+      return 1
+    fi
+    has_model=$(echo "$is_jq" | jq -r ".data[].id" || true)
+    if [[ -z $has_model ]]; then
+      return 1
+    fi
+    echo $has_model
+}
+export -f get_model_name_from_pod
+
 function render_workload_templates {
     local workload=${1:-all}
 

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -251,6 +251,14 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
       export LLMDBENCH_HARNESS_STACK_ENDPOINT_URL="http://${LLMDBENCH_HARNESS_STACK_ENDPOINT_NAME}${LLMDBENCH_VLLM_COMMON_FQDN}:${LLMDBENCH_HARNESS_STACK_ENDPOINT_PORT}"
       announce "ℹ️ Stack Endpoint URL detected is \"$LLMDBENCH_HARNESS_STACK_ENDPOINT_URL\""
 
+      received_model_name=$(get_model_name_from_pod $LLMDBENCH_VLLM_COMMON_NAMESPACE $(get_image ${LLMDBENCH_IMAGE_REGISTRY} ${LLMDBENCH_IMAGE_REPO} ${LLMDBENCH_IMAGE_NAME} ${LLMDBENCH_IMAGE_TAG}) ${LLMDBENCH_HARNESS_STACK_ENDPOINT_URL} 80)
+      if [[ ${received_model_name} == ${LLMDBENCH_DEPLOY_CURRENT_MODEL} ]]; then
+        announce "ℹ️ Stack model detected is $received_model_name"
+      else
+        announce "❌ Stack model detected is \"$received_model_name\" (instead of $LLMDBENCH_DEPLOY_CURRENT_MODEL)!"
+        exit 1
+      fi
+
       if [[ $LLMDBENCH_HARNESS_DEBUG -eq 1 ]]; then
         render_workload_templates all
 


### PR DESCRIPTION
Introduces the function `get_model_name_from_pod`. This function is the used to get the served model name from the `pod` or `service` and the obtained name is compared with `LLMDBENCH_DEPLOY_CURRENT_MODEL`.

Used both on `smoketest` (step `9` of `standup.sh`) and `run.sh`