### PR TITLE
feat: implement queue-based async telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,18 +575,6 @@ Results are saved in the native format of each harness, as well as a universal B
 
 The analysis pipeline generates per-request distribution plots, cross-treatment comparison tables and charts, and Prometheus metric visualizations. Analysis runs both inside the harness container (automatically) and locally via `--analyze`. For interactive exploration, a Jupyter notebook is also available at [`docs/analysis/README.md`](docs/analysis/README.md).
 
-### Telemetry
-
-The tool includes a non-blocking, asynchronous telemetry system to push benchmark results and metadata to a central receiver.
-
-- **Asynchronous**: Telemetry data is queued and pushed in a background thread, ensuring that benchmark execution is not blocked by network latency.
-- **Authentication**: Supports OIDC token authentication (e.g., for Google Cloud Run) by setting `LLMDBENCH_TELEMETRY_TOKEN` or using the Google auth provider.
-- **Configuration**:
-  - `LLMDBENCH_TELEMETRY_ENABLED=1`: Enable telemetry.
-  - `LLMDBENCH_TELEMETRY_ENDPOINT=https://...`: The HTTP endpoint to receive telemetry.
-  - `LLMDBENCH_TELEMETRY_TOKEN=...`: Provide a raw OIDC token directly.
-  - `LLMDBENCH_TELEMETRY_AUTH_PROVIDER=google`: Automatically fetch OIDC tokens using Google default credentials.
-
 ## Dependencies
 
 - [llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra.git)

--- a/README.md
+++ b/README.md
@@ -575,6 +575,18 @@ Results are saved in the native format of each harness, as well as a universal B
 
 The analysis pipeline generates per-request distribution plots, cross-treatment comparison tables and charts, and Prometheus metric visualizations. Analysis runs both inside the harness container (automatically) and locally via `--analyze`. For interactive exploration, a Jupyter notebook is also available at [`docs/analysis/README.md`](docs/analysis/README.md).
 
+### Telemetry
+
+The tool includes a non-blocking, asynchronous telemetry system to push benchmark results and metadata to a central receiver.
+
+- **Asynchronous**: Telemetry data is queued and pushed in a background thread, ensuring that benchmark execution is not blocked by network latency.
+- **Authentication**: Supports OIDC token authentication (e.g., for Google Cloud Run) by setting `LLMDBENCH_TELEMETRY_TOKEN` or using the Google auth provider.
+- **Configuration**:
+  - `LLMDBENCH_TELEMETRY_ENABLED=1`: Enable telemetry.
+  - `LLMDBENCH_TELEMETRY_ENDPOINT=https://...`: The HTTP endpoint to receive telemetry.
+  - `LLMDBENCH_TELEMETRY_TOKEN=...`: Provide a raw OIDC token directly.
+  - `LLMDBENCH_TELEMETRY_AUTH_PROVIDER=google`: Automatically fetch OIDC tokens using Google default credentials.
+
 ## Dependencies
 
 - [llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra.git)

--- a/llmdbenchmark/README.md
+++ b/llmdbenchmark/README.md
@@ -19,6 +19,7 @@ llmdbenchmark/
 ├── smoketests/              -- Post-deployment validation (health, inference, config checks)
 ├── standup/                 -- Standup phase steps (provision infrastructure, deploy models)
 ├── teardown/                -- Teardown phase steps (uninstall, clean up resources)
