### PR TITLE
Clarify installation steps for config explorer

### DIFF
--- a/config_explorer/Home.py
+++ b/config_explorer/Home.py
@@ -7,7 +7,6 @@ import streamlit as st
 import db
 import util
 from src.config_explorer.capacity_planner import *
-from huggingface_hub.errors import *
 from decimal import Decimal
 
 def update_gpu_spec():
@@ -128,8 +127,6 @@ def parallelism_specification():
     """
     user_scenario = st.session_state[util.USER_SCENARIO_KEY]
     model_config = user_scenario.model_config
-    total_accelerators = user_scenario.gpu_count_avail
-    gpu_memory = user_scenario.get_gpu_memory(db.gpu_specs)
 
     with st.container(border=True):
         st.write("**Parallelism Configuration**")

--- a/config_explorer/README.md
+++ b/config_explorer/README.md
@@ -49,7 +49,7 @@ Running the Streamlit frontend requires cloning the `llm-d-benchmark` repo. Make
 ```
 git clone https://github.com/llm-d/llm-d-benchmark.git
 pip install -r config_explorer/requirements-streamlit.txt
-streamlit run config_explorer/Home.py
+.venv/bin/streamlit run config_explorer/Home.py
 ```
 
 ### Library

--- a/config_explorer/README.md
+++ b/config_explorer/README.md
@@ -44,7 +44,7 @@ There are two ways to interact with the Configuration Explorer: via an experimen
 ### Frontend
 A Streamlit frontend is provided to showcase the capabilities of the Configuration Explorer rapidly. Since the core functions are in a module, users may feel free to build their own frontend, such as a CLI, by making use of those functions.
 
-Running the Streamlit frontend requires cloning the `llm-d-benchmark` repo.
+Running the Streamlit frontend requires cloning the `llm-d-benchmark` repo. Make sure you have already installed the required dependencies for the `config_explorer` package following the Installation guide [here](#installation).
 
 ```
 git clone https://github.com/llm-d/llm-d-benchmark.git


### PR DESCRIPTION
Clarify steps to installing the UI of config explorer, since it's separate from the lib but requires installing lib first.