### PR TITLE
Add universal report conversion post-processing step to GuideLLM harness

### DIFF
--- a/workload/harnesses/guidellm-llm-d-benchmark.sh
+++ b/workload/harnesses/guidellm-llm-d-benchmark.sh
@@ -4,4 +4,19 @@ cd /workspace/guidellm/
 cp -f /workspace/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
 guidellm benchmark --$(cat /workspace/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^^g' -e 's^=none$^^g') --output-path=$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/results.json > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
-exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC
+
+# If benchmark harness returned with an error, exit here
+if [[ $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC -ne 0 ]]; then
+  echo "Harness returned with error $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC"
+  exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC
+fi
+echo "Harness completed successfully."
+
+# Convert results into universal format
+convert.py $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR -w guidellm > $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/results_$(date -u +%Y-%m-%d_%H.%M.%S).yaml 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+export LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC=$?
+if [[ $LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC -ne 0 ]]; then
+  echo "convert.py returned with error $LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC"
+  exit $LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC
+fi
+echo "Results data conversion completed successfully."

--- a/workload/report/README.md
+++ b/workload/report/README.md
@@ -125,6 +125,7 @@ metrics: # These are the aggregate results from benchmarking
   requests:
     total: 32
     failures: 0
+    incomplete: 1
     input_length:
       units: count
       mean: 628.606060606061

--- a/workload/report/report_json_schema.json
+++ b/workload/report/report_json_schema.json
@@ -548,6 +548,18 @@
           "default": null,
           "title": "Failures"
         },
+        "incomplete": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Incomplete"
+        },
         "input_length": {
           "$ref": "#/$defs/Statistics"
         },
@@ -706,6 +718,21 @@
           "default": null,
           "title": "Median"
         },
+        "mode": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mode"
+        },
         "stddev": {
           "anyOf": [
             {
@@ -733,6 +760,51 @@
           "default": null,
           "title": "Min"
         },
+        "p001": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "P001"
+        },
+        "p01": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "P01"
+        },
+        "p05": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "P05"
+        },
         "p10": {
           "anyOf": [
             {
@@ -748,6 +820,21 @@
           "default": null,
           "title": "P10"
         },
+        "p25": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "P25"
+        },
         "p50": {
           "anyOf": [
             {
@@ -762,6 +849,21 @@
           ],
           "default": null,
           "title": "P50"
+        },
+        "p75": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "P75"
         },
         "p90": {
           "anyOf": [
@@ -807,6 +909,21 @@
           ],
           "default": null,
           "title": "P99"
+        },
+        "p999": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "P999"
         },
         "max": {
           "anyOf": [

--- a/workload/report/schema.py
+++ b/workload/report/schema.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from enum import StrEnum, auto
 import json
 from operator import attrgetter
@@ -243,13 +245,20 @@ class Statistics(BaseModel):
     units: Units
     mean: float
     median: Optional[float | int] = None
+    mode: Optional[float | int] = None
     stddev: Optional[float] = None
     min: Optional[float | int] = None
+    p001: Optional[float | int] = None
+    p01: Optional[float | int] = None
+    p05: Optional[float | int] = None
     p10: Optional[float | int] = None
+    p25: Optional[float | int] = None
     p50: Optional[float | int] = None
+    p75: Optional[float | int] = None
     p90: Optional[float | int] = None
     p95: Optional[float | int] = None
     p99: Optional[float | int] = None
+    p999: Optional[float | int] = None
     max: Optional[float | int] = None
 
 
@@ -259,7 +268,9 @@ class Requests(BaseModel):
     total: int
     """Total number of requests sent."""
     failures: Optional[int] = None
-    """Number of requests which did not result in a completed response."""
+    """Number of requests which responded with an error."""
+    incomplete: Optional[int] = None
+    """Number of requests which were not completed."""
     input_length: Statistics
     """Input sequence length."""
     output_length: Statistics


### PR DESCRIPTION
This implements conversion to the standard benchmark report format with the GuideLLM harness for #162 (and #216).