### PR TITLE
🐛 Revert Python to 3.13 — vllm requires <3.14

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.3-slim-bookworm
+FROM python:3.13-slim-bookworm
 
 RUN apt-get update; \
     apt-get install -y \


### PR DESCRIPTION
## Summary
- Dependabot bumped Python from 3.12.9 to 3.14.3 in #660
- vllm requires Python `<3.14,>=3.10`, so the Docker build fails:
  ```
  ERROR: Package 'vllm' requires a different Python: 3.14.3 not in '<3.14,>=3.10'
  ```
- Pins base image to `python:3.13-slim-bookworm` (latest compatible minor)

## Root Cause
[Dependabot PR #660](https://github.com/llm-d/llm-d-benchmark/pull/660) auto-merged a major Python version bump that broke vllm compatibility.

## Test plan
- [ ] Re-trigger OCP nightly after merge — image should build successfully
- [ ] Verify vllm, guidellm, inference-perf all install correctly in the container