### PR TITLE
🐛 Fix broken reusable workflow references

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   typos:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-typos.yml@main

--- a/.github/workflows/ci-signed-commits.yaml
+++ b/.github/workflows/ci-signed-commits.yaml
@@ -3,7 +3,7 @@ on: pull_request_target
 
 jobs:
   signed-commits:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   links:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-md-link-check.yml@main

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   gatekeeper:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   prow:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   auto-merge:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -3,4 +3,4 @@ on: pull_request
 
 jobs:
   remove-lgtm:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/unstale.yaml
+++ b/.github/workflows/unstale.yaml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   unstale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@2b273d6
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
     permissions:
       issues: write


### PR DESCRIPTION
## Summary
- Replace short SHA `@2b273d6` with `@main` for all llm-d-infra reusable workflow references
- GitHub Actions requires a full 40-char SHA, branch name, or tag — the 7-char short SHA doesn't resolve
- **All 9 caller workflows are currently broken**, failing with: `failed to fetch workflow: reference to workflow should be either a valid branch, tag, or commit`

## Test plan
- [x] Verify all workflow files updated
- [ ] Confirm prow-pr-automerge stops failing on schedule trigger
- [ ] Confirm prow commands work on this PR