### PR TITLE
🐛 Restore permissions for Copilot SWE agent assignment

### DIFF
--- a/.github/workflows/upstream-auto-fix.yml
+++ b/.github/workflows/upstream-auto-fix.yml
@@ -12,8 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: write      # Copilot SWE agent needs write to create branches
   issues: write
-  pull-requests: read
+  pull-requests: write # Copilot SWE agent needs write to create PRs
 
 jobs:
   assign-copilot:


### PR DESCRIPTION
## Problem
PR #747 reduced workflow permissions following a Copilot review recommendation. However, the Copilot SWE agent needs `contents: write` and `pull-requests: write` to create branches and PRs when assigned to an issue.

Test issue #749 confirmed the `Forbidden` error on assignment with reduced permissions.

## Fix
Restore `contents: write` and `pull-requests: write` with comments explaining why they're needed (matching kubestellar/console auto-qa pattern).

## Testing
- [x] Issue #749 triggered the workflow and showed `Forbidden` error
- [ ] After merge, will re-test with a new issue