### PR TITLE
🐛 Build nightly image for amd64 only (fix arm64 build failure)

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -13,6 +13,10 @@ inputs:
   registry:
     required: true
     description: Container registry (e.g., ghcr.io/llm-d)
+  platform:
+    required: false
+    description: Target platform(s) for buildx (e.g., linux/amd64,linux/arm64)
+    default: 'linux/amd64,linux/arm64'
 runs:
   using: "composite"
   steps:
@@ -33,7 +37,7 @@ runs:
     - name: Build image
       run: |
         docker buildx build \
-          --platform linux/amd64,linux/arm64  \
+          --platform ${{ inputs.platform }}  \
           -t ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.tag }} \
           -f build/Dockerfile \
           --push .

--- a/.github/workflows/ci-nighly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nighly-benchmark-gke.yaml
@@ -35,6 +35,7 @@ jobs:
           image-name: llm-d-benchmark
           registry: ghcr.io/llm-d
           github-token: ${{ secrets.GHCR_TOKEN }}
+          platform: linux/amd64
 
   run-benchmark-gke:
     name: CI - Nightly Benchmark on GKE

--- a/.github/workflows/ci-nighly-benchmark-ocp.yaml
+++ b/.github/workflows/ci-nighly-benchmark-ocp.yaml
@@ -35,6 +35,7 @@ jobs:
           image-name: llm-d-benchmark
           registry: ghcr.io/llm-d
           github-token: ${{ secrets.GHCR_TOKEN }}
+          platform: linux/amd64
 
   run-benchmark:
     name: Benchmark Test


### PR DESCRIPTION
## Summary
- Multi-arch Docker build fails on arm64 (QEMU emulation) with `BackendUnavailable: Cannot import 'scikit_build_core.build'` during vllm install
- All benchmark targets (OCP, GKE) are amd64 — arm64 is not needed for nightly images
- Adds `platform` input to `docker-build-and-push` action (defaults to multi-arch for backward compatibility with releases)
- Nightly workflows override to `linux/amd64` only — faster build, avoids arm64 QEMU issues

## Changes
- `.github/actions/docker-build-and-push/action.yml` — new `platform` input with default `linux/amd64,linux/arm64`
- Both nightly workflows — pass `platform: linux/amd64`

## Test plan
- [ ] Re-trigger OCP nightly after merge — image build should complete in ~5min (no arm64 QEMU)
- [ ] Release builds (ci-release.yaml) still build multi-arch by default