### PR TITLE
🐛 Split nightly image build into separate job (fix Docker on k8s-util)

### DIFF
--- a/.github/workflows/ci-nighly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nighly-benchmark-gke.yaml
@@ -20,8 +20,25 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
+  build-image:
+    name: Build Nightly Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build and push nightly image
+        uses: ./.github/actions/docker-build-and-push
+        with:
+          tag: nightly
+          image-name: llm-d-benchmark
+          registry: ghcr.io/llm-d
+          github-token: ${{ secrets.GHCR_TOKEN }}
+
   run-benchmark-gke:
     name: CI - Nightly Benchmark on GKE
+    needs: build-image
     runs-on: [k8s-util]
     timeout-minutes: 240
 
@@ -36,14 +53,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Build and push nightly image
-        uses: ./.github/actions/docker-build-and-push
-        with:
-          tag: nightly
-          image-name: llm-d-benchmark
-          registry: ghcr.io/llm-d
-          github-token: ${{ secrets.GHCR_TOKEN }}
 
       - name: Install Python 3.11
         uses: actions/setup-python@v6

--- a/.github/workflows/ci-nighly-benchmark-ocp.yaml
+++ b/.github/workflows/ci-nighly-benchmark-ocp.yaml
@@ -20,14 +20,10 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
 
 jobs:
-  run-benchmark:
-    name: Benchmark Test
-    runs-on: [k8s-util]
-    timeout-minutes: 240
-
-    env:
-      LLMDBENCH_IMAGE_TAG: nightly
-
+  build-image:
+    name: Build Nightly Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,6 +35,19 @@ jobs:
           image-name: llm-d-benchmark
           registry: ghcr.io/llm-d
           github-token: ${{ secrets.GHCR_TOKEN }}
+
+  run-benchmark:
+    name: Benchmark Test
+    needs: build-image
+    runs-on: [k8s-util]
+    timeout-minutes: 240
+
+    env:
+      LLMDBENCH_IMAGE_TAG: nightly
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
- The `k8s-util` self-hosted runner does not have Docker daemon, causing `docker buildx` to fail with "Cannot connect to the Docker daemon"
- Splits the nightly image build into a separate `build-image` job on `ubuntu-latest` (which has Docker)
- The benchmark job (`run-benchmark` / `run-benchmark-gke`) now depends on `build-image` via `needs:`
- Applies to both OCP and GKE nightly benchmark workflows

## Root Cause
PR #675 added `LLMDBENCH_IMAGE_TAG: nightly` and a build step to fix the stale `v0.4.7` image, but the build step was placed in the same job that runs on `k8s-util` which lacks Docker daemon access.

## Test plan
- [ ] Re-trigger OCP nightly after merge — image build should succeed on ubuntu-latest, then benchmark runs on k8s-util
- [ ] Verify GKE nightly also picks up the fix