### PR TITLE
Feature: Added tuneable cli arguments for timeouts during standup and run

### DIFF
--- a/config/scenarios/cicd/kind-sim.yaml
+++ b/config/scenarios/cicd/kind-sim.yaml
@@ -43,7 +43,7 @@ scenario:
     # No GPU accelerators
     accelerator:
       count: 0
-      memory: 24  # To pass capacity planner sanity checking
+      memory: 24 # To pass capacity planner sanity checking
 
     # Minimal gateway resources for Kind
     gateway:

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -756,6 +756,7 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         run_config_file=run_config_file,
         generate_config_only=getattr(args, "generate_config", False),
         dataset_url=getattr(args, "dataset", None),
+        harness_data_access_timeout=int(getattr(args, "data_access_timeout", 120) or 120),
     )
 
     executor = StepExecutor(
@@ -1237,6 +1238,7 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_WVA": ("wva", "--wva"),
         "LLMDBENCH_SERVICE_ACCOUNT": ("serviceaccount", "--serviceaccount"),
         "LLMDBENCH_HARNESS_ENVVARS_TO_YAML": ("envvarspod", "--envvarspod"),
+        "LLMDBENCH_DATA_ACCESS_TIMEOUT": ("data_access_timeout", "--data-access-timeout"),
     }
 
     active = {k: v for k, v in os.environ.items() if k in _ENV_TO_CLI}

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -417,6 +417,7 @@ def _do_standup(args, logger, render_plan_errors):
         model_name=plan_info.get("model_name"),
         logger=logger,
         standalone_deploy_timeout=int(getattr(args, "standalone_deploy_timeout", 900) or 900),
+        gateway_deploy_timeout=int(getattr(args, "gateway_deploy_timeout", 120) or 120),
     )
 
     _check_model_access(context, all_stacks_info, logger)
@@ -1241,6 +1242,7 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_HARNESS_ENVVARS_TO_YAML": ("envvarspod", "--envvarspod"),
         "LLMDBENCH_DATA_ACCESS_TIMEOUT": ("data_access_timeout", "--data-access-timeout"),
         "LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT": ("standalone_deploy_timeout", "--standalone-deploy-timeout"),
+        "LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT": ("gateway_deploy_timeout", "--gateway-deploy-timeout"),
     }
 
     active = {k: v for k, v in os.environ.items() if k in _ENV_TO_CLI}

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -416,6 +416,7 @@ def _do_standup(args, logger, render_plan_errors):
         harness_namespace=harness_ns,
         model_name=plan_info.get("model_name"),
         logger=logger,
+        standalone_deploy_timeout=int(getattr(args, "standalone_deploy_timeout", 900) or 900),
     )
 
     _check_model_access(context, all_stacks_info, logger)
@@ -1239,6 +1240,7 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_SERVICE_ACCOUNT": ("serviceaccount", "--serviceaccount"),
         "LLMDBENCH_HARNESS_ENVVARS_TO_YAML": ("envvarspod", "--envvarspod"),
         "LLMDBENCH_DATA_ACCESS_TIMEOUT": ("data_access_timeout", "--data-access-timeout"),
+        "LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT": ("standalone_deploy_timeout", "--standalone-deploy-timeout"),
     }
 
     active = {k: v for k, v in os.environ.items() if k in _ENV_TO_CLI}

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -418,6 +418,7 @@ def _do_standup(args, logger, render_plan_errors):
         logger=logger,
         standalone_deploy_timeout=int(getattr(args, "standalone_deploy_timeout", 900) or 900),
         gateway_deploy_timeout=int(getattr(args, "gateway_deploy_timeout", 120) or 120),
+        modelservice_deploy_timeout=int(getattr(args, "modelservice_deploy_timeout", 1500) or 1500),
     )
 
     _check_model_access(context, all_stacks_info, logger)
@@ -1243,6 +1244,7 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_DATA_ACCESS_TIMEOUT": ("data_access_timeout", "--data-access-timeout"),
         "LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT": ("standalone_deploy_timeout", "--standalone-deploy-timeout"),
         "LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT": ("gateway_deploy_timeout", "--gateway-deploy-timeout"),
