### PR TITLE
Back up existing working directory in new e2e runs

### DIFF
--- a/setup/e2e.sh
+++ b/setup/e2e.sh
@@ -200,7 +200,13 @@ source ${LLMDBENCH_CONTROL_DIR}/env.sh
 sweeptmpdir=$(mktemp -d -t sweepXXX)
 generate_standup_parameter_scenarios $sweeptmpdir $LLMDBENCH_SCENARIO_FULL_PATH $LLMDBENCH_HARNESS_EXPERIMENT_TREATMENTS
 
-rm -rf $LLMDBENCH_CONTROL_WORK_DIR
+if [[ -d $LLMDBENCH_CONTROL_WORK_DIR ]]; then
+  backup_suffix=$(date +"%Y-%m-%d_%H.%M.%S")
+  backup_target=$(echo $LLMDBENCH_CONTROL_WORK_DIR | $LLMDBENCH_CONTROL_SCMD 's^/$^^').$backup_suffix
+  announce "Backing up existing working directory \"$LLMDBENCH_CONTROL_WORK_DIR\" --> \"$backup_target\""
+  mv -f $LLMDBENCH_CONTROL_WORK_DIR $backup_target
+fi
+
 for scenario in $(ls $sweeptmpdir/setup/treatment_list/); do
   export LLMDBENCH_CLIOVERRIDE_DEPLOY_SCENARIO=$sweeptmpdir/setup/treatment_list/$scenario
   sid=$(sed -e 's/[^[:alnum:]][^[:alnum:]]*/_/g' <<<"${scenario%.sh}")  # remove non alphanumeric and .sh


### PR DESCRIPTION
As it exists, when running `./setup/e2e.sh` where the working directory specified in `LLMDBENCH_CONTROL_WORK_DIR` already exists, the directory will be forcefully removed without warning. This can result in the permanent loss of valuable result data.

This PR changes the behavior to move the existing directory to a backup location, and announce that it is doing so.