### PR TITLE
Fix path handling for directories with space characters in run.sh and functions.sh

### DIFF
--- a/setup/functions.sh
+++ b/setup/functions.sh
@@ -654,9 +654,9 @@ function render_workload_templates {
 
     local workload=$(echo $workload | $LLMDBENCH_CONTROL_SCMD 's^\.yaml^^g' )
     if [[ $workload == "all" ]]; then
-      workload_template_list=$(find ${LLMDBENCH_HARNESS_PROFILES_DIR}/ -name "*.yaml.in")
+      workload_template_list=$(find "${LLMDBENCH_HARNESS_PROFILES_DIR}/" -name "*.yaml.in")
     else
-      workload_template_list=$(find ${LLMDBENCH_HARNESS_PROFILES_DIR}/ -name "${workload}.yaml.in")
+      workload_template_list=$(find "${LLMDBENCH_HARNESS_PROFILES_DIR}/" -name "${workload}.yaml.in")
     fi
 
     rm -f "$LLMDBENCH_CONTROL_WORK_DIR/workload/profiles/overrides.txt"
@@ -670,7 +670,7 @@ function render_workload_templates {
     fi
 
     announce "🛠️ Rendering \"$workload\" workload profile templates under \"${LLMDBENCH_HARNESS_PROFILES_DIR}\"..."
-    for workload_template_full_path in $workload_template_list; do
+    while IFS= read -r workload_template_full_path; do
       workload_template_type=$(echo ${workload_template_full_path} | rev | cut -d '/' -f 2 | rev)
       workload_template_file_name=$(echo ${workload_template_full_path} | rev | cut -d '/' -f 1 | rev | $LLMDBENCH_CONTROL_SCMD -e "s^\.yaml.in$^^g")
       workload_output_file="${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/$workload_template_type/$workload_template_file_name"
@@ -679,12 +679,12 @@ function render_workload_templates {
       if [[ -d "$treatment_list_dir" ]]; then
         for treatment in $(ls "$treatment_list_dir"); do
             workload_output_file_suffix=$(echo ${treatment} | cut -d '.' -f 1)
-            render_template $workload_template_full_path ${workload_output_file}_${workload_output_file_suffix}.yaml ${treatment_list_dir}/$treatment 0 0
+            render_template "$workload_template_full_path" "${workload_output_file}_${workload_output_file_suffix}.yaml" "${treatment_list_dir}/$treatment" 0 0
         done
       else
-        render_template $workload_template_full_path $workload_output_file.yaml $LLMDBENCH_CONTROL_WORK_DIR/workload/profiles/overrides.txt 0 0
+        render_template "$workload_template_full_path" "$workload_output_file.yaml" "$LLMDBENCH_CONTROL_WORK_DIR/workload/profiles/overrides.txt" 0 0
       fi
-    done
+    done < <(echo "$workload_template_list")
     announce "✅ Done rendering \"$workload\" workload profile templates to \"${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/\""
 }
 export -f render_workload_templates

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -17,11 +17,11 @@
 set -euo pipefail
 
 if [[ $0 != "-bash" ]]; then
-    pushd `dirname "$(realpath $0)"` > /dev/null 2>&1
+    pushd "`dirname "$(realpath $0)"`" > /dev/null 2>&1
 fi
 
 export LLMDBENCH_ENV_VAR_LIST=$(env | grep ^LLMDBENCH | cut -d '=' -f 1)
-export LLMDBENCH_CONTROL_DIR=$(realpath $(pwd)/)
+export LLMDBENCH_CONTROL_DIR=$(realpath "$(pwd)/")
 export LLMDBENCH_CONTROL_CALLER=$(echo $0 | rev | cut -d '/' -f 1 | rev)
 export LLMDBENCH_STEPS_DIR="$LLMDBENCH_CONTROL_DIR/steps"
 
@@ -29,9 +29,9 @@ if [ $0 != "-bash" ] ; then
     popd  > /dev/null 2>&1
 fi
 
-export LLMDBENCH_MAIN_DIR=$(realpath ${LLMDBENCH_CONTROL_DIR}/../)
+export LLMDBENCH_MAIN_DIR=$(realpath "${LLMDBENCH_CONTROL_DIR}/../")
 
-source ${LLMDBENCH_CONTROL_DIR}/env.sh
+source "${LLMDBENCH_CONTROL_DIR}/env.sh"
 
 export LLMDBENCH_CONTROL_DRY_RUN=${LLMDBENCH_CONTROL_DRY_RUN:-0}
 export LLMDBENCH_CONTROL_VERBOSE=${LLMDBENCH_CONTROL_VERBOSE:-0}
@@ -243,12 +243,12 @@ if [[ $LLMDBENCH_CONTROL_ENVIRONMENT_TYPE_STANDALONE_ACTIVE -eq 0 && $LLMDBENCH_
   fi
 fi
 
-$LLMDBENCH_CONTROL_PCMD ${LLMDBENCH_STEPS_DIR}/05_ensure_harness_namespace_prepared.py 2> ${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stderr.log 1> ${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stdout.log
+$LLMDBENCH_CONTROL_PCMD "${LLMDBENCH_STEPS_DIR}/05_ensure_harness_namespace_prepared.py" 2> "${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stderr.log" 1> "${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stdout.log"
 if [[ $? -ne 0 ]]; then
   announce "❌ Error while attempting to setup the harness namespace"
-  cat ${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stderr.log
+  cat "${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stderr.log"
   echo "---------------------------"
-  cat ${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stdout.log
+  cat "${LLMDBENCH_CONTROL_WORK_DIR}/setup/commands/05_ensure_harness_namespace_prepare_stdout.log"
   exit 1
 fi
 set -euo pipefail
@@ -448,17 +448,17 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
 
         generate_profile_parameter_treatments ${LLMDBENCH_HARNESS_NAME} ${LLMDBENCH_HARNESS_EXPERIMENT_TREATMENTS}
 
-        workload_template_full_path=$(find ${LLMDBENCH_HARNESS_PROFILES_DIR}/${LLMDBENCH_HARNESS_NAME}/ | grep ${LLMDBENCH_HARNESS_EXPERIMENT_PROFILE} | head -n 1 || true)
+        workload_template_full_path=$(find "${LLMDBENCH_HARNESS_PROFILES_DIR}/${LLMDBENCH_HARNESS_NAME}/"  | grep ${LLMDBENCH_HARNESS_EXPERIMENT_PROFILE} | head -n 1 || true)
         if [[ -z $workload_template_full_path ]]; then
-          announce "❌ Could not find workload template \"$LLMDBENCH_HARNESS_EXPERIMENT_PROFILE\" inside directory \"${LLMDBENCH_HARNESS_PROFILES_DIR}/${LLMDBENCH_HARNESS_NAME}/\" (variable $LLMDBENCH_HARNESS_EXPERIMENT_PROFILE)"
+    announce "❌ Could not find workload template \"$LLMDBENCH_HARNESS_EXPERIMENT_PROFILE\" inside directory \"${LLMDBENCH_HARNESS_PROFILES_DIR}/${LLMDBENCH_HARNESS_NAME}/\" (variable \$LLMDBENCH_HARNESS_EXPERIMENT_PROFILE)"
           exit 1
         fi
 
         render_workload_templates ${LLMDBENCH_HARNESS_EXPERIMENT_PROFILE}
         export LLMDBENCH_HARNESS_PROFILE_HARNESS_LIST=$LLMDBENCH_HARNESS_NAME
 
-        export LLMDBENCH_RUN_EXPERIMENT_HARNESS=$(find ${LLMDBENCH_MAIN_DIR}/workload/harnesses -name ${LLMDBENCH_HARNESS_NAME}* | rev | cut -d '/' -f1 | rev)
-        export LLMDBENCH_RUN_EXPERIMENT_ANALYZER=$(find ${LLMDBENCH_MAIN_DIR}/analysis/ -name ${LLMDBENCH_HARNESS_NAME}* | rev | cut -d '/' -f1 | rev)
+        export LLMDBENCH_RUN_EXPERIMENT_HARNESS=$(find "${LLMDBENCH_MAIN_DIR}/workload/harnesses" -name ${LLMDBENCH_HARNESS_NAME}* | rev | cut -d '/' -f1 | rev)
+        export LLMDBENCH_RUN_EXPERIMENT_ANALYZER=$(find "${LLMDBENCH_MAIN_DIR}/analysis/" -name ${LLMDBENCH_HARNESS_NAME}* | rev | cut -d '/' -f1 | rev)
 
       fi
 
@@ -469,13 +469,13 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
 
       export LLMDBENCH_RUN_EXPERIMENT_ID_PREFIX=""
 
-      for treatment in $(ls "${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/"*.yaml); do
+  for treatment in $(ls "${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/"*.yaml 2>/dev/null); do
 
         export LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME=$(echo $treatment | rev | cut -d '/' -f 1 | rev)
         export LLMDBENCH_HARNESS_EXPERIMENT_PROFILE=$(echo $treatment | rev | cut -d '/' -f 1 | rev)
 
         tf=$(cat ${treatment} | grep "#treatment" | tail -1 | "$LLMDBENCH_CONTROL_SCMD" 's/^#//' || true)
-        if [[ -f "${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/treatment_list/$tf" ]]; then
+        if [[ -f "${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/treatment_list/$tf" ]];  then
           tid=$(sed -e 's/[^[:alnum:]][^[:alnum:]]*/_/g' <<<"${tf%.txt}")   # remove non alphanumeric and .txt
           tid=${tid#treatment_}
           if [ -z "${LLMDBENCH_RUN_EXPERIMENT_ID}" ]; then
@@ -488,7 +488,7 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
           fi
 
           echo
-          cat ${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/treatment_list/$tf | grep -v ^1i# | cut -d '^' -f 3
+          cat "${LLMDBENCH_CONTROL_WORK_DIR}/workload/profiles/${workload_type}/treatment_list/$tf" | grep -v ^1i# | cut -d '^' -f 3
           echo
         fi
 
@@ -500,8 +500,8 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
           export LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_SUFFIX=${LLMDBENCH_HARNESS_NAME}_${LLMDBENCH_RUN_EXPERIMENT_ID}_${LLMDBENCH_HARNESS_STACK_NAME}
           export LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR=${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_PREFIX}/${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_SUFFIX}_${i}
 
-          local_results_dir=${LLMDBENCH_CONTROL_WORK_DIR}/results/${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_SUFFIX}
-          local_analysis_dir=${LLMDBENCH_CONTROL_WORK_DIR}/analysis/${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_SUFFIX}
+          local_results_dir="${LLMDBENCH_CONTROL_WORK_DIR}/results/${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_SUFFIX}"
+          local_analysis_dir="${LLMDBENCH_CONTROL_WORK_DIR}/analysis/${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_SUFFIX}"
           llmdbench_execute_cmd "mkdir -p \"${local_results_dir}_${i}\" && mkdir -p \"${local_analysis_dir}_${i}\"" \
                 "${LLMDBENCH_CONTROL_DRY_RUN}" \
                 "${LLMDBENCH_CONTROL_VERBOSE}"
@@ -518,7 +518,7 @@ for method in ${LLMDBENCH_DEPLOY_METHODS//,/ }; do
             if [[ "$LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE" == /* ]]; then
               potential_gaie_path=$(echo $LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE'.yaml' | $LLMDBENCH_CONTROL_SCMD 's^.yaml.yaml^.yaml^g')
             else
-              potential_gaie_path=$(echo ${LLMDBENCH_MAIN_DIR}/setup/presets/gaie/$LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE'.yaml' | $LLMDBENCH_CONTROL_SCMD 's^.yaml.yaml^.yaml^g')
+              potential_gaie_path=$(echo "${LLMDBENCH_MAIN_DIR}/setup/presets/gaie/$LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE".yaml | $LLMDBENCH_CONTROL_SCMD 's^.yaml.yaml^.yaml^g')
             fi
 
             if [[ -f $potential_gaie_path ]]; then


### PR DESCRIPTION
 ## Problem
Scripts in `setup/run.sh` and `setup/functions.sh` fail silently when llm-d-benchmark is installed in a directory containing space characters (e.g., `/home/user/My Projects/llm-d/llm-d-benchmark`).

 ## Root Cause
Unquoted path variables cause bash to split paths on spaces, leading to "No such file or directory" errors.

## Solution
- Quote all path variables in `pushd`, `realpath`, `source`, and `find` commands
- Quote all arguments to `render_template` function
- Change `for loop` to `while read loop` for proper handling of space characters in path variables
- Add error suppression to `ls` command in `treatment loop`

This fixes silent failures when llm-d-benchmark is installed in a directory path containing space characters.

## Testing
- ✅ Syntax validation passes: `bash -n setup/run.sh`
- ✅ Successfully executes on paths with spaces
- ✅ No regression on paths without spaces

## Files Changed
- `setup/run.sh`: 9 quoting fixes
- `setup/functions.sh`: 4 quoting fixes