### PR TITLE
🐛 Add failure diagnostics to nightly benchmark workflows

### DIFF
--- a/.github/workflows/ci-nighly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nighly-benchmark-gke.yaml
@@ -117,6 +117,30 @@ jobs:
         run: ./setup/teardown.sh -c gke_H100_fb -t standalone -d
         shell: bash
 
+      - name: Collect failure diagnostics
+        if: failure()
+        run: |
+          echo "=== Pod status ==="
+          kubectl get pods -n llmdbenchcicd -o wide || true
+          echo ""
+          echo "=== Describe failed pods ==="
+          for pod in $(kubectl get pods -n llmdbenchcicd --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl describe -n llmdbenchcicd "$pod" || true
+          done
+          echo ""
+          echo "=== Pod logs (crashed/errored) ==="
+          for pod in $(kubectl get pods -n llmdbenchcicd --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null); do
+            echo "--- $pod logs ---"
+            kubectl logs -n llmdbenchcicd "$pod" --tail=200 --all-containers || true
+            echo "--- $pod previous logs ---"
+            kubectl logs -n llmdbenchcicd "$pod" --previous --tail=200 --all-containers 2>/dev/null || true
+          done
+          echo ""
+          echo "=== Recent events ==="
+          kubectl get events -n llmdbenchcicd --sort-by='.lastTimestamp' | tail -30 || true
+        shell: bash
+
       - name: Archive benchmark results as GitHub artifact
         if: success() || failure()
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci-nighly-benchmark-ocp.yaml
+++ b/.github/workflows/ci-nighly-benchmark-ocp.yaml
@@ -154,6 +154,37 @@ jobs:
           ./setup/e2e.sh -c ocp_fb -t modelservice --deep -l vllm-benchmark
         shell: bash
 
+      - name: Collect failure diagnostics
+        if: failure()
+        run: |
+          echo "=== Pod status ==="
+          kubectl get pods -n llmdbenchcicd -o wide || true
+          echo ""
+          echo "=== Describe failed pods ==="
+          for pod in $(kubectl get pods -n llmdbenchcicd --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl describe -n llmdbenchcicd "$pod" || true
+          done
+          echo ""
+          echo "=== Pod logs (crashed/errored) ==="
+          for pod in $(kubectl get pods -n llmdbenchcicd --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null); do
+            echo "--- $pod logs ---"
+            kubectl logs -n llmdbenchcicd "$pod" --tail=200 --all-containers || true
+            echo "--- $pod previous logs ---"
+            kubectl logs -n llmdbenchcicd "$pod" --previous --tail=200 --all-containers 2>/dev/null || true
+          done
+          echo ""
+          echo "=== Harness launcher pods ==="
+          kubectl get pods -n llmdbenchcicd -l app=llmdbench-harness-launcher -o wide || true
+          for pod in $(kubectl get pods -n llmdbenchcicd -l app=llmdbench-harness-launcher -o name 2>/dev/null); do
+            echo "--- $pod logs ---"
+            kubectl logs -n llmdbenchcicd "$pod" --tail=200 --all-containers || true
+          done
+          echo ""
+          echo "=== Recent events ==="
+          kubectl get events -n llmdbenchcicd --sort-by='.lastTimestamp' | tail -30 || true
+        shell: bash
+
       - name: Install AWS CLI
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
## Summary
- Both GKE and OCP nightly benchmarks consistently fail but don't capture pod-level logs, making root cause diagnosis impossible from CI alone
- Adds a "Collect failure diagnostics" step to both workflows that runs only on failure
- Captures pod status, describe, container logs (current + previous), and recent events from the `llmdbenchcicd` namespace
- OCP workflow additionally captures harness launcher pod logs specifically

## Context

**GKE (#668):** vLLM standalone pod for `meta-llama/Llama-3.2-1B` starts running then crashes ~30 seconds later. Without pod logs we can't determine if it's a GPU driver issue, model loading error, or image incompatibility.

**OCP (#669):** Standalone benchmarks all pass. Modelservice E2E deployment succeeds and smoketest passes. But the harness launcher pod that runs the actual benchmark crashes within ~2 minutes in simulator mode. Without harness pod logs we can't determine the crash cause.

## What's Added

A `Collect failure diagnostics` step in each workflow:
```yaml
- name: Collect failure diagnostics
  if: failure()
  run: |
    kubectl get pods -n llmdbenchcicd -o wide
    kubectl describe <failed pods>
    kubectl logs <failed pods> --tail=200 --all-containers
    kubectl logs <failed pods> --previous --tail=200
    kubectl get events -n llmdbenchcicd --sort-by='.lastTimestamp'
```

## Test Plan
- [ ] Trigger GKE nightly — when standup fails, pod logs should appear in CI output
- [ ] Trigger OCP nightly — when harness crashes, harness pod logs should appear in CI output
- [ ] Verify diagnostic step doesn't run on success (conditional `if: failure()`)