+├── telemetry/               -- Queue-based async usage telemetry
 ├── utilities/               -- Shared helpers (Kubernetes, endpoint detection, cloud upload)
 └── exceptions/              -- Custom exception hierarchy
 ```
@@ -47,6 +48,24 @@ A typical benchmark session follows this pipeline:
 5. **Teardown** -- Execute teardown steps: uninstall Helm releases, delete pods/secrets/ConfigMaps, clean cluster-scoped resources (5 steps, 00-04).
 
 The `experiment` command automates this lifecycle across multiple setup treatments (Design of Experiments).
+
+## Telemetry
+
+The package includes a queue-based asynchronous HTTP telemetry system to track usage.
+
+### Configuration
+Telemetry is enabled and configured via environment variables:
+* `LLMDBENCH_TELEMETRY_ENABLED`: Set to `true` to enable.
+* `LLMDBENCH_TELEMETRY_ENDPOINT`: The HTTP URL to POST JSON data to.
+* `LLMDBENCH_TELEMETRY_API_KEY`: Optional API key sent in `X-API-Key` header.
+
+### Usage in Code
+```python
+from llmdbenchmark.telemetry import get_telemetry
+
+if telemetry := get_telemetry():
+    telemetry.push({"event": "action_name", "custom_data": "value"})
+```
 
 ## How Submodules Relate
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -27,6 +27,8 @@ from llmdbenchmark.utilities.os.filesystem import (
     resolve_specification_file,
 )
 from llmdbenchmark.interface.commands import Command
+from llmdbenchmark.telemetry import init_telemetry, get_telemetry
+import getpass
 from llmdbenchmark.interface import plan, standup, teardown, run
 from llmdbenchmark.interface import smoketest as smoketest_interface
 from llmdbenchmark.interface import experiment as experiment_interface
@@ -1208,6 +1210,9 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_WORKSPACE": ("workspace", "--workspace"),
         "LLMDBENCH_BASE_DIR": ("base_dir", "--base-dir"),
         "LLMDBENCH_SPEC": ("specification_file", "--spec"),
+        "LLMDBENCH_TELEMETRY_ENABLED": ("telemetry_enabled", "--telemetry-enabled"),
+        "LLMDBENCH_TELEMETRY_PROVIDER": ("telemetry_provider", "--telemetry-provider"),
+        "LLMDBENCH_TELEMETRY_ENDPOINT": ("telemetry_endpoint", "--telemetry-endpoint"),
         "LLMDBENCH_DRY_RUN": ("dry_run", "--dry-run"),
         "LLMDBENCH_VERBOSE": ("verbose", "--verbose"),
         "LLMDBENCH_NON_ADMIN": ("non_admin", "--non-admin"),
@@ -1413,6 +1418,24 @@ def cli() -> None:
     )
 
     parser.add_argument(
+        "--telemetry-enabled",
+        action="store_true",
+        help="Enable telemetry reporting.",
+    )
+
+    parser.add_argument(
+        "--telemetry-provider",
+        default=env("LLMDBENCH_TELEMETRY_PROVIDER", "http"),
+        help="Telemetry provider (e.g., http).",
+    )
+
+    parser.add_argument(
+        "--telemetry-endpoint",
+        default=env("LLMDBENCH_TELEMETRY_ENDPOINT"),
+        help="Telemetry endpoint URL.",
+    )
+
+    parser.add_argument(
         "--version",
         "--ver",
         action="version",
@@ -1441,6 +1464,8 @@ def cli() -> None:
         args.dry_run = env_bool("LLMDBENCH_DRY_RUN")
     if not args.verbose:
         args.verbose = env_bool("LLMDBENCH_VERBOSE")
+    if not args.telemetry_enabled:
+        args.telemetry_enabled = env_bool("LLMDBENCH_TELEMETRY_ENABLED")
     if not args.non_admin:
         args.non_admin = env_bool("LLMDBENCH_NON_ADMIN")
     if hasattr(args, "monitoring") and not args.monitoring:
@@ -1527,6 +1552,32 @@ def cli() -> None:
     )
 
     logger.line_break()
+
+    # Telemetry Hook
+    config.telemetry_enabled = args.telemetry_enabled
+    config.telemetry_provider = args.telemetry_provider
+    config.telemetry_endpoint = args.telemetry_endpoint
+    config.telemetry_api_key = env("LLMDBENCH_TELEMETRY_API_KEY")
+
+    if config.telemetry_enabled:
+        init_telemetry(logger=logger)
+
+    if telemetry := get_telemetry():
+        telemetry_data = {
+            "user": getpass.getuser(),
+            "time": int(time.time() * 1000),
+            "command": args.command,
+            "config": {
+                "specification_file": str(args.specification_file),
+                "workspace": str(config.workspace),
+                "dry_run": config.dry_run,
+                "verbose": config.verbose,
+            },
+            "environment": {
+                "LLMDBENCH_BASE_DIR": str(args.base_dir),
+            }
+        }
+        telemetry.push(telemetry_data)
 
     dispatch_cli(args, logger)
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1213,6 +1213,8 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_TELEMETRY_ENABLED": ("telemetry_enabled", "--telemetry-enabled"),
         "LLMDBENCH_TELEMETRY_PROVIDER": ("telemetry_provider", "--telemetry-provider"),
         "LLMDBENCH_TELEMETRY_ENDPOINT": ("telemetry_endpoint", "--telemetry-endpoint"),
+        "LLMDBENCH_TELEMETRY_AUTH_PROVIDER": ("telemetry_auth_provider", "--telemetry-auth-provider"),
+        "LLMDBENCH_TELEMETRY_TOKEN": ("telemetry_token", "--telemetry-token"),
         "LLMDBENCH_DRY_RUN": ("dry_run", "--dry-run"),
         "LLMDBENCH_VERBOSE": ("verbose", "--verbose"),
         "LLMDBENCH_NON_ADMIN": ("non_admin", "--non-admin"),
@@ -1436,6 +1438,18 @@ def cli() -> None:
     )
 
     parser.add_argument(
+        "--telemetry-auth-provider",
+        default=env("LLMDBENCH_TELEMETRY_AUTH_PROVIDER"),
+        help="Telemetry authentication provider (e.g., google).",
+    )
+
+    parser.add_argument(
+        "--telemetry-token",
+        default=env("LLMDBENCH_TELEMETRY_TOKEN"),
+        help="Manual OIDC token or API key for telemetry auth.",
+    )
+
+    parser.add_argument(
         "--version",
         "--ver",
         action="version",
@@ -1557,7 +1571,8 @@ def cli() -> None:
     config.telemetry_enabled = args.telemetry_enabled
     config.telemetry_provider = args.telemetry_provider
     config.telemetry_endpoint = args.telemetry_endpoint
-    config.telemetry_api_key = env("LLMDBENCH_TELEMETRY_API_KEY")
+    config.telemetry_auth_provider = args.telemetry_auth_provider
+    config.telemetry_token = args.telemetry_token
 
     if config.telemetry_enabled:
         init_telemetry(logger=logger)

--- a/llmdbenchmark/config.py
+++ b/llmdbenchmark/config.py
@@ -18,6 +18,10 @@ class WorkspaceConfig:
     log_dir: Optional[Path] = None
     verbose: bool = False
     dry_run: bool = False
+    telemetry_enabled: bool = False
+    telemetry_provider: str = "http"
+    telemetry_endpoint: Optional[str] = None
+    telemetry_api_key: Optional[str] = None
 
 
 # Configured in cli.py via setup_workspace()

--- a/llmdbenchmark/config.py
+++ b/llmdbenchmark/config.py
@@ -21,7 +21,8 @@ class WorkspaceConfig:
     telemetry_enabled: bool = False
     telemetry_provider: str = "http"
     telemetry_endpoint: Optional[str] = None
-    telemetry_api_key: Optional[str] = None
+    telemetry_auth_provider: Optional[str] = None
+    telemetry_token: Optional[str] = None
 
 
 # Configured in cli.py via setup_workspace()

--- a/llmdbenchmark/telemetry/README.md
+++ b/llmdbenchmark/telemetry/README.md
@@ -1,0 +1,33 @@
+# Telemetry
+
+This module provides a non-blocking, asynchronous telemetry system to push benchmark results and metadata to a central receiver.
+
+## Architecture
+
+The telemetry system consists of:
+
+1.  **`init_telemetry`**: A singleton initialization function in `__init__.py` that sets up the provider based on configuration.
+2.  **`HttpTelemetryProvider`**: An HTTP POST implementation that uses a background queue worker to send data without blocking the main execution thread.
+3.  **Auth Providers**: Pluggable authentication providers. Currently supports Google OIDC token impersonation via `google_auth_provider.py`.
+
+## Configuration
+
+Telemetry is configured via environment variables or command-line flags:
+
+*   `LLMDBENCH_TELEMETRY_ENABLED`: Set to `1` or `true` to enable telemetry.
+*   `LLMDBENCH_TELEMETRY_ENDPOINT`: The full URL of the receiver endpoint (e.g., `https://receiver/telemetry`).
+*   `LLMDBENCH_TELEMETRY_TOKEN`: Optional. A raw OIDC ID token to use for authentication. The client will automatically prefix it with `Bearer `.
+*   `LLMDBENCH_TELEMETRY_AUTH_PROVIDER`: Set to `google` to automatically fetch OIDC tokens using Google Default Credentials.
+
+## Usage
+
+To use telemetry in local tests against a Cloud Run receiver requiring authentication:
+
+```bash
+LLMDBENCH_TELEMETRY_TOKEN=$(gcloud auth print-identity-token --impersonate-service-account="YOUR_SA@YOUR_PROJECT.iam.gserviceaccount.com" --audiences="https://your-receiver-url.run.app") \
+llmdbenchmark --spec your-spec \
+  --telemetry-enabled \
+  --telemetry-provider=http \
+  --telemetry-endpoint https://your-receiver-url.run.app/telemetry \
+  run ...
+```

