### PR TITLE
Fix nvidia acceleratorType errors on CPU scenarios

### DIFF
--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -226,6 +226,15 @@ class WorkloadMonitoringStep(Step):
                 for key, value in ns.items():
                     selectors.append((f"{method}.nodeSelector", key, str(value)))
 
+            # Only validate acceleratorType labels if the template will actually
+            # render them. This mirrors the Jinja guards in 13_ms-values.yaml.j2
+            # and 14_standalone-deployment_yaml.j2 so CPU scenarios (which leave
+            # the nvidia acceleratorType defaults untouched because they set
+            # accelerator.count=0) don't flag spurious "nvidia label not found"
+            # errors against pure-CPU clusters.
+            if not self._method_renders_accelerator_type(method, method_config):
+                continue
+
             accel_type = method_config.get("acceleratorType", {})
             label_key = accel_type.get("labelKey", "")
             label_value = accel_type.get("labelValue", "")
@@ -290,6 +299,58 @@ class WorkloadMonitoringStep(Step):
             if labels.get(key) == value:
                 return True
         return False
+
+    @staticmethod
+    def _method_renders_accelerator_type(
+        method: str, method_config: dict
+    ) -> bool:
+        """Return True if the Jinja template will actually render acceleratorType
+        for the given method given its config.
+
+        Mirrors the guards in the templates so the validator does not flag
+        labels that are never actually used:
+
+        - standalone: ``standalone.enabled and standalone.parallelism.tensor > 0``
+          (see 14_standalone-deployment_yaml.j2 lines 1, 80)
+        - decode:     ``decode_create and decode_accel_count > 0`` where
+          ``decode_create = decode.enabled or decode.replicas > 0`` and
+          ``decode_accel_count = decode.accelerator.count if defined else
+          decode.parallelism.tensor``
+          (see 13_ms-values.yaml.j2 lines 11, 252)
+        - prefill:    same logic as decode, with ``prefill`` (see 13_ms-values.yaml.j2
+          lines 12, 674)
+        """
+        def _coerce_int(value, default: int = 0) -> int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        def _accel_count(cfg: dict) -> int:
+            accel = cfg.get("accelerator")
+            if isinstance(accel, dict) and "count" in accel:
+                return _coerce_int(accel.get("count"), 0)
+            return _coerce_int(
+                cfg.get("parallelism", {}).get("tensor"), 0
+            )
+
+        if method == "standalone":
+            if not method_config.get("enabled", False):
+                return False
+            tensor = _coerce_int(
+                method_config.get("parallelism", {}).get("tensor"), 0
+            )
+            return tensor > 0
+
+        # decode and prefill share the same create/accel_count logic
+        if "enabled" in method_config:
+            created = bool(method_config.get("enabled"))
+        else:
+            created = _coerce_int(method_config.get("replicas"), 0) > 0
+        if not created:
+            return False
+
+        return _accel_count(method_config) > 0
 
     def _capacity_planner_sanity_check(
         self,

--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -306,19 +306,6 @@ class WorkloadMonitoringStep(Step):
     ) -> bool:
         """Return True if the Jinja template will actually render acceleratorType
         for the given method given its config.
-
-        Mirrors the guards in the templates so the validator does not flag
-        labels that are never actually used:
-
-        - standalone: ``standalone.enabled and standalone.parallelism.tensor > 0``
-          (see 14_standalone-deployment_yaml.j2 lines 1, 80)
-        - decode:     ``decode_create and decode_accel_count > 0`` where
-          ``decode_create = decode.enabled or decode.replicas > 0`` and
-          ``decode_accel_count = decode.accelerator.count if defined else
-          decode.parallelism.tensor``
-          (see 13_ms-values.yaml.j2 lines 11, 252)
-        - prefill:    same logic as decode, with ``prefill`` (see 13_ms-values.yaml.j2
-          lines 12, 674)
         """
         def _coerce_int(value, default: int = 0) -> int:
             try:

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -568,15 +568,21 @@ class DeployModelserviceStep(Step):
         if prom_ca_cert and "wva" in wva_config and "prometheus" in wva_config["wva"]:
             wva_config["wva"]["prometheus"]["caCert"] = prom_ca_cert
 
+        # Only extract an accelerator prefix for WVA if decode actually runs
+        # on accelerators. For CPU scenarios (accelerator.count=0) the
+        # acceleratorType defaults inherited from defaults.yaml are unused,
+        # so WVA's ``va.accelerator`` is left blank instead of picking up
+        # a stale "H100" / "A100" prefix from the nvidia defaults.
         affinity_str = ""
         decode_cfg = plan_config.get("decode", {})
-        accel_types = decode_cfg.get("acceleratorType", {})
-        if accel_types:
-            label_values = accel_types.get("labelValues", [])
-            if label_values:
-                affinity_str = str(label_values[0])
-            elif accel_types.get("labelValue"):
-                affinity_str = str(accel_types["labelValue"])
+        if self._decode_uses_accelerator(decode_cfg):
+            accel_types = decode_cfg.get("acceleratorType", {})
+            if accel_types:
+                label_values = accel_types.get("labelValues", [])
+                if label_values:
+                    affinity_str = str(label_values[0])
+                elif accel_types.get("labelValue"):
+                    affinity_str = str(accel_types["labelValue"])
         accelerator_type = self._find_accelerator_prefix(affinity_str) or ""
         if "va" in wva_config:
             wva_config["va"]["accelerator"] = accelerator_type
