### PR TITLE
Add warmup to workload profiles, disable prefix caching where not evaluated

### DIFF
--- a/workload/profiles/vllm-benchmark/random_concurrent.yaml.in
+++ b/workload/profiles/vllm-benchmark/random_concurrent.yaml.in
@@ -6,6 +6,8 @@ random-input-len: 10000
 random-output-len: 1000
 max-concurrency: 1
 num-prompts: 32
+num-warmups: 3
 percentile-metrics: "ttft,tpot,itl,e2el"
 metric-percentiles: "0.1,1,5,10,25,75,90,95,99,99.9"
 ignore-eos: none
+no-enable-prefix-caching: none

--- a/workload/profiles/vllm-benchmark/sanity_random.yaml.in
+++ b/workload/profiles/vllm-benchmark/sanity_random.yaml.in
@@ -3,6 +3,8 @@ model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
 base-url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
 max-concurrency: 1
 num-prompts: 20
+num-warmups: 3
 dataset-name: random
 percentile-metrics: "ttft,tpot,itl,e2el"
 metric-percentiles: "0.1,1,5,10,25,75,90,95,99,99.9"
+no-enable-prefix-caching: none

--- a/workload/profiles/vllm-benchmark/sharegpt.yaml.in
+++ b/workload/profiles/vllm-benchmark/sharegpt.yaml.in
@@ -5,6 +5,7 @@ dataset-name: sharegpt
 dataset-path: REPLACE_ENV_LLMDBENCH_RUN_DATASET_DIR/REPLACE_ENV_LLMDBENCH_RUN_DATASET_FILE
 max-concurrency: 512
 num-prompts: 2000
+num-warmups: 3
 request-rate: 8
 sharegpt-output-len: 1024
 percentile-metrics: "ttft,tpot,itl,e2el"


### PR DESCRIPTION
- Add warmup requests to vLLM benchmark profiles
- Disable prefix caching in profiles where measuring caching is not the desired benchmark