### PR TITLE
Use --serviceaccount value when creating model verification pod

### DIFF
--- a/llmdbenchmark/run/steps/step_03_verify_model.py
+++ b/llmdbenchmark/run/steps/step_03_verify_model.py
@@ -86,6 +86,7 @@ class VerifyModelStep(Step):
             plan_config,
             max_retries=3,
             retry_interval=10,
+            service_account=context.harness_service_account,
         )
 
         if error:

--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -17,7 +17,7 @@ def _rand_suffix(length: int = 8) -> str:
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
 
 
-def _build_overrides(plan_config: dict | None) -> list[str]:
+def _build_overrides(plan_config: dict | None, service_account: str | None = None) -> list[str]:
     """Build --overrides args for ephemeral curl pods (imagePullSecrets, serviceAccount)."""
     overrides: dict = {}
     if plan_config:
@@ -26,9 +26,10 @@ def _build_overrides(plan_config: dict | None) -> list[str]:
             overrides.setdefault("spec", {})["imagePullSecrets"] = [
                 {"name": pull_secret}
             ]
-        sa_name = plan_config.get("serviceAccount", {}).get("name")
-        if sa_name:
-            overrides.setdefault("spec", {})["serviceAccountName"] = sa_name
+            
+    sa_name = service_account or (plan_config.get("serviceAccount", {}).get("name") if plan_config else None)
+    if sa_name:
+        overrides.setdefault("spec", {})["serviceAccountName"] = sa_name
 
     if overrides:
         return ["--overrides", f"'{json.dumps(overrides)}'"]
@@ -381,6 +382,7 @@ def test_model_serving(
     plan_config: dict | None = None,
     max_retries: int = 12,
     retry_interval: int = 15,
+    service_account: str | None = None,
 ) -> str | None:
     """Test an endpoint by querying /v1/models via an ephemeral curl pod.
 
@@ -392,7 +394,7 @@ def test_model_serving(
     """
     protocol = "https" if str(port) == "443" else "http"
     url = f"{protocol}://{host}:{port}/v1/models"
-    override_args = _build_overrides(plan_config)
+    override_args = _build_overrides(plan_config, service_account=service_account)
     curl_image = "curlimages/curl"
     last_error: str | None = None
 


### PR DESCRIPTION
Use the value of the `--serviceaccount` CLI flag when creating the pre-flight model verification pod. Previously, the flag only applied to later stages of the pipeline.

Previously I was getting this error when using `--serviceaccount default`:
```
2026-03-30 23:17:47,439 - ERROR   - ❌ [03] Stack 'gpu-example': FAILED: [03] verify_model (gpu-example): FAILED - Model verification failed: Curl to 35.212.211.79:80 failed: Error from server (Forbidden): pods "smoketest-mmso11ko" is forbidden: error looking up service account adinilfeld-gemma-3/inference-perf-runner: serviceaccount "inference-perf-runner" not found
```
This change fixed the error:
```
2026-03-30 23:27:56,009 - INFO    - >> [03] Stack 'gpu-example': Verify model is served at endpoint
2026-03-30 23:27:56,045 - INFO    -     │ Verifying model 'google/gemma-3-27b-it' at http://35.212.211.79...
2026-03-30 23:28:02,866 - INFO    -     │ Model 'google/gemma-3-27b-it' verified at http://35.212.211.79
2026-03-30 23:28:02,867 - INFO    - ✅ [03] Stack 'gpu-example': Completed: verify_model
```