### PR TITLE
add parser to replace model.name automatically

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -287,6 +287,76 @@ This allows public models (e.g. `facebook/opt-125m`) to be deployed without a to
 
 The `enabled` flag is auto-computed during plan rendering by `_resolve_hf_token()` in `render_plans.py`. It checks `HF_TOKEN`, `LLMDBENCH_HF_TOKEN`, and the scenario YAML in that order.
 
+## Config Variable Substitution
+
+Scenario files support `${dotted.path}` references that are resolved at render time against the merged config. This avoids hard-coding values like model names in multiple places.
+
+### Syntax
+
+Use `${section.key}` to reference any scalar value in the config. The path must contain at least one dot — this distinguishes config variables from shell variables, which are left untouched.
+
+| Pattern | Resolved? | Why |
+|---|---|---|
+| `${model.name}` | Yes | Dotted path → config lookup |
+| `${model.path}` | Yes | Dotted path → config lookup |
+
+### Available variables
+
+Any scalar value in the merged config (defaults + scenario) can be referenced. Common examples:
+
+| Variable | Resolves to | Example value |
+|---|---|---|
+| `${model.name}` | `model.name` | `facebook/opt-125m` |
+| `${model.path}` | `model.path` | `models/facebook/opt-125m` |
+| `${model.huggingfaceId}` | `model.huggingfaceId` | `facebook/opt-125m` |
+| `${model.maxModelLen}` | `model.maxModelLen` | `32768` |
+| `${namespace.name}` | `namespace.name` | `my-namespace` |
+
+### Where to use
+
+Config variables work in any string field in the scenario YAML, including fields that are normally passed through as raw text:
+
+- `customCommand` — vLLM serve commands for decode/prefill/standalone
+- `extraEnvVars` — environment variable values
+- `pluginsCustomConfig` — inline EPP plugin configuration
+
+### Example
+
+```yaml
+scenario:
+  - name: my-scenario
+    model:
+      name: meta-llama/Llama-3.1-8B
+      path: models/meta-llama/Llama-3.1-8B
+
+    decode:
+      vllm:
+        customCommand: |
+          vllm serve /model-cache/${model.path} \
+            --served-model-name ${model.name} \
+            --port $VLLM_METRICS_PORT
+      extraEnvVars:
+        - name: SERVED_MODEL_NAME
+          value: "${model.name}"
+
+    inferenceExtension:
+      pluginsCustomConfig:
+        my-config.yaml: |
+          plugins:
+            - type: tokenizer
+              parameters:
+                modelName: "${model.name}"
+```
+
+Shell variables like `$VLLM_METRICS_PORT` are preserved for runtime resolution. Config variables like `${model.name}` are substituted at render time.
+
+### Behavior
+
+- Substitution runs after all resolvers (model, namespace, version, etc.) so all values are available.
+- If a reference cannot be resolved, it is left as-is and a warning is logged.
+- Non-string values (integers, booleans) are converted to strings when embedded.
+- The original config dict is not mutated — a deep copy is used.
+
 ## Model Artifact Protocol (`modelservice.uriProtocol`)
 
 Controls how the modelservice Helm chart locates and loads model weights. Set via `modelservice.uriProtocol` in your scenario or defaults.

--- a/config/scenarios/cicd/kind-sim.yaml
+++ b/config/scenarios/cicd/kind-sim.yaml
@@ -111,7 +111,7 @@ scenario:
           cpu: "0"
 
       vllm:
-        customCommand: "/app/llm-d-inference-sim --model /model-cache/models/facebook/opt-125m --port 8000 --served-model-name facebook/opt-125m"
+        customCommand: "/app/llm-d-inference-sim --model /model-cache/${model.path} --port 8000 --served-model-name ${model.name}"
 
     # Decode configuration -- use image's default entrypoint (inference-sim)
     decode:

--- a/config/scenarios/examples/sim.yaml
+++ b/config/scenarios/examples/sim.yaml
@@ -115,7 +115,7 @@ scenario:
         pullPolicy: IfNotPresent
 
       vllm:
