### PR TITLE
Fill in stack details from ev.yaml if ConfigMap unavailable

### DIFF
--- a/benchmark_report/core.py
+++ b/benchmark_report/core.py
@@ -38,7 +38,6 @@ def import_csv_with_header(file_path: str) -> dict[str, list[Any]]:
     Returns:
         dict: Imported data where the header provides key names.
     """
-    check_file(file_path)
     with open(file_path, "r", encoding="UTF-8") as file:
         for ii, line in enumerate(file):
             if ii == 0:
@@ -124,7 +123,6 @@ def import_yaml(file_path: str) -> dict[Any, Any]:
     Returns:
         dict: Imported data.
     """
-    check_file(file_path)
     with open(file_path, "r", encoding="UTF-8") as file:
         data = yaml.safe_load(file)
     return data
@@ -159,8 +157,6 @@ def import_benchmark_report(br_file: str) -> BenchmarkReport:
     Returns:
         BenchmarkReport: Imported benchmark report supplemented with run data.
     """
-    check_file(br_file)
-
     # Import benchmark report as a dict following the schema of BenchmarkReport
     br_dict = import_yaml(br_file)
 

--- a/benchmark_report/native_to_br0_2.py
+++ b/benchmark_report/native_to_br0_2.py
@@ -590,8 +590,17 @@ def _populate_benchmark_report_from_envars() -> dict:
     # Get configmap with standup parameters
     params_cm = get_configmap(context_dict, "llm-d-benchmark-standup-parameters")
 
-    ev_str: str = get_nested(params_cm, ["data", "ev.yaml"])
-    ev_dict = yaml.safe_load(ev_str) if ev_str else {}
+    if params_cm:
+        ev_str: str = get_nested(params_cm, ["data", "ev.yaml"])
+        ev_dict = yaml.safe_load(ev_str) if ev_str else {}
+    else:
+        # Could not get parameters from ConfigMap, try /standup/ev.yaml
+        try:
+            ev_file = "/standup/ev.yaml"
+            ev_dict = import_yaml(ev_file)
+        except Exception as e:
+            sys.stderr.write(f"Failed to retrieve {ev_file}: {e}\n")
+            ev_dict = {}
 
     # Fill in more run details
     update_dict(br_dict, _populate_run(ev_dict))


### PR DESCRIPTION
This PR adds the ability to import stack details from `/standup/ev.yaml` if the `llm-d-benchmark-standup-parameters` ConfigMap is unavailable.

The process with this PR looks like:
If `llm-d-benchmark-standup-parameters` ConfigMap is unavailable to fill in stack details in benchmark report, print an error message to `stderr` then try to import `/standup/ev.yaml`. If that fails, print another error message, and continue to generate the benchmark report with what is known.