@@ -757,6 +763,29 @@ class DeployModelserviceStep(Step):
             if prefix in affinity_string:
                 return prefix
         return None
+
+    @staticmethod
+    def _decode_uses_accelerator(decode_cfg: dict) -> bool:
+        """Return True if decode will request GPU accelerators at render time.
+
+        Mirrors the guard in ``13_ms-values.yaml.j2`` (``decode_accel_count > 0``)
+        so callers do not pick up the nvidia ``acceleratorType`` defaults
+        from ``defaults.yaml`` when decode is configured for CPU
+        (``decode.accelerator.count == 0``).
+        """
+        if not decode_cfg:
+            return False
+
+        def _to_int(value, default: int = 0) -> int:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return default
+
+        accel = decode_cfg.get("accelerator")
+        if isinstance(accel, dict) and "count" in accel:
+            return _to_int(accel.get("count"), 0) > 0
+        return _to_int(decode_cfg.get("parallelism", {}).get("tensor"), 0) > 0
 
     @staticmethod
     def _get_random_node_port(

--- a/tests/test_workload_monitoring_guards.py
+++ b/tests/test_workload_monitoring_guards.py
@@ -1,0 +1,263 @@
+"""Tests for the acceleratorType validation guards in step_03_workload_monitoring.
+
+These guards mirror the Jinja template's ``*_accel_count > 0`` / ``enabled`` /
+``replicas > 0`` conditions so that the standup validator does not flag
+``nvidia.com/gpu.product=NVIDIA-H100-80GB-HBM3`` (inherited from defaults.yaml)
+on pure-CPU scenarios, where the template never actually emits that selector.
+
+Also covers the matching helper in step_09_deploy_modelservice that controls
+whether WVA's ``va.accelerator`` is populated from ``decode.acceleratorType``.
+"""
+
+from __future__ import annotations
+
+from llmdbenchmark.standup.steps.step_03_workload_monitoring import (
+    WorkloadMonitoringStep,
+)
+from llmdbenchmark.standup.steps.step_09_deploy_modelservice import (
+    DeployModelserviceStep,
+)
+
+
+# ---------------------------------------------------------------------------
+# _method_renders_accelerator_type: standalone
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_disabled_does_not_render():
+    """standalone.enabled=false → acceleratorType is not rendered."""
+    cfg = {
+        "enabled": False,
+        "parallelism": {"tensor": 2},
+        "acceleratorType": {
+            "labelKey": "nvidia.com/gpu.product",
+            "labelValue": "NVIDIA-H100-80GB-HBM3",
+        },
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "standalone", cfg
+    ) is False
+
+
+def test_standalone_enabled_with_tensor_parallelism_renders():
+    """standalone.enabled=true and tensor>0 → acceleratorType is rendered."""
+    cfg = {
+        "enabled": True,
+        "parallelism": {"tensor": 2},
+        "acceleratorType": {
+            "labelKey": "nvidia.com/gpu.product",
+            "labelValue": "NVIDIA-H100-80GB-HBM3",
+        },
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "standalone", cfg
+    ) is True
+
+
+def test_standalone_enabled_with_zero_tensor_does_not_render():
+    """standalone.enabled=true but tensor=0 → no affinity block."""
+    cfg = {
+        "enabled": True,
+        "parallelism": {"tensor": 0},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "standalone", cfg
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# _method_renders_accelerator_type: decode / prefill create guards
+# ---------------------------------------------------------------------------
+
+
+def test_decode_not_created_when_enabled_false():
+    """decode.enabled=false → no decode section, no acceleratorType."""
+    cfg = {
+        "enabled": False,
+        "replicas": 2,
+        "accelerator": {"count": 1},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg
+    ) is False
+
+
+def test_decode_not_created_when_replicas_zero_and_enabled_unset():
+    """No decode.enabled and decode.replicas=0 → decode section not created."""
+    cfg = {
+        "replicas": 0,
+        "accelerator": {"count": 1},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg
+    ) is False
+
+
+def test_decode_created_via_replicas_with_accelerator():
+    """No decode.enabled but decode.replicas>0 and accelerator.count>0 → render."""
+    cfg = {
+        "replicas": 2,
+        "accelerator": {"count": 1},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg
+    ) is True
+
+
+def test_decode_cpu_scenario_with_accelerator_count_zero():
+    """The CPU scenario case: decode exists but accelerator.count=0 → no render.
+
+    This is the bug the guard is protecting against -- in the CPU example
+    scenario, ``decode.acceleratorType`` is inherited from defaults.yaml (nvidia)
+    but ``decode.accelerator.count`` is 0, so the template does not emit it.
+    The validator must not flag it either.
+    """
+    cfg = {
+        "replicas": 2,
+        "accelerator": {"count": 0},
+        "parallelism": {"tensor": 1},  # tensor>0 but accelerator.count wins
+        "acceleratorType": {
+            "labelKey": "nvidia.com/gpu.product",
+            "labelValue": "NVIDIA-H100-80GB-HBM3",
+        },
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg
+    ) is False
+
+
+def test_decode_falls_back_to_parallelism_tensor_when_accelerator_missing():
+    """If decode.accelerator is not set, the template uses parallelism.tensor."""
+    cfg_with_tensor = {
+        "replicas": 2,
+        "parallelism": {"tensor": 2},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg_with_tensor
+    ) is True
+
+    cfg_tensor_zero = {
+        "replicas": 2,
+        "parallelism": {"tensor": 0},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg_tensor_zero
+    ) is False
+
+
+def test_prefill_disabled_scenario():
+    """prefill.enabled=false → no prefill section, no acceleratorType."""
+    cfg = {
+        "enabled": False,
+        "replicas": 0,
+        "accelerator": {"count": 0},
+        "acceleratorType": {
+            "labelKey": "nvidia.com/gpu.product",
+            "labelValue": "NVIDIA-H100-80GB-HBM3",
+        },
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "prefill", cfg
+    ) is False
+
+
+def test_prefill_enabled_with_gpu():
+    """prefill.enabled=true and accelerator.count>0 → render."""
+    cfg = {
+        "enabled": True,
+        "replicas": 1,
+        "accelerator": {"count": 1},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "prefill", cfg
+    ) is True
+
+
+def test_integer_coercion_handles_string_values():
+    """YAML numeric fields sometimes arrive as strings; must still compare."""
+    cfg = {
+        "enabled": True,
+        "replicas": "2",
+        "accelerator": {"count": "0"},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg
+    ) is False
+
+
+def test_integer_coercion_handles_garbage_values():
+    """Non-numeric garbage in count falls back to 0 (i.e. no render)."""
+    cfg = {
+        "enabled": True,
+        "replicas": "2",
+        "accelerator": {"count": "banana"},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert WorkloadMonitoringStep._method_renders_accelerator_type(
+        "decode", cfg
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# _decode_uses_accelerator (step_09 WVA)
+# ---------------------------------------------------------------------------
+
+
+def test_wva_decode_uses_accelerator_count_zero_returns_false():
+    """CPU scenario: decode.accelerator.count=0 → WVA sees no accelerator."""
+    decode_cfg = {
+        "replicas": 2,
+        "accelerator": {"count": 0},
+        "acceleratorType": {
+            "labelKey": "nvidia.com/gpu.product",
+            "labelValue": "NVIDIA-H100-80GB-HBM3",
+        },
+    }
+    assert DeployModelserviceStep._decode_uses_accelerator(decode_cfg) is False
+
+
+def test_wva_decode_uses_accelerator_count_positive_returns_true():
+    """GPU scenario: decode.accelerator.count>0 → WVA picks up accelerator."""
+    decode_cfg = {
+        "replicas": 2,
+        "accelerator": {"count": 1},
+        "acceleratorType": {
+            "labelKey": "nvidia.com/gpu.product",
+            "labelValue": "NVIDIA-H100-80GB-HBM3",
+        },
+    }
+    assert DeployModelserviceStep._decode_uses_accelerator(decode_cfg) is True
+
+
+def test_wva_decode_falls_back_to_tensor_parallelism():
+    """When decode.accelerator is unset, the template uses tensor parallelism."""
+    decode_with_tensor = {
+        "replicas": 2,
+        "parallelism": {"tensor": 4},
+        "acceleratorType": {"labelKey": "k", "labelValue": "v"},
+    }
+    assert (
+        DeployModelserviceStep._decode_uses_accelerator(decode_with_tensor)
+        is True
+    )
+
+    decode_tensor_zero = {
+        "replicas": 2,
+        "parallelism": {"tensor": 0},
+    }
+    assert (
+        DeployModelserviceStep._decode_uses_accelerator(decode_tensor_zero)
+        is False
+    )
+
+
+def test_wva_decode_empty_config_returns_false():
+    assert DeployModelserviceStep._decode_uses_accelerator({}) is False
+    assert DeployModelserviceStep._decode_uses_accelerator(None) is False


### PR DESCRIPTION
## Summary

- Standup on pure-CPU scenarios was failing `step_03_workload_monitoring` with `Node selector label 'nvidia.com/gpu.product=NVIDIA-H100-80GB-HBM3' not found on any cluster node`, even though the rendered modelservice values correctly use `kubernetes.io/os: linux` affinity and no nvidia labels. 

- `defaults.yaml` hardcodes nvidia values for `decode.acceleratorType` / `prefill.acceleratorType`, which CPU scenarios inherit via `deep_merge` (they only override `accelerator.count: 0`). The Jinja template correctly guards on `decode_accel_count > 0` and so never emits the labels but the validator was reading them from `plan_config` unconditionally and flagging them as "missing on the cluster."

- This PR fixes the above