### PR TITLE
Revert unsupported warmup, move no-enable-prefix-caching to correct spot

### DIFF
--- a/scenarios/guides/pd-disaggregation.sh
+++ b/scenarios/guides/pd-disaggregation.sh
@@ -92,6 +92,7 @@ export LLMDBENCH_VLLM_MODELSERVICE_PREFILL_EXTRA_ARGS="[\
 --kv-transfer-config____'{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'____\
 --disable-log-requests____\
 --disable-uvicorn-access-log____\
+--no-enable-prefix-caching____\
 --max-model-len____REPLACE_ENV_LLMDBENCH_VLLM_COMMON_MAX_MODEL_LEN\
 ]"
 
@@ -111,6 +112,7 @@ export LLMDBENCH_VLLM_MODELSERVICE_DECODE_EXTRA_ARGS="[\
 --kv-transfer-config____'{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}'____\
 --disable-log-requests____\
 --disable-uvicorn-access-log____\
+--no-enable-prefix-caching____\
 --max-model-len____REPLACE_ENV_LLMDBENCH_VLLM_COMMON_MAX_MODEL_LEN\
 ]"
 

--- a/workload/profiles/inference-perf/pd.yaml.in
+++ b/workload/profiles/inference-perf/pd.yaml.in
@@ -1,0 +1,37 @@
+load:
+  type: constant
+  stages:
+  - rate: 10
+    duration: 60
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: random
+  input_distribution:
+    min: 10             # min length of the synthetic prompts
+    max: 100            # max length of the synthetic prompts
+    mean: 50            # mean length of the synthetic prompts
+    std: 10             # standard deviation of the length of the synthetic prompts
+    total_count: 100    # total number of prompts to generate to fit the above mentioned distribution constraints
+  output_distribution:
+    min: 10             # min length of the output to be generated
+    max: 100            # max length of the output to be generated
+    mean: 50            # mean length of the output to be generated
+    std: 10             # standard deviation of the length of the output to be generated
+    total_count: 100    # total number of output lengths to generate to fit the above mentioned distribution constraints
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace

--- a/workload/profiles/vllm-benchmark/random_concurrent.yaml.in
+++ b/workload/profiles/vllm-benchmark/random_concurrent.yaml.in
@@ -6,8 +6,6 @@ random-input-len: 10000
 random-output-len: 1000
 max-concurrency: 1
 num-prompts: 32
-num-warmups: 3
 percentile-metrics: "ttft,tpot,itl,e2el"
 metric-percentiles: "0.1,1,5,10,25,75,90,95,99,99.9"
 ignore-eos: none
-no-enable-prefix-caching: none

--- a/workload/profiles/vllm-benchmark/sanity_random.yaml.in
+++ b/workload/profiles/vllm-benchmark/sanity_random.yaml.in
@@ -3,8 +3,6 @@ model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
 base-url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
 max-concurrency: 1
 num-prompts: 20
-num-warmups: 3
 dataset-name: random
 percentile-metrics: "ttft,tpot,itl,e2el"
 metric-percentiles: "0.1,1,5,10,25,75,90,95,99,99.9"
-no-enable-prefix-caching: none

--- a/workload/profiles/vllm-benchmark/sharegpt.yaml.in
+++ b/workload/profiles/vllm-benchmark/sharegpt.yaml.in
@@ -5,7 +5,6 @@ dataset-name: sharegpt
 dataset-path: REPLACE_ENV_LLMDBENCH_RUN_DATASET_DIR/REPLACE_ENV_LLMDBENCH_RUN_DATASET_FILE
 max-concurrency: 512
 num-prompts: 2000
-num-warmups: 3
 request-rate: 8
 sharegpt-output-len: 1024
 percentile-metrics: "ttft,tpot,itl,e2el"


### PR DESCRIPTION
vLLM benchmarking needs to be updated in the harness to support warmup. Current profiles are broken without this change, so this PR removes the changes from #499. In addition, the `--no-enable-prefix-caching` argument was mistakenly added to the workload profile rather than scenario.