### PR TITLE
re-enable multiple ns

### DIFF
--- a/setup/functions.py
+++ b/setup/functions.py
@@ -471,8 +471,9 @@ def model_attribute(model: str, attribute: str) -> str:
     #  split the model name into provider and rest
     provider, model_part = model.split('/', 1) if '/' in model else ("", model)
 
+    ns = os.getenv("LLMDBENCH_VLLM_COMMON_NAMESPACE")
     hash_object = hashlib.sha256()
-    hash_object.update(modelid.encode('utf-8'))
+    hash_object.update(f'{ns}/{modelid}'.encode('utf-8'))
     digest = hash_object.hexdigest()
     modelid_label = f"{modelid[:8]}-{digest[:8]}-{modelid[-8:]}"
 

--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -26,7 +26,7 @@ function model_attribute {
   local attribute=$2
 
   local modelid=$(echo $model | cut -d: -f2 | $LLMDBENCH_CONTROL_SCMD -e "s^/^-^g" -e "s^\.^-^g")
-  local modelid_label="$(echo -n $modelid | cut -d '/' -f 1 | cut -c1-8)-$(echo -n $modelid | sha256sum | awk '{print $1}' | cut -c1-8)-$(echo -n $modelid | cut -d '/' -f 2 | rev | cut -c1-8 | rev)"
+  local modelid_label="$(echo -n $modelid | cut -d '/' -f 1 | cut -c1-8)-$(echo -n "$LLMDBENCH_VLLM_COMMON_NAMESPACE/$modelid" | sha256sum | awk '{print $1}' | cut -c1-8)-$(echo -n $modelid | cut -d '/' -f 2 | rev | cut -c1-8 | rev)"
 
   local modelcomponents=$(echo $model | cut -d '/' -f 2 |  tr '[:upper:]' '[:lower:]' | $LLMDBENCH_CONTROL_SCMD -e 's^qwen^qwen-^g' -e 's^-^\n^g')
   local provider=$(echo $model | cut -d '/' -f 1)


### PR DESCRIPTION
Make sure that the same model can be deployed in different namespaces.
Inability to do so is regression from changes to support llm-d-infra v0.3.0.
There is a naming conflict with the `ClusterRole` and `ClusterRoleBinding` (created by gaie)
Fixed by including namespace in hash used to define names of objects.
