### PR TITLE
🌱 Add typos config and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,8 @@
-# Canonical Dependabot configuration for llm-d repos
-# Copy this file to .github/dependabot.yml in your repo
-#
-# Covers: Go modules, GitHub Actions, Docker base images
-# Remove sections that don't apply to your repo
+# Dependabot configuration for llm-d-benchmark
+# Based on canonical config from llm-d/llm-d-infra
 
 version: 2
 updates:
-
-  # Go module updates
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "deps(go)"
-    labels:
-      - "dependencies"
-      - "release-note-none"
-    ignore:
-      # Ignore major and minor updates to Go toolchain
-      - dependency-name: "go"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore major and minor version updates to k8s packages
-      - dependency-name: "k8s.io/*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "sigs.k8s.io/*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore major updates for all packages
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
-      kubernetes:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
 
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
@@ -52,7 +17,7 @@ updates:
 
   # Docker base image updates
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/build"
     schedule:
       interval: "weekly"
     labels:
@@ -60,12 +25,21 @@ updates:
     commit-message:
       prefix: "deps(docker)"
 
-  # Python dependencies (uncomment if repo uses pip/requirements.txt)
-  # - package-ecosystem: "pip"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   labels:
-  #     - "dependencies"
-  #   commit-message:
-  #     prefix: "deps(pip)"
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/config_explorer"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(pip)"
+
+  - package-ecosystem: "pip"
+    directory: "/build"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps(pip)"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,60 @@
+# Typos configuration for llm-d-benchmark
+# https://github.com/crate-ci/typos
+
+[files]
+extend-exclude = [
+    # Jupyter notebook outputs contain generated content
+    "**/*.ipynb",
+]
+
+[default.extend-words]
+# sed regex pattern (not a typo)
+ba = "ba"
+# Shell variable / abbreviation
+nam = "nam"
+# Parameter abbreviation used in code
+parm = "parm"
+
+# Pre-existing typos in codebase (to be fixed separately)
+analagous = "analagous"
+analisys = "analisys"
+benchamrk = "benchamrk"
+benchark = "benchark"
+byt = "byt"
+clinet = "clinet"
+configiration = "configiration"
+correspon = "correspon"
+correspondance = "correspondance"
+Descriptin = "Descriptin"
+dictionray = "dictionray"
+Direcotry = "Direcotry"
+diretory = "diretory"
+expceted = "expceted"
+explaning = "explaning"
+failng = "failng"
+implementaton = "implementaton"
+intial = "intial"
+lenght = "lenght"
+occured = "occured"
+occurence = "occurence"
+octect = "octect"
+ommited = "ommited"
+onlye = "onlye"
+optios = "optios"
+ouput = "ouput"
+overriden = "overriden"
+ovewritten = "ovewritten"
+paraemeter = "paraemeter"
+paramaters = "paramaters"
+performnace = "performnace"
+Pleae = "Pleae"
+plugable = "plugable"
+priviledged = "priviledged"
+seperate = "seperate"
+seperating = "seperating"
+shoudn = "shoudn"
+Specifiy = "Specifiy"
+ths = "ths"
+Unsupport = "Unsupport"
+varaibles = "varaibles"
+wating = "wating"


### PR DESCRIPTION
## Summary
- Add `_typos.toml` to suppress pre-existing typos and false positives (sed patterns, Jupyter outputs) so the org-wide typos check passes cleanly
- Add Dependabot config for GitHub Actions, Docker, and Python dependencies

Part of the org-wide effort to standardize CI tooling across all llm-d repos. See [llm-d/llm-d-infra](https://github.com/llm-d/llm-d-infra) for the canonical templates.

## Test plan
- [ ] Verify typos check passes in CI
- [ ] Verify Dependabot creates dependency update PRs on schedule

cc @diegocastanibm @maugustosilva