### PR TITLE
Fix GKE benchmark workflow: set python library path explicitly

### DIFF
--- a/.github/workflows/ci-nighly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nighly-benchmark-gke.yaml
@@ -39,6 +39,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Set LD_LIBRARY_PATH
+        run: |
+          echo "LD_LIBRARY_PATH=$(python -c 'import sys; from pathlib import Path; print(Path(sys.executable).parent.parent / "lib")'):$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        shell: bash
+
       - name: Display OS used
         run: |
           cat /etc/*os-*


### PR DESCRIPTION
Address the failure to find libpython3.11 by explicitly adding it to library path. An example failure is [here](https://github.com/llm-d/llm-d-benchmark/actions/runs/18825882983/job/53708429351)