### PR TITLE
Fix insertion of additional environment variables to generated YAML

### DIFF
--- a/setup/functions.py
+++ b/setup/functions.py
@@ -974,27 +974,41 @@ def add_command_line_options(args_string):
             return ""
 
 
-def add_additional_env_to_yaml(env_vars_string):
+def add_additional_env_to_yaml(env_vars_string: str) -> str:
     """
     Generate additional environment variables YAML.
     Equivalent to the bash add_additional_env_to_yaml function.
+
+    Args:
+        env_vars_string (str): Comma separated list of environment variable
+            names to be converted to name/value pairs OR a path to a file
+            containing a YAML snippet to be indented but otherwise not
+            interpreted.
+
+    Returns:
+        str: YAML snippet to be inserted to YAML template.
     """
-    if not env_vars_string:
-        return ""
 
     # Determine indentation based on environment type
     standalone_active = int(os.environ.get("LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_STANDALONE_ACTIVE", 0))
     modelservice_active = int(os.environ.get("LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_MODELSERVICE_ACTIVE", 0))
 
     if standalone_active == 1:
-        name_indent = "        "  # 8 spaces
-        value_indent = "          "  # 10 spaces
+        name_indent = " " * 8
+        value_indent = " " * 10
     elif modelservice_active == 1:
-        name_indent = "      "    # 6 spaces
-        value_indent = "        "  # 8 spaces
+        name_indent = " " * 6
+        value_indent = " " * 8
     else:
-        name_indent = "        "  # default 8 spaces
-        value_indent = "          "  # default 10 spaces
+        name_indent = " " * 8
+        value_indent = " " * 10
+
+    if os.access(env_vars_string, os.R_OK):
+        lines = []
+        with open(env_vars_string, 'r') as file:
+            for line in file:
+                lines.append(name_indent + line.rstrip())
+        return '\n'.join(lines)
 
     # Parse environment variables (comma-separated list)
     env_lines = []

--- a/setup/steps/06_deploy_vllm_standalone_models.py
+++ b/setup/steps/06_deploy_vllm_standalone_models.py
@@ -78,7 +78,8 @@ def main():
             llmdbench_execute_cmd(
                 actual_cmd=kubectl_deploy_cmd,
                 dry_run=int(ev.get("control_dry_run", 0)),
-                verbose=int(ev.get("control_verbose", 0))
+                verbose=int(ev.get("control_verbose", 0)),
+                fatal=True
             )
 
             # Generate Service YAML


### PR DESCRIPTION
Many of the experiment examples include a set of extra environment variables to be added to the deployment YAML. This is given as a section of YAML written to a temporary file stored in the environment variable `LLMDBENCH_VLLM_COMMON_ENVVARS_TO_YAML`.

When performing a E2E experiment with `standalone` deployment, the path to this temporary file is written to the YAML template, rather than the snippet contained in this file.

This PR augments the functionality of `add_additional_env_to_yaml()` to recognize when the input to this function is a file (rather than string of comma separated environment variable names), and when it is a file it will import the contents and indent them to the appropriate amount.

This PR also halts standup when the deployment fails, rather than log it and move on only to break later.