### PR TITLE
Update PD-disagg well-lit path experiment

### DIFF
--- a/experiments/pd-disaggregation.yaml
+++ b/experiments/pd-disaggregation.yaml
@@ -15,29 +15,27 @@ setup:
     LLMDBENCH_VLLM_MODELSERVICE_DECODE_REPLICAS: "1,2,4"
     LLMDBENCH_VLLM_MODELSERVICE_DECODE_TENSOR_PARALLELISM: "2,4,8"
   treatments:
-    - "modelservice,NA,NA,6,2,1,4"
-    - "modelservice,NA,NA,4,2,1,8"
     - "modelservice,NA,NA,8,1,1,8"
+    - "modelservice,NA,NA,4,2,1,8"
+    - "modelservice,NA,NA,2,4,1,8"
+    - "modelservice,NA,NA,6,2,1,4"
     - "modelservice,NA,NA,4,2,2,4"
-    - "modelservice,NA,NA,4,2,4,2"
-    - "modelservice,NA,NA,2,2,4,4"
-    - "standalone,2,8,NA,NA,NA,NA"
-    - "standalone,4,8,NA,NA,NA,NA"
+    - "modelservice,NA,NA,2,2,3,4"
+    - "standalone,1,2,NA,NA,NA,NA"
+    - "standalone,1,4,NA,NA,NA,NA"
+    - "standalone,1,8,NA,NA,NA,NA"
 run:
   factors:
     - max-concurrency
     - num-prompts
   levels:
-    max-concurrency: "1,4,8,16,32,64,128,256,512,1024"
-    num-prompts: "10,40,80,160,320,640,1280,2560,5120,10240"
+    max-concurrency: "1,8,32,64,128,256"
+    num-prompts: "10,80,320,640,1280,2560"
   treatments:
     - "1,10"
-    - "4,40"
     - "8,80"
-    - "16,160"
     - "32,320"
     - "64,640"
     - "128,1280"
     - "256,2560"
-    - "512,5120"
-    - "1024,10240"
+


### PR DESCRIPTION
- Reduce number of `max-concurrency` values to sweep, greatly reducing run time
- Add all combinations of P/D with 16 accelerators where TP of decode is greater than TP of prefill
- Only test standalone sweeps with a single replica