-        customCommand: "/app/llm-d-inference-sim --model /model-cache/models/facebook/opt-125m --port 8000 --served-model-name facebook/opt-125m"
+        customCommand: "/app/llm-d-inference-sim --model /model-cache/${model.path} --port 8000 --served-model-name ${model.name}"
 
     # =========================================================================
     # MODELSERVICE -- Only applies when modelservice.enabled: true

--- a/config/scenarios/examples/spyre.yaml
+++ b/config/scenarios/examples/spyre.yaml
@@ -190,7 +190,7 @@ scenario:
 
       vllm:
         customCommand: |
-          /home/senuser/container-scripts/simple_vllm_serve.sh ibm-ai-platform/micro-g3.3-8b-instruct-1b \
+          /home/senuser/container-scripts/simple_vllm_serve.sh ${model.name} \
           --port $VLLM_INFERENCE_PORT \
           --max-model-len $VLLM_MAX_MODEL_LEN \
           --max-num-seq $VLLM_MAX_NUM_SEQ \
@@ -207,7 +207,7 @@ scenario:
         - name: PORT
           value: "8000"
         - name: SERVED_MODEL_NAME
-          value: "ibm-ai-platform/micro-g3.3-8b-instruct-1b"
+          value: "${model.name}"
         - name: FLEX_COMPUTE
           value: SENTIENT
         - name: FLEX_DEVICE
@@ -287,8 +287,8 @@ scenario:
 
       vllm:
         customCommand: |
-          /home/senuser/container-scripts/simple_vllm_serve.sh /model-cache/models/ibm-ai-platform/micro-g3.3-8b-instruct-1b \
-          --served-model-name ibm-ai-platform/micro-g3.3-8b-instruct-1b \
+          /home/senuser/container-scripts/simple_vllm_serve.sh /model-cache/${model.path} \
+          --served-model-name ${model.name} \
           --port $VLLM_METRICS_PORT \
           --max-model-len $VLLM_MAX_MODEL_LEN \
           --tensor-parallel-size $VLLM_TENSOR_PARALLELISM \
@@ -305,7 +305,7 @@ scenario:
         - name: PORT
           value: "8000"
         - name: SERVED_MODEL_NAME
-          value: "ibm-ai-platform/micro-g3.3-8b-instruct-1b"
+          value: "${model.name}"
         - name: FLEX_COMPUTE
           value: SENTIENT
         - name: FLEX_DEVICE

--- a/config/scenarios/guides/precise-prefix-cache-aware.yaml
+++ b/config/scenarios/guides/precise-prefix-cache-aware.yaml
@@ -83,7 +83,7 @@ scenario:
                   blockSize: 64
                 indexerConfig:
                   tokenizersPoolConfig:
-                    modelName: "Qwen/Qwen3-32B"
+                    modelName: "${model.name}"
                     local: null
                     hf: null
                     uds:

--- a/config/scenarios/guides/simulated-accelerators.yaml
+++ b/config/scenarios/guides/simulated-accelerators.yaml
@@ -54,7 +54,7 @@ scenario:
         port: 8000
         # Custom command -- sim image uses /app/llm-d-inference-sim, not vllm serve.
         # Note: model name is hardcoded here. Update if model.name changes.
-        customCommand: "/app/llm-d-inference-sim --model /model-cache/models/facebook/opt-125m --port $VLLM_INFERENCE_PORT --served-model-name facebook/opt-125m"
+        customCommand: "/app/llm-d-inference-sim --model /model-cache/${model.path} --port $VLLM_INFERENCE_PORT --served-model-name ${model.name}"
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods (continued)

--- a/config/scenarios/guides/wide-ep-lws.yaml
+++ b/config/scenarios/guides/wide-ep-lws.yaml
@@ -241,8 +241,8 @@ scenario:
         # Only --kv-transfer-config and --kv-events-config from vllmCommon
         # are appended if enabled.
         customCommand: |
