### PR TITLE
🐛 Add connectivity wait to vllm-benchmark harness

### DIFF
--- a/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
+++ b/workload/harnesses/vllm-benchmark-llm-d-benchmark.sh
@@ -4,6 +4,27 @@ mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
 cd ${LLMDBENCH_RUN_WORKSPACE_DIR}/vllm/
 cp -f ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
 en=$(cat ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r .executable)
+
+# Wait for vLLM endpoint to be ready before running benchmark
+ENDPOINT_URL=$(cat ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r '.["base-url"]')
+if [[ -n "$ENDPOINT_URL" && "$ENDPOINT_URL" != "null" ]]; then
+  MAX_WAIT=60
+  INTERVAL=10
+  echo "Waiting for vLLM endpoint at ${ENDPOINT_URL}/v1/models ..."
+  for i in $(seq 1 $MAX_WAIT); do
+    if curl -sf -o /dev/null --max-time 5 "${ENDPOINT_URL}/v1/models" 2>/dev/null; then
+      echo "vLLM endpoint is ready (attempt $i/${MAX_WAIT})"
+      break
+    fi
+    if [[ $i -eq $MAX_WAIT ]]; then
+      echo "ERROR: vLLM endpoint not ready after ${MAX_WAIT} attempts ($((MAX_WAIT * INTERVAL))s)"
+      exit 1
+    fi
+    echo "Attempt $i/${MAX_WAIT}: endpoint not ready, retrying in ${INTERVAL}s..."
+    sleep $INTERVAL
+  done
+fi
+
 echo "Running warmup with 3 prompts"
 vllm bench serve --$(cat ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/vllm-benchmark/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | grep -v "^executable" | yq -r 'to_entries | map("\(.key)=\(.value)") | join(" --")' | sed -e 's^=none ^ ^g' -e 's^=none$^^g' -e 's^num-prompts=[0-9]*^num-prompts=3^')  --seed $(date +%s) > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
 echo "Running main benchmark"


### PR DESCRIPTION
## Summary
- vllm bench serve has no built-in retry/wait logic (unlike inference-perf and guidellm)
- When the vLLM endpoint is momentarily unreachable, all 20 requests fail with `ClientConnectorError`, resulting in 0 completed requests and a downstream `ZeroDivisionError` in benchmark-report
- Adds a curl-based health check loop that waits up to 10 minutes for the vLLM `/v1/models` endpoint to respond before starting the warmup and main benchmark

## Test plan
- [ ] Re-trigger BM-OCP nightly and verify vllm-benchmark step passes
- [ ] Verify health check logs appear in harness pod output