### PR TITLE
Clarify authentication error message in GPU recommender UI

### DIFF
--- a/config_explorer/pages/2_GPU_Recommender.py
+++ b/config_explorer/pages/2_GPU_Recommender.py
@@ -80,13 +80,6 @@ model_id = st.sidebar.text_input(
     help="Enter the HuggingFace model ID"
 )
 
-hf_token = st.sidebar.text_input(
-    "HuggingFace Token (for gated models)",
-    type="password",
-    value="",
-    help="Enter your HuggingFace token for accessing gated models (e.g., Llama, Gemma). Leave empty for public models."
-)
-
 # Workload parameters
 st.sidebar.subheader("Workload Parameters")
 input_len = st.sidebar.number_input(
@@ -207,8 +200,7 @@ if run_analysis:
                 gpu_list=selected_gpus if selected_gpus else None,
                 max_ttft=max_ttft,
                 max_itl=max_itl,
-                max_latency=max_latency,
-                hf_token=hf_token if hf_token else None
+                max_latency=max_latency
             )
 
             # Run recommendation
@@ -242,7 +234,20 @@ if run_analysis:
 
             # Check for gated model errors
             if "gated" in error_str or "401" in error_str or "403" in error_str or "unauthorized" in error_str:
-                st.error("🔒 **This model is gated and requires authentication. Please enter your Hugging Face token in the sidebar and try again.**")
+                st.error("🔒 **This model is gated and requires authentication**")
+                st.info("""
+                **To access gated models:**
+
+                1. **Request access** to the model on [HuggingFace](https://huggingface.co/)
+                2. **Generate a token** from your [HuggingFace settings page](https://huggingface.co/settings/tokens)
+                3. **Set the environment variable** before running the application:
+                   ```bash
+                   export HF_TOKEN=your_token_here
+                   ```
+                4. **Restart** the Streamlit application
+
+                **Popular gated models:** Llama 3, Gemma, Mistral, etc.
+                """)
                 with st.expander("🔍 View detailed error"):
                     st.exception(e)
             else:

--- a/config_explorer/src/config_explorer/recommender/recommender.py
+++ b/config_explorer/src/config_explorer/recommender/recommender.py
@@ -26,9 +26,6 @@ class GPURecommender:
         max_ttft: Optional[float] = None,
         max_itl: Optional[float] = None,
         max_latency: Optional[float] = None,
-        
-        # Authentication
-        hf_token: Optional[str] = None,
     ):
         """
         Initialize GPU Recommender.
@@ -45,12 +42,11 @@ class GPURecommender:
             max_ttft: Maximum time to first token constraint (ms)
             max_itl: Maximum inter-token latency constraint (ms)
             max_latency: Maximum end-to-end latency constraint (s)
-            hf_token: HuggingFace token for accessing gated models. If None, uses HF_TOKEN environment variable.
         """
 
-        # Read HF Token from parameter or environment variable
-        if hf_token is None:
-            hf_token = os.getenv("HF_TOKEN", None)
+        # Read HF Token from environment variable
+        hf_token = os.getenv("HF_TOKEN", None)
+
         self.input_len = input_len
         self.output_len = output_len
         self.model_id = model_id


### PR DESCRIPTION
The current GPU recommender UI does not accept an HF_Token in the web console. It must be configured as a HF_TOKEN env var when the user starts Streamlit, which won't be the best way if hosting this service. This fix provides each user the ability to use their own HF_Token for gated models. 

I explored this further. Because we are relying on llm-optimizer, and they are the one in charge of querying HF directly for model configs, they only accept `HF_TOKEN` env var. That means we cannot prompt user to enter their hf token in the UI.  They must either start Streamlit with HF_TOKEN already set in their environment. When hosting this service, I don't think there's a better way to estimate gated models. 


