### PR TITLE
feat: Fix secret for monitoring epp 

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -809,7 +809,7 @@ The inference extension has its own monitoring config under `inferenceExtension.
 ```yaml
 inferenceExtension:
   monitoring:
-    secretName: kv-events-gateway-sa-metrics-reader-secret
+    secretName: inference-gateway-sa-metrics-reader-secret
     interval: "10s"
     prometheus:
       enabled: true

--- a/config/templates/jinja/12_gaie-values.yaml.j2
+++ b/config/templates/jinja/12_gaie-values.yaml.j2
@@ -34,7 +34,7 @@ inferenceExtension:
 {% endif %}
   monitoring:
     secret:
-      name: {{ inferenceExtension.monitoring.secretName | default('kv-events-gateway-sa-metrics-reader-secret') }}
+      name: {{ inferenceExtension.monitoring.secretName | default('inference-gateway-sa-metrics-reader-secret') }}
     interval: "{{ inferenceExtension.monitoring.interval | default('10s') }}"
     prometheus:
       enabled: {{ inferenceExtension.monitoring.prometheus.enabled | default(true) | lower }}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -521,7 +521,7 @@ inferenceExtension:
   volumeMounts: []
   # Monitoring configuration for the EPP (Endpoint Picker Pod)
   monitoring:
-    secretName: kv-events-gateway-sa-metrics-reader-secret
+    secretName: inference-gateway-sa-metrics-reader-secret
     interval: "10s"
     prometheus:
       enabled: true


### PR DESCRIPTION
# Summary

We have been utilizing the _wrong_ secret name for monitoring `epp`, this PR fixes that.