### PR TITLE
remove accessLogging for helm chart schema validation error

### DIFF
--- a/setup/steps/07_deploy_setup.py
+++ b/setup/steps/07_deploy_setup.py
@@ -19,7 +19,6 @@ def gateway_values(provider: str, host: str, service: str, ev: dict) -> str:
   gatewayClassName: istio
   gatewayParameters:
     enabled: true
-    accessLogging: false
     logLevel: error
     resources:
       limits:


### PR DESCRIPTION
This fix is to match with the `llm-d-infra` chart otherwise it'll cause the following error: 
```bash
STDERR:
  Error: values don't meet the specifications of the schema(s) in the following chart(s):
  llm-d-infra:
  - at '/gateway/gatewayParameters': additional properties 'accessLogging' not allowed

COMBINED OUTPUT:
  Release "infra-llmdbench" does not exist. Installing it now.
  Error: values don't meet the specifications of the schema(s) in the following chart(s):
  llm-d-infra:
  - at '/gateway/gatewayParameters': additional properties 'accessLogging' not allowed

2026-03-24 18:08:22,387 - ERROR - ❌  Failed Failed installing chart "infra-llmdbench" (exit code: 1)
```