### PR TITLE
[Run] Add pre/post workload hooks to run_only.sh

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-30T10:06:26Z",
+  "generated_at": "2026-03-28T18:30:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,11 +77,130 @@
     }
   ],
   "results": {
-    "hack/deploy/env.sh": [
+    "analysis/analysis.ipynb": [
       {
-        "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
+        "hashed_secret": "9544acdf7fa427b600b5fa585603ff4cba075a23",
         "is_verified": false,
-        "line_number": 12,
+        "line_number": 214,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f3b2be733e289651eff4d2cda8a767570eb1ac5e",
+        "is_verified": false,
+        "line_number": 278,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "38614f50621d39de5243d64d74e1c3a72d325194",
+        "is_verified": false,
+        "line_number": 345,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bf74bc9ee145a327bec0b870af5b08208d931e94",
+        "is_verified": false,
+        "line_number": 594,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "224bf292272788ab38bb2f87505e6ac627c73803",
+        "is_verified": false,
+        "line_number": 604,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff6ac99e61becc289589353a7374ecb26840d1d6",
+        "is_verified": false,
+        "line_number": 704,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9ec87b4e234619e731cc83c8df6cb3a827541cc9",
+        "is_verified": false,
+        "line_number": 766,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "benchmark_report/README.md": [
+      {
+        "hashed_secret": "6f146252d0ecb24c0210d7ca13e9c31ace9d327a",
+        "is_verified": false,
+        "line_number": 102,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61b50a7436c6fe203c603ffbf3b522456da6630d",
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4bcd972e67085a8e67c0b1f4770b1192f65c9156",
+        "is_verified": false,
+        "line_number": 135,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "benchmark_report/br_v0_2_example.yaml": [
+      {
+        "hashed_secret": "ea269867b057855f42084f04739114058bb26bb5",
+        "is_verified": false,
+        "line_number": 207,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "docs/tutorials/run/run_interactively_example.md": [
+      {
+        "hashed_secret": "3a0d729c8109be0c4aa5d37a1f90da7a9bae0720",
+        "is_verified": false,
+        "line_number": 319,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "existing_stack/config_template.yaml": [
+      {
+        "hashed_secret": "4aa354112755c1753cf93ba7f388ccfb63b64338",
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "scenarios/cicd/kind_sim_fb.sh": [
+      {
+        "hashed_secret": "bfd771eeaca535a4c1080bc1a6667640c9c6799e",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "scenarios/cicd/ocp_fb.sh": [
+      {
+        "hashed_secret": "bfd771eeaca535a4c1080bc1a6667640c9c6799e",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "setup/env.sh": [
+      {
+        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
+        "is_verified": false,
+        "line_number": 118,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/existing_stack/config_template.yaml
+++ b/existing_stack/config_template.yaml
@@ -26,6 +26,10 @@ env:
   - name: RAYON_NUM_THREADS
     value: "4"
 
+# hooks:                            # optional: scripts to run on the harness pod between workloads
+#   pre_workload: "echo 'preparing for workload'"       # runs before each workload
+#   post_workload: "echo 'cleaning up after workload'"  # runs after each workload
+
 workload:                         # yaml configuration for harness workload(s)
   
   # an example workload using random synthetic data

--- a/existing_stack/run_only.sh
+++ b/existing_stack/run_only.sh
@@ -41,6 +41,8 @@ Usage: ${_script_name} -c <config-file> [options]
     -c/--config path to configuration file
     -o/--output destination for the results. (e.g. local/folder, gs://my-bucket, s3://my-bucket)
     -R/--repeat number of times to repeat the experiment (default: 1). Results are aggregated with mean/std dev.
+    --pre-workload bash script to run on the harness pod before each workload (overrides config hooks.pre_workload)
+    --post-workload bash script to run on the harness pod after each workload (overrides config hooks.post_workload)
     -v/--verbose print the command being executed, and result
     -d/--debug execute harness in "debug-mode"
     -n/--dry-run do not execute commands, just print what would be executed
@@ -261,6 +263,20 @@ while [[ $# -gt 0 ]]; do
         _repeat="$2"
         shift
         ;;
+        --pre-workload=*)
+        _cli_pre_workload=$(echo $key | cut -d '=' -f 2-)
+        ;;
+        --pre-workload)
+        _cli_pre_workload="$2"
+        shift
+        ;;
+        --post-workload=*)
+        _cli_post_workload=$(echo $key | cut -d '=' -f 2-)
+        ;;
+        --post-workload)
+        _cli_post_workload="$2"
+        shift
+        ;;
         -n|--dry-run)
         export $kubectl=1
         ;;
@@ -297,6 +313,16 @@ if ! [[ -f $_config_file  ]]; then
   exit 1
 fi
 eval $( yq -o shell '. | del(.workload)| del (.env)' "$_config_file")
+
+# Resolve workload hooks (CLI flags override config file values)
+# ========================================================
+_pre_workload="${_cli_pre_workload:-${hooks_pre_workload:-}}"
+_post_workload="${_cli_post_workload:-${hooks_post_workload:-}}"
+if [[ -n "$_pre_workload" || -n "$_post_workload" ]]; then
+  announce "ℹ️ Workload hooks configured:
+  pre_workload: ${_pre_workload:-(none)}
+  post_workload: ${_post_workload:-(none)}"
+fi
 
 # Verify output destination
 # ========================================================
@@ -500,6 +526,16 @@ for _run_idx in $(seq 1 $_repeat); do
       _run_experiment_id="${_uid}_${workload}"
     fi
     announce "ℹ️ Running benchmark with workload ${workload} (experiment_id=${_run_experiment_id})."
+
+    # Run pre-workload hook
+    if [[ -n "${_pre_workload}" ]]; then
+      announce "🔧 Running pre-workload hook..."
+      $control_kubectl exec -i ${_pod_name} -n ${harness_namespace} -- bash -c "${_pre_workload}"
+      if [[ $? -ne 0 ]]; then
+        announce "⚠️ Warning: pre-workload hook failed for workload ${workload}."
+      fi
+    fi
+
     run_workload=$(cat <<RUN_WORKLOAD
     # redirect to root fds so that kubectl logs can capture output
     exec 1> >(tee /proc/1/fd/1 >&1)
@@ -512,6 +548,16 @@ RUN_WORKLOAD
     )
     : | ${_timeout} $control_kubectl exec -i ${_pod_name} -n ${harness_namespace} -- bash -c "$run_workload"
     res=$?
+
+    # Run post-workload hook
+    if [[ -n "${_post_workload}" ]]; then
+      announce "🔧 Running post-workload hook..."
+      $control_kubectl exec -i ${_pod_name} -n ${harness_namespace} -- bash -c "${_post_workload}"
+      if [[ $? -ne 0 ]]; then
+        announce "⚠️ Warning: post-workload hook failed for workload ${workload}."
+      fi
+    fi
+
     if [ $res -eq 0 ]; then
       announce "ℹ️ Benchmark workload ${workload} (repeat ${_run_idx}/${_repeat}) complete."
     elif [ $res -eq 124 ]; then


### PR DESCRIPTION
## Summary

Adds support for user-defined bash scripts that run on the harness pod before and after each workload execution. Closes #718.

### Two ways to configure hooks

**1. Config YAML** — add a `hooks` section:
```yaml
hooks:
  pre_workload: "echo 'clearing cache' && sync"
  post_workload: "nvidia-smi --query-gpu=utilization.gpu --format=csv >> /tmp/gpu_snapshots.log"
```

**2. CLI flags** (override config values):
```bash
./existing_stack/run_only.sh -c config.yaml \
  --pre-workload "echo preparing" \
  --post-workload "echo cleanup done"
```

### Use cases
- Clear KV caches or warm-up state between workloads
- Collect GPU state snapshots before/after each benchmark
- Restart sidecar services between runs
- Reset test conditions for reproducible benchmarking

### Changes
- `existing_stack/run_only.sh`: Add `--pre-workload` / `--post-workload` CLI flags, resolve hooks from config (`hooks.pre_workload` / `hooks.post_workload`) with CLI override, execute hooks via `kubectl exec` on the harness pod before/after each workload
- `existing_stack/config_template.yaml`: Add commented-out `hooks` section as documentation

### Backward compatible
No behavior change when hooks are not configured. Hook failures produce warnings but do not abort the benchmark run.

## Test plan

- [ ] Verify no hooks configured → identical behavior to current
- [ ] Verify hooks from config YAML are executed on harness pod
- [ ] Verify CLI `--pre-workload` / `--post-workload` override config values
- [ ] Verify hook failure produces warning but does not abort the benchmark

