### PR TITLE
Correct units captured by Inference Perf

### DIFF
--- a/workload/report/convert.py
+++ b/workload/report/convert.py
@@ -777,7 +777,7 @@ def import_inference_perf(results_file: str) -> BenchmarkReport:
             },
             "latency": {
                 "time_to_first_token": {
-                    "units": Units.MS,
+                    "units": Units.S,
                     "mean": results['successes']['latency']['time_to_first_token']['mean'],
                     "min": results['successes']['latency']['time_to_first_token']['min'],
                     "p0p1": results['successes']['latency']['time_to_first_token']['p0.1'],
@@ -794,7 +794,7 @@ def import_inference_perf(results_file: str) -> BenchmarkReport:
                     "max": results['successes']['latency']['time_to_first_token']['max'],
                 },
                 "normalized_time_per_output_token": {
-                    "units": Units.MS_PER_TOKEN,
+                    "units": Units.S_PER_TOKEN,
                     "mean": results['successes']['latency']['normalized_time_per_output_token']['mean'],
                     "min": results['successes']['latency']['normalized_time_per_output_token']['min'],
                     "p0p1": results['successes']['latency']['normalized_time_per_output_token']['p0.1'],
@@ -811,7 +811,7 @@ def import_inference_perf(results_file: str) -> BenchmarkReport:
                     "max": results['successes']['latency']['normalized_time_per_output_token']['max'],
                 },
                 "time_per_output_token": {
-                    "units": Units.MS_PER_TOKEN,
+                    "units": Units.S_PER_TOKEN,
                     "mean": results['successes']['latency']['time_per_output_token']['mean'],
                     "min": results['successes']['latency']['time_per_output_token']['min'],
                     "p0p1": results['successes']['latency']['time_per_output_token']['p0.1'],
@@ -828,7 +828,7 @@ def import_inference_perf(results_file: str) -> BenchmarkReport:
                     "max": results['successes']['latency']['time_per_output_token']['max'],
                 },
                 "inter_token_latency": {
-                    "units": Units.MS_PER_TOKEN,
+                    "units": Units.S_PER_TOKEN,
                     "mean": results['successes']['latency']['inter_token_latency']['mean'],
                     "min": results['successes']['latency']['inter_token_latency']['min'],
                     "p0p1": results['successes']['latency']['inter_token_latency']['p0.1'],
@@ -845,7 +845,7 @@ def import_inference_perf(results_file: str) -> BenchmarkReport:
                     "max": results['successes']['latency']['inter_token_latency']['max'],
                 },
                 "request_latency": {
-                    "units": Units.MS,
+                    "units": Units.S,
                     "mean": results['successes']['latency']['request_latency']['mean'],
                     "min": results['successes']['latency']['request_latency']['min'],
                     "p0p1": results['successes']['latency']['request_latency']['p0.1'],

--- a/workload/report/schema.py
+++ b/workload/report/schema.py
@@ -245,7 +245,7 @@ units_portion = [Units.PERCENT, Units.FRACTION]
 units_time = [Units.MS, Units.S]
 units_memory = [Units.MB, Units.GB, Units.TB, Units.MIB, Units.GIB, Units.TIB]
 units_bandwidth = [Units.MBIT_PER_S, Units.GBIT_PER_S, Units.TBIT_PER_S, Units.MB_PER_S, Units.GB_PER_S, Units.TB_PER_S]
-units_gen_latency = [Units.MS_PER_TOKEN]
+units_gen_latency = [Units.MS_PER_TOKEN, Units.S_PER_TOKEN]
 units_power = [Units.WATTS]
 
 

--- a/workload/report/schema.py
+++ b/workload/report/schema.py
@@ -203,6 +203,8 @@ class Units(StrEnum):
             GiB per second
         MS_PER_TOKEN: str
             Milliseconds per token
+        S_PER_TOKEN: str
+            Seconds per token
         WATTS: str
             Watts
     """
@@ -233,6 +235,7 @@ class Units(StrEnum):
     TB_PER_S = 'TB/s'
     # Generation latency
     MS_PER_TOKEN = 'ms/token'
+    S_PER_TOKEN = 's/token'
     # Power
     WATTS = "Watts"
 


### PR DESCRIPTION
It appears Inference Perf records all metrics in seconds.

@achandrasekar please make sure I've got all the units correct and haven't missed anything, thanks.