### PR TITLE
Auto-provision RBAC and enable pod-native auth for run-only mode

### DIFF
--- a/benchmark_report/native_to_br0_2.py
+++ b/benchmark_report/native_to_br0_2.py
@@ -147,20 +147,23 @@ def get_configmap(
     Returns:
         dict: ConfigMap contents as a dict, or empty dict if retrieval fails.
     """
-    if not context_dict:
-        sys.stderr.write("Empty context dictionary provided\n")
-        return {}
-
     try:
         from kubernetes import client, config as k8s_config
 
-        # Write context to a temporary file
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            yaml.dump(context_dict, f)
-            kubeconfig_path = f.name
+        # Try in-cluster config first
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            if not context_dict:
+                sys.stderr.write("Empty context dictionary provided and not in-cluster\n")
+                return {}
+            # Write context to a temporary file
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+                yaml.dump(context_dict, f)
+                kubeconfig_path = f.name
 
-        # Load the Kubernetes config from the temporary file
-        k8s_config.load_kube_config(config_file=kubeconfig_path)
+            # Load the Kubernetes config from the temporary file
+            k8s_config.load_kube_config(config_file=kubeconfig_path)
 
         # Create API client
         v1 = client.CoreV1Api()

--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
@@ -147,20 +147,23 @@ def get_configmap(
     Returns:
         dict: ConfigMap contents as a dict, or empty dict if retrieval fails.
     """
-    if not context_dict:
-        sys.stderr.write("Empty context dictionary provided\n")
-        return {}
-
     try:
         from kubernetes import client, config as k8s_config
 
-        # Write context to a temporary file
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            yaml.dump(context_dict, f)
-            kubeconfig_path = f.name
+        # Try in-cluster config first
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            if not context_dict:
+                sys.stderr.write("Empty context dictionary provided and not in-cluster\n")
+                return {}
+            # Write context to a temporary file
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+                yaml.dump(context_dict, f)
+                kubeconfig_path = f.name
 
-        # Load the Kubernetes config from the temporary file
-        k8s_config.load_kube_config(config_file=kubeconfig_path)
+            # Load the Kubernetes config from the temporary file
+            k8s_config.load_kube_config(config_file=kubeconfig_path)
 
         # Create API client
         v1 = client.CoreV1Api()

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -255,6 +255,8 @@ class DeployHarnessStep(Step):
                 # Service account override (-q)
                 if context.harness_service_account:
                     template_values["harness"]["serviceAccount"] = context.harness_service_account
+                elif plan_config and "serviceAccount" in plan_config:
+                    template_values["harness"]["serviceAccount"] = plan_config["serviceAccount"].get("name", "default")
 
                 # Extra env vars to propagate into pod (-g)
                 if context.harness_envvars_to_pod:

--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -394,6 +394,38 @@ def test_model_serving(
     """
     protocol = "https" if str(port) == "443" else "http"
     url = f"{protocol}://{host}:{port}/v1/models"
+    
+    # Auto-ensure service account and RBAC
+    sa_name = service_account or (plan_config.get("serviceAccount", {}).get("name") if plan_config else "default")
+    if sa_name:
+        if sa_name != "default":
+            sa_check = cmd.kube("get", "sa", sa_name, "--namespace", namespace, check=False)
+            if not sa_check.success or "not found" in (sa_check.stderr + sa_check.stdout).lower():
+                cmd.logger.log_info(f"ServiceAccount '{sa_name}' not found, auto-creating it...")
+                cmd.kube("create", "sa", sa_name, "--namespace", namespace, check=False)
+        
+        # Always ensure the required RBAC role exists
+        role_name = f"{sa_name}-role"
+        role_check = cmd.kube("get", "role", role_name, "--namespace", namespace, check=False)
+        if not role_check.success or "not found" in (role_check.stderr + role_check.stdout).lower():
+            cmd.logger.log_info(f"RBAC Role '{role_name}' missing for ServiceAccount '{sa_name}', auto-creating it...")
+            cmd.kube(
+                "create", "role", role_name,
+                "--verb=get,list", "--resource=configmaps,pods,pods/log",
+                "--namespace", namespace,
+                check=False
+            )
+            
+            # Always ensure RoleBinding
+            binding_name = f"{sa_name}-binding"
+            cmd.kube(
+                "create", "rolebinding", binding_name,
+                f"--role={role_name}",
+                f"--serviceaccount={namespace}:{sa_name}",
+                "--namespace", namespace,
+                check=False
+            )
+
     override_args = _build_overrides(plan_config, service_account=service_account)
     curl_image = "curlimages/curl"
     last_error: str | None = None


### PR DESCRIPTION
This pull request resolves `403 Forbidden` errors when executing the `llm-d-benchmark` harness in "run-only" mode against existing endpoints. Previously, executing the harness without the full `standup` lifecycle caused the validation pod to run with missing permissions or fail to authenticate entirely due to a strict reliance on external `gcloud` credentials. When this occurred, the benchmark harness would give errors during endpoint validation, such as the following:

> Warning: LLMDBENCH_VLLM_MODELSERVICE_GAIE_PRESETS_CONFIG empty.ERROR:root:exec: process returned 1. F0403 17:37:22.806475     521 cred.go:145] print credential failed with error: Failed to retrieve access token:: failure while executing gcloud, with args [config config-helper --format=json]: exec: "gcloud": executable file not found in $PATH (err: )

> {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"configmaps \"llm-d-benchmark-standup-parameters\" is forbidden: User \"system:serviceaccount:adinilfeld-gemma-3:default\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"adinilfeld-gemma-3\"","reason":"Forbidden","details":{"name":"llm-d-benchmark-standup-parameters","kind":"configmaps"},"code":403}

To resolve this, I implemented three fixes: updating `native_to_br0_2.py` to prioritize native `k8s_config.load_incluster_config()` so pod-based auth succeeds (avoiding the `gcloud` error above), injecting runtime auto-provisioning logic into `endpoint.py` to ensure the active ServiceAccount possesses the necessary RBAC `Role` and `RoleBinding` objects for reading ConfigMaps and pod logs, and patching `step_07_deploy_harness.py` to correctly fall back to the plan-defined ServiceAccount when none is explicitly provided via the CLI.

Note that even after these fixes, we still get the following error due to Issue #876. But hopefully that will be resolved by future work, which is unblocked by this PR:
> Warning: LLMDBENCH_VLLM_MODELSERVICE_GAIE_PRESETS_CONFIG empty.Failed to retrieve ConfigMap 'llm-d-benchmark-standup-parameters': (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'Audit-Id': 'cf403724-0fb8-4ef9-87e1-c07bdc4d7f18', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': '321d79a3-f7a8-44cd-93d6-047031e76a14', 'X-Kubernetes-Pf-Prioritylevel-Uid': 'c6397ef5-6c47-4702-b855-3a4582c56b30', 'Date': 'Fri, 03 Apr 2026 18:41:32 GMT', 'Content-Length': '248'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"configmaps \"llm-d-benchmark-standup-parameters\" not found","reason":"NotFound","details":{"name":"llm-d-benchmark-standup-parameters","kind":"configmaps"},"code":404}