### PR TITLE
force bash in python `subprocess.run`

### DIFF
--- a/setup/functions.py
+++ b/setup/functions.py
@@ -147,14 +147,14 @@ def llmdbench_execute_cmd(
             if not verbose and silent:
                 # correspon to eval with writing log
                 with open(stdout_log, 'w') as f_out, open(stderr_log, 'w') as f_err:
-                    result = subprocess.run(actual_cmd, shell=True, stdout=f_out, stderr=f_err, check=False)
+                    result = subprocess.run(actual_cmd, shell=True, executable="/bin/bash", stdout=f_out, stderr=f_err, check=False)
             elif not verbose and not silent:
                 # run with no log
-                result = subprocess.run(actual_cmd, shell=True, check=False)
+                result = subprocess.run(actual_cmd, shell=True, executable="/bin/bash", check=False)
             else:
                 # run with verbose
                 announce(msg)
-                result = subprocess.run(actual_cmd, shell=True, check=False)
+                result = subprocess.run(actual_cmd, shell=True, executable="/bin/bash", check=False)
 
             ecode = result.returncode
 

--- a/setup/steps/02_ensure_gateway_provider.py
+++ b/setup/steps/02_ensure_gateway_provider.py
@@ -185,6 +185,7 @@ def setup_gateway_infrastructure(
         result = subprocess.run(
             cmd,
             shell=True,
+            executable="/bin/bash",
             env=env,
             capture_output=not verbose,
             text=True


### PR DESCRIPTION
Small change to make sure `bash` is used when calling from python with `shell=True`.
Since we are using `source` in some of the scripts we need bash (`/bin/sh` sometimes linked to `dash`, e.g., in wsl).   