### PR TITLE
Updated inference-perf harness to v0.2.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -46,7 +46,7 @@ RUN cd fmperf; \
 
 ARG INFERENCE_PERF_REPO=https://github.com/kubernetes-sigs/inference-perf.git
 ARG INFERENCE_PERF_BRANCH=main
-ARG INFERENCE_PERF_COMMIT=aa3fd7fb0be6506aa82ad7f9aa4bb50d9626980b
+ARG INFERENCE_PERF_COMMIT=1ccc48b6bb9c9abb61558b719041fb000b265e59
 RUN git clone --branch ${INFERENCE_PERF_BRANCH} ${INFERENCE_PERF_REPO}
 RUN cd inference-perf; \
     git checkout ${INFERENCE_PERF_COMMIT}; \


### PR DESCRIPTION
Update to the latest commit in [v0.2.0](https://github.com/kubernetes-sigs/inference-perf/releases/tag/v0.2.0)