### PR TITLE
Simplify usage of JSON schema generation in CLI

### DIFF
--- a/benchmark_report/cli.py
+++ b/benchmark_report/cli.py
@@ -62,10 +62,7 @@ def main() -> None:
     parser.add_argument(
         "-j",
         "--json-schema",
-        type=str,
-        nargs="?",
-        const="0.1",
-        default=None,
+        action=argparse.BooleanOptionalAction,
         help="Print JSON Schema for Benchmark Report.",
     )
 
@@ -73,7 +70,7 @@ def main() -> None:
 
     if args.json_schema:
         # Print JSON Schema and exit
-        print(make_json_schema(args.json_schema))
+        print(make_json_schema(args.br_version))
         sys.exit(0)
 
     if args.br_version == "0.1":


### PR DESCRIPTION
Currently, to generate a JSON schema the `--json-schema` flag to the CLI has an optional argument for the version number (defaults to `0.1`). However, there is also a `--br-version` flag (defaults to `0.1`), which is used for conversion output.

This PR makes `--json-schema` a boolean option, which when enabled takes the benchmark report version from the `--br-version` flag.