### PR TITLE
Check if service can be identified in step 10

### DIFF
--- a/setup/steps/10_smoketest.sh
+++ b/setup/steps/10_smoketest.sh
@@ -10,9 +10,7 @@ else
   pod_string=decode
   route_string=${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-inference-gateway
 
-  if [[ $LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_MODELSERVICE_ACTIVE -eq 1 ]]; then
-    service=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get gateway --no-headers | grep ^infra-${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-inference-gateway)
-  fi
+  service=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get gateway --no-headers | grep ^infra-${LLMDBENCH_VLLM_MODELSERVICE_RELEASE}-inference-gateway)
 fi
 
 if [[ $(echo $service | wc) -eq 0 ]]; then


### PR DESCRIPTION
Shen standing up, if existing services exist there is the possibility of grabbing the wrong service and breaking things.

This PR adds checks that a service can be uniquely identified, and fails if this is not the case with messages that will be helpful in debugging.