### PR TITLE
feat: introduce harness namespace step in run sequence

### DIFF
--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -133,18 +133,19 @@ Steps are registered in `steps/__init__.py` via `get_run_steps()`:
 |------|------|-------------|
 | 00 | `RunPreflightStep` | Validate cluster connectivity, harness namespace, output destination |
 | 01 | `RunCleanupPreviousStep` | Delete leftover harness pods/configmaps from previous runs |
-| 02 | `DetectEndpointStep` | Auto-detect model-serving endpoint (standalone service, gateway, or `-U` override) |
-| 03 | `VerifyModelStep` | Verify model is served at endpoint via `/v1/models` |
-| 04 | `RenderProfilesStep` | Render workload profile templates with runtime values; handle experiment treatments |
-| 05 | `CreateProfileConfigmapStep` | Create ConfigMaps for workload profiles and harness scripts |
-| 06 | `DeployHarnessStep` | Deploy harness pod(s), wait for completion, collect results, capture logs |
-| 07 | `WaitCompletionStep` | Wait for harness pods (used when step 06 does not inline waiting) |
-| 08 | `CollectResultsStep` | Collect results from PVC to local workspace |
-| 11 | `AnalyzeResultsStep` | Run local analysis on results (before upload so artifacts are included) |
-| 09 | `UploadResultsStep` | Upload results to cloud storage (GCS/S3) |
-| 10 | `RunCleanupPostStep` | Delete harness pods and ConfigMaps |
+| 02 | `HarnessNamespaceStep` | Prepare harness namespace (PVC, data access pod) |
+| 03 | `DetectEndpointStep` | Auto-detect model-serving endpoint (standalone service, gateway, or `-U` override) |
+| 04 | `VerifyModelStep` | Verify model is served at endpoint via `/v1/models` |
+| 05 | `RenderProfilesStep` | Render workload profile templates with runtime values; handle experiment treatments |
+| 06 | `CreateProfileConfigmapStep` | Create ConfigMaps for workload profiles and harness scripts |
+| 07 | `DeployHarnessStep` | Deploy harness pod(s), wait for completion, collect results, capture logs |
+| 08 | `WaitCompletionStep` | Wait for harness pods (used when step 07 does not inline waiting) |
+| 09 | `CollectResultsStep` | Collect results from PVC to local workspace |
+| 12 | `AnalyzeResultsStep` | Run local analysis on results (before upload so artifacts are included) |
+| 10 | `UploadResultsStep` | Upload results to cloud storage (GCS/S3) |
+| 11 | `RunCleanupPostStep` | Delete harness pods and ConfigMaps |
 
-Note: Step 11 (analyze) runs before step 09 (upload) so analysis artifacts are included in the upload.
+Note: Step 12 (analyze) runs before step 10 (upload) so analysis artifacts are included in the upload.
 
 ## Common Patterns
 

--- a/llmdbenchmark/run/steps/__init__.py
+++ b/llmdbenchmark/run/steps/__init__.py
@@ -4,25 +4,29 @@ from llmdbenchmark.executor.step import Step
 
 from llmdbenchmark.run.steps.step_00_preflight import RunPreflightStep
 from llmdbenchmark.run.steps.step_01_cleanup_previous import RunCleanupPreviousStep
