### PR TITLE
Sync gh-aw workflows from llm-d-infra

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,0 +1,14 @@
+{
+  "entries": {
+    "actions/github-script@v8": {
+      "repo": "actions/github-script",
+      "version": "v8",
+      "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
+    },
+    "github/gh-aw/actions/setup@v0.45.0": {
+      "repo": "github/gh-aw/actions/setup",
+      "version": "v0.45.0",
+      "sha": "58d1d157fbac0f1204798500faefc4f7461ebe28"
+    }
+  }
+}

--- a/.github/workflows/link-checker.lock.yml
+++ b/.github/workflows/link-checker.lock.yml
@@ -1,12 +1,12 @@
 #
-#    ___                   _   _
-#   / _ \                 | | (_)
-#  | |_| | __ _  ___ _ __ | |_ _  ___
+#    ___                   _   _      
+#   / _ \                 | | (_)     
+#  | |_| | __ _  ___ _ __ | |_ _  ___ 
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__
+#  | | | | (_| |  __/ | | | |_| | (__ 
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/
+#  _    _ |___/ 
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
@@ -54,7 +54,7 @@ jobs:
       comment_repo: ""
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check workflow file timestamps
@@ -91,11 +91,11 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Create gh-aw temp directory
@@ -131,7 +131,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-
+            
             const awInfo = {
               engine_id: "copilot",
               engine_name: "GitHub Copilot CLI",
@@ -161,13 +161,13 @@ jobs:
               },
               created_at: new Date().toISOString()
             };
-
+            
             // Write to /tmp/gh-aw directory to avoid inclusion in PR
             const tmpPath = '/tmp/gh-aw/aw_info.json';
             fs.writeFileSync(tmpPath, JSON.stringify(awInfo, null, 2));
             console.log('Generated aw_info.json at:', tmpPath);
             console.log(JSON.stringify(awInfo, null, 2));
-
+            
             // Set model as output for reuse in other steps/jobs
             core.setOutput('model', awInfo.model);
       - name: Validate COPILOT_GITHUB_TOKEN secret
@@ -386,17 +386,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-
+          
           PORT=3001
-
+          
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-
+          
           echo "Safe Outputs MCP server will run on port ${PORT}"
-
+          
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -414,9 +414,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-
+          
           bash /opt/gh-aw/actions/start_safe_outputs_server.sh
-
+          
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -428,7 +428,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p /tmp/gh-aw/mcp-config
-
+          
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="80"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -438,10 +438,10 @@ jobs:
           export MCP_GATEWAY_PAYLOAD_DIR="/tmp/gh-aw/mcp-payloads"
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export DEBUG="*"
-
+          
           export GH_AW_ENGINE="copilot"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_LOCKDOWN -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.1.4'
