### PR TITLE
fix: Extract IP values through standard status.addresses object lookups

### DIFF
--- a/llm_d_stack_discovery/discovery/tracer.py
+++ b/llm_d_stack_discovery/discovery/tracer.py
@@ -294,6 +294,12 @@ class StackTracer:  # pylint: disable=too-many-instance-attributes
                 for listener in spec.get("listeners", []):
                     if listener.get("hostname") == hostname:
                         return gateway
+                
+                # Check status.addresses for IP-based gateway discovery
+                status = gateway.obj.get("status", {})
+                for address in status.get("addresses", []):
+                    if address.get("value") == hostname:
+                        return gateway
 
             logger.info("No gateway found for hostname: %s", hostname)
         except Exception as e:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
Allows for providing a Gateway address to the `llm_d_stack_discovery` tool, by routing through standard `status.addresses` parameters. For example, the below example previously gave an error, but now works as expected:
```
adinilfeld@adinilfeld:~$ PYTHONPATH=/usr/local/google/home/adinilfeld/src/llm-d-benchmark python -m llm_d_stack_discovery.cli http://35.212.211.79 --output-format benchmark-report
2026-03-31 18:26:44,578 - INFO - Connecting to Kubernetes cluster...
2026-03-31 18:26:45,564 - INFO - 'privileged' SCC not found (not OpenShift)
2026-03-31 18:26:45,578 - INFO - Detected GAIE API version: inference.networking.k8s.io/v1
2026-03-31 18:26:45,578 - INFO - Starting stack discovery from URL: http://35.212.211.79
2026-03-31 18:26:45,578 - INFO - Parsed URL: {'scheme': 'http', 'hostname': '35.212.211.79', 'port': 80, 'path': '', 'full_url': 'http://35.212.211.79'}
2026-03-31 18:26:45,691 - INFO - No gateway found for hostname: 35.212.211.79
2026-03-31 18:26:45,737 - INFO - No service found for endpoint: 35.212.211.79:80
[]
```