### PR TITLE
🐛 fix: build nightly benchmark image from main

### DIFF
--- a/.github/workflows/ci-nighly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nighly-benchmark-gke.yaml
@@ -31,10 +31,19 @@ jobs:
       GKE_CLUSTER_ZONE: us-east5
       GATEWAY: gke-l7-regional-external-managed
       GATEWAY_TYPE: gke
+      LLMDBENCH_IMAGE_TAG: nightly
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Build and push nightly image
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          tag: nightly
+          image-name: llm-d-benchmark
+          registry: ghcr.io/llm-d
+          github-token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Install Python 3.11
         uses: actions/setup-python@v6

--- a/.github/workflows/ci-nighly-benchmark-ocp.yaml
+++ b/.github/workflows/ci-nighly-benchmark-ocp.yaml
@@ -25,9 +25,21 @@ jobs:
     runs-on: [k8s-util]
     timeout-minutes: 240
 
+    env:
+      LLMDBENCH_IMAGE_TAG: nightly
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Build and push nightly image
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          tag: nightly
+          image-name: llm-d-benchmark
+          registry: ghcr.io/llm-d
+          github-token: ${{ secrets.GHCR_TOKEN }}
+
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- Nightly benchmarks resolve `LLMDBENCH_IMAGE_TAG=auto` to the latest release tag (`v0.4.7`), meaning fixes merged to `main` don't take effect until a new release is cut
- This caused the Pydantic schema fix (#673) to have no effect on the nightly runs — the harness launcher pod still crashes with `ValidationError: Input should be greater than or equal to 1`
- Add a build step to both OCP and GKE nightly workflows that builds the image from current checkout and pushes as `ghcr.io/llm-d/llm-d-benchmark:nightly`
- Set `LLMDBENCH_IMAGE_TAG=nightly` so harness launcher pods use the freshly built image

## Changes
- `ci-nighly-benchmark-ocp.yaml`: Add image build step + set `LLMDBENCH_IMAGE_TAG=nightly`
- `ci-nighly-benchmark-gke.yaml`: Same

## Test plan
- [ ] Verify `GHCR_TOKEN` secret exists in repo (needed for image push)
- [ ] Merge and re-trigger OCP nightly to validate the fix
- [ ] Confirm harness launcher pods use `nightly` tag instead of `v0.4.7`

Fixes: #672