### PR TITLE
set TORCH_CUDA_ARCH_LIST in preprocess script

### DIFF
--- a/setup/steps/06_deploy_vllm_standalone_models.py
+++ b/setup/steps/06_deploy_vllm_standalone_models.py
@@ -325,6 +325,8 @@ spec:
           value: "{ev.get('vllm_standalone_vllm_logging_level', '')}"
         - name: HF_HOME
           value: {ev.get('vllm_standalone_pvc_mountpoint', '')}
+        - name: LLMDBENCH_VLLM_COMMON_AFFINITY
+          value: "{os.environ.get('LLMDBENCH_VLLM_COMMON_AFFINITY', '')}"
         - name: HUGGING_FACE_HUB_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
In preprocess scritp, set env. TORCH_CUDA_ARCH_LIST with the gpu capability of the gpu to be used in order to speed pytorch compilation.