+        "LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT": ("modelservice_deploy_timeout", "--modelservice-deploy-timeout"),
     }
 
     active = {k: v for k, v in os.environ.items() if k in _ENV_TO_CLI}

--- a/llmdbenchmark/executor/README.md
+++ b/llmdbenchmark/executor/README.md
@@ -208,6 +208,7 @@ Mutable dataclass populated incrementally across phases. Shared by all steps and
 | `endpoint_url` | `str or None` | Explicit endpoint (run-only mode) |
 | `run_config_file` | `str or None` | Run config YAML path |
 | `analyze_locally` | `bool` | Run local analysis after collection |
+| `data_access_timeout` | `int` | Seconds to wait for the harness data-access pod to become Ready (default: 120). |
 
 ### Key Methods
 

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -93,6 +93,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
 
     # Standup pod deployment timeouts
     standalone_deploy_timeout: int = 900
+    gateway_deploy_timeout: int = 120
 
     # Run-only mode (existing-stack)
     endpoint_url: str | None = None

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -89,6 +89,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     harness_service_account: str | None = None
     harness_envvars_to_pod: str | None = None
     analyze_locally: bool = False
+    harness_data_access_timeout: int = 120
 
     # Run-only mode (existing-stack)
     endpoint_url: str | None = None

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -91,6 +91,9 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     analyze_locally: bool = False
     harness_data_access_timeout: int = 120
 
+    # Standup pod deployment timeouts
+    standalone_deploy_timeout: int = 900
+
     # Run-only mode (existing-stack)
     endpoint_url: str | None = None
     run_config_file: str | None = None

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -94,6 +94,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # Standup pod deployment timeouts
     standalone_deploy_timeout: int = 900
     gateway_deploy_timeout: int = 120
+    modelservice_deploy_timeout: int = 1500
 
     # Run-only mode (existing-stack)
     endpoint_url: str | None = None

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -118,6 +118,7 @@ Executes benchmark experiments against deployed infrastructure.
 | `-U` / `--endpoint-url` | `LLMDBENCH_ENDPOINT_URL` | Explicit endpoint URL (run-only mode) |
 | `-c` / `--config` | -- | Run config YAML file (run-only mode) |
 | `--generate-config` | -- | Generate run config and exit |
+| `--data-access-timeout` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready. |
 
 ### teardown (`teardown.py`)
 
@@ -156,3 +157,4 @@ Orchestrates a full DoE experiment with automatic standup/run/teardown per setup
 | `-d` / `--debug` | -- | Debug mode (sleep infinity) |
 | `--stop-on-error` | -- | Abort experiment on first failure |
 | `--skip-teardown` | -- | Leave stacks running after each treatment |
+| `--data-access-timeout` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready. |

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -78,6 +78,7 @@ Provisions model infrastructure from a specification. Implicitly generates a pla
 | `-k` / `--kubeconfig` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--skip-smoketest` | -- | Skip automatic post-standup smoketests |
 | `--standalone-deploy-timeout` | `LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT` | Seconds to wait for the vLLM pods to deploy during standup in standalone mode. |
+| `--gateway-deploy-timeout` | `LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT` | Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice. |
 
 ### smoketest (`smoketest.py`)
 

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -79,6 +79,7 @@ Provisions model infrastructure from a specification. Implicitly generates a pla
 | `--skip-smoketest` | -- | Skip automatic post-standup smoketests |
 | `--standalone-deploy-timeout` | `LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT` | Seconds to wait for the vLLM pods to deploy during standup in standalone mode. |
 | `--gateway-deploy-timeout` | `LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT` | Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice. |
+| `--modelservice-deploy-timeout` | `LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT` | Seconds to wait for decode, prefill and inference pool pods to deploy during standup with modelservice (Generic timeout for Step 9). |
 
 ### smoketest (`smoketest.py`)
 

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -77,6 +77,7 @@ Provisions model infrastructure from a specification. Implicitly generates a pla
 | `--parallel` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
 | `-k` / `--kubeconfig` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--skip-smoketest` | -- | Skip automatic post-standup smoketests |
+| `--standalone-deploy-timeout` | `LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT` | Seconds to wait for the vLLM pods to deploy during standup in standalone mode. |
 
 ### smoketest (`smoketest.py`)
 

