### PR TITLE
Stack component validation fixes to draft benchmark report v0.2

### DIFF
--- a/benchmark_report/br_v0_2_example.yaml
+++ b/benchmark_report/br_v0_2_example.yaml
@@ -29,7 +29,6 @@ scenario:
       role: prefill # One of prefill, decode, aggregate
       model:
         name: Qwen/Qwen3-0.6B
-        precision: FP8
       accelerator:
         model: NVIDIA-H100-80GB-HBM3
         count: 8
@@ -57,14 +56,25 @@ scenario:
         VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
 
   - metadata: 
-      kind: router 
+      kind: generic
       schema_version: 0.0.1
       label: epp-0
       cfg_id: 47000e70c655e88198e0dc4e57d41d5f
-      description: "Optional description of this component"
+      description: "This is a router, but no standardized component for this exists"
+    # This component uses the ComponentStandardizedBase, where the standardized
+    # section contains only "tool" and "tool_version", but otherwise this kind
+    # has no other features.
     standardized:
+      # tool and tool_version are the only required fields
       tool: llm-d-inference-scheduler
       tool_version: ghcr.io/llm-d/llm-d-inference-scheduler:0.3.2
+      # Other fields are not validated, and can be anything
+      kind_draft: router
+      some_config_param: 93
+      another_thing:
+        - a: 5
+        - a: 1
+        - b: 3
     native:
       config: # Configuration used (in this case a manifest of a k8s custom resource)
         apiVersion: inference.networking.x-k8s.io/v1alpha1

--- a/benchmark_report/schema_v0_2_components.py
+++ b/benchmark_report/schema_v0_2_components.py
@@ -3,9 +3,9 @@ Standardized component classes for v0.2 benchmark reports.
 """
 
 from enum import StrEnum, auto
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-
 
 # Default model_config to apply to Pydantic classes
 MODEL_CONFIG = ConfigDict(
@@ -14,6 +14,10 @@ MODEL_CONFIG = ConfigDict(
     populate_by_name=False, # Must use alias name, not internal field name
     validate_assignment=True, # Validate field assignment after init
 )
+
+###############################################################################
+# Base class for standardized section of a component
+###############################################################################
 
 class ComponentStandardizedBase(BaseModel):
     """Component configuration details in standardized format.
@@ -30,47 +34,40 @@ class ComponentStandardizedBase(BaseModel):
     tool_version: str
     """Version of tool."""
 
+###############################################################################
+# Generic component, kind: generic
+#
+# Use for any components that do not have a formal schema defined for the
+# standardized section.
+###############################################################################
 
-class ComponentStandardizedTolerantBase(BaseModel):
-    """Component configuration details in loosely defined standardized format.
+class Generic(BaseModel):
+    """Component configuration for a generic component.
 
-    This class is a base class that can be used on its own, or inherited by the
-    a class defining a native format for a particular component type.
-
-    This base allows for extra attributes to be added without validation (most
-    benchmark report classes forbid this). Use this base for development of
-    component classes, or when a class for your component does not exist but
-    you don't want to write your own class.
+    This class  allows for extra attributes to be added without validation.
+    Use this for development of new component classes, or when a class for your
+    component does not exist but you don't want to write your own class.
     """
 
     model_config = MODEL_CONFIG.copy()
-    model_config["extra"] = "allow"
+    model_config["extra"] = "allow" # Here we allow for extra unvalidated fields
 
+    kind: Literal["generic"] = Field(
+        exclude=True,
+        json_schema_extra={"exclude": True},
+        description=(
+            "Do not populate this field, this is for internal validation and"
+            " will be copied over from the metadata section."
+        )
+    )
     tool: str
     """Particular tool used for this component."""
     tool_version: str
     """Version of tool."""
-    tolerant_schema: bool = Field(
-        True,
-        description=(
-            "This field is to distinguish between a tolerant "
-            '"standardized" component schema, and the usual strict schema which'
-            "does not allow fields to be added that are not part of the defined"
-            "schema. The value of this field does not change behavior, its"
-            "existence alone indicates a tolerant schema."
-        )
-    )
 
-    @model_validator(mode="after")
-    def enforce_tolerant_true(self):
-        """To avoid confusion, enforce tolerant_schema=True."""
-        if not self.tolerant_schema:
-            raise ValueError(
-                'A tolerant "standardized" schema necessitates tolerant_schema=True'
-            )
-        return self
-
-
+###############################################################################
+# Inference engine, kind: inference_engine
+###############################################################################
 
 class HostType(StrEnum):
     """
@@ -125,9 +122,22 @@ class InferenceEngineAccelerator(BaseModel):
 class InferenceEngine(ComponentStandardizedBase):
     """Component configuration for an inference engine."""
 
+    kind: Literal["inference_engine"] = Field(
+        exclude=True,
+        json_schema_extra={"exclude": True},
+        description=(
+            "Do not populate this field, this is for internal validation and"
+            " will be copied over from the metadata section."
+        )
+    )
     role: HostType
     """Type of model serving host."""
     model: InferenceEngineModel
     """Hosted model details."""
     accelerator: InferenceEngineAccelerator
     """Accelerator hardware details."""
+
+
+# All supported component classes
+COMPONENTS = Generic | InferenceEngine
+


### PR DESCRIPTION
Fix validation handling of different stack components, choosing the appropriate "standardized" schema based on the `kind`. Add a `generic` kind which can be used for anything that doesn't have a formal specification.