### PR TITLE
(emergency fix) fix model_attribute

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -25,7 +25,7 @@ function model_attribute {
   local model=$1
   local attribute=$2
 
-  local modelid=$(echo $model | cut -d/ -f2)
+  local modelid=$(echo $model | cut -d: -f2)
   local modelid_label="$(echo -n $modelid | cut -d '/' -f 1 | cut -c1-8)-$(echo -n $modelid | sha256sum | awk '{print $1}' | cut -c1-8)-$(echo -n $modelid | cut -d '/' -f 2 | rev | cut -c1-8 | rev)"
 
   # TODO handle this in a more appropriate way


### PR DESCRIPTION
PR https://github.com/llm-d/llm-d-benchmark/pull/243 accidentally changed the delimiter here https://github.com/llm-d/llm-d-benchmark/blob/main/setup/functions.sh#L28 from `:` to `/`. This PR fixes that.