### PR TITLE
[Standup] Bugfix: Add missing param for 06_deploy_vllm_standalone_models

### DIFF
--- a/setup/steps/06_deploy_vllm_standalone_models.py
+++ b/setup/steps/06_deploy_vllm_standalone_models.py
@@ -28,7 +28,7 @@ def main():
             ev.update({key.split("LLMDBENCH_")[1].lower(): os.environ.get(key)})
 
     # Check if standalone environment is active
-    if is_standalone_deployment():
+    if is_standalone_deployment(ev):
 
         # Check storage class
         if not check_storage_class():


### PR DESCRIPTION
This PR resolves `TypeError: is_standalone_deployment() missing 1 required positional argument: 'ev'` when running `standup.sh`.