### PR TITLE
[Standup][Run] Add support for "constants" on experiment files

### DIFF
--- a/experiments/precise-prefix-cache-aware.yaml
+++ b/experiments/precise-prefix-cache-aware.yaml
@@ -1,13 +1,18 @@
 setup:
+  constants:
+    - LLMDBENCH_VLLM_COMMON_MAX_MODEL_LEN: 12000
+    - LLMDBENCH_VLLM_COMMON_BLOCK_SIZE: 64
   factors:
     - LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE
   levels:
-    LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE: "default,prefix-cache-estimate-config,prefix-cache-tracking-config"
+    LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE: default,prefix-cache-estimate-config,prefix-cache-tracking-config
   treatments:
-    default: "default"
-    cache_estimate: "prefix-cache-estimate-config"
-    cache_tracking: "prefix-cache-tracking-config"
+    default: default
+    cache_estimate: prefix-cache-estimate-config
+    cache_tracking: prefix-cache-tracking-config
 run:
+  constants:
+    - streaming: true
   factors:
     - num_groups
     - system_prompt_len

--- a/setup/env.sh
+++ b/setup/env.sh
@@ -312,7 +312,7 @@ if [[ ! -z $LLMDBENCH_SCENARIO_FULL_PATH ]]; then
 elif [[ $LLMDBENCH_SCENARIO_FULL_PATH == "${LLMDBENCH_MAIN_DIR}/scenarios/none.sh" ]]; then
   touch ${LLMDBENCH_MAIN_DIR}/scenarios/none.sh
 else
-  echo "❌ Scenario file \"$LLMDBENCH_SCENARIO_FULL_PATH\" could not be found."
+  echo "❌ Scenario file \"$LLMDBENCH_SCENARIO_FULL_PATH\" ($LLMDBENCH_DEPLOY_SCENARIO) could not be found."
   exit 1
 fi
 


### PR DESCRIPTION
Both `setup` and `run` now can have a `constants` section, where a list of variables to be applied to each treatment can be specified (example in precise-prefix-cache-aware.yaml).

Fixed a bug that caused treatments to get value assigned to commented out variables to be ignored.

Fixed a bug that prevented backups of `LLMDBENCH_CONTROL_WORK_DIR` between treatments.