--- a/llmdbenchmark/telemetry/__init__.py
+++ b/llmdbenchmark/telemetry/__init__.py
@@ -22,10 +22,20 @@ def init_telemetry(logger=None):
     if config.telemetry_provider == "http":
         if config.telemetry_endpoint:
             from llmdbenchmark.telemetry.http import HttpTelemetryProvider
+            
+            # bearer_token is a function that returns the full Authorization header value or None.
+            # It must include the "Bearer " prefix if a token is present.
+            bearer_token = lambda: None
+            if config.telemetry_token:
+                bearer_token = lambda: f"Bearer {config.telemetry_token}"
+            elif config.telemetry_auth_provider == "google":
+                from llmdbenchmark.telemetry.google_auth_provider import get_google_bearer_token_provider
+                bearer_token = get_google_bearer_token_provider(config.telemetry_endpoint, logger)
+                
             _telemetry_instance = HttpTelemetryProvider(
                 config.telemetry_endpoint, 
-                config.telemetry_api_key, 
-                logger
+                logger,
+                bearer_token=bearer_token
             )
             
             def wait_for_telemetry():

--- a/llmdbenchmark/telemetry/__init__.py
+++ b/llmdbenchmark/telemetry/__init__.py
@@ -1,0 +1,45 @@
+# Telemetry module
+
+import atexit
+from typing import Optional
+from llmdbenchmark.config import config
+from llmdbenchmark.logging.logger import get_logger
+
+_telemetry_instance = None
+
+def init_telemetry(logger=None):
+    """Initialize the telemetry singleton."""
+    global _telemetry_instance
+    if _telemetry_instance is not None:
+        return _telemetry_instance
+
+    if not config.telemetry_enabled:
+        return None
+
+    if logger is None:
+        logger = get_logger(config.log_dir, config.verbose, __name__)
+
+    if config.telemetry_provider == "http":
+        if config.telemetry_endpoint:
+            from llmdbenchmark.telemetry.http import HttpTelemetryProvider
+            _telemetry_instance = HttpTelemetryProvider(
+                config.telemetry_endpoint, 
+                config.telemetry_api_key, 
+                logger
+            )
+            
+            def wait_for_telemetry():
+                logger.log_info("Waiting for telemetry to finish sending...", emoji="⏳")
+                _telemetry_instance.stop()
+                
+            atexit.register(wait_for_telemetry)
+        else:
+            logger.log_info("Telemetry enabled but provider 'http' not fully configured (missing endpoint).", emoji="⚠️")
+    else:
+        logger.log_info(f"Telemetry enabled but provider '{config.telemetry_provider}' not supported.", emoji="⚠️")
+        
+    return _telemetry_instance
+
+def get_telemetry():
+    """Get the telemetry singleton instance."""
+    return _telemetry_instance