-          exec vllm serve /model-cache/models/Qwen/Qwen3-30B-A3B \
-            --served-model-name Qwen/Qwen3-30B-A3B \
+          exec vllm serve /model-cache/${model.path} \
+            --served-model-name ${model.name} \
             --port $VLLM_INFERENCE_PORT \
             --trust-remote-code \
             --disable-uvicorn-access-log \
@@ -389,8 +389,8 @@ scenario:
         # Only --kv-transfer-config and --kv-events-config from vllmCommon
         # are appended if enabled.
         customCommand: |
-          exec vllm serve /model-cache/models/Qwen/Qwen3-30B-A3B \
-            --served-model-name Qwen/Qwen3-30B-A3B \
+          exec vllm serve /model-cache/${model.path} \
+            --served-model-name ${model.name} \
             --port $VLLM_METRICS_PORT \
             --trust-remote-code \
             --disable-uvicorn-access-log \

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -8,6 +8,7 @@ import base64
 import hashlib
 import json
 import os
+import re
 from copy import deepcopy
 from pathlib import Path
 from typing import Optional, Any
@@ -504,6 +505,64 @@ class RenderPlans:
 
         return values
 
+    # Matches ${dotted.path} but NOT ${SHELL_VAR} (no dots).
+    _CONFIG_VAR_RE = re.compile(r"\$\{([\w]+(?:\.[\w]+)+)\}")
+
+    def _substitute_config_variables(self, values: dict) -> dict:
+        """Replace ``${dotted.path}`` references in string values with resolved config values.
+
+        Walks the config dict recursively. For every string value, substitutes
+        ``${model.name}``-style references with the corresponding value from
+        the config. Shell variables like ``$VLLM_PORT`` or ``${SINGLE_WORD}``
+        are left untouched because the regex requires at least one dot.
+        """
+        result = deepcopy(values)
+        self._substitute_recursive(result, result)
+        return result
+
+    def _substitute_recursive(self, node: Any, root: dict) -> None:
+        """Recursively substitute config variable references in place."""
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if isinstance(value, str):
+                    node[key] = self._substitute_string(value, root)
+                elif isinstance(value, (dict, list)):
+                    self._substitute_recursive(value, root)
+        elif isinstance(node, list):
+            for i, item in enumerate(node):
+                if isinstance(item, str):
+                    node[i] = self._substitute_string(item, root)
+                elif isinstance(item, (dict, list)):
+                    self._substitute_recursive(item, root)
+
+    def _substitute_string(self, text: str, root: dict) -> str:
+        """Replace all ``${dotted.path}`` patterns in a single string."""
+        def _replace(match: re.Match) -> str:
+            path = match.group(1)
+            value = self._resolve_dotted_path(path, root)
+            if value is None:
+                self.logger.log_warning(
+                    f"⚠️  Config variable '${{{path}}}' could not be resolved, "
+                    "leaving as-is"
+                )
+                return match.group(0)
+            return str(value)
+
+        return self._CONFIG_VAR_RE.sub(_replace, text)
+
+    @staticmethod
+    def _resolve_dotted_path(path: str, root: dict) -> Optional[str]:
+        """Resolve a dotted path like ``model.name`` against the config dict."""
+        current = root
+        for part in path.split("."):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                return None
+        if isinstance(current, (dict, list)):
+            return None
+        return current
+
     _HF_TOKEN_SENTINELS = {"REPLACE_TOKEN", "REPLACE_TOKEN_B64", ""}
 
     def _resolve_hf_token(self, values: dict) -> dict:
@@ -691,6 +750,7 @@ class RenderPlans:
         merged_values = self._resolve_monitoring(merged_values)
         merged_values = self._resolve_hf_token(merged_values)
         merged_values = self._resolve_model_id_label(merged_values)
+        merged_values = self._substitute_config_variables(merged_values)
 
         from llmdbenchmark.parser.config_schema import validate_config
 

