### PR TITLE
Loosen required package versions

### DIFF
--- a/config_explorer/pyproject.toml
+++ b/config_explorer/pyproject.toml
@@ -9,14 +9,14 @@ description = "Finding the most optimal configuration of llm-d."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "huggingface_hub==0.34.4",
-    "matplotlib==3.10.5",
-    "numpy==2.3.2",
-    "pandas==2.3.1",
-    "pydantic==2.11.7",
-    "PyYAML==6.0.2",
-    "scipy==1.16.1",
-    "transformers==4.55.4",
+    "huggingface_hub>=0.34.4",
+    "matplotlib>=3.10.5",
+    "numpy>=2.3.2",
+    "pandas>=2.3.1",
+    "pydantic>=2.11.7",
+    "PyYAML>=6.0.2",
+    "scipy>=1.16.1",
+    "transformers>=4.55.4",
     "llm-optimizer @ git+https://github.com/bentoml/llm-optimizer.git",
 ]
 

--- a/config_explorer/requirements-streamlit.txt
+++ b/config_explorer/requirements-streamlit.txt
@@ -1,2 +1,2 @@
-plotly==6.3.0
-streamlit==1.48.0
+plotly>=6.3.0
+streamlit>=1.48.0

--- a/config_explorer/requirements.txt
+++ b/config_explorer/requirements.txt
@@ -1,8 +1,8 @@
-huggingface_hub==0.34.4
-matplotlib==3.10.5
-numpy==2.3.2
-pandas==2.3.1
-pydantic==2.11.7
-PyYAML==6.0.2
-scipy==1.16.1
-transformers==4.55.4
+huggingface_hub>=0.34.4
+matplotlib>=3.10.5
+numpy>=2.3.2
+pandas>=2.3.1
+pydantic>=2.11.7
+PyYAML>=6.0.2
+scipy>=1.16.1
+transformers>=4.55.4


### PR DESCRIPTION
Allow Python packages equal or greater than specified version.

Unnecessarily restricting the version can cause complications in fulfilling requirements in some systems.