### PR TITLE
Add Prerequisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Provide a single source of automation for repeatable and reproducible experiment
 
 ## Prerequisites 
 Please refer to the official [llm-d prerequisites](https://github.com/llm-d/llm-d?tab=readme-ov-file#pre-requisites) for the most up-to-date requirements.
-For the client setup, the provided `install-deps.sh` (described in the next section) will download and install the necessary tools.
+For the client setup, the provided `install-deps.sh` will download and install the necessary tools.
 
 ### Administrative Requirements
 Deploying the llm-d stack requires **cluster-level admin** privileges, as you will be configuring cluster-level resources.
 However, the scripts can be executed by **namespace-level admin** users, as long as the [Kubernetes infrastructure components](https://github.com/llm-d-incubation/llm-d-infra) are configured and the **target namespace already exists**.
 
 
-### 📦 Repository Setup
+## 📦 Repository Setup
 
 ```
 git clone https://github.com/llm-d/llm-d-benchmark.git


### PR DESCRIPTION
Adding a Prerequisites section to the README and an "Administrative Requirements" subsection to clarify privilege levels for deployment and script execution.