### PR TITLE
Clarify warning message in analysis notebook

### DIFF
--- a/analysis/analysis.ipynb
+++ b/analysis/analysis.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "041839c2-0d6a-44b1-b7e1-de6cc8a575ce",
    "metadata": {},
    "outputs": [
@@ -81,13 +81,18 @@
     "runs = xp.make_benchmark_runs_df()\n",
     "\n",
     "# Populate the runs DataFrame\n",
+    "# Note: If you are using Python <=3.12 and not importing from symbolic links,\n",
+    "# you may ignore the warning\n",
+    "# \"Symbolic link recursion not supported below Python 3.13\"\n",
     "for sdir in search_dirs:\n",
     "    print(f'Searching for benchmark report files within {sdir}')\n",
     "    # Find all benchmark report files in the directory\n",
-    "    for br_file in xp.get_benchmark_report_files(sdir, recurse_symlinks=True):\n",
+    "    br_files = xp.get_benchmark_report_files(sdir, recurse_symlinks=True)\n",
+    "    for br in br_files:\n",
     "        #print(f'Importing {br_file}')\n",
     "        # Import the results and add to the runs DataFrame\n",
-    "        xp.add_benchmark_report_to_df(runs, br_file)"
+    "        xp.add_benchmark_report_to_df(runs, br)\n",
+    "    print(f'Imported {len(br_files)} files')"
    ]
   },
   {


### PR DESCRIPTION
When data is first imported in the analysis Jupyter notebook, if a user is working with Python 3.12 or below they will see the warning message `Symbolic link recursion not supported below Python 3.13`. This is only important if part of the data they are trying to import is symbolically linked.

This warning, in addition to the lack of indication that anything has loaded, leads to a confusing user experience. This PR adds a comment to note this warning may be ignored if symbolic links are not used, and additionally prints a message to show how many files have been imported once the import completes (rather than end silently).