--- a/llmdbenchmark/interface/experiment.py
+++ b/llmdbenchmark/interface/experiment.py
@@ -103,6 +103,12 @@ def add_subcommands(parser: argparse._SubParsersAction):
         help="Seconds to wait for harness completion (0 = do not wait).",
     )
     exp_parser.add_argument(
+        "--data-access-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_DATA_ACCESS_TIMEOUT"),
+        help="Seconds to wait for the harness data-access pod to become Ready.",
+    )
+    exp_parser.add_argument(
         "-x",
         "--dataset",
         default=env("LLMDBENCH_DATASET"),

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -99,6 +99,12 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env("LLMDBENCH_DATASET"),
         help="URL for dataset to be replayed by the harness.",
     )
+    run_parser.add_argument(
+        "--data-access-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_DATA_ACCESS_TIMEOUT"),
+        help="Seconds to wait for the harness data-access pod to become Ready.",
+    )
 
     # Monitoring
     run_parser.add_argument(

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -90,5 +90,11 @@ def add_subcommands(parser: argparse._SubParsersAction):
         "--standalone-deploy-timeout",
         type=int,
         default=env_int("LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT"),
-        help="Seconds to wait for the vLLM pods to deploy in standalone mode.",
+        help="Seconds to wait for the vLLM pods to deploy during standup in standalone mode.",
+    )
+    standup_parser.add_argument(
+        "--gateway-deploy-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT"),
+        help="Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice.",
     )

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -98,3 +98,9 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env_int("LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT"),
         help="Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice.",
     )
+    standup_parser.add_argument(
+        "--modelservice-deploy-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT"),
+        help="Seconds to wait for decode, prefill and inference pool pods to deploy during standup with modelservice.",
+    )

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -86,3 +86,9 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=False,
         help="Skip automatic smoketest after standup completes.",
     )
+    standup_parser.add_argument(
+        "--standalone-deploy-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT"),
+        help="Seconds to wait for the vLLM pods to deploy in standalone mode.",
+    )

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -21,12 +21,14 @@ def add_subcommands(parser: argparse._SubParsersAction):
         help="Step list (comma-separated values or ranges, e.g. 0,1,5 or 1-7).",
     )
     standup_parser.add_argument(
-        "-c", "--scenario",
+        "-c",
+        "--scenario",
         default=env("LLMDBENCH_SCENARIO"),
         help="Scenario file to source environment variables from.",
     )
     standup_parser.add_argument(
-        "-m", "--models",
+        "-m",
+        "--models",
         default=env("LLMDBENCH_MODELS"),
         help="List of models to be stood up.",
     )
