### PR TITLE
Add missing number of GPUs field to configuration explorer

### DIFF
--- a/config_explorer/src/config_explorer/explorer.py
+++ b/config_explorer/src/config_explorer/explorer.py
@@ -134,6 +134,11 @@ COLUMNS = {
         dtype='str',
         label='Accelerator',
     ),
+    'Num_GPUs': ColumnProperties(
+        dtype='int',
+        label='Number of GPUs',
+        pref=Pref.LOW,
+    ),
     'DP': ColumnProperties(
         dtype='int',
         label='DP',


### PR DESCRIPTION
An entry for `Num_GPUs` was missing in `COLUMNS` dictionary, resulting in this field being left out of the `DataFrame`.