### PR TITLE
named treatments

### DIFF
--- a/experiments/precise_prefix_cache_aware.yaml
+++ b/experiments/precise_prefix_cache_aware.yaml
@@ -4,9 +4,9 @@ setup:
   levels:
     LLMDBENCH_VLLM_MODELSERVICE_GAIE_PRESETS: "default,prefix-cache-estimate-config,prefix-cache-tracking-config"
   treatments:
-    - "default"
-    - "prefix-cache-estimate-config"
-    - "prefix-cache-tracking-config"
+    default: "default"
+    cache_estimate: "prefix-cache-estimate-config"
+    cache_tracking: "prefix-cache-tracking-config"
 run:
   factors:
     - num_groups
@@ -15,6 +15,6 @@ run:
     num_groups: "40,60"
     system_prompt_len: "80000,5000,1000"
   treatments:
-    - "40,8000"
-    - "60,5000"
-    - "60,1000"
+    long: "40,8000"
+    medium: "60,5000"
+    short: "60,1000"

--- a/setup/e2e.sh
+++ b/setup/e2e.sh
@@ -203,6 +203,9 @@ generate_standup_parameter_scenarios $sweeptmpdir $LLMDBENCH_SCENARIO_FULL_PATH 
 rm -rf $LLMDBENCH_CONTROL_WORK_DIR
 for scenario in $(ls $sweeptmpdir/setup/treatment_list/); do
   export LLMDBENCH_CLIOVERRIDE_DEPLOY_SCENARIO=$sweeptmpdir/setup/treatment_list/$scenario
