### PR TITLE
Add new categories and process name to nop harness result report

### DIFF
--- a/analysis/nop-analyze_results.py
+++ b/analysis/nop-analyze_results.py
@@ -43,10 +43,13 @@ def get_env_variables(keys: list[str]) -> list[str]:
     return envs
 
 
-def get_formatted_output(column: str, df: pd.DataFrame) -> str:
+def get_formatted_output(columns: list[str], df: pd.DataFrame) -> str:
     """get formatted output"""
-    max_len = df[column].astype(str).str.len().max()
-    formatters = {column: lambda x: f"{x:<{max_len}}"}
+    formatters = {}
+    for column in columns:
+        max_len = df[column].astype(str).str.len().max()
+        formatters[column] = lambda x, max=max_len: f"{x:<{max}}"
+
     df_string = df.to_string(formatters=formatters, index=False)
 
     lines = df_string.split("\n")
@@ -54,8 +57,8 @@ def get_formatted_output(column: str, df: pd.DataFrame) -> str:
 
     # Insert the separator after the header line
     lines.insert(1, separator)
-
-    return f"{'\n'.join(lines)}\n"
+    line = "\n".join(lines)
+    return f"{line}\n"
 
 
 def create_categories_dataframe(
@@ -68,11 +71,13 @@ def create_categories_dataframe(
     blank_string = "  " * level if level > 0 else ""
     total = 0.0
     for category in categories:
+        process = category.get("process", "")
         elapsed = category["elapsed"]["value"]
         total += elapsed
         elapsed_str = f"{elapsed:.3f}" if elapsed != 0 else ""
         data = {
             "Category": [category["title"]],
+            "Process": [process],
             "Elapsed(secs)": [elapsed_str],
         }
         data = pd.DataFrame(data)
@@ -86,6 +91,7 @@ def create_categories_dataframe(
     df_total = pd.DataFrame(
         {
             "Category": [blank_string + "Total"],
+            "Process": [""],
             "Elapsed(secs)": [f"{total:.3f}"],
         }
     )
@@ -98,59 +104,70 @@ def write_benchmark_scenario(file: io.TextIOWrapper, benchmark_report: Benchmark
     """write benchmark scenario to file"""
 
     scenario = benchmark_report.scenario
-    file.write(f"Scenario harness: {scenario.load.name}\n")
-    file.write(f" Load Format    : {scenario.metadata['load_format']}\n")
-    file.write(f" Sleep Mode On  : {scenario.metadata['sleep_mode']}\n")
-    file.write(f" Model          : {scenario.model.name}\n")
+    file.write("Scenario\n")
+    file.write(f" Harness       : {scenario.load.name}\n")
+    file.write(f" Load Format   : {scenario.metadata['load_format']}\n")
+    file.write(f" Sleep Mode On : {scenario.metadata['sleep_mode']}\n")
+    file.write(f" Model         : {scenario.model.name}\n")
     for engine in scenario.platform.engine:
         file.write(" Engine\n")
-        file.write(f"  Name          : {engine.name}\n")
-        file.write(f"  Version       : {engine.version}\n")
-        file.write(f"  Args          : {str(engine.args)}\n")
+        file.write(f"  Name         : {engine.name}\n")
+        file.write(f"  Version      : {engine.version}\n")
+        file.write(f"  Args         : {str(engine.args)}\n")
 
 
 def write_benchmark_reports(file: io.TextIOWrapper, benchmark_report: BenchmarkReport):
     """write benchmark reports to file"""
 
     write_benchmark_scenario(file, benchmark_report)
-    file.write("\n\n\n")
+    file.write("\n")
 
-    data = {
-        "Start Time": [
-            datetime.fromtimestamp(benchmark_report.metrics.time.start)
-            .astimezone()
-            .isoformat()
-        ],
-        "Stop Time": [
-            datetime.fromtimestamp(benchmark_report.metrics.time.stop)
-            .astimezone()
-            .isoformat()
-        ],
-        "Duration(secs)": [f"{benchmark_report.metrics.time.duration:.3f}"],
-    }
-    data_frame = pd.DataFrame(data)
-    file.write(get_formatted_output("Start Time", data_frame))
-    file.write("\n\n\n")
+    time_iso = (
+        datetime.fromtimestamp(benchmark_report.metrics.time.start)
+        .astimezone()
+        .isoformat()
+    )
+    duration = benchmark_report.metrics.time.duration
 
     metrics_metadata = benchmark_report.metrics.metadata
-    data = {
-        "Elapsed(secs)": [f"{metrics_metadata['load_time']['value']:.3f}"],
-        "Rate(GiB/secs)": [f"{metrics_metadata['transfer_rate']['value']:.3f}"],
-        "Sleep(secs)": [f"{metrics_metadata['sleep']['value']:.3f}"],
-        "Freed GPU(GiB)": [f"{metrics_metadata['gpu_freed']['value']:.2f}"],
-        "In Use GPU(GiB)": [f"{metrics_metadata['gpu_in_use']['value']:.2f}"],
-        "Wake(secs)": [f"{metrics_metadata['wake']['value']:.3f}"],
-    }
-    data_frame = pd.DataFrame(data)
-    file.write(get_formatted_output("Elapsed(secs)", data_frame))
+    elapsed = metrics_metadata["load_time"]["value"]
+    rate = metrics_metadata["transfer_rate"]["value"]
+    sleep = metrics_metadata["sleep"]["value"]
+    freed = metrics_metadata["gpu_freed"]["value"]
+    use = metrics_metadata["gpu_in_use"]["value"]
+    wake = metrics_metadata["wake"]["value"]
+    load_cached_compiled_graph = metrics_metadata.get("load_cached_compiled_graph")
+    compile_graph = metrics_metadata.get("compile_graph")
+
+    file.write("Benchmark\n")
+    file.write(f"  Start                    : {time_iso}\n")
+    file.write(f"  Elapsed(secs)            : {duration:7.3f}\n")
+    file.write("   Model Load\n")
+    file.write(f"     Elapsed(secs)         : {elapsed:7.3f}\n")
+    file.write(f"     Rate(GiB/secs)        : {rate:7.3f}\n")
+    if load_cached_compiled_graph is not None or compile_graph is not None:
+        file.write("   Compiled Graph\n")
+        if load_cached_compiled_graph is not None:
+            file.write(
+                f"     Load from Cache(secs) : {load_cached_compiled_graph['value']:7.3f}\n"
+            )
+        if compile_graph is not None:
+            file.write(f"     Compile(secs)         : {compile_graph['value']:7.3f}\n")
+    file.write("   Sleep\n")
+    file.write(f"     Elapsed(secs)         : {sleep:7.3f}\n")
+    file.write("      Memory GPU(GiB)\n")
+    file.write(f"        Freed              : {freed:7.3f}\n")
+    file.write(f"        in Use             : {use:7.3f}\n")
+    file.write("   Wake\n")
+    file.write(f"     Elapsed(secs)         : {wake:7.3f}\n")
 
     categories = metrics_metadata.get("categories")
     if categories is None:
         return
 
-    file.write("\n\n\n")
+    file.write("\n")
     data_frame = create_categories_dataframe(categories, 0, pd.DataFrame())
-    file.write(get_formatted_output("Category", data_frame))
+    file.write(get_formatted_output(["Category", "Process"], data_frame))
 
 
 def main():

--- a/workload/report/convert.py
+++ b/workload/report/convert.py
@@ -937,6 +937,9 @@ def import_nop(results_file: str) -> BenchmarkReport:
         for cat in cat_list:
             cat_dict = {}
             cat_dict["title"] = cat["title"]
+            process = cat.get("process")
+            if process is not None:
+                cat_dict["process"] = process["name"]
             cat_dict["elapsed"] = {
                         "units": Units.S,
                         "value": cat["elapsed"],
@@ -1084,6 +1087,14 @@ def import_nop(results_file: str) -> BenchmarkReport:
             },
         },
     }
+
+    for name in ["load_cached_compiled_graph", "compile_graph"]:
+        value = results["metrics"].get(name)
+        if value is not None:
+            results_dict["metrics"]["metadata"][name] = {
+                                "units": Units.S,
+                                "value": value,
+                            }
 
     update_dict(br_dict, results_dict)
 


### PR DESCRIPTION
This PR relates to `nop` harness on an vLLM standalone server. It adds/changes some of the categories and adds the process name to the report.
The new analysis output looks like this:
```
Scenario
 Harness       : nop
 Load Format   : auto
 Sleep Mode On : True
 Model         : ibm-granite/granite-3.2-8b-instruct
 Engine
  Name         : quay.io/manoelmrqs/vllm-openai-custom:0.10.2
  Version      : 0.1.dev9987+ge61eb5e09
  Args         : {'enable_sleep_mode': True, 'gpu_memory_utilization': 0.95, 'max_model_len': 16384, 'model': 'ibm-granite/granite-3.2-8b-instruct', 'model_loader_extra_config': {'enable_multithread_load': True, 'num_threads': 8}, 'model_tag': 'ibm-granite/granite-3.2-8b-instruct'}

Benchmark
  Start                    : 2025-09-30T17:21:04.432381+00:00
  Elapsed(secs)            :   7.144
   Model Load
     Elapsed(secs)         :   6.111
     Rate(GiB/secs)        :   2.496
   Compiled Graph
     Load from Cache(secs) :   1.246
   Sleep
     Elapsed(secs)         :   5.675
      Memory GPU(GiB)
        Freed              :  75.380
        in Use             :   1.750
   Wake
     Elapsed(secs)         :   0.328

             Category        Process Elapsed(secs)
--------------------------------------------------
Detect Platform                              0.051
LLM Imports                                  5.458
Get Model Info        APIServer              0.424
Worker Initialization EngineCore_DP0         2.345
Model Loading         EngineCore_DP0         6.681
Pytorch Compilation   EngineCore_DP0         6.089
  Dynamo              EngineCore_DP0         3.732
  Inductor            EngineCore_DP0         2.357
  Total                                      6.089
CUDA Graph Capture    EngineCore_DP0         5.620
API Server Starts     APIServer              0.003
Total                                       26.671

```