--- a/llmdbenchmark/telemetry/google_auth_provider.py
+++ b/llmdbenchmark/telemetry/google_auth_provider.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Optional
+
+def get_google_oidc_token(audience: str, logger) -> Optional[str]:
+    """Fetch Google OIDC ID token for the given audience."""
+    logger.log_info(f"[telemetry] Attempting to fetch OIDC token for audience: {audience}")
+    try:
+        import google.auth
+        import google.auth.transport.requests
+        from google.oauth2 import id_token
+
+        credentials, project = google.auth.default()
+        auth_req = google.auth.transport.requests.Request()
+        token = id_token.fetch_id_token(auth_req, audience=audience)
+        return token
+    except ImportError:
+        logger.log_info("[telemetry] google-auth not installed, skipping OIDC token fetch.")
+        return None
+    except Exception as e:
+        logger.log_info(f"[telemetry] Could not fetch OIDC token: {e}")
+        return None
+
+def get_google_bearer_token_provider(endpoint: str, logger):
+    """Returns a function that fetches a Google OIDC token and adds Bearer prefix."""
+    from urllib.parse import urlparse
+    parsed_url = urlparse(endpoint)
+    audience = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    
+    def get_bearer():
+        t = get_google_oidc_token(audience, logger)
+        return f"Bearer {t}" if t else None
+        
+    return get_bearer