+  sid=$(sed -e 's/[^[:alnum:]][^[:alnum:]]*/_/g' <<<"${scenario%.sh}")  # remove non alphanumeric and .sh
+  sid=${sid#treatment_}
+  export LLMDBENCH_RUN_EXPERIMENT_ID=$(date +%s)-${sid}
 
   $LLMDBENCH_MAIN_DIR/setup/standup.sh
   ec=$?

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -970,32 +970,35 @@ function generate_standup_parameter_scenarios {
   rm -rf $output_dir
   mkdir -p $output_dir
 
-  if [[ -z $standup_parameter_file || ! -s $standup_parameter_file || $(cat $standup_parameter_file | yq -r .setup) == "null" ]]; then
-    cp -f $scenario_file ${scenario_dir}/setup/treatment_list/treatment_1.sh
+  if [[ -z $standup_parameter_file || ! -s $standup_parameter_file || $(cat $standup_parameter_file | yq -r .setup.treatments) == "null" ]]; then
+    cp -f $scenario_file ${scenario_dir}/setup/treatment_list/treatment_none.sh
     return 0
   fi
 
   mkdir -p ${scenario_dir}/setup/experiments/
   cp -f $standup_parameter_file ${LLMDBENCH_CONTROL_WORK_DIR}/setup/experiments/
 
-  i=1
-  for treatment in $(cat $standup_parameter_file | yq -r '.setup.treatments[]'); do
-    cat $scenario_file > $output_dir/treatment_$i.sh
-    $LLMDBENCH_CONTROL_SCMD -i "1i#treatment_$i"  $output_dir/treatment_$i.sh
+  cat $standup_parameter_file | yq -r .setup.treatments | while IFS=: read -r name treatment; do
+    if [ -z "$treatment" ]; then  # handle list without keys
+      treatment=$(yq .[] <<<"$name")
+      name=setup_${treatment//,/_}
+    fi
+    name=$(sed -e 's/[^[:alnum:]][^[:alnum:]]*/_/g' <<<"${name}")   # remove non alphanumeric
+    cat $scenario_file > $output_dir/treatment_$name.sh
+    $LLMDBENCH_CONTROL_SCMD -i "1i#treatment_$name"  $output_dir/treatment_$name.sh
     local j=1
     for value in $(echo $treatment | $LLMDBENCH_CONTROL_SCMD 's/,/ /g'); do
       local param=$(cat $standup_parameter_file | yq -r ".setup.factors[$(($j - 1))]")
-      has_param=$(cat $output_dir/treatment_$i.sh | grep "$param=" || true)
+      has_param=$(cat $output_dir/treatment_$name.sh | grep "$param=" || true)
       if [[ -z $has_param ]]; then
-        echo "$param=$value" >> $output_dir/treatment_$i.sh
+        echo "$param=$value" >> $output_dir/treatment_$name.sh
       else
-        $LLMDBENCH_CONTROL_SCMD -i "s^$param=.*^$param=$value^g"  $output_dir/treatment_$i.sh
+        $LLMDBENCH_CONTROL_SCMD -i "s^$param=.*^$param=$value^g"  $output_dir/treatment_$name.sh
       fi
-      $LLMDBENCH_CONTROL_SCMD -i "s^REPLACE_TREATMENT_NR^treatment_$i^g"  $output_dir/treatment_$i.sh
-      $LLMDBENCH_CONTROL_SCMD -i "s^_treatment_nr^treatment_$i^g"  $output_dir/treatment_$i.sh
+      $LLMDBENCH_CONTROL_SCMD -i "s^REPLACE_TREATMENT_NR^treatment_$name^g"  $output_dir/treatment_$name.sh
+      $LLMDBENCH_CONTROL_SCMD -i "s^_treatment_nr^treatment_$name^g"  $output_dir/treatment_$name.sh
       j=$((j+1))
     done
-    i=$((i+1))
   done
 }
 export -f generate_standup_parameter_scenarios
@@ -1015,23 +1018,26 @@ function generate_profile_parameter_treatments {
 
   cp -f $run_parameter_file ${LLMDBENCH_CONTROL_WORK_DIR}/workload/experiments/
 
-  i=1
-  for treatment in $(cat $run_parameter_file | yq -r '.run.treatments[]'); do
-    echo "1i#treatment_$i.txt" >> $output_dir/treatment_$i.txt
+  cat $run_parameter_file | yq -r .run.treatments | while IFS=: read -r name treatment; do
+    if [ -z "$treatment" ]; then  # handle list without keys
+      treatment=$(yq .[] <<<"$name")
+      name=run_${treatment//,/_}
+    fi
+    name=$(sed -e 's/[^[:alnum:]][^[:alnum:]]*/_/g' <<<"${name}")   # remove non alphanumeric
+    echo "1i#treatment_${name}.txt" >> $output_dir/treatment_${name}.txt
     local j=1
     for value in $(echo $treatment | $LLMDBENCH_CONTROL_SCMD 's/,/ /g'); do
       local param=$(cat $run_parameter_file | yq -r ".run.factors[$(($j - 1))]")
-      echo "s^$param: .*^$param: $value^g" >> $output_dir/treatment_$i.txt
+      echo "s^$param: .*^$param: $value^g" >> $output_dir/treatment_${name}.txt
       j=$((j+1))
     done
     if [[ ! -z $LLMDBENCH_HARNESS_EXPERIMENT_PROFILE_OVERRIDES ]]; then
       for entry in $(echo $LLMDBENCH_HARNESS_EXPERIMENT_PROFILE_OVERRIDES | $LLMDBENCH_CONTROL_SCMD 's^,^ ^g'); do
         parm=$(echo $entry | cut -d '=' -f 1)
         val=$(echo $entry | cut -d '=' -f 2)
-        echo "s^$parm:.*^$parm: $val^g" >> $output_dir/treatment_$i.txt
+        echo "s^$parm:.*^$parm: $val^g" >> $output_dir/treatment_${name}.txt
       done
     fi
-    i=$((i+1))
   done
 }
 export -f generate_profile_parameter_treatments

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -316,7 +316,14 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
 
         tf=$(cat ${treatment} | grep "#treatment" | tail -1 | $LLMDBENCH_CONTROL_SCMD 's/^#//' || true)
         if [[ -f ${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/treatment_list/$tf ]]; then
-          export LLMDBENCH_RUN_EXPERIMENT_ID=$(echo $tf | $LLMDBENCH_CONTROL_SCMD 's^\.txt^^g')
+          tid=$(sed -e 's/[^[:alnum:]][^[:alnum:]]*/_/g' <<<"${tf%.txt}")   # remove non alphanumeric and .txt
+          tid=${tid#treatment_}
+          if [ -z "${LLMDBENCH_RUN_EXPERIMENT_ID}" ]; then
+            export LLMDBENCH_RUN_EXPERIMENT_ID=$(date +%s)-${tid}
+          else
+            export LLMDBENCH_RUN_EXPERIMENT_ID=${LLMDBENCH_RUN_EXPERIMENT_ID}-${tid}
+          fi
+          # $(echo $tf | $LLMDBENCH_CONTROL_SCMD 's^\.txt^^g')
           echo
           cat ${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/treatment_list/$tf | grep -v ^1i# | cut -d '^' -f 3
           echo


### PR DESCRIPTION
Add names to treatments and generated experiment IDs so it is easier to browse the results.
Unnamed treatments also supported.

For example:
```
setup:
  factors:
    - LLMDBENCH_VLLM_MODELSERVICE_GAIE_PRESETS
  levels:
    LLMDBENCH_VLLM_MODELSERVICE_GAIE_PRESETS: "default,prefix-cache-estimate-config,prefix-cache-tracking-config"
  treatments:
    default: "default"
    cache_estimate: "prefix-cache-estimate-config"
    cache_tracking: "prefix-cache-tracking-config"
run:
  factors:
    - num_groups
    - system_prompt_len
  levels:
    num_groups: "40,60"
    system_prompt_len: "80000,5000,1000"
  treatments:
    long: "40,8000"
    medium: "60,5000"
    short: "60,1000"
```
The 4th experiment ID and result folder would be  HARNESS_DATE-`cache_estimate-long`_MODEL.

An unnamed treatment like `- 5000,80` would be named `run_5000_80`
