### PR TITLE
Allow import and conversion of all runs in GuideLLM results

### DIFF
--- a/workload/report/convert.py
+++ b/workload/report/convert.py
@@ -1210,10 +1210,11 @@ if __name__ == "__main__":
         default=WorkloadGenerator.VLLM_BENCHMARK,
         help=f'Workload generator used, one of: {str([member.value for member in WorkloadGenerator])[1:-1]}')
     parser.add_argument(
-        '-i', '--index',
+        '-i',
+        '--index',
         type=int,
         default=None,
-        help='Benchmark index to import, for results files containing multiple runs.')
+        help='Benchmark index to import, for results files containing multiple runs. Default behavior creates benchmark reports for all runs.')
 
     args = parser.parse_args()
     if args.output_file and os.path.exists(


### PR DESCRIPTION
Address #485 

### CLI updates
When no output filename is provided, benchmark report YAMLs will print to standard out separated by a comment indicating which iteration follows.

When an output filename is provided, this filename will be suffixed with the index number (before the extension) for each benchmark report. No changes are needed to `guidellm-llm-d-benchmark.sh` to make use of this.

Default behavior is to create a benchmark report for each run in a GuideLLM report. If an index is provided with the `-i` argument, then a single benchmark report for results from that index will be created (if `-i 0` is passed, then the behavior will be identical to how `convert.py` works today).

### Library changes

`import_guidellm()` now has an `index` argument (defaults to 0) to indicate which index of results should be imported. A `scenario.load.metadata.stage` section was added to record this index (same as is done with Inference Perf).

`import_guidellm_all()` was added, which will import all results as a list of `BenchmarkReport` objects.