### PR TITLE
Update workload profiles 

### DIFF
--- a/workload/profiles/inference-perf/sanity_random.yaml.in
+++ b/workload/profiles/inference-perf/sanity_random.yaml.in
@@ -3,6 +3,7 @@ load:
   stages:
   - rate: 1
     duration: 30
+  request_timeout: 30
 api:
   type: completion
   streaming: true

--- a/workload/profiles/vllm-benchmark/fixed_dataset.yaml.in
+++ b/workload/profiles/vllm-benchmark/fixed_dataset.yaml.in
@@ -1,0 +1,11 @@
+executable: benchmark_serving.py
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+base-url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+dataset-name: custom
+dataset-path: REPLACE_ENV_LLMDBENCH_RUN_DATASET_DIR/REPLACE_ENV_LLMDBENCH_RUN_DATASET_FILE
+max-concurrency: 4
+num-prompts: 2000
+percentile-metrics: "ttft,tpot,itl,e2el"
+metric-percentiles: "99,100"
+ignore-eos: none
+custom-output-len: -1


### PR DESCRIPTION
- Add custom dataset profile for vllm-benchmark
- Add request_timeout (default is 30) for sanity_random in inference-perf