### PR TITLE
docs: Add inline comments providing recommended storage classes

### DIFF
--- a/config/scenarios/examples/cpu.yaml
+++ b/config/scenarios/examples/cpu.yaml
@@ -43,6 +43,19 @@ scenario:
       maxNumSeq: 32
 
     # -------------------------------------------------------------------------
+    # PVC Configuration
+    # Corresponds to: LLMDBENCH_VLLM_COMMON_PVC_STORAGE_CLASS (left for auto-detect)
+    # -------------------------------------------------------------------------
+    # Uncomment to override storage class:
+    # storage:
+    #   workloadPvc:
+    #     storageClassName: standard-rwx       # GKE
+    #   modelPvc:
+    #     storageClassName: standard-rwx       # GKE
+    #     # storageClassName: shared-vast       # Kubernetes
+    #     # storageClassName: ocs-storagecluster-cephfs  # OpenShift
+    #     size: 1Ti
+    # -------------------------------------------------------------------------
     # Affinity / Node Selection
     # Corresponds to: LLMDBENCH_VLLM_COMMON_AFFINITY=kubernetes.io/os:linux
     # By default, affinity is disabled and pods schedule on any available node.

--- a/config/scenarios/examples/gpu.yaml
+++ b/config/scenarios/examples/gpu.yaml
@@ -38,12 +38,13 @@ scenario:
     # -------------------------------------------------------------------------
     # Uncomment to override storage class:
     # storage:
+    #   workloadPvc:
+    #     storageClassName: standard-rwx       # GKE
     #   modelPvc:
     #     storageClassName: standard-rwx       # GKE
     #     # storageClassName: shared-vast       # Kubernetes
     #     # storageClassName: ocs-storagecluster-cephfs  # OpenShift
     #     size: 1Ti
-
     # -------------------------------------------------------------------------
     # Affinity / Node Selection
     # Corresponds to: LLMDBENCH_VLLM_COMMON_AFFINITY (left for auto-detect)

--- a/config/scenarios/examples/sim-small.yaml
+++ b/config/scenarios/examples/sim-small.yaml
@@ -233,7 +233,13 @@ scenario:
     #                 LLMDBENCH_VLLM_COMMON_PVC_ACCESS_MODE=ReadWriteOnce
     # -------------------------------------------------------------------------
     storage:
+      # Uncomment to override storage class:
+      # workloadPvc:
+      #   storageClassName: standard-rwx       # GKE
       modelPvc:
+        # storageClassName: standard-rwx       # GKE
+        # storageClassName: shared-vast       # Kubernetes
+        # storageClassName: ocs-storagecluster-cephfs  # OpenShift
         size: 2Gi
         accessMode: ReadWriteOnce
       uriProtocol: hf

--- a/config/scenarios/examples/sim.yaml
+++ b/config/scenarios/examples/sim.yaml
@@ -19,6 +19,20 @@ scenario:
       huggingfaceId: facebook/opt-125m
       gpuMemoryUtilization: 0
 
+    # -------------------------------------------------------------------------
+    # PVC Configuration
+    # Corresponds to: LLMDBENCH_VLLM_COMMON_PVC_STORAGE_CLASS (left for auto-detect)
+    # -------------------------------------------------------------------------
+    # Uncomment to override storage class:
+    # storage:
+    #   workloadPvc:
+    #     storageClassName: standard-rwx       # GKE
+    #   modelPvc:
+    #     storageClassName: standard-rwx       # GKE
+    #     # storageClassName: shared-vast       # Kubernetes
+    #     # storageClassName: ocs-storagecluster-cephfs  # OpenShift
+    #     size: 1Ti
+
     # Affinity / Node Selection
     # By default, affinity is disabled and pods schedule on any available node.
     # Options:

--- a/config/scenarios/examples/spyre.yaml
+++ b/config/scenarios/examples/spyre.yaml
@@ -79,6 +79,14 @@ scenario:
     # Corresponds to: LLMDBENCH_VLLM_COMMON_EXTRA_PVC_NAME=spyre-precompiled-model
     # -------------------------------------------------------------------------
     storage:
+      # Uncomment to override storage class:
+      # workloadPvc:
+      #   storageClassName: standard-rwx       # GKE
+      # modelPvc:
+      #   storageClassName: standard-rwx       # GKE
+      #   # storageClassName: shared-vast       # Kubernetes
+      #   # storageClassName: ocs-storagecluster-cephfs  # OpenShift
+      #   size: 1Ti
       extraPvc:
         name: spyre-precompiled-model
 


### PR DESCRIPTION
Add inline comments providing recommended storage classes across different platforms.

This is useful to make it more clear what changes need to be made in order to volumes to be successfully provisioned on different platforms. For example, GKE will fail to provision the "workload" volume unless the PVC's `storageClassName` is overridden to `standard-rwx`.