### PR TITLE
Add UID envar to harness pod

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -585,6 +585,10 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     volumeMounts:
     - name: results
       mountPath: /requests


### PR DESCRIPTION
Add a `POD_UID` environment variable to the harness pop, having a unique ID for any instantiation of a harness pod. This will be used to tie together experiments that happen within a pod, such as multi-stage runs with Inference Perf.