--- a/tests/test_config_variable_substitution.py
+++ b/tests/test_config_variable_substitution.py
@@ -1,0 +1,130 @@
+"""Tests for ${dotted.path} config variable substitution in render_plans.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+
+@pytest.fixture
+def renderer():
+    """Create a RenderPlans instance with a mock logger."""
+    logger = MagicMock()
+    logger.log_warning = MagicMock()
+    logger.log_info = MagicMock()
+    r = RenderPlans.__new__(RenderPlans)
+    r.logger = logger
+    return r
+
+
+class TestSubstituteConfigVariables:
+    """Tests for _substitute_config_variables()."""
+
+    def test_basic_substitution(self, renderer):
+        values = {
+            "model": {"name": "meta-llama/Llama-3.1-8B"},
+            "field": "served model is ${model.name}",
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["field"] == "served model is meta-llama/Llama-3.1-8B"
+
+    def test_nested_path(self, renderer):
+        values = {
+            "model": {"name": "my-model", "path": "models/my-model"},
+            "decode": {
+                "vllm": {
+                    "customCommand": "serve /cache/${model.path} --served-model-name ${model.name}"
+                }
+            },
+        }
+        result = renderer._substitute_config_variables(values)
+        assert (
+            result["decode"]["vllm"]["customCommand"]
+            == "serve /cache/models/my-model --served-model-name my-model"
+        )
+
+    def test_shell_vars_left_alone(self, renderer):
+        values = {
+            "model": {"name": "test-model"},
+            "field": "${model.name} --port $VLLM_PORT --len $VLLM_MAX_MODEL_LEN",
+        }
+        result = renderer._substitute_config_variables(values)
+        assert (
+            result["field"]
+            == "test-model --port $VLLM_PORT --len $VLLM_MAX_MODEL_LEN"
+        )
+
+    def test_shell_braced_vars_left_alone(self, renderer):
+        """${SINGLE_WORD} without dots should NOT be substituted."""
+        values = {
+            "field": "port is ${VLLM_PORT}",
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["field"] == "port is ${VLLM_PORT}"
+
+    def test_unresolvable_ref_left_as_is(self, renderer):
+        values = {"field": "value is ${nonexistent.key}"}
+        result = renderer._substitute_config_variables(values)
+        assert result["field"] == "value is ${nonexistent.key}"
+        renderer.logger.log_warning.assert_called_once()
+
+    def test_non_string_values_unchanged(self, renderer):
+        values = {
+            "model": {"name": "test"},
+            "count": 42,
+            "enabled": True,
+            "ratio": 0.5,
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["count"] == 42
+        assert result["enabled"] is True
+        assert result["ratio"] == 0.5
+
+    def test_list_of_env_vars(self, renderer):
+        values = {
+            "model": {"name": "my-org/my-model"},
+            "extraEnvVars": [
+                {"name": "MODEL", "value": "${model.name}"},
+                {"name": "PORT", "value": "8000"},
+            ],
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["extraEnvVars"][0]["value"] == "my-org/my-model"
+        assert result["extraEnvVars"][1]["value"] == "8000"
+
+    def test_multiple_refs_in_one_string(self, renderer):
+        values = {
+            "model": {"name": "my-model", "path": "models/my-model"},
+            "field": "${model.name} at ${model.path}",
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["field"] == "my-model at models/my-model"
+
+    def test_dict_or_list_value_not_substituted(self, renderer):
+        """Dotted paths resolving to dicts or lists should not be substituted."""
+        values = {
+            "model": {"name": "test", "nested": {"deep": "value"}},
+            "field": "ref is ${model.nested}",
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["field"] == "ref is ${model.nested}"
+
+    def test_original_values_not_mutated(self, renderer):
+        values = {
+            "model": {"name": "original"},
+            "field": "${model.name}",
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["field"] == "original"
+        assert values["field"] == "${model.name}"
+
+    def test_numeric_value_substituted_as_string(self, renderer):
+        values = {
+            "model": {"maxModelLen": 32768},
+            "field": "max len is ${model.maxModelLen}",
+        }
+        result = renderer._substitute_config_variables(values)
+        assert result["field"] == "max len is 32768"


### PR DESCRIPTION
Add a parser to update model name and path automatically in the scenario yaml files instead of having hard-coded values. 