### PR TITLE
fix spec for args

### DIFF
--- a/scenarios/examples/inference-scheduling.sh
+++ b/scenarios/examples/inference-scheduling.sh
@@ -113,8 +113,8 @@ export LLMDBENCH_VLLM_MODELSERVICE_DECODE_EXTRA_ARGS="[\
 --kv-transfer-config____'{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'____\
 --disable-log-requests____\
 --disable-uvicorn-access-log____\
---max-model-len____REPLACE_ENV_LLMDBENCH_VLLM_COMMON_MAX_MODEL_LEN\
---tensor-parallel-size____REPLACE_ENV_LLMDBENCH_VLLM_MODELSERVICE_DECODE_TENSOR_PARALLELISM \
+--max-model-len____REPLACE_ENV_LLMDBENCH_VLLM_COMMON_MAX_MODEL_LEN____\
+--tensor-parallel-size____REPLACE_ENV_LLMDBENCH_VLLM_MODELSERVICE_DECODE_TENSOR_PARALLELISM\
 ]"
 
 # Local directory to copy benchmark runtime files and results


### PR DESCRIPTION
As specified, the some of the args for the `inference-scheduling` scenario are generated like this:
```
 93       - "16000--tensor-parallel-size"
 94       - "4
```
This should be:
```
 93       - "16000"
 94       - "--tensor-parallel-size"
 95       - "4"
```.
This PR fixes this. As best as I can tell by inspection, the other scenarios (in `scenarios/example`) don't have this problem.