### PR TITLE
[Standup] Add longer (actually infinite) timeouts for httproutes on modelservice

### DIFF
--- a/setup/e2e.sh
+++ b/setup/e2e.sh
@@ -242,5 +242,5 @@ for scenario in $(ls $sweeptmpdir/setup/treatment_list/); do
     backup_work_dir $sid 1
     exit $ec
   fi
-  mv $LLMDBENCH_CONTROL_WORK_DIR/ $LLMDBENCH_CONTROL_WORK_DIR.$sid/
+  backup_work_dir $sid 1
 done

--- a/setup/steps/09_deploy_via_modelservice.sh
+++ b/setup/steps/09_deploy_via_modelservice.sh
@@ -53,6 +53,9 @@ if [[ $LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_MODELSERVICE_ACTIVE -eq 1 ]]; then
         name: ${LLMDBENCH_DEPLOY_CURRENT_MODEL_ID_LABEL}-gaie
         port: 8000
         weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
 EOF
     fi
 
@@ -93,6 +96,9 @@ routing:
         name: ${LLMDBENCH_DEPLOY_CURRENT_MODEL_ID_LABEL}-gaie
         port: 8000
         weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 0s
       matches:
       - path:
           type: PathPrefix

--- a/setup/teardown.sh
+++ b/setup/teardown.sh
@@ -179,7 +179,7 @@ if [[ $LLMDBENCH_CONTROL_DEEP_CLEANING -eq 0 ]]; then
     fi
 
     if [[ ${LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_STANDALONE_ACTIVE} -eq 0 && ${LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_MODELSERVICE_ACTIVE} -eq 1 ]]; then
-      tgtres=$(echo "$tgtres" | grep -E "p2p|inference-gateway|inferencepool|llm-route|base-model|endpoint-picker|inference-route|inference-gateway-secret|inference-gateway-params|inference-gateway|fmperf|lmbenchmark" || true)
+      tgtres=$(echo "$tgtres" | grep -E "p2p|inference-gateway|inferencepool|inferencepools.inference.networking.x-k8s.io|llm-route|base-model|endpoint-picker|inference-route|inference-gateway-secret|inference-gateway-params|inference-gateway|fmperf|lmbenchmark" || true)
     fi
 
     for delres in $tgtres; do


### PR DESCRIPTION
Ensure that inferencepools.inference.networking.x-k8s.io are cleaned up on teardown

Fixes for e2e