### PR TITLE
Check for OSL of `None` or `<1` in workload when creating benchark report

### DIFF
--- a/benchmark_report/native_to_br0_2.py
+++ b/benchmark_report/native_to_br0_2.py
@@ -533,10 +533,13 @@ def import_vllm_benchmark(results_file: str) -> BenchmarkReportV02:
     osl_value = None
     for arg, value in args.items():
         if arg.endswith("output-len"):
-            osl_value = int(value)
+            try:
+                osl_value = int(value)
+            except ValueError:
+                osl_value = None
             break
     osl = None
-    if osl_value:
+    if osl_value and osl_value >= 1:
         osl = {
             "value": osl_value,
             "distribution": Distribution.FIXED,
@@ -715,10 +718,13 @@ def import_inference_max(results_file: str) -> BenchmarkReportV02:
     osl_value = None
     for arg, value in args.items():
         if arg.endswith("output-len"):
-            osl_value = int(value)
+            try:
+                osl_value = int(value)
+            except ValueError:
+                osl_value = None
             break
     osl = None
-    if osl_value:
+    if osl_value and osl_value >= 1:
         osl = {
             "value": osl_value,
             "distribution": Distribution.FIXED,

--- a/benchmark_report/schema_v0_2.py
+++ b/benchmark_report/schema_v0_2.py
@@ -121,9 +121,7 @@ class SequenceLength(BaseModel):
 
     distribution: Distribution
     """Sequence length distribution type."""
-    # Do not enforce a value of >=1, as vllm bench (for example) uses OSL of -1
-    # to represent not restricting output length.
-    value: int | float
+    value: int | float = Field(..., ge=1)
     """Primary value."""
     std_dev: float | None = Field(None, ge=0)
     """Standard deviation (if Gaussian)."""


### PR DESCRIPTION
The benchmark report v0.2 schema currently enforces that sequence length values must be greater or equal to `1`. However, `vllm bench` uses an OSL of `-1` or `None` to [represent not restricting the output length](https://github.com/vllm-project/vllm/pull/31881).

This PR checks for `None` or `<1` values before populating the OSL of the workload.