-from llmdbenchmark.run.steps.step_02_detect_endpoint import DetectEndpointStep
-from llmdbenchmark.run.steps.step_03_verify_model import VerifyModelStep
-from llmdbenchmark.run.steps.step_04_render_profiles import RenderProfilesStep
-from llmdbenchmark.run.steps.step_05_create_profile_configmap import (
+from llmdbenchmark.run.steps.step_02_harness_namespace import HarnessNamespaceStep
+from llmdbenchmark.run.steps.step_03_detect_endpoint import DetectEndpointStep
+from llmdbenchmark.run.steps.step_04_verify_model import VerifyModelStep
+from llmdbenchmark.run.steps.step_05_render_profiles import RenderProfilesStep
+from llmdbenchmark.run.steps.step_06_create_profile_configmap import (
     CreateProfileConfigmapStep,
 )
-from llmdbenchmark.run.steps.step_06_deploy_harness import DeployHarnessStep
-from llmdbenchmark.run.steps.step_07_wait_completion import WaitCompletionStep
-from llmdbenchmark.run.steps.step_08_collect_results import CollectResultsStep
-from llmdbenchmark.run.steps.step_09_upload_results import UploadResultsStep
-from llmdbenchmark.run.steps.step_10_cleanup_post import RunCleanupPostStep
-from llmdbenchmark.run.steps.step_11_analyze_results import AnalyzeResultsStep
+from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
+from llmdbenchmark.run.steps.step_08_wait_completion import WaitCompletionStep
+from llmdbenchmark.run.steps.step_09_collect_results import CollectResultsStep
+from llmdbenchmark.run.steps.step_10_upload_results import UploadResultsStep
+from llmdbenchmark.run.steps.step_11_cleanup_post import RunCleanupPostStep
+from llmdbenchmark.run.steps.step_12_analyze_results import AnalyzeResultsStep
+from llmdbenchmark.executor.step import Phase
 
 
 def get_run_steps() -> list[Step]:
     """Return all run-phase steps in execution order."""
+
     return [
         RunPreflightStep(),
         RunCleanupPreviousStep(),
+        HarnessNamespaceStep(),
         DetectEndpointStep(),
         VerifyModelStep(),
         RenderProfilesStep(),

--- a/llmdbenchmark/run/steps/step_02_harness_namespace.py
+++ b/llmdbenchmark/run/steps/step_02_harness_namespace.py
@@ -1,0 +1,19 @@
+"""Step 02 -- Prepare the harness namespace."""
+
+from llmdbenchmark.standup.steps.step_05_harness_namespace import (
+    HarnessNamespaceStep as _HarnessNamespaceStep,
+)
+from llmdbenchmark.executor.step import Phase
+
+
+class HarnessNamespaceStep(_HarnessNamespaceStep):
+    """Prepare the namespace for the benchmark harness.
+    
+    This inherits from the standup phase's step_05, but overrides the step
+    number so it correctly sequences into the run pipeline.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.number = 2
+        self.phase = Phase.RUN

--- a/llmdbenchmark/run/steps/step_03_detect_endpoint.py
+++ b/llmdbenchmark/run/steps/step_03_detect_endpoint.py
@@ -18,7 +18,7 @@ class DetectEndpointStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=2,
+            number=3,
             name="detect_endpoint",
             description="Detect model serving endpoint",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_04_verify_model.py
+++ b/llmdbenchmark/run/steps/step_04_verify_model.py
@@ -12,7 +12,7 @@ class VerifyModelStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=3,
+            number=4,
             name="verify_model",
             description="Verify model is served at endpoint",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_05_render_profiles.py
+++ b/llmdbenchmark/run/steps/step_05_render_profiles.py
@@ -19,7 +19,7 @@ class RenderProfilesStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=4,
+            number=5,
             name="render_profiles",
             description="Render workload profile templates",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_06_create_profile_configmap.py
+++ b/llmdbenchmark/run/steps/step_06_create_profile_configmap.py
@@ -14,7 +14,7 @@ class CreateProfileConfigmapStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=5,
+            number=6,
             name="create_profile_configmap",
             description="Create profile and harness-scripts ConfigMaps",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -36,7 +36,7 @@ class DeployHarnessStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=6,
+            number=7,
             name="deploy_harness",
             description="Deploy harness pod(s) for benchmark execution",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_08_wait_completion.py
+++ b/llmdbenchmark/run/steps/step_08_wait_completion.py
@@ -12,7 +12,7 @@ class WaitCompletionStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=7,
+            number=8,
             name="wait_completion",
             description="Wait for harness pod(s) to complete",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_09_collect_results.py
+++ b/llmdbenchmark/run/steps/step_09_collect_results.py
@@ -12,7 +12,7 @@ class CollectResultsStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=8,
+            number=9,
             name="collect_results",
             description="Collect results from PVC to local workspace",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_10_upload_results.py
+++ b/llmdbenchmark/run/steps/step_10_upload_results.py
@@ -17,7 +17,7 @@ class UploadResultsStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=9,
+            number=10,
             name="upload_results",
             description="Upload results to cloud storage",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_11_cleanup_post.py
+++ b/llmdbenchmark/run/steps/step_11_cleanup_post.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
-from llmdbenchmark.run.steps.step_05_create_profile_configmap import (
+from llmdbenchmark.run.steps.step_06_create_profile_configmap import (
     HARNESS_SCRIPTS_CONFIGMAP,
 )
 from llmdbenchmark.utilities.kube_helpers import delete_pods_by_label
@@ -15,7 +15,7 @@ class RunCleanupPostStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=10,
+            number=11,
             name="run_cleanup_post",
             description="Clean up harness pods and ConfigMaps",
             phase=Phase.RUN,

--- a/llmdbenchmark/run/steps/step_12_analyze_results.py
+++ b/llmdbenchmark/run/steps/step_12_analyze_results.py
@@ -17,7 +17,7 @@ class AnalyzeResultsStep(Step):
 
     def __init__(self):
         super().__init__(
-            number=11,
+            number=12,
             name="analyze_results",
             description="Run local analysis on collected results",
             phase=Phase.RUN,


### PR DESCRIPTION
Shifts the step indices of the `run` workflow and injects the `harness_namespace` step into early processing (`step_02_harness_namespace.py`). Previously, this step only ran during the `standup` phase, so benchmarking runs against an existing stack (which skip straight to the `run` phase) would fail because of the missing `llm-d-benchmark-preprocesses` ConfigMap.
