### PR TITLE
[fix] Use -p/--namespace when kubeconfig context has no namespace set

### DIFF
--- a/setup/env.sh
+++ b/setup/env.sh
@@ -517,6 +517,11 @@ fi
 
 export LLMDBENCH_CONTROL_CLUSTER_NAMESPACE=$(${LLMDBENCH_CONTROL_KCMD} config view --minify --output 'jsonpath={..namespace}')
 
+# If namespace couldn't be detected from kubeconfig but was provided via CLI, use that
+if [[ -z $LLMDBENCH_CONTROL_CLUSTER_NAMESPACE && -n $LLMDBENCH_VLLM_COMMON_NAMESPACE ]]; then
+  export LLMDBENCH_CONTROL_CLUSTER_NAMESPACE=$LLMDBENCH_VLLM_COMMON_NAMESPACE
+fi
+
 export LLMDBENCH_CONTROL_DEPLOY_IS_OPENSHIFT=${LLMDBENCH_CONTROL_DEPLOY_IS_OPENSHIFT:-0}
 is_ocp=$($LLMDBENCH_CONTROL_KCMD api-resources 2>&1 | grep 'route.openshift.io' || true)
 if [[ ! -z ${is_ocp} ]]; then


### PR DESCRIPTION
Added logic to use a CLI-provided namespace if the namespace cannot be detected from kubeconfig.

User reported issue from the [community slack](https://llm-d.slack.com/archives/C08Q5FAFXUP/p1762856435488549)

When a kubeconfig context has no namespace field set, the script fails with:

```
❌ Unable automatically detect namespace. Environment variable "LLMDBENCH_CONTROL_CLUSTER_NAMESPACE". 
Specify namespace via CLI option "-p/--namespace" or environment variable "LLMDBENCH_HARNESS_NAMESPACE"
```

This occurs even when `-p/--namespace` is provided, because:
1. `LLMDBENCH_CONTROL_CLUSTER_NAMESPACE` is read from the kubeconfig context ([line 518](https://github.com/llm-d/llm-d-benchmark/blob/9b56c90dfde71458aa9bbe1057ac603426274ffc/setup/env.sh#L518))
2. If the context has no namespace, it remains empty
3. The `-p` flag sets `LLMDBENCH_VLLM_COMMON_NAMESPACE` but not `LLMDBENCH_CONTROL_CLUSTER_NAMESPACE`
4. The validation check at line [202](https://github.com/llm-d/llm-d-benchmark/blob/9b56c90dfde71458aa9bbe1057ac603426274ffc/setup/run.sh#L202) in `run.sh` fails because `LLMDBENCH_CONTROL_CLUSTER_NAMESPACE` is empty

In this scenario the user is working in the default namespace (or any namespace) whose kubeconfig context doesn't specify a namespace and they should be able to use `-p/--namespace` to provide it. 

This solution adds a fallback after kubeconfig detection: if `LLMDBENCH_CONTROL_CLUSTER_NAMESPACE` is empty and `LLMDBENCH_VLLM_COMMON_NAMESPACE` is set (via `-p`), use that value.

This ensures:
- Existing behavior is preserved (kubeconfig namespace takes precedence when present)
- The `-p` flag works as expected when kubeconfig detection fails
- No breaking changes (only applies when detection returns empty)
