### PR TITLE
fixes for run_only.sh 

### DIFF
--- a/benchmark_report/native_to_br0_2.py
+++ b/benchmark_report/native_to_br0_2.py
@@ -236,7 +236,7 @@ def _populate_load() -> dict:
             "load": {
                 "standardized": {
                     "tool_version": os.environ.get("LLMDBENCH_HARNESS_VERSION", ""),
-                    "parallelism": os.environ.get("LLMDBENCH_HARNESS_LOAD_PARALLELISM"),
+                    "parallelism": os.environ.get("LLMDBENCH_HARNESS_LOAD_PARALLELISM", 1),
                 },
                 "native": {
                     "args": args,


### PR DESCRIPTION
Several small fixes:

- Handle bucket verification
- Set default harness parallelism to 1 for report v 0.2
- Handle multiple workloads correctly (there was a bug that stopped after first one).
- Handle output redirection, so can see benchmark progress (as well as logging on pod)