-
+          
           mkdir -p /home/runner/.copilot
           cat << GH_AW_MCP_CONFIG_EOF | bash /opt/gh-aw/actions/start_mcp_gateway.sh
           {
@@ -507,9 +507,9 @@ jobs:
           </important>
           <instructions>
           To create or modify GitHub resources (issues, discussions, pull requests, etc.), you MUST call the appropriate safe output tool. Simply writing content will NOT work - the workflow requires actual tool calls.
-
-          Temporary IDs: Some safe output tools support a temporary ID field (usually named temporary_id) so you can reference newly-created items elsewhere in the SAME agent output (for example, using #aw_abc1 in a later body).
-
+          
+          Temporary IDs: Some safe output tools support a temporary ID field (usually named temporary_id) so you can reference newly-created items elsewhere in the SAME agent output (for example, using #aw_abc1 in a later body). 
+          
           **IMPORTANT - temporary_id format rules:**
           - If you DON'T need to reference the item later, OMIT the temporary_id field entirely (it will be auto-generated if needed)
           - If you DO need cross-references/chaining, you MUST match this EXACT validation regex: /^aw_[A-Za-z0-9]{3,8}$/i
@@ -518,13 +518,13 @@ jobs:
           - INVALID examples: aw_ab (too short), aw_123456789 (too long), aw_test-id (contains hyphen), aw_id_123 (contains underscore)
           - VALID examples: aw_abc, aw_abc1, aw_Test123, aw_A1B2C3D4, aw_12345678
           - To generate valid IDs: use 3-8 random alphanumeric characters or omit the field to let the system auto-generate
-
+          
           Do NOT invent other aw_* formats — downstream steps will reject them with validation errors matching against /^aw_[A-Za-z0-9]{3,8}$/i.
-
+          
           Discover available tools from the safeoutputs MCP server.
-
+          
           **Critical**: Tool calls write structured data that downstream jobs process. Without tool calls, follow-up actions will be skipped.
-
+          
           **Note**: If you made no other safe output tool calls during this workflow execution, call the "noop" tool to provide a status message indicating completion or that no actions were needed.
           </instructions>
           </safe-outputs>
@@ -555,7 +555,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-
+          
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF' >> "$GH_AW_PROMPT"
           </system>
@@ -579,7 +579,7 @@ jobs:
         with:
           script: |
             const substitutePlaceholders = require('/opt/gh-aw/actions/substitute_placeholders.cjs');
-
+            
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -657,7 +657,7 @@ jobs:
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
           LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
-
+          
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
@@ -796,12 +796,12 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -883,18 +883,18 @@ jobs:
       success: ${{ steps.parse_results.outputs.success }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent artifacts
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/threat-detection/
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/threat-detection/
@@ -979,7 +979,7 @@ jobs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -1018,12 +1018,12 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1045,3 +1045,4 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/safe_output_handler_manager.cjs');
             await main();
+

--- a/.github/workflows/link-checker.md
+++ b/.github/workflows/link-checker.md
@@ -50,7 +50,7 @@ Get the list of changed markdown files in this PR:
 gh pr diff ${{ github.event.pull_request.number }} --name-only | grep '\.md$'
 ```
 
-If no markdown files changed, exit cleanly with a message: "No markdown files changed in this PR."
+If no markdown files changed, exit immediately — do not post any comment.
 
 #### Step 2: Extract and Check Links
 
@@ -105,7 +105,7 @@ If ALL broken links are external and returned 5xx or timeout (i.e., all "possibl
 
 If there are definitely broken links (404, internal file missing), add the `broken-links` label.
 
-If all links are OK, do not post a comment.
+If all links are OK, exit immediately — do not post any comment. The CI status communicates success.
 
 ### Domain-Specific Knowledge
 

--- a/.github/workflows/typo-checker.lock.yml
+++ b/.github/workflows/typo-checker.lock.yml
@@ -1,12 +1,12 @@
 #
-#    ___                   _   _
-#   / _ \                 | | (_)
-#  | |_| | __ _  ___ _ __ | |_ _  ___
+#    ___                   _   _      
+#   / _ \                 | | (_)     
+#  | |_| | __ _  ___ _ __ | |_ _  ___ 
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__
+#  | | | | (_| |  __/ | | | |_| | (__ 
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/
+#  _    _ |___/ 
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
@@ -56,7 +56,7 @@ jobs:
       comment_repo: ""
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check workflow file timestamps
@@ -93,11 +93,11 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Create gh-aw temp directory
@@ -133,7 +133,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-
+            
             const awInfo = {
               engine_id: "copilot",
               engine_name: "GitHub Copilot CLI",
@@ -163,13 +163,13 @@ jobs:
               },
               created_at: new Date().toISOString()
             };
-
+            
             // Write to /tmp/gh-aw directory to avoid inclusion in PR
             const tmpPath = '/tmp/gh-aw/aw_info.json';
             fs.writeFileSync(tmpPath, JSON.stringify(awInfo, null, 2));
             console.log('Generated aw_info.json at:', tmpPath);
             console.log(JSON.stringify(awInfo, null, 2));
-
+            
             // Set model as output for reuse in other steps/jobs
             core.setOutput('model', awInfo.model);
       - name: Validate COPILOT_GITHUB_TOKEN secret
@@ -352,17 +352,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-
+          
           PORT=3001
-
+          
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-
+          
           echo "Safe Outputs MCP server will run on port ${PORT}"
-
+          
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -380,9 +380,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-
+          
           bash /opt/gh-aw/actions/start_safe_outputs_server.sh
-
+          
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -394,7 +394,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p /tmp/gh-aw/mcp-config
-
+          
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="80"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -404,10 +404,10 @@ jobs:
           export MCP_GATEWAY_PAYLOAD_DIR="/tmp/gh-aw/mcp-payloads"
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export DEBUG="*"
-
+          
           export GH_AW_ENGINE="copilot"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_LOCKDOWN -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.1.4'
-
+          
           mkdir -p /home/runner/.copilot
           cat << GH_AW_MCP_CONFIG_EOF | bash /opt/gh-aw/actions/start_mcp_gateway.sh
           {
@@ -473,9 +473,9 @@ jobs:
           </important>
           <instructions>
           To create or modify GitHub resources (issues, discussions, pull requests, etc.), you MUST call the appropriate safe output tool. Simply writing content will NOT work - the workflow requires actual tool calls.
-
-          Temporary IDs: Some safe output tools support a temporary ID field (usually named temporary_id) so you can reference newly-created items elsewhere in the SAME agent output (for example, using #aw_abc1 in a later body).
-
+          
+          Temporary IDs: Some safe output tools support a temporary ID field (usually named temporary_id) so you can reference newly-created items elsewhere in the SAME agent output (for example, using #aw_abc1 in a later body). 
+          
           **IMPORTANT - temporary_id format rules:**
           - If you DON'T need to reference the item later, OMIT the temporary_id field entirely (it will be auto-generated if needed)
           - If you DO need cross-references/chaining, you MUST match this EXACT validation regex: /^aw_[A-Za-z0-9]{3,8}$/i
@@ -484,13 +484,13 @@ jobs:
           - INVALID examples: aw_ab (too short), aw_123456789 (too long), aw_test-id (contains hyphen), aw_id_123 (contains underscore)
           - VALID examples: aw_abc, aw_abc1, aw_Test123, aw_A1B2C3D4, aw_12345678
           - To generate valid IDs: use 3-8 random alphanumeric characters or omit the field to let the system auto-generate
-
+          
           Do NOT invent other aw_* formats — downstream steps will reject them with validation errors matching against /^aw_[A-Za-z0-9]{3,8}$/i.
-
+          
           Discover available tools from the safeoutputs MCP server.
-
+          
           **Critical**: Tool calls write structured data that downstream jobs process. Without tool calls, follow-up actions will be skipped.
-
+          
           **Note**: If you made no other safe output tool calls during this workflow execution, call the "noop" tool to provide a status message indicating completion or that no actions were needed.
           </instructions>
           </safe-outputs>
@@ -521,7 +521,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-
+          
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF' >> "$GH_AW_PROMPT"
           </system>
@@ -545,7 +545,7 @@ jobs:
         with:
           script: |
             const substitutePlaceholders = require('/opt/gh-aw/actions/substitute_placeholders.cjs');
-
+            
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -623,7 +623,7 @@ jobs:
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
           LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
-
+          
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
@@ -762,12 +762,12 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -849,18 +849,18 @@ jobs:
       success: ${{ steps.parse_results.outputs.success }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent artifacts
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/threat-detection/
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/threat-detection/
@@ -945,7 +945,7 @@ jobs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check team membership for workflow
@@ -984,12 +984,12 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1011,3 +1011,4 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/safe_output_handler_manager.cjs');
             await main();
+

--- a/.github/workflows/typo-checker.md
+++ b/.github/workflows/typo-checker.md
@@ -47,7 +47,7 @@ Filter to relevant file types (skip binary files, lock files, generated files):
 - Include: `*.md`, `*.yml`, `*.yaml`, `*.go`, `*.py`, `*.sh`, `*.txt`, `*.json`, `*.toml`
 - Exclude: `*.lock.yml`, `*.lock`, `*_generated*`, `vendor/`, `node_modules/`, `*.pb.go`
 
-If no relevant files changed, exit cleanly.
+If no relevant files changed, exit immediately — do not post any comment.
 
 #### Step 2: Get Changed Content
 
@@ -125,7 +125,7 @@ This checker recognizes llm-d domain terminology. If a valid term was incorrectl
 </details>
 ```
 
-If no typos are found, do not post a comment.
+If no typos are found, exit immediately — do not post any comment. The CI status communicates success.
 
 ### Important Rules
 

--- a/.github/workflows/upstream-monitor.lock.yml
+++ b/.github/workflows/upstream-monitor.lock.yml
@@ -1,12 +1,12 @@
 #
-#    ___                   _   _
-#   / _ \                 | | (_)
-#  | |_| | __ _  ___ _ __ | |_ _  ___
+#    ___                   _   _      
+#   / _ \                 | | (_)     
+#  | |_| | __ _  ___ _ __ | |_ _  ___ 
 #  |  _  |/ _` |/ _ \ '_ \| __| |/ __|
-#  | | | | (_| |  __/ | | | |_| | (__
+#  | | | | (_| |  __/ | | | |_| | (__ 
 #  \_| |_/\__, |\___|_| |_|\__|_|\___|
 #          __/ |
-#  _    _ |___/
+#  _    _ |___/ 
 # | |  | |                / _| |
 # | |  | | ___ _ __ _  __| |_| | _____      ____
 # | |/\| |/ _ \ '__| |/ /|  _| |/ _ \ \ /\ / / ___|
@@ -22,11 +22,11 @@
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
 # Monitors upstream dependencies for new releases and breaking changes.
-# Runs daily to check tracked upstream projects. Creates GitHub issues
-# when breaking changes are detected that affect this repository's code,
-# configuration, or CI pipelines.
+# Runs daily to check tracked upstream projects. A shell pre-check script
+# detects version changes deterministically; the agent only runs when
+# changes are found, dramatically reducing token consumption on quiet days.
 #
-# frontmatter-hash: b8a1eb3bc6aa9a27f087b1b3aee4d06468c5fab874fadc81fe47fd14641a8903
+# frontmatter-hash: a091783488657b66775c999105e014fc954f28de71a9b2e09983fa0c30384a1a
 
 name: "Upstream Dependency Monitor"
 "on":
@@ -51,7 +51,7 @@ jobs:
       comment_repo: ""
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Check workflow file timestamps
@@ -90,11 +90,11 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Checkout repository
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Create gh-aw temp directory
@@ -130,7 +130,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-
+            
             const awInfo = {
               engine_id: "copilot",
               engine_name: "GitHub Copilot CLI",
@@ -160,13 +160,13 @@ jobs:
               },
               created_at: new Date().toISOString()
             };
-
+            
             // Write to /tmp/gh-aw directory to avoid inclusion in PR
             const tmpPath = '/tmp/gh-aw/aw_info.json';
             fs.writeFileSync(tmpPath, JSON.stringify(awInfo, null, 2));
             console.log('Generated aw_info.json at:', tmpPath);
             console.log(JSON.stringify(awInfo, null, 2));
-
+            
             // Set model as output for reuse in other steps/jobs
             core.setOutput('model', awInfo.model);
       - name: Validate COPILOT_GITHUB_TOKEN secret
@@ -424,17 +424,17 @@ jobs:
           # Mask immediately to prevent timing vulnerabilities
           API_KEY=$(openssl rand -base64 45 | tr -d '/+=')
           echo "::add-mask::${API_KEY}"
-
+          
           PORT=3001
-
+          
           # Set outputs for next steps
           {
             echo "safe_outputs_api_key=${API_KEY}"
             echo "safe_outputs_port=${PORT}"
           } >> "$GITHUB_OUTPUT"
-
+          
           echo "Safe Outputs MCP server will run on port ${PORT}"
-
+          
       - name: Start Safe Outputs MCP HTTP Server
         id: safe-outputs-start
         env:
@@ -452,9 +452,9 @@ jobs:
           export GH_AW_SAFE_OUTPUTS_TOOLS_PATH
           export GH_AW_SAFE_OUTPUTS_CONFIG_PATH
           export GH_AW_MCP_LOG_DIR
-
+          
           bash /opt/gh-aw/actions/start_safe_outputs_server.sh
-
+          
       - name: Start MCP Gateway
         id: start-mcp-gateway
         env:
@@ -466,7 +466,7 @@ jobs:
         run: |
           set -eo pipefail
           mkdir -p /tmp/gh-aw/mcp-config
-
+          
           # Export gateway environment variables for MCP config and gateway script
           export MCP_GATEWAY_PORT="80"
           export MCP_GATEWAY_DOMAIN="host.docker.internal"
@@ -476,10 +476,10 @@ jobs:
           export MCP_GATEWAY_PAYLOAD_DIR="/tmp/gh-aw/mcp-payloads"
           mkdir -p "${MCP_GATEWAY_PAYLOAD_DIR}"
           export DEBUG="*"
-
+          
           export GH_AW_ENGINE="copilot"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_LOCKDOWN -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.1.4'
-
+          
           mkdir -p /home/runner/.copilot
           cat << GH_AW_MCP_CONFIG_EOF | bash /opt/gh-aw/actions/start_mcp_gateway.sh
           {
@@ -545,9 +545,9 @@ jobs:
           </important>
           <instructions>
           To create or modify GitHub resources (issues, discussions, pull requests, etc.), you MUST call the appropriate safe output tool. Simply writing content will NOT work - the workflow requires actual tool calls.
-
-          Temporary IDs: Some safe output tools support a temporary ID field (usually named temporary_id) so you can reference newly-created items elsewhere in the SAME agent output (for example, using #aw_abc1 in a later body).
-
+          
+          Temporary IDs: Some safe output tools support a temporary ID field (usually named temporary_id) so you can reference newly-created items elsewhere in the SAME agent output (for example, using #aw_abc1 in a later body). 
+          
           **IMPORTANT - temporary_id format rules:**
           - If you DON'T need to reference the item later, OMIT the temporary_id field entirely (it will be auto-generated if needed)
           - If you DO need cross-references/chaining, you MUST match this EXACT validation regex: /^aw_[A-Za-z0-9]{3,8}$/i
@@ -556,13 +556,13 @@ jobs:
           - INVALID examples: aw_ab (too short), aw_123456789 (too long), aw_test-id (contains hyphen), aw_id_123 (contains underscore)
           - VALID examples: aw_abc, aw_abc1, aw_Test123, aw_A1B2C3D4, aw_12345678
           - To generate valid IDs: use 3-8 random alphanumeric characters or omit the field to let the system auto-generate
-
+          
           Do NOT invent other aw_* formats — downstream steps will reject them with validation errors matching against /^aw_[A-Za-z0-9]{3,8}$/i.
-
+          
           Discover available tools from the safeoutputs MCP server.
-
+          
           **Critical**: Tool calls write structured data that downstream jobs process. Without tool calls, follow-up actions will be skipped.
-
+          
           **Note**: If you made no other safe output tool calls during this workflow execution, call the "noop" tool to provide a status message indicating completion or that no actions were needed.
           </instructions>
           </safe-outputs>
@@ -593,7 +593,7 @@ jobs:
           - **workflow-run-id**: __GH_AW_GITHUB_RUN_ID__
           {{/if}}
           </github-context>
-
+          
           GH_AW_PROMPT_EOF
           cat << 'GH_AW_PROMPT_EOF' >> "$GH_AW_PROMPT"
           </system>
@@ -617,7 +617,7 @@ jobs:
         with:
           script: |
             const substitutePlaceholders = require('/opt/gh-aw/actions/substitute_placeholders.cjs');
-
+            
             // Call the substitution function
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
@@ -658,7 +658,7 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        timeout-minutes: 30
+        timeout-minutes: 20
         run: |
           set -o pipefail
           sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --allow-domains '*.githubusercontent.com,*.pythonhosted.org,anaconda.org,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,binstar.org,bootstrap.pypa.io,codeload.github.com,conda.anaconda.org,conda.binstar.org,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,files.pythonhosted.org,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pip.pypa.io,ppa.launchpad.net,pypi.org,pypi.python.org,raw.githubusercontent.com,registry.npmjs.org,repo.anaconda.com,repo.continuum.io,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.18.0 --skip-pull \
@@ -694,7 +694,7 @@ jobs:
           # This ensures they are in /tmp/gh-aw/ where secret redaction can scan them
           SESSION_STATE_DIR="$HOME/.copilot/session-state"
           LOGS_DIR="/tmp/gh-aw/sandbox/agent/logs"
-
+          
           if [ -d "$SESSION_STATE_DIR" ]; then
             echo "Copying Copilot session state files from $SESSION_STATE_DIR to $LOGS_DIR"
             mkdir -p "$LOGS_DIR"
@@ -832,12 +832,12 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -921,18 +921,18 @@ jobs:
       success: ${{ steps.parse_results.outputs.success }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent artifacts
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-artifacts
           path: /tmp/gh-aw/threat-detection/
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/threat-detection/
@@ -945,7 +945,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           WORKFLOW_NAME: "Upstream Dependency Monitor"
-          WORKFLOW_DESCRIPTION: "Monitors upstream dependencies for new releases and breaking changes.\nRuns daily to check tracked upstream projects. Creates GitHub issues\nwhen breaking changes are detected that affect this repository's code,\nconfiguration, or CI pipelines."
+          WORKFLOW_DESCRIPTION: "Monitors upstream dependencies for new releases and breaking changes.\nRuns daily to check tracked upstream projects. A shell pre-check script\ndetects version changes deterministically; the agent only runs when\nchanges are found, dramatically reducing token consumption on quiet days."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1032,12 +1032,12 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Setup Scripts
-        uses: github/gh-aw/actions/setup@v0.50.4
+        uses: github/gh-aw/actions/setup@58d1d157fbac0f1204798500faefc4f7461ebe28 # v0.45.0
         with:
           destination: /opt/gh-aw/actions
       - name: Download agent output artifact
         continue-on-error: true
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: agent-output
           path: /tmp/gh-aw/safeoutputs/
@@ -1059,3 +1059,4 @@ jobs:
             setupGlobals(core, github, context, exec, io);
             const { main } = require('/opt/gh-aw/actions/safe_output_handler_manager.cjs');
             await main();
+

--- a/.github/workflows/upstream-monitor.md
+++ b/.github/workflows/upstream-monitor.md
@@ -1,9 +1,9 @@
 ---
 description: |
   Monitors upstream dependencies for new releases and breaking changes.
-  Runs daily to check tracked upstream projects. Creates GitHub issues
-  when breaking changes are detected that affect this repository's code,
-  configuration, or CI pipelines.
+  Runs daily to check tracked upstream projects. A shell pre-check script
+  detects version changes deterministically; the agent only runs when
+  changes are found, dramatically reducing token consumption on quiet days.
 
 on:
   schedule:
@@ -30,7 +30,7 @@ tools:
   web-fetch:
   bash: [ ":*" ]
 
-timeout-minutes: 30
+timeout-minutes: 20
 ---
 
 # Upstream Dependency Monitor
@@ -43,94 +43,100 @@ Your name is ${{ github.workflow }}. You are an **Upstream Dependency Monitor** 
 
 Detect upstream dependency releases that may break builds, deployments, or CI pipelines in this repository — before contributors hit the wall.
 
-### Tracked Dependencies
+### Efficiency Rules (READ FIRST)
 
-Read the file `docs/upstream-versions.md` to get the current version pins and file locations. That file is the **single source of truth** for what we track.
+You MUST follow these rules to minimize token usage:
 
-If `docs/upstream-versions.md` does not exist or is empty, exit cleanly — there are no tracked dependencies yet.
+1. **Run the pre-check script as your very first action** — it handles all version checking deterministically
+2. **If no changes detected, stop immediately** — do not explore further
+3. **Never manually check dependency versions** — the script already did this
+4. **Batch all grep operations** into single commands using `\|` alternation
+5. **Limit all command output** with `| head -20` to avoid flooding context
+6. **Keep issue bodies concise** — bullet points, not paragraphs
 
-### Your Workflow
+### Step 1: Run Pre-Check Script (MANDATORY FIRST STEP)
 
-#### Step 1: Load Current Pins
+Download and run the deterministic pre-check script that checks all tracked dependencies for new releases.
 
-Read `docs/upstream-versions.md` to understand:
-- Which version/SHA is currently pinned for each dependency
-- Which files contain those pins (Dockerfile, go.mod, helmfile, workflow YAML, etc.)
-- The upstream repository for each dependency
+> **Note**: The script is sourced from the org-owned `llm-d/llm-d-infra` repo's `main` branch.
+> Branch protection and required reviews guard against unauthorized changes.
+> Pinning to a commit SHA is impractical here because the script is updated in the same repo
+> and would require coordinated SHA updates across all consuming repos on every change.
 
-#### Step 2: Check for New Releases
+```bash
+curl -sfL https://raw.githubusercontent.com/llm-d/llm-d-infra/main/scripts/check-upstream-releases.sh | bash || true
+```
 
-For each tracked dependency:
+Then read the results:
 
-1. Use the GitHub API via bash to check for new releases:
+```bash
+cat /tmp/upstream-check-results.json
+```
+
+**Decision point based on the JSON output:**
+
+- If `"changed_count": 0` → Stop immediately. All dependencies are up to date. No further action needed.
+- If `"error"` is present at the top level → Stop and report the error. The script could not run properly.
+- If `"changed_count"` > 0 → Continue to Step 2 with **only** the dependencies listed in `"changes"`.
+
+### Step 2: Check for Duplicate Issues
+
+Before creating any issues, check if they already exist for the changed dependencies:
+
+```bash
+gh issue list --state open --search 'label:"upstream-breaking-change" OR label:"upstream-update"' --json title,number --jq '.[].title'
+```
+
+If an open issue already covers a dependency's version bump (same dependency name and target version in the title), skip that dependency entirely.
+
+### Step 3: Analyze Breaking Changes (Changed Dependencies Only)
+
+For each changed dependency from the JSON that does not already have an open issue:
+
+1. **Fetch the release notes** using web-fetch on the `release_url` from the JSON output
+2. **Scan for breaking changes** — look for keywords: "BREAKING", "removed", "renamed", "deprecated", major version bumps
+3. **If potentially breaking, check impact on this repo:**
    ```bash
-   gh api repos/{owner}/{repo}/releases/latest --jq '.tag_name'
+   grep -rn "PATTERN1\|PATTERN2\|PATTERN3" . --include="*.go" --include="*.py" --include="*.yaml" --include="*.yml" --include="*.sh" --include="Dockerfile*" --include="*.toml" | head -20
    ```
-
-2. For commit-SHA-pinned deps, check if the pinned commit is behind the latest tag:
-   ```bash
-   gh api repos/{owner}/{repo}/compare/{pinned_sha}...HEAD --jq '.ahead_by'
-   ```
-
-3. For PyPI packages, check the latest version:
-   ```bash
-   curl -s https://pypi.org/pypi/{package}/json | jq -r '.info.version'
-   ```
-
-4. Compare with the version in `docs/upstream-versions.md`
-
-#### Step 3: Analyze Breaking Changes
-
-When a new release is detected, analyze it for breaking changes:
-
-1. **Fetch the changelog/release notes** using web-fetch on the release page
-2. **Check the diff between pinned version and latest** for:
-   - Renamed CLI arguments, flags, or environment variables
-   - Changed API signatures, function names, or class names
-   - Modified configuration parameter names or formats
-   - Helm chart `values.yaml` schema changes
-   - Removed or renamed exported symbols
-   - Protocol or wire format changes
-   - Minimum version requirement bumps (Go, Python, Node, etc.)
-
-3. **Cross-reference against this repository's usage** by grepping:
-   ```bash
-   grep -r "old_name_or_flag" . --include="*.go" --include="*.py" --include="*.yaml" --include="*.yml" --include="*.md" --include="Dockerfile*" --include="*.toml"
-   ```
-
-4. **Classify the impact**:
+4. **Classify the impact:**
    - **CRITICAL**: Breaks builds or deployments immediately
    - **HIGH**: Breaks specific configurations or workflows
    - **MEDIUM**: May affect optional features or future upgrades
    - **LOW**: Informational — new version available, no breaking changes detected
 
-#### Step 4: Report Findings
+### Step 4: Create Issues
+
+Create GitHub issues for changed dependencies using the `create_issue` safe output.
 
 **For breaking changes (CRITICAL/HIGH):**
-Create a GitHub issue with:
 - Title: `[Upstream Breaking Change] {project} {old_version} → {new_version}`
-- Body: what changed, which files are affected (with paths and line numbers), suggested fixes, links to upstream release notes
 - Labels: `upstream-breaking-change`, `critical` or `high`
 
-**For non-breaking new releases (MEDIUM/LOW):**
-Create a GitHub issue with:
+**For non-breaking updates (MEDIUM/LOW):**
 - Title: `[Upstream Update] {project} {old_version} → {new_version}`
 - Labels: `upstream-update`, `medium` or `low`
 
-**If no new releases detected:** Exit cleanly, no issues created.
+**Issue body should include (keep concise):**
+- Current pin vs new version
+- File locations that need updating (from the pre-check JSON)
+- Breaking changes summary (2-3 bullet points max)
+- Link to upstream release notes
+- Suggested action
+
+If multiple dependencies changed, combine them into a single issue titled:
+`[Upstream Updates] {count} dependencies have new releases`
 
 ### Important Rules
 
-1. **Never create duplicate issues.** Search existing open issues first:
-   ```bash
-   gh issue list --label upstream-breaking-change --state open --search "{project}"
-   gh issue list --label upstream-update --state open --search "{project}"
-   ```
-2. **Be specific about what breaks.** Map changes to specific files in the repo.
+1. **Never create duplicate issues.** Always check existing open issues first.
+2. **Be specific about what breaks.** Include file paths and line numbers.
 3. **Always include the upstream release URL** in the issue body.
-4. **Watch for transitive breaks** — e.g., a Go dependency bump that requires a newer Go version.
+4. **Watch for transitive breaks** — e.g., a dependency bump that requires a newer Go or Python version.
 
 ### Exit Conditions
-- Exit if `docs/upstream-versions.md` does not exist or is empty
-- Exit if no upstream projects have new releases since last check
-- Exit if GitHub API rate limits are exceeded (log a warning)
+
+- Exit immediately if the pre-check script reports 0 changes
+- Exit if `docs/upstream-versions.md` does not exist (script will report this as an error)
+- Exit if the pre-check script encounters a rate limit error
+- Exit if all changed dependencies already have open issues


### PR DESCRIPTION
## Automated gh-aw Workflow Sync

This PR syncs the pre-compiled gh-aw workflows from [`llm-d/llm-d-infra`](https://github.com/llm-d/llm-d-infra).

### Synced workflows
- `upstream-monitor.md` + `upstream-monitor.lock.yml` — daily upstream dependency monitor
- `link-checker.md` + `link-checker.lock.yml` — PR link checker
- `typo-checker.md` + `typo-checker.lock.yml` — PR typo checker

### What to do
1. Review the diff
2. Merge — no `gh aw compile` needed, lock files are pre-compiled

> Created by the [sync workflow](https://github.com/llm-d/llm-d-infra/actions) in llm-d-infra.