@@ -37,27 +39,32 @@ def add_subcommands(parser: argparse._SubParsersAction):
         help="Namespaces to use (deploy_namespace, benchmark_namespace).",
     )
     standup_parser.add_argument(
-        "-t", "--methods",
+        "-t",
+        "--methods",
         default=env("LLMDBENCH_METHODS"),
         help="Standup methods (standalone, modelservice).",
     )
     standup_parser.add_argument(
-        "-a", "--affinity",
+        "-a",
+        "--affinity",
         default=env("LLMDBENCH_AFFINITY"),
         help="Kubernetes node affinity configuration.",
     )
     standup_parser.add_argument(
-        "-b", "--annotations",
+        "-b",
+        "--annotations",
         default=env("LLMDBENCH_ANNOTATIONS"),
         help="Kubernetes pod annotations.",
     )
     standup_parser.add_argument(
-        "-r", "--release",
+        "-r",
+        "--release",
         default=env("LLMDBENCH_RELEASE"),
         help="Modelservice Helm chart release name.",
     )
     standup_parser.add_argument(
-        "-u", "--wva",
+        "-u",
+        "--wva",
         default=env("LLMDBENCH_WVA"),
         help="Enable Workload Variant Autoscaler.",
     )

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -124,6 +124,7 @@ llmdbenchmark --spec guides/inference-scheduling run -p <NS> -z
 | `--analyze` | | Run local analysis on collected results |
 | `-s STEPS` | | Step filter (e.g., `0,1,6` or `2-8`) |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` | Kubeconfig path |
+| `--data-access-timeout N` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready (default: 120). |
 
 ## Step Details
 

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -90,10 +90,11 @@ class HarnessNamespaceStep(Step):
             configmap_namespaces.append(model_ns)
         self._create_preprocesses_configmap(cmd, context, configmap_namespaces, errors)
 
+        timeout = context.harness_data_access_timeout
         wait_result = cmd.wait_for_pods(
             label="role=llm-d-benchmark-data-access",
             namespace=harness_ns,
-            timeout=120,
+            timeout=timeout,
             poll_interval=5,
             description="harness data-access pod",
         )

--- a/llmdbenchmark/standup/steps/step_06_standalone_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_standalone_deploy.py
@@ -138,10 +138,11 @@ class StandaloneDeployStep(Step):
                 self._require_config(plan_config, "standalone", "replicas")
             )
 
+            timeout = context.standalone_deploy_timeout
             wait_result = cmd.wait_for_pods(
                 label=f"app={deploy_name}",
                 namespace=namespace,
-                timeout=900,
+                timeout=timeout,
                 poll_interval=10,
                 description=f"standalone {deploy_name}",
             )

--- a/llmdbenchmark/standup/steps/step_08_deploy_gaie.py
+++ b/llmdbenchmark/standup/steps/step_08_deploy_gaie.py
@@ -92,10 +92,11 @@ class DeployGaieStep(Step):
             else:
                 gw_label = "app.kubernetes.io/name=llm-d-infra"
 
+            timeout = context.gateway_deploy_timeout
             gateway_wait = cmd.wait_for_pods(
                 label=gw_label,
                 namespace=namespace,
-                timeout=120,
+                timeout=timeout,
                 poll_interval=10,
                 description="gateway infra",
             )

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -53,6 +53,7 @@ class DeployModelserviceStep(Step):
         release = self._require_config(plan_config, "release")
         model_id_label = plan_config.get("model_id_label", "")
         inference_port = self._require_config(plan_config, "vllmCommon", "inferencePort")
+        timeout = context.modelservice_deploy_timeout # Generic timeout for all pods in step 9
 
         if not context.dry_run:
             pc_error = self._check_priority_class(cmd, plan_config, context)
@@ -124,7 +125,7 @@ class DeployModelserviceStep(Step):
             decode_wait = cmd.wait_for_pods(
                 label="llm-d.ai/role=decode",
                 namespace=namespace,
-                timeout=1500,
+                timeout=timeout,
                 poll_interval=10,
                 description="decode pods",
             )
@@ -171,7 +172,7 @@ class DeployModelserviceStep(Step):
                 prefill_wait = cmd.wait_for_pods(
                     label="llm-d.ai/role=prefill",
                     namespace=namespace,
-                    timeout=1500,
+                    timeout=timeout,
                     poll_interval=10,
                     description="prefill pods",
                 )
@@ -181,7 +182,7 @@ class DeployModelserviceStep(Step):
             pool_wait = cmd.wait_for_pods(
                 label=f"inferencepool={model_id_label}-gaie-epp",
                 namespace=namespace,
-                timeout=1500,
+                timeout=timeout,
                 poll_interval=10,
                 description="inference pool",
             )


### PR DESCRIPTION
I have added the following cli arguments to run.py and standup.py, so that the user can tune the timeout duration when pods are being deployed:

run.py:
- `harness_data_access_timeout` in step 5: harness namespace

standup.py:
- `standalone_deploy_timeout` in step 6: standalone deploy
- `gateway_deploy_timeout` in step 8: deploy gateway
- `modelservice_deploy_timeout` in step 9: deploy modelservice

Readme info:
| `--data-access-timeout` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready. |
| `--standalone-deploy-timeout` | `LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT` | Seconds to wait for the vLLM pods to deploy during standup in standalone mode. |
| `--gateway-deploy-timeout` | `LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT` | Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice. |
| `--modelservice-deploy-timeout` | `LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT` | Seconds to wait for decode, prefill and inference pool pods to deploy during standup with modelservice (Generic timeout for Step 9). |


I have tested that all the arguments are accessible from the cli and they successfully modify the timeout period of their respective `wait_for_pods` function. 