### PR TITLE
minor grep change for hf secret

### DIFF
--- a/setup/run.sh
+++ b/setup/run.sh
@@ -306,7 +306,7 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
 
       if [[ $LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_STANDALONE_ACTIVE -eq 0 && $LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_MODELSERVICE_ACTIVE -eq 0 ]]; then
         announce "🔍 Trying to find a matching hugging face token (hf.*token*.)..."
-        export LLMDBENCH_VLLM_COMMON_HF_TOKEN_NAME=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get secrets --no-headers | grep -E .*hf.*token.* | awk '{print $1}')
+        export LLMDBENCH_VLLM_COMMON_HF_TOKEN_NAME=$(${LLMDBENCH_CONTROL_KCMD} --namespace "$LLMDBENCH_VLLM_COMMON_NAMESPACE" get secrets --no-headers | grep -E llm-d-hf.*token.* | awk '{print $1}')
         if [[ ! -z $LLMDBENCH_VLLM_COMMON_HF_TOKEN_NAME ]]; then
           announce "ℹ️ Hugging face token detected is \"$LLMDBENCH_VLLM_COMMON_HF_TOKEN_NAME\""
         else


### PR DESCRIPTION
If I have more than one secret which matches the following check:
``` 
get secrets --no-headers | grep -E .*hf.*token.* | awk '{print $1}'
```
then the run command fails here:
```
$ ./run.sh -c "$(realpath ./myenv-offloading.sh)"  -w "chatbot_sharegpt" -m TroyDoesAI/Llama-3.1-8B-Instruct

⚠️ WARNING: environment variable LLMDBENCH_CLUSTER_URL=auto. Will attempt to use current context "effi/api-fmaas-vllm-d-fmaas-res-ibm-com:6443/EFFIO@il.ibm.com" (api.fmaas-vllm-d.fmaas.res.ibm.com).
Error from server (Forbidden): clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "EFFIO@il.ibm.com" cannot list resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope
==> Tue Nov 18 11:46:28 IST 2025 - ./run.sh - ✅ Verified the model "TroyDoesAI/Llama-3.1-8B-Instruct" is not gated, access is authorized by default
==> Tue Nov 18 11:46:43 IST 2025 - ./run.sh - 🗑️ Deleting pod "llmdbench-inference-perf-launcher"...
==> Tue Nov 18 11:46:46 IST 2025 - ./run.sh - ℹ️ Done deleting pod "llmdbench-inference-perf-launcher" (it will be now recreated)
==> Tue Nov 18 11:46:46 IST 2025 - ./run.sh - ⚠️ Deployment method - vllm-offloading - is neither "standalone" nor "modelservice".
==> Tue Nov 18 11:46:46 IST 2025 - ./run.sh - 🔍 Trying to find a matching endpoint name...
==> Tue Nov 18 11:46:48 IST 2025 - ./run.sh - ℹ️ Stack Endpoint URL detected is "http://vllm-offloading.effi.svc.cluster.local:8125"
==> Tue Nov 18 11:46:48 IST 2025 - ./run.sh - 🔍 Trying to find a matching hugging face token (hf.*token*.)...
==> Tue Nov 18 11:46:49 IST 2025 - ./run.sh - ℹ️ Hugging face token detected is "hf-token llm-d-hf-token"
==> Tue Nov 18 11:46:49 IST 2025 - ./run.sh - 🔍 Trying to detect the model name served by the stack (http://vllm-offloading.effi.svc.cluster.local:8125)...
==> Tue Nov 18 11:46:53 IST 2025 - ./run.sh - ℹ️ Stack model detected is "TroyDoesAI/Llama-3.1-8B-Instruct"
==> Tue Nov 18 11:46:53 IST 2025 - ./run.sh - 🛠️ Rendering "chatbot_sharegpt" workload profile templates under "/home/effi/llm-d-benchmark/workload/profiles/"...
==> Tue Nov 18 11:46:54 IST 2025 - ./run.sh - ✅ Done rendering "chatbot_sharegpt" workload profile templates to "/home/effi/llm-d-benchmark/runs/workload/profiles/"
==> Tue Nov 18 11:46:57 IST 2025 - ./run.sh - 🚀 Starting pod "llmdbench-inference-perf-launcher" for model "TroyDoesAI/Llama-3.1-8B-Instruct" (TroyDoesAI/Llama-3.1-8B-Instruct)...
ERROR while executing command "oc --kubeconfig /home/effi/llm-d-benchmark/runs/environment/context.ctx apply -f /home/effi/llm-d-benchmark/runs/setup/yamls/pod_benchmark-launcher.yaml"
error: error parsing /home/effi/llm-d-benchmark/runs/setup/yamls/pod_benchmark-launcher.yaml: error converting YAML to JSON: yaml: line 83: could not find expected ':'
```