### PR TITLE
delete app=llm-d-benchmark-harness pods

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -504,6 +504,9 @@ function deploy_harness_config {
         llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} --namespace ${LLMDBENCH_HARNESS_NAMESPACE} delete pod -l app=${LLMDBENCH_HARNESS_POD_LABEL}" \
             ${LLMDBENCH_CONTROL_DRY_RUN} \
             ${LLMDBENCH_CONTROL_VERBOSE}
+        llmdbench_execute_cmd "${LLMDBENCH_CONTROL_KCMD} --namespace ${LLMDBENCH_HARNESS_NAMESPACE} delete pod -l app=llm-d-benchmark-harness" \
+            ${LLMDBENCH_CONTROL_DRY_RUN} \
+            ${LLMDBENCH_CONTROL_VERBOSE}
         announce "✅ Pods with label \"app=${LLMDBENCH_HARNESS_POD_LABEL}\" for model \"$model\" deleted"
     elif [[ $LLMDBENCH_HARNESS_WAIT_TIMEOUT -eq 0 ]]; then
       announce "ℹ️ Harness was started with LLMDBENCH_HARNESS_WAIT_TIMEOUT=0. Will NOT wait for pod \"${LLMDBENCH_HARNESS_POD_LABEL}\" for model \"$model\" to be in \"Completed\" state. The pod can be accessed through \"${LLMDBENCH_CONTROL_KCMD} --namespace ${LLMDBENCH_HARNESS_NAMESPACE} exec -it pod/<POD_NAME> -- bash\""


### PR DESCRIPTION
At the end of a run, llm-d-benchmark deletes pods with label app=llmdbench-harness-launcher but does not delete pods with label app=llm-d-benchmark-harness such as access-to-harness-data-*.  These pods need to be deleted, or else we fail the collection of run results at the very end of a run if there are old runs that used different harness.  

Perhaps the right long term approach is use the llmdbench-harness-launcher for the harness data pod?  I wasn't sure, so in this PR is simply added a delete statement. 