### PR TITLE
🐛 Account for preemptable GPUs in CKS benchmark simulator fallback

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-cks.yaml
+++ b/.github/workflows/ci-nightly-benchmark-cks.yaml
@@ -99,6 +99,18 @@ jobs:
           kubectl-view-allocations -h
         shell: bash
 
+      - name: Count preemptible GPUs (negative-priority pods)
+        run: |
+          # Count GPUs held by Running pods with priority < 0 (e.g. hpc-verification at -1).
+          # Our benchmark pods (default priority 0) will preempt these, so they
+          # should count as "available" for the simulator-fallback decision.
+          PREEMPTABLE_GPUS=$(kubectl get pods --all-namespaces -o json | \
+            jq '[.items[] | select((.spec.priority // 0) < 0 and .status.phase == "Running") |
+              (.spec.containers[]?.resources.limits["nvidia.com/gpu"] // "0" | tonumber)] | add // 0')
+          echo "PREEMPTABLE_GPUS=$PREEMPTABLE_GPUS" >> $GITHUB_ENV
+          echo "Preemptible GPUs (held by negative-priority Running pods): $PREEMPTABLE_GPUS"
+        shell: bash
+
       - name: Cleanup target cloud (modelservice)
         env:
           LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
@@ -116,7 +128,8 @@ jobs:
         env:
           LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
         run: |
-          if [[ $(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) - 10.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
+          AVAIL=$(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) + ${PREEMPTABLE_GPUS:-0}" | bc)
+          if [[ $(echo "$AVAIL - 10.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR (available+preemptible=$AVAIL < 10)"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
           ./setup/standup.sh -c cks_fb -t standalone
         shell: bash
 
@@ -152,7 +165,8 @@ jobs:
         env:
           LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
         run: |
-          if [[ $(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) - 20.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
+          AVAIL=$(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) + ${PREEMPTABLE_GPUS:-0}" | bc)
+          if [[ $(echo "$AVAIL - 20.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR (available+preemptible=$AVAIL < 20)"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
           ./setup/e2e.sh -c cks_fb -t modelservice --deep
         shell: bash
 
@@ -160,7 +174,8 @@ jobs:
         env:
           LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
         run: |
-          if [[ $(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) - 20.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
+          AVAIL=$(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) + ${PREEMPTABLE_GPUS:-0}" | bc)
+          if [[ $(echo "$AVAIL - 20.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR (available+preemptible=$AVAIL < 20)"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
           ./setup/e2e.sh -c cks_fb -t modelservice --deep -l guidellm -w sanity_concurrent.yaml
         shell: bash
 
@@ -168,7 +183,8 @@ jobs:
         env:
           LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
         run: |
-          if [[ $(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) - 20.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
+          AVAIL=$(echo "$(kubectl-view-allocations -r gpu -o csv | grep resource,nvidia.com/gpu | cut -d ',' -f 11) + ${PREEMPTABLE_GPUS:-0}" | bc)
+          if [[ $(echo "$AVAIL - 20.00" | bc | cut -d '.' -f 1) -lt 0 ]]; then echo "LLM-D SIMULATOR (available+preemptible=$AVAIL < 20)"; sed -i 's^####^^g' scenarios/cicd/cks_fb.sh; fi
           ./setup/e2e.sh -c cks_fb -t modelservice --deep -l vllm-benchmark
         shell: bash
 


### PR DESCRIPTION
## Summary
- Adds a step to count GPUs held by negative-priority pods (e.g. `hpc-verification` at priority -1)
- Includes preemptable GPUs in the available count when deciding whether to fall back to simulator mode
- Affects all 4 GPU checks: standalone standup (10 GPU threshold) and 3 modelservice E2E steps (20 GPU threshold)

## Context
CKS cluster runs `hpc-verification` every hour for ~59 minutes at priority -1, consuming all 64 GPUs. Our benchmark pods at default priority 0 can preempt these, but the existing GPU check only sees "0 available" and falls back to simulator mode — meaning benchmarks never run on real GPUs when hpc-verification is active.

## Test plan
- [ ] Trigger CKS benchmark while hpc-verification is running
- [ ] Verify preemptable GPU count is logged correctly
- [ ] Verify benchmark runs on real GPUs instead of falling back to simulator