### PR TITLE
Add precise-prefix EppConfig

### DIFF
--- a/scenarios/guides/precise-prefix-cache-aware.sh
+++ b/scenarios/guides/precise-prefix-cache-aware.sh
@@ -24,6 +24,7 @@ export LLMDBENCH_VLLM_COMMON_PVC_MODEL_CACHE_SIZE=1Ti
 
 # Routing configuration (via gaie)
 #export LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE="default-plugins.yaml" (default is "plugins-v2.yaml")
+export LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE="precise-prefix-cache-aware"
 
 # Routing configuration (via modelservice)
 #export LLMDBENCH_VLLM_MODELSERVICE_INFERENCE_MODEL=true # already the default

--- a/setup/presets/gaie/precise-prefix-cache-aware.yaml
+++ b/setup/presets/gaie/precise-prefix-cache-aware.yaml
@@ -1,0 +1,26 @@
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: single-profile-handler
+  - type: precise-prefix-cache-scorer
+    parameters:
+      indexerConfig:
+        tokenProcessorConfig:
+          blockSize: 64
+          hashSeed: "42"
+        tokenizersPoolConfig:
+          hf:
+            tokenizersCacheDir: "/tmp/tokenizers"
+  - type: kv-cache-utilization-scorer
+  - type: queue-scorer
+  - type: max-score-picker
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: precise-prefix-cache-scorer
+        weight: 3.0
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 2.0
+      - pluginRef: queue-scorer
+        weight: 2.0
+      - pluginRef: max-score-picker


### PR DESCRIPTION
Added a new `setup/presets/gaie` yaml with the `precise-prefix-cache-scorer`. 
The file is taken from [llm-d precise-prefix well-lit path](https://github.com/llm-d/llm-d/blob/main/guides/precise-prefix-cache-aware/gaie-kv-events/values.yaml#L44).

Previously, the `scenarios/guides/precise-prefix-cache-aware.sh` resulted in llm-d stack deployment without the  `precise-prefix-cache-scorer`. 

_Note: Maybe modifications to `experiments/precise-prefix-cache-aware.yaml`  are needed as well_