### PR TITLE
[emergency fix] fix check for dry run

### DIFF
--- a/setup/steps/04_ensure_model_namespace_prepared.py
+++ b/setup/steps/04_ensure_model_namespace_prepared.py
@@ -161,7 +161,7 @@ def main():
                 job_name="download-model",
                 namespace=ev["vllm_common_namespace"],
                 timeout=ev["vllm_common_pvc_download_timeout"],
-                dry_run=ev["control_dry_run"]
+                dry_run=ev["control_dry_run"] == '1' 
             ))
 
     if is_openshift(api) and ev["deploy_methods"] == "modelservice" :


### PR DESCRIPTION
Incorrect check for dry run. The wait for download to complete does not wait. this causes problems later by interactions in other steps.
Fixes https://github.com/llm-d/llm-d-benchmark/issues/282.