### PR TITLE
🐛 Fix ZeroDivisionError when vllm-benchmark has 0 completions

### DIFF
--- a/benchmark_report/native_to_br0_1.py
+++ b/benchmark_report/native_to_br0_1.py
@@ -344,12 +344,12 @@ def import_vllm_benchmark(results_file: str) -> BenchmarkReportV01:
                     "input_length": {
                         "units": Units.COUNT,
                         "mean": results.get("total_input_tokens", 0)
-                        / results.get("completed", -1),
+                        / (results.get("completed", 0) or 1),
                     },
                     "output_length": {
                         "units": Units.COUNT,
                         "mean": results.get("total_output_tokens", 0)
-                        / results.get("completed", -1),
+                        / (results.get("completed", 0) or 1),
                     },
                 },
                 "latency": {

--- a/benchmark_report/native_to_br0_2.py
+++ b/benchmark_report/native_to_br0_2.py
@@ -659,7 +659,7 @@ def import_vllm_benchmark(results_file: str) -> BenchmarkReportV02:
     source = LoadSource.RANDOM if ds_name == "random" else LoadSource.SAMPLED
 
     # Calculate ISL, as fallback option
-    isl_value = results.get("total_input_tokens", 0) / results.get("completed", -1)
+    isl_value = results.get("total_input_tokens", 0) / (results.get("completed", 0) or 1)
     # Get requested ISL, if it is in arguments from --sonnet-input-len or
     # --random-input-len
     for arg, value in args.items():
@@ -727,7 +727,7 @@ def import_vllm_benchmark(results_file: str) -> BenchmarkReportV02:
                             "output_length": {
                                 "units": Units.COUNT,
                                 "mean": results.get("total_output_tokens", 0)
-                                / results.get("completed", -1),
+                                / (results.get("completed", 0) or 1),
                             },
                         },
                         "latency": {
@@ -844,7 +844,7 @@ def import_inference_max(results_file: str) -> BenchmarkReportV02:
     source = LoadSource.RANDOM if ds_name == "random" else LoadSource.SAMPLED
 
     # Calculate ISL, as fallback option
-    isl_value = results.get("total_input_tokens", 0) / results.get("completed", -1)
+    isl_value = results.get("total_input_tokens", 0) / (results.get("completed", 0) or 1)
     # Get requested ISL, if it is in arguments from --sonnet-input-len or
     # --random-input-len
     for arg, value in args.items():


### PR DESCRIPTION
## Summary
- When all vllm-benchmark requests fail (e.g. service unreachable), `completed` is `0`
- `benchmark-report` divides by `results.get("completed", -1)` — the `-1` default only guards against a **missing** key, not `0`
- Causes `ZeroDivisionError` in both BR v0.1 (`native_to_br0_1.py:346-352`) and v0.2 (`native_to_br0_2.py:662,730,847`)
- Fix: `(results.get("completed", 0) or 1)` — defaults to 1 when completed is 0, yielding 0 for computed means

## Root Cause
The nightly OCP benchmark's vllm-benchmark harness lost connectivity to the vLLM service (`ClientConnectorError: Cannot connect to host`), causing all 20 requests to fail with 0 completions. The analysis script then crashed on division by zero instead of gracefully handling 0 results.

## Test plan
- [ ] Verify analysis handles `completed: 0` without crashing
- [ ] Verify normal runs (completed > 0) are unaffected