--- a/llmdbenchmark/telemetry/http.py
+++ b/llmdbenchmark/telemetry/http.py
@@ -10,9 +10,9 @@ from llmdbenchmark.logging.logger import get_logger
 class HttpTelemetryProvider(TelemetryProvider):
     """HTTP POST implementation of TelemetryProvider with a background queue worker."""
 
-    def __init__(self, endpoint: str, api_key: str, logger=None):
+    def __init__(self, endpoint: str, logger=None, bearer_token=lambda: None):
         self.endpoint = endpoint
-        self.api_key = api_key
+        self.bearer_token = bearer_token
         self.logger = logger or get_logger(
             config.log_dir, verbose=config.verbose, log_name=__name__
         )
@@ -46,8 +46,9 @@ class HttpTelemetryProvider(TelemetryProvider):
         headers = {
             "Content-Type": "application/json",
         }
-        if self.api_key:
-            headers["X-API-Key"] = self.api_key
+
+        if token := self.bearer_token():
+            headers["Authorization"] = token
 
         try:
             # We use a timeout to avoid blocking forever if the endpoint is hung
@@ -55,7 +56,7 @@ class HttpTelemetryProvider(TelemetryProvider):
                 self.endpoint,
                 json=data,
                 headers=headers,
-                timeout=5.0
+                timeout=30.0
             )
             if response.status_code != 200 and response.status_code != 201:
                 self.logger.log_error(

--- a/llmdbenchmark/telemetry/http.py
+++ b/llmdbenchmark/telemetry/http.py
@@ -1,0 +1,76 @@
+import json
+import sys
+import requests
+import threading
+import queue
+from llmdbenchmark.telemetry.interface import TelemetryProvider
+from llmdbenchmark.config import config
+from llmdbenchmark.logging.logger import get_logger
+
+class HttpTelemetryProvider(TelemetryProvider):
+    """HTTP POST implementation of TelemetryProvider with a background queue worker."""
+
+    def __init__(self, endpoint: str, api_key: str, logger=None):
+        self.endpoint = endpoint
+        self.api_key = api_key
+        self.logger = logger or get_logger(
+            config.log_dir, verbose=config.verbose, log_name=__name__
+        )
+        
+        self.queue = queue.Queue()
+        self.worker_thread = threading.Thread(target=self._worker, daemon=True)
+        self.worker_thread.start()
+
+    def push(self, data: dict) -> None:
+        """Put telemetry data into the queue."""
+        if not self.endpoint:
+            return
+        self.queue.put(data)
+
+    def _worker(self) -> None:
+        """Background worker that processes the queue."""
+        while True:
+            try:
+                data = self.queue.get()
+                if data is None:
+                    # Sentinel value to stop the worker
+                    self.queue.task_done()
+                    break
+                
+                self._push_payload(data)
+                self.queue.task_done()
+            except Exception as e:
+                self.logger.log_error(f"[telemetry] Error in worker thread: {e}")
+
+    def _push_payload(self, data: dict) -> None:
+        headers = {
+            "Content-Type": "application/json",
+        }
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+
+        try:
+            # We use a timeout to avoid blocking forever if the endpoint is hung
+            response = requests.post(
+                self.endpoint,
+                json=data,
+                headers=headers,
+                timeout=5.0
+            )
+            if response.status_code != 200 and response.status_code != 201:
+                self.logger.log_error(
+                    f"[telemetry] Failed to push telemetry, status code: {response.status_code}"
+                )
+            else:
+                self.logger.log_info("[telemetry] Telemetry pushed successfully.", emoji="📊")
+        except requests.Timeout:
+            self.logger.log_error("[telemetry] Timeout pushing telemetry.")
+        except requests.RequestException as e:
+            self.logger.log_error(f"[telemetry] Failed to push telemetry: {e}")
+
+    def stop(self) -> None:
+        """Stop the background worker and wait for it to finish."""
+        self.queue.put(None)
+        self.worker_thread.join()
+
+

--- a/llmdbenchmark/telemetry/interface.py
+++ b/llmdbenchmark/telemetry/interface.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+
+class TelemetryProvider(ABC):
+    """Abstract base class for telemetry providers."""
+
+    @abstractmethod
+    def push(self, data: dict) -> None:
+        """Push telemetry data.
+
+        Args:
+            data: A dictionary containing telemetry fields.
+        """
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "huggingface_hub",
     "transformers",
     "pydantic>=2.0",
+    "google-auth",
 ]
 
 #


### PR DESCRIPTION
Add a telemtry provider interface and http implementation.

Supports publish json data to a http endpoint with corresponding api-key