### PR TITLE
Add universal report conversion step to vLLM benchmark harness

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -76,6 +76,7 @@ RUN echo "fmperf: ${FM_PERF_REPO} ${FM_PERF_BRANCH}" > /workspace/repos.txt; \
 RUN ln -s /usr/bin/sleep /usr/local/bin/sleep
 
 ADD workload/harnesses/ /usr/local/bin/
+COPY workload/report/*.py /usr/local/bin/
 COPY analysis/fmperf-analyze_results.py /usr/local/bin/fmperf-analyze_results.py
 COPY analysis/inference-perf-analyze_results.sh /usr/local/bin/inference-perf-analyze_results.sh
 COPY analysis/nop-analyze_results.py /usr/local/bin/nop-analyze_results.py

--- a/build/llm-d-benchmark.sh
+++ b/build/llm-d-benchmark.sh
@@ -4,7 +4,7 @@ export LLMDBENCH_RUN_EXPERIMENT_HARNESS_EC=1
   export LLMDBENCH_HARNESS_NAME=${1}
   export LLMDBENCH_RUN_EXPERIMENT_HARNESS=$(find /usr/local/bin | grep ${1}.*-llm-d-benchmark | rev | cut -d '/' -f 1 | rev)
   export LLMDBENCH_RUN_EXPERIMENT_ANALYZER=$(find /usr/local/bin | grep ${1}.*-analyze_results | rev | cut -d '/' -f 1 | rev)
-  export LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR=/requests/$(echo $LLMDBENCH_RUN_EXPERIMENT_HARNESS | sed "s^-llm-d-benchmark^^g" | cut -d '.' -f 1)_${LLMDBENCH_RUN_EXPERIMENT_ID}_${LLMDBENCH_HARNESS_STACK_NAME}
+  export LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR=/requests/$(echo $LLMDBENCH_RUN_EXPERIMENT_HARNESS | sed "s^-llm-d-benchmark^^g" | cut -d '.' -f 1)_${LLMDBENCH_RUN_EXPERIMENT_ID}_${LLMDBENCH_HARNESS_STACK_NAME}_${date -u +%Y-%m-%d_%H.%M.%S}
   export LLMDBENCH_CONTROL_WORK_DIR=$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR
 fi
 if [[ ! -z $2 ]]; then

--- a/build/requirements-analysis.txt
+++ b/build/requirements-analysis.txt
@@ -1,4 +1,6 @@
-pandas
 matplotlib>=3.7.0
 numpy>=1.22.0
 seaborn>=0.12.0
+pandas
+pydantic>=2.11.7
+PyYAML>=6.0.2

--- a/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
+++ b/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
 cd /workspace/vllm-benchmark/
 cp -f /workspace/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
@@ -6,4 +7,13 @@ en=$(cat /workspace/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_W
 python benchmarks/${en} --$(cat /workspace/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g' -e 's^=none$^^g')  --seed $(date +%s) --save-result > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
 find /workspace/vllm-benchmark -maxdepth 1 -mindepth 1 -name '*.json' -exec mv -t "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"/ {} +
-exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC
+
+# If benchmark harness returned with an error, exit here
+if [[ $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC -ne 0 ]]; then
+  exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC
+fi
+
+# Convert results into universal format
+convert.py $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR -w vllm-benchmark > $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/results_${date -u +%Y-%m-%d_%H.%M.%S}.yaml 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+export LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC=$?
+exit $LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC

--- a/workload/report/convert.py
+++ b/workload/report/convert.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+
+# This script imports data from a benchmark run in llm-d-benchmark using any
+# supported harness, and converts the results into a data file with a
+# standardized format. This format can then be used for post processing that is
+# not specialized to a particular harness.
+
+import argparse
+import datetime
+import os
+import re
+import sys
+import yaml
+
+from schema import BenchmarkRun, Units, WorkloadGenerator
+
+
+def import_yaml(file_path: str) -> dict[any, any]:
+    """Import a JSON/YAML file as a dict.
+
+    Args:
+        file_path (str): Path to JSON/YAML file.
+
+    Returns:
+        dict: Imported data.
+    """
+    if not os.path.isfile(file_path):
+        raise Exception('File does not exist: %s' % file_path)
+    with open(file_path, 'r', encoding='UTF-8') as file:
+        data = yaml.safe_load(file)
+    return data
+
+
+def _import_llmd_benchmark_run_data(results_path: str) -> dict:
+    """Import scenario data from llm-d-benchmark run givin the results path.
+
+    Args:
+        results_path (str): Path to results directory.
+
+    Returns:
+        dict: Imported data about scenario following schema of BenchmarkRun.
+    """
+    variables_file = os.path.join(results_path, os.pardir, os.pardir, 'environment', 'variables')
+    if not os.path.isfile(variables_file):
+        # We do not have this information available to us.
+        return {}
+
+    # TODO
+    return {}
+
+
+def _vllm_timestamp_to_epoch(date_str: str) -> int:
+    """Convert timestamp from vLLM benchmark into seconds from Unix epoch.
+
+    String format is YYYYMMDD-HHMMSS in UTC.
+
+    Args:
+        date_str (str): Timestamp from vLLM benchmark.
+
+    Returns:
+        int: Seconds from Unix epoch.
+    """
+    date_str = date_str.strip()
+    if not re.search('[0-9]{8}-[0-9]{6}', date_str):
+        raise Exception('Invalid date format: %s' % date_str)
+    year = int(date_str[0:4])
+    month = int(date_str[4:6])
+    day = int(date_str[6:8])
+    hour = int(date_str[9:11])
+    minute = int(date_str[11:13])
+    second = int(date_str[13:15])
+    return datetime.datetime(year, month, day, hour, minute, second).timestamp()
+
+
+def import_vllm_benchmark(results_path: str) -> BenchmarkRun:
+    """Import data from a vLLM benchmark run as a BenchmarkRun.
+
+    Args:
+        results_path (str): Path to results directory.
+
+    Returns:
+        BenchmarkRun: Imported data.
+    """
+    if not os.path.exists(results_path):
+        raise Exception('Invalid results path: %s' % results_path)
+
+    results_files = []
+    # Sort data files, assuming this correlates with age. This assumption is
+    # only true if the filename includes the date and no other features of the
+    # filename are modified.
+    for file in sorted(os.listdir(results_path)):
+        if not re.search('^vllm.+\\.json$', file):
+            # Skip files that do not match result data filename
+            continue
+        results_files.append(file)
+
+    if len(results_files) == 0:
+        raise Exception('No results file exists: %s' % results_path)
+    if len(results_files) > 1:
+        sys.stderr.write('Warning: multiple results files exist, selecting last: %s\n' %
+            results_files)
+
+    # Import results file from vLLM benchmark
+    results = import_yaml(os.path.join(results_path, results_files[-1]))
+
+    # Import scenario details from llm-d-benchmark run as a dict following the
+    # schema of BenchmarkRun
+    br_dict = _import_llmd_benchmark_run_data(results_path)
+    # Append to that dict the data from vLLM benchmark
+    br_dict.update({
+        "scenario": {
+            "model": {"name": results['model_id']},
+            "load": {
+                "name": WorkloadGenerator.VLLM_BENCHMARK,
+                "args": {
+                    "num_prompts": results['num_prompts'],
+                    "request_rate": results['request_rate'],
+                    "burstiness":results['burstiness'],
+                    "max_concurrency": results['max_concurrency'],
+                },
+            },
+        },
+        "metrics": {
+            "time": {
+                "duration": results['duration'],
+                "start": _vllm_timestamp_to_epoch(results['date']),
+            },
+            "requests": {
+                "total": results['completed'],
+                "input_length": {
+                    "units": Units.COUNT,
+                    "mean": results['total_input_tokens']/results['completed'],
+                },
+                "output_length": {
+                    "units": Units.COUNT,
+                    "mean": results['total_output_tokens']/results['completed'],
+                },
+            },
+            "latency": {
+                "time_to_first_token": {
+                    "units": Units.MS,
+                    "mean": results['mean_ttft_ms'],
+                    "median": results['median_ttft_ms'],
+                    "stddev": results['std_ttft_ms'],
+                    "p90": results['p90_ttft_ms'],
+                    "p95": results['p95_ttft_ms'],
+                    "p99": results['p99_ttft_ms'],
+                },
+                "time_per_output_token": {
+                    "units": Units.MS_PER_TOKEN,
+                    "mean": results['mean_tpot_ms'],
+                    "median": results['median_tpot_ms'],
+                    "stddev": results['std_tpot_ms'],
+                    "p90": results['p90_tpot_ms'],
+                    "p95": results['p95_tpot_ms'],
+                    "p99": results['p99_tpot_ms'],
+                },
+                "inter_token_latency": {
+                    "units": Units.MS_PER_TOKEN,
+                    "mean": results['mean_itl_ms'],
+                    "median": results['median_itl_ms'],
+                    "stddev": results['std_itl_ms'],
+                    "p90": results['p90_itl_ms'],
+                    "p95": results['p95_itl_ms'],
+                    "p99": results['p99_itl_ms'],
+                },
+                "request_latency": {
+                    "units": Units.MS,
+                    "mean": results['mean_e2el_ms'],
+                    "median": results['median_e2el_ms'],
+                    "stddev": results['std_e2el_ms'],
+                    "p90": results['p90_e2el_ms'],
+                    "p95": results['p95_e2el_ms'],
+                    "p99": results['p99_e2el_ms'],
+                },
+            },
+            "throughput": {
+                "output_tokens_per_sec": results['output_throughput'],
+                "total_tokens_per_sec": results['total_token_throughput'],
+                "requests_per_sec": results['request_throughput'],
+            },
+        },
+    })
+
+    return BenchmarkRun(**br_dict)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description='Convert benchmark run data to standard format.')
+    parser.add_argument(
+        'results_path',
+        type=str,
+        help='Path to results directory.')
+    parser.add_argument(
+        '-w', '--workload-generator',
+        type=str,
+        default=WorkloadGenerator.VLLM_BENCHMARK,
+        help='Workload generator used.')
+
+    args = parser.parse_args()
+
+    match args.workload_generator:
+        case WorkloadGenerator.FMPERF:
+            raise NotImplementedError('Workload generator not yet supported')
+        case WorkloadGenerator.GUIDELLM:
+            raise NotImplementedError('Workload generator not yet supported')
+        case WorkloadGenerator.INFERENCE_PERF:
+            raise NotImplementedError('Workload generator not yet supported')
+        case WorkloadGenerator.VLLM_BENCHMARK:
+            import_vllm_benchmark(args.results_path).print_yaml()
+        case _:
+            sys.stderr.write('Unsupported workload generator: %s\n' %
+                args.workload_generator)
+            sys.stderr.write('Must be one of: %s\n' %
+                str([wg.value for wg in WorkloadGenerator])[1:-1])
+            sys.exit(1)

--- a/workload/report/schema.py
+++ b/workload/report/schema.py
@@ -239,6 +239,7 @@ class Statistics(BaseModel):
 
     units: Units
     mean: float
+    median: Optional[float | int] = None
     stddev: Optional[float] = None
     min: Optional[float | int] = None
     p10: Optional[float | int] = None
@@ -430,7 +431,7 @@ class BenchmarkRun(BaseModel):
         }
 
         # Get lengths for fields that are defined
-        for entity in entity_lengths:
+        for entity in entity_lengths.copy():
             try:
                 entity_lengths[entity] = len(attrgetter(entity)(self))
             except AttributeError:


### PR DESCRIPTION
This is the next step in implementing #162, which incorporates a post-processing step to the vLLM benchmark harness creating a report in the standardized benchmarking format.