### PR TITLE
auto render host and add VLLM_INFERENCE_PORT in default template

### DIFF
--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -15,7 +15,7 @@
 {% set port = vllmCommon.kvEvents.port -%}
 {% set publisher = vllmCommon.kvEvents.publisher -%}
 {% set topic_prefix = vllmCommon.kvEvents.topicPrefix -%}
-{"enable_kv_cache_events":true,"publisher":"{{ publisher }}","endpoint":"tcp://{{ service_name }}.{{ ns }}.svc.cluster.local:{{ port }}","topic":"{{ topic_prefix }}@${POD_IP}@{{ model.name }}"}
+{"enable_kv_cache_events":true,"publisher":"{{ publisher }}","endpoint":"tcp://{{ service_name }}.{{ ns }}.svc.cluster.local:{{ port }}","topic":"{{ topic_prefix }}@$(POD_IP):$(VLLM_INFERENCE_PORT)@{{ model.name }}"}
 {%- endmacro %}
 
 {# Macro to build vLLM serve command with templated arguments #}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -621,7 +621,7 @@ vllmCommon:
   # KV Events Configuration (for precise prefix cache aware routing)
   # When enabled, adds --kv-events-config to vllm serve command
   # Generates endpoint: tcp://<serviceName>.<namespace>.svc.cluster.local:<port>
-  # Generates topic: <topicPrefix>@${POD_IP}@<model.name>
+  # Generates topic: <topicPrefix>@$(POD_IP):$(VLLM_INFERENCE_PORT)@<model.name>
   kvEvents:
     enabled: false  # Set to true in scenario to enable
     publisher: zmq

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -505,6 +505,31 @@ class RenderPlans:
 
         return values
 
+    def _resolve_inference_pool_host(self, values: dict) -> dict:
+        """Auto-populate destinationRule.host from model_id_label when not set.
+
+        The Kubernetes service name for the GAIE EPP is always
+        ``{model_id_label}-gaie-epp``.  If a scenario's
+        ``inferenceExtension.inferencePoolProviderConfig.destinationRule``
+        exists but has no ``host``, fill it in automatically so that
+        scenario authors don't need to compute the hashed label by hand.
+        """
+        dest_rule = (
+            values
+            .get("inferenceExtension", {})
+            .get("inferencePoolProviderConfig", {})
+            .get("destinationRule")
+        )
+        if dest_rule is not None and not dest_rule.get("host"):
+            model_id_label = values.get("model_id_label", "")
+            if model_id_label:
+                dest_rule["host"] = f"{model_id_label}-gaie-epp"
+                self.logger.log_info(
+                    f"Auto-resolved destinationRule.host to "
+                    f"'{dest_rule['host']}'"
+                )
+        return values
+
     # Matches ${dotted.path} but NOT ${SHELL_VAR} (no dots).
     _CONFIG_VAR_RE = re.compile(r"\$\{([\w]+(?:\.[\w]+)+)\}")
 
@@ -750,6 +775,7 @@ class RenderPlans:
         merged_values = self._resolve_monitoring(merged_values)
         merged_values = self._resolve_hf_token(merged_values)
         merged_values = self._resolve_model_id_label(merged_values)
+        merged_values = self._resolve_inference_pool_host(merged_values)
         merged_values = self._substitute_config_variables(merged_values)
 
         from llmdbenchmark.parser.config_schema import validate_config


### PR DESCRIPTION
1. Add `VLLM_INFERENCE_PORT` in default template to match with `llm-d` guides. 
2. Auto render host to match with the scenario below https://github.com/llm-d/llm-d-benchmark/blob/bd834949091e9b67c8e8afbc25f5a22687aa2c03/config/scenarios/guides/precise-prefix-cache-aware.yaml#L118