### PR TITLE
fix redundant volumes and volume mounts in the standalone yaml file

### DIFF
--- a/setup/steps/06_deploy_vllm_standalone_models.py
+++ b/setup/steps/06_deploy_vllm_standalone_models.py
@@ -277,13 +277,6 @@ spec:
           requests:
 {requests_str}
         volumeMounts:
-        - name: preprocesses
-          mountPath: /setup/preprocess
-        - name: cache-volume
-          mountPath: {ev['vllm_standalone_pvc_mountpoint']}
-          readOnly: true
-        - name: shm
-          mountPath: /dev/shm
         {extra_volume_mounts}
 {add_pull_secret(ev)}
 """
@@ -339,30 +332,12 @@ spec:
           requests:
 {requests_str}
         volumeMounts:
-        - name: preprocesses
-          mountPath: /setup/preprocess
-        - name: cache-volume
-          mountPath: {ev['vllm_standalone_pvc_mountpoint']}
-          readOnly: true
-        - name: shm
-          mountPath: /dev/shm
         {extra_volume_mounts}
 {add_pull_secret(ev)}
 """
     deployment_yaml += f"""
       volumes:
-      - name: preprocesses
-        configMap:
-          name: llm-d-benchmark-preprocesses
-          defaultMode: 0500
-      - name: cache-volume
-        persistentVolumeClaim:
-          claimName: {ev['vllm_common_pvc_name']}
       {extra_volumes}
-      - name: shm
-        emptyDir:
-          medium: Memory
-          sizeLimit: {ev['vllm_common_shm_mem']}
 """
     return deployment_yaml
 


### PR DESCRIPTION
Volumes and volume mounts have been defined in the scenario files as `LLMDBENCH_VLLM_COMMON_EXTRA_VOLUMES` and `LLMDBENCH_VLLM_COMMON_EXTRA_VOLUME_MOUNTS`. Therefore, this PR is to remove duplicate definitions in the template for the 06 standalone step. 