### PR TITLE
minor fixes to model_attribute

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -26,11 +26,12 @@ function model_attribute {
   local attribute=$2
 
   local modelid=$(echo $model | cut -d: -f2 | $LLMDBENCH_CONTROL_SCMD -e "s^/^-^g" -e "s^\.^-^g")
-  local modelid_label="$(echo -n $modelid | cut -d '/' -f 1 | cut -c1-8)-$(echo -n "$LLMDBENCH_VLLM_COMMON_NAMESPACE/$modelid" | sha256sum | awk '{print $1}' | cut -c1-8)-$(echo -n $modelid | cut -d '/' -f 2 | rev | cut -c1-8 | rev)"
+  local SHA256CMD=$(type -p gsha256sum || type -p sha256sum)
+  local modelid_label="$(echo -n $modelid | cut -d '/' -f 1 | cut -c1-8)-$(echo -n "$LLMDBENCH_VLLM_COMMON_NAMESPACE/$modelid" | $SHA256CMD | awk '{print $1}' | cut -c1-8)-$(echo -n $modelid | cut -d '/' -f 2 | rev | cut -c1-8 | rev)"
 
   local modelcomponents=$(echo $model | cut -d '/' -f 2 |  tr '[:upper:]' '[:lower:]' | $LLMDBENCH_CONTROL_SCMD -e 's^qwen^qwen-^g' -e 's^-^\n^g')
   local provider=$(echo $model | cut -d '/' -f 1)
-  local type=$(echo "${modelcomponents}" | grep -Ei "nstruct|hf|chat|speech|vision|opt")
+  local modeltype=$(echo "${modelcomponents}" | grep -Ei "nstruct|hf|chat|speech|vision|opt" || echo base)
   local parameters=$(echo "${modelcomponents}" | grep -Ei "[0-9].*b|[0-9].*m" | $LLMDBENCH_CONTROL_SCMD -e 's^a^^' -e 's^\.^p^')
   local majorversion=$(echo "${modelcomponents}" | grep -Ei "^[0-9]" | grep -Evi "b|E" |  $LLMDBENCH_CONTROL_SCMD -e "s/$parameters//g" | cut -d '.' -f 1)
   if [[ -z $majorversion ]]; then

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -202,7 +202,7 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
 
     validate_model_name ${LLMDBENCH_DEPLOY_CURRENT_MODEL}
 
-    export LLMDBENCH_HARNESS_STACK_NAME=$(echo ${method} | $LLMDBENCH_CONTROL_SCMD 's^modelservice^llm-d^g')-$(model_attribute $model parameters)-$(model_attribute $model type)
+    export LLMDBENCH_HARNESS_STACK_NAME=$(echo ${method} | $LLMDBENCH_CONTROL_SCMD 's^modelservice^llm-d^g')-$(model_attribute $model parameters)-$(model_attribute $model modeltype)
 
     export LLMDBENCH_DEPLOY_CURRENT_TOKENIZER=$(model_attribute $model model)
 

--- a/setup/steps/06_deploy_vllm_standalone_models.py
+++ b/setup/steps/06_deploy_vllm_standalone_models.py
@@ -409,7 +409,7 @@ def generate_httproute_yaml(ev, model, model_label):
 
     # Get model attributes for backend reference
     model_parameters = model_attribute(model, "parameters")
-    model_type = model_attribute(model, "type")
+    model_type = model_attribute(model, "modeltype")
 
     httproute_yaml = f"""apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute

--- a/setup/steps/06_deploy_vllm_standalone_models.sh
+++ b/setup/steps/06_deploy_vllm_standalone_models.sh
@@ -175,7 +175,7 @@ spec:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: vllm-standalone-$(model_attribute $model parameters)-vllm-$$(model_attribute $model label)-$(model_attribute $model type)
+    - name: vllm-standalone-$(model_attribute $model parameters)-vllm-$$(model_attribute $model label)-$(model_attribute $model modeltype)
       port: ${LLMDBENCH_VLLM_COMMON_INFERENCE_PORT}
 EOF
 

--- a/util/unit_test/model_attribute_function.sh
+++ b/util/unit_test/model_attribute_function.sh
@@ -30,7 +30,7 @@ model_list="meta-llama/Llama-3.2-3B-Instruct RedHatAI/Llama-3.3-70B-Instruct-FP8
 for i in $model_list
 do
   echo "--------------------------------------------------------------------------------------------------------"
-  for j in model modelid modelid_label modelcomponents provider type parameters majorversion kind label folder as_label
+  for j in model modelid modelid_label modelcomponents provider modeltype parameters majorversion kind label folder as_label
   do
     k=$(python3 -c "import sys; sys.path.append(\"$LLMDBENCH_MAIN_DIR/setup\"); import functions; print(functions.model_attribute(\"$i\", \"$j\"))")
     printf "%-15s %-45s %-50s\n" "$j" "| $(model_attribute $i $j)" "| $k"
@@ -41,6 +41,6 @@ for method in modelservice standalone
 do
   for model in $model_list
   do
-    echo "$(echo ${method} | $LLMDBENCH_CONTROL_SCMD 's^modelservice^llm-d^g')-$(model_attribute $model parameters)-$(model_attribute $model type)"
+    echo "$(echo ${method} | $LLMDBENCH_CONTROL_SCMD 's^modelservice^llm-d^g')-$(model_attribute $model parameters)-$(model_attribute $model modeltype)"
   done
 done


### PR DESCRIPTION
Minor bugs that break `run.sh` in some cases:
1. Some mac have `gsha256sum` instead of `sha256sum`
2. Changed `type` to `modeltype` to avoid use of reserved word
3. Added default type ("base") when type is empty (e.g., `Qwen/Qwen3-32B`) -- `run.sh` is using model type as suffix and should not be empty 