### PR TITLE
Re-add Kubernetes as a dependency on pod

### DIFF
--- a/build/requirements-analysis.txt
+++ b/build/requirements-analysis.txt
@@ -5,3 +5,4 @@ pandas>=2.2.3
 pydantic>=2.11.7
 PyYAML>=6.0.2
 scipy>=1.16.0
+kubernetes>=24.2.0


### PR DESCRIPTION
This needed dependency was accidentally removed during the discontinuation of support for fmperf