### PR TITLE
Lazy load kubernetes in benchmark report convert script

### DIFF
--- a/benchmark_report/native_to_br0_2.py
+++ b/benchmark_report/native_to_br0_2.py
@@ -17,7 +17,6 @@ from datetime import datetime, timezone
 
 import numpy as np
 import yaml
-from kubernetes import client, config as k8s_config
 
 from .base import Units, WorkloadGenerator
 from .core import (
@@ -110,6 +109,8 @@ def get_configmap(
         return {}
 
     try:
+        from kubernetes import client, config as k8s_config
+
         # Write context to a temporary file
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump(context_dict, f)


### PR DESCRIPTION
Lazy load `kubernetes` to minimize requirements. `kubernetes` is only needed when this script is executed inside a harness pod.