### PR TITLE
Remove ISL/OSL binning hack now that config explorer UI supports bounds

### DIFF
--- a/config_explorer/src/config_explorer/explorer.py
+++ b/config_explorer/src/config_explorer/explorer.py
@@ -37,7 +37,6 @@ of metrics, showing, for example, the tradeoff between throughput and latency.
 
 import builtins
 from dataclasses import dataclass
-from math import floor # only needed for HACK to remove when UI supports bounds
 import os
 from pathlib import Path
 from typing import Any
@@ -282,14 +281,6 @@ WORKLOAD_COLUMNS = {
         dtype='int',
         label='Output Sequence Length',
     ),
-    'ISL_500': ColumnProperties(  # HACK to remove when UI supports bounds
-        dtype='int',              # HACK to remove when UI supports bounds
-        label='ISL Nearest 500',  # HACK to remove when UI supports bounds
-    ),                            # HACK to remove when UI supports bounds
-    'OSL_500': ColumnProperties(  # HACK to remove when UI supports bounds
-        dtype='int',              # HACK to remove when UI supports bounds
-        label='OSL Nearest 500',  # HACK to remove when UI supports bounds
-    ),                            # HACK to remove when UI supports bounds
     'Target_OSL': ColumnProperties(
         dtype='int',
         label='Target OSL',
@@ -764,7 +755,10 @@ class SLO:
         if COLUMNS[self.col].dtype != 'float':
             raise TypeError(f'Column must have float datatype: {self.col}')
         if COLUMNS[self.col].pref == Pref.NEUTRAL:
-            raise Exception(f'Column must have a preferred direction: {self.col}')
+            raise Exception(
+                f'Column must have a preferred direction: {
+                    self.col}')
+
 
 def col_base(col: str) -> str:
     """Get original column name, removing bound prefixes if present.
@@ -1008,7 +1002,7 @@ def add_benchmark_report_to_df(
     # Get workload details
     max_qps = None
     concurrency = None
-    system_prompt_length = None # Common prefix length
+    system_prompt_length = None  # Common prefix length
     question_length = None      # Length after common prefix
     groups = None               # Number of user groups with distinct prompts
     prompts_per_group = None    # Common prefixes within a group
@@ -1024,12 +1018,18 @@ def add_benchmark_report_to_df(
             stage_list = get_nested(args, ['load', 'stages'])
             max_qps = stage_list[stage].get('rate')
         # Request characteristics
-        system_prompt_length = get_nested(args, ['data', 'shared_prefix', 'system_prompt_len'])
-        question_length = get_nested(args, ['data', 'shared_prefix', 'question_len'])
+        system_prompt_length = get_nested(
+            args, ['data', 'shared_prefix', 'system_prompt_len'])
+        question_length = get_nested(
+            args, ['data', 'shared_prefix', 'question_len'])
         groups = get_nested(args, ['data', 'shared_prefix', 'num_groups'])
-        prompts_per_group = get_nested(args, ['data', 'shared_prefix', 'num_prompts_per_group'])
+        prompts_per_group = get_nested(
+            args, ['data', 'shared_prefix', 'num_prompts_per_group'])
 
-        target_osl = int(get_nested(args, ['data', 'shared_prefix', 'output_len'], -1))
+        target_osl = int(
+            get_nested(
+                args, [
+                    'data', 'shared_prefix', 'output_len'], -1))
     elif report.scenario.load.name == schema.WorkloadGenerator.VLLM_BENCHMARK:
         concurrency = args.get('max_concurrency')
     elif report.scenario.load.name == schema.WorkloadGenerator.GUIDELLM:
@@ -1037,7 +1037,7 @@ def add_benchmark_report_to_df(
         # If stage metadata is missing, this benchmark report is from an older
         # version of convert.py that only took stage 0 results.
         stage = report.scenario.load.metadata.get('stage', 0)
-        
+
         if 'rate' in args:
             max_qps = args['rate'][stage]
         concurrencies = get_nested(args, ['profile', 'measured_concurrencies'])
@@ -1107,8 +1107,6 @@ def add_benchmark_report_to_df(
         'Workload_Generator': report.scenario.load.name,
         'ISL': int(round(report.metrics.requests.input_length.mean)),
         'OSL': int(round(report.metrics.requests.output_length.mean)),
-        'ISL_500': floor(report.metrics.requests.input_length.mean / 500) * 500 + 250, # HACK to remove when UI supports bounds
-        'OSL_500': floor(report.metrics.requests.output_length.mean / 500) * 500 + 250, # HACK to remove when UI supports bounds
         'Target_OSL': target_osl,
         'Max_Concurrency': concurrency,
         'Max_QPS': max_qps,


### PR DESCRIPTION
Remove unneeded components that added special binned ISL and OSL columns.

Other changes (formatting) are due to autopep8.