### PR TITLE
fix pd-disaggregation

### DIFF
--- a/config/scenarios/guides/pd-disaggregation.yaml
+++ b/config/scenarios/guides/pd-disaggregation.yaml
@@ -83,10 +83,52 @@ scenario:
 
     # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
-    # Corresponds to: LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE="default-plugins.yaml"
+    # Corresponds to: LLMDBENCH_VLLM_MODELSERVICE_GAIE_PLUGINS_CONFIGFILE="pd-config.yaml"
+    # Reference: https://github.com/llm-d/llm-d/blob/main/guides/pd-disaggregation/gaie-pd/values.yaml
     # -------------------------------------------------------------------------
     inferenceExtension:
-      pluginsConfigFile: "default-plugins.yaml"
+      pluginsConfigFile: "pd-config.yaml"
+      pluginsCustomConfig:
+        pd-config.yaml: |
+          # ALWAYS DO PD IN THIS EXAMPLE (THRESHOLD 0)
+          apiVersion: inference.networking.x-k8s.io/v1alpha1
+          kind: EndpointPickerConfig
+          featureGates:
+            - prepareDataPlugins
+          plugins:
+            - type: prefill-header-handler
+            - type: prefix-cache-scorer
+              parameters:
+                maxPrefixBlocksToMatch: 256
+                lruCapacityPerServer: 31250
+            - type: queue-scorer
+            - type: prefill-filter
+            - type: decode-filter
+            - type: max-score-picker
+            - type: prefix-based-pd-decider
+              parameters:
+                nonCachedTokens: 16
+            - type: pd-profile-handler
+              parameters:
+                primaryPort: 0
+                deciderPluginName: prefix-based-pd-decider
+          schedulingProfiles:
+            - name: prefill
+              plugins:
+                - pluginRef: prefill-filter
+                - pluginRef: max-score-picker
+                - pluginRef: prefix-cache-scorer
+                  weight: 2
+                - pluginRef: queue-scorer
+                  weight: 1
+            - name: decode
+              plugins:
+                - pluginRef: decode-filter
+                - pluginRef: max-score-picker
+                - pluginRef: prefix-cache-scorer
+                  weight: 2
+                - pluginRef: queue-scorer
+                  weight: 1
     
     # =========================================================================
     # COMMON -- Applies to all deployment methods (continued)
@@ -278,7 +320,7 @@ scenario:
           runAsGroup: 0
           runAsUser: 0
         imagePullPolicy: Always
-      
+
       # -----------------------------------------------------------------------
       # Additional Volume Mounts
       # Corresponds to: LLMDBENCH_VLLM_MODELSERVICE_DECODE_EXTRA_VOLUME_MOUNTS

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -635,14 +635,11 @@ decode:
 {# ========================================================================== #}
 {# Prefill probe port:
    The helm chart never injects the routing proxy on prefill pods (only decode).
-   - When proxy is ENABLED: prefill vLLM binds to vllm.port (8200) with no proxy
-     in front. Probes must check 8200 where vLLM actually listens.
-   - When proxy is DISABLED: prefill vLLM binds to servicePort (8000) directly.
-     Probes check 8000.
-   This deviates from the bash (which always used 8000), but fixes prefill pods
-   getting stuck at 0/1 Running due to probes checking a port with nothing listening. #}
-{% set proxy_enabled = not (routing is defined and routing.proxy is defined and routing.proxy.enabled is defined and not routing.proxy.enabled) -%}
-{% set prefill_effective_port = (prefill.vllm.port if prefill.vllm is defined and prefill.vllm.port is defined else decode.vllm.port) if proxy_enabled else (prefill.vllm.servicePort if prefill.vllm is defined and prefill.vllm.servicePort is defined else decode.vllm.servicePort) -%}
+   Prefill vLLM always binds to servicePort (8000) directly -- matching the
+   _macros.j2 fix that forces prefill to use VLLM_INFERENCE_PORT. This ensures
+   the routing sidecar on decode pods can reach prefill on port 8000 for P/D
+   disaggregation, and probes check the port where vLLM actually listens. #}
+{% set prefill_effective_port = prefill.vllm.servicePort if prefill.vllm is defined and prefill.vllm.servicePort is defined else decode.vllm.servicePort -%}
 prefill:
   create: {{ prefill_create | lower }}
 {% if prefill_create %}

--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -59,8 +59,14 @@
    When proxy is enabled, vLLM binds to vllm.port (8200) and the proxy
    handles the servicePort (8000) to vllmPort (8200) forwarding.
    The port env var is set accordingly: VLLM_INFERENCE_PORT (8000) when no proxy,
-   VLLM_METRICS_PORT (8200) when proxy is enabled. #}
-{% set use_inference_port = (routing is defined and routing.proxy is defined and routing.proxy.enabled is defined and not routing.proxy.enabled) -%}
+   VLLM_METRICS_PORT (8200) when proxy is enabled.
+   IMPORTANT: Prefill pods NEVER have the routing proxy (the Helm chart only
+   injects it on decode pods), so prefill must always use VLLM_INFERENCE_PORT
+   (8000) regardless of the proxy setting. Without this, the routing sidecar
+   on decode pods cannot reach the prefill pod (connection refused on 8000
+   while vLLM listens on 8200). #}
+{% set proxy_disabled = (routing is defined and routing.proxy is defined and routing.proxy.enabled is defined and not routing.proxy.enabled) -%}
+{% set use_inference_port = proxy_disabled or mode == 'prefill' -%}
 {% set port_var = '$VLLM_INFERENCE_PORT' if use_inference_port else '$VLLM_METRICS_PORT' -%}
 {{ preprocess_script }}; vllm serve {{ model.cacheBase }}/{{ model.path }} \
   --host {{ vllmCommon.host }} \


### PR DESCRIPTION
There were two issues with PD disaggregation:

- `pd-disaggregation.yaml` was using default plugin instead of the correct one: https://github.com/llm-d/llm-d-benchmark/blob/c6d55e82d8d9a696492f3e19022a8ed0970ee3bb/config/scenarios/guides/pd-disaggregation.yaml#L89
    - Correct plugin: [values.yaml](https://github.com/llm-d/llm-d/blob/main/guides/pd-disaggregation/gaie-pd/values.yaml)
- The `routing-proxy` sidecar on decode pods was trying to reach the prefill pod at port `8000` but prefill vLLM was listening on port `8200`. The request would fail with "connection refused" and fall back to decode-only mode.