### PR TITLE
🐛 Allow accelerator count=0 in benchmark report schema for simulator mode

### DIFF
--- a/benchmark_report/schema_v0_2_components.py
+++ b/benchmark_report/schema_v0_2_components.py
@@ -99,12 +99,12 @@ class InferenceEngineParallelism(BaseModel):
 
     model_config = MODEL_CONFIG.copy()
 
-    tp: int = Field(1, ge=1, description="Tensor parallelism.")
-    dp: int = Field(1, ge=1, description="Data parallelism.")
+    tp: int = Field(1, ge=0, description="Tensor parallelism.")
+    dp: int = Field(1, ge=0, description="Data parallelism.")
     dp_local: int = Field(
-        1, ge=1, description="Local data parallelism for this engine instance."
+        1, ge=0, description="Local data parallelism for this engine instance."
     )
-    workers: int = Field(1, ge=1, description="Number of workers.")
+    workers: int = Field(1, ge=0, description="Number of workers.")
     ep: int = Field(1, ge=1, description="Expert parallelism.")
     pp: int = Field(1, ge=1, description="Pipeline parallelism.")
 
@@ -116,7 +116,7 @@ class InferenceEngineAccelerator(BaseModel):
 
     model: str
     """Hardware model name."""
-    count: int = Field(..., ge=1, description="Total utilized accelerator count.")
+    count: int = Field(..., ge=0, description="Total utilized accelerator count.")
     parallelism: InferenceEngineParallelism
     """Parallelism utilized."""
 


### PR DESCRIPTION
## Summary
- Change `ge=1` to `ge=0` for `InferenceEngineAccelerator.count` and `InferenceEngineParallelism` fields (tp, dp, dp_local, workers) in `benchmark_report/schema_v0_2_components.py`
- Allows simulator mode (0 GPUs) to pass Benchmark Report v0.2 validation
- Standalone benchmarks are unaffected (they already pass)

Closes #672

## Root Cause
The nightly OCP benchmark activates simulator mode when <20 GPUs are available, using `llm-d-inference-sim` with 0 GPUs. The `benchmark-report` Pydantic schema rejected `accelerator.count=0` with `ValidationError`.

## Test plan
- [ ] Re-trigger nightly OCP benchmark — modelservice E2E step should now pass
- [ ] Verify standalone benchmarks still pass (no change in behavior for count >= 1)