### PR TITLE
Add component health to benchmark report

### DIFF
--- a/benchmark_report/br_v0_2_example.yaml
+++ b/benchmark_report/br_v0_2_example.yaml
@@ -212,8 +212,6 @@ scenario:
           token: null
           trust_remote_code: null
 
-# Add optional time series
-# Add confidence interval
 results:
   request_performance: # Stack performance as seen by users
     aggregate: # Statistical summary of results (required)
@@ -347,6 +345,7 @@ results:
           units: s
           mean: 0.0368578234128654
 
+    # NOTE: Time series data is likely to be replaced with links to the actual data
     time_series: # Optional time series data
       throughput:
         input_token_rate:
@@ -406,6 +405,7 @@ results:
             p90: 0.04262634576298297
             p95: 0.045246614259667695
 
+  # NOTE: Observability data is likely to be replaced with links to the actual data
   observability:
     scrape_info:
       interval_seconds: 15
@@ -500,4 +500,22 @@ results:
             value: 6.72e10
 
   profiling:
-    anything_goes: 5
+    anything_goes: 5 # The schema under profiling is currently open-ended
+
+  component_health: # Component health and reliability metrics during benchmark
+    - component_label: vllm-svc-0  # References scenario.stack[0].metadata.label
+      total_restarts: 3 # This includes restarts for all replicas
+      failed_replicas: 1 # Number of replicas that had a restart
+      replica_health:
+        - replica_id: vllm-svc-0-pod-1 # Some unique ID to identify a replica
+          restarts: 1
+          healthy: True # Status at completion of benchmark
+          logs: https://logs.example.com/vllm-svc-0-pod-1
+        - replica_id: vllm-svc-0-pod-2
+          restarts: 2
+          healthy: False
+          logs: /path/to/logs/vllm.log
+        - replica_id: vllm-svc-0-pod-3
+          restarts: 0
+          healthy: True
+          logs: s3://path/to/logs/vllm.log

--- a/benchmark_report/schema_v0_2.py
+++ b/benchmark_report/schema_v0_2.py
@@ -19,7 +19,6 @@ from .base import (
 )
 from .schema_v0_2_components import COMPONENTS
 
-
 # BenchmarkReport schema version
 VERSION = "0.2"
 
@@ -641,6 +640,41 @@ class Observability(BaseModel):
 
 
 ###############################################################################
+# Component health
+###############################################################################
+
+
+class ReplicaHealth(BaseModel):
+    """Health information for a specific replica."""
+
+    model_config = MODEL_CONFIG.copy()
+
+    replica_id: str
+    """Unique identifier for this replica (e.g., pod name)."""
+    restarts: int | None = Field(None, ge=0)
+    """Number of times this replica restarted during the benchmark."""
+    healthy: bool | None = None
+    """Healthy status at completion of benchmark."""
+    logs: str | None = None
+    """Reference to logs for this specific replica."""
+
+
+class ComponentHealth(BaseModel):
+    """Health and reliability metrics for a component during the benchmark."""
+
+    model_config = MODEL_CONFIG.copy()
+
+    component_label: str
+    """References the component's label from scenario.stack[].metadata.label"""
+    total_restarts: int | None = Field(None, ge=0)
+    """Total restarts across all replicas during benchmark."""
+    failed_replicas: int | None = Field(None, ge=0)
+    """Number of replicas that hand one or more failures during benchmark."""
+    replica_health: list[ReplicaHealth] | None = None
+    """Per-replica health details."""
+
+
+###############################################################################
 # Benchmark Report top-level classes
 ###############################################################################
 
@@ -701,6 +735,9 @@ class Results(BaseModel):
 
     profiling: Any | None = None
     """Profiling results."""
+
+    component_health: list[ComponentHealth] | None = None
+    """Component health and reliability metrics during benchmark."""
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added optional `component_health` field under `results`.

Pydantic model can be sanity checked against example YAML with this one-liner (executed from root of llm-d-benchmark repository):
```bash
python -c "import benchmark_report; import yaml; br=benchmark_report.import_benchmark_report('benchmark_report/br_v0_2_example.yaml'); print(yaml.dump(br.dump(), indent=2))"
```