### PR TITLE
Populate benchmark report with environment details only if deplo method is standalone or modelservice

### DIFF
--- a/workload/report/convert.py
+++ b/workload/report/convert.py
@@ -121,7 +121,7 @@ def _get_llmd_benchmark_envars() -> dict:
         return {}
 
     if 'LLMDBENCH_DEPLOY_METHODS' not in os.environ:
-        # Cannot determine deployment method
+        sys.stderr.write('Warning: LLMDBENCH_DEPLOY_METHODS undefined, cannot determine deployment method.')
         return {}
 
     if os.environ['LLMDBENCH_DEPLOY_METHODS'] == 'standalone':
@@ -205,6 +205,7 @@ def _get_llmd_benchmark_envars() -> dict:
 
     # Pre-existing deployment, cannot extract details about unknown inference
     # service environment
+    sys.stderr.write('Warning: LLMDBENCH_DEPLOY_METHODS is not "modelservice" or "standalone", cannot extract environmental details.')
     return {}
 
 


### PR DESCRIPTION
When creating a benchmark report in the harness pod, only attempt to pull details from environment variables if `LLMDBENCH_DEPLOY_METHODS` is defined as `standalone` or `modelservice`, otherwise keep environmental details blanks. This is necessary for pre-deployed experiments.