### PR TITLE
fix capacity_validator on the number of accelerators

### DIFF
--- a/llmdbenchmark/utilities/capacity_validator.py
+++ b/llmdbenchmark/utilities/capacity_validator.py
@@ -357,14 +357,18 @@ def _extract_params(
     dp = int(parallelism.get("data", 1))
     pp = 1  # Pipeline parallelism not yet exposed per-method
 
+    accel_section = plan_config.get("accelerator", {})
+    method_accel_count = method_config.get("accelerator", {}).get("count")
+    global_accel_count = accel_section.get("count")
+
     accelerator_nr = int(
         method_config.get(
             "acceleratorNr",
-            parallelism.get("workers", tp * pp * dp),
+            method_accel_count
+            or global_accel_count
+            or tp * pp * dp,
         )
     )
-
-    accel_section = plan_config.get("accelerator", {})
     accel_type = method_config.get("acceleratorType", {}).get(
         "labelValue", ""
     ) or accel_section.get("type", "")


### PR DESCRIPTION
The fix reads the actual device count from `accelerator.count` to determine the number of accelerators. Using `worker` is inaccurate since some acclerators use a single worker process to manage multiple devices. 