### PR TITLE
add support for context length aware router

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -22,6 +22,7 @@ All declarative configuration for `llmdbenchmark` lives in this directory. The t
 - [Affinity Configuration](#affinity-configuration)
 - [Scenario Organization](#scenario-organization)
 - [vLLM Command Generation](#vllm-command-generation)
+- [Context-Length-Aware Routing](#context-length-aware-routing)
 - [Init Containers](#init-containers)
 - [Harness Entrypoint Configuration](#harness-entrypoint-configuration)
 - [Flow Control Configuration](#flow-control-configuration)
@@ -773,6 +774,167 @@ When `decode.vllm.customCommand` or `prefill.vllm.customCommand` is set, the aut
 ### Preprocess script
 
 The preprocess script runs before the vLLM command (separated by `;` or `&&`). Priority: `decode.vllm.customPreprocessCommand` > `vllmCommon.preprocessScript` > default (`/bin/true`).
+
+---
+
+## Context-Length-Aware Routing
+
+This section explains how to configure per-pod context-length-aware routing. This feature allows different decode (or prefill) pods to handle different context length ranges, enabling the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) to route requests to the most appropriate pod based on token count.
+
+### How It Works
+
+The setup has three layers:
+
+1. **Scenario YAML** -- you define `contextLengthRanges` and optionally `vllmVariants` per role (decode/prefill)
+2. **Template rendering** -- the benchmark tool converts these lists into environment variables injected into pods:
+   - `LLMDBENCH_POD_LABELS` for pod self-labeling (format: `label_eq_value,label_eq_value`)
+   - `,,`-delimited `VLLM_*` env vars for per-pod vllm parameter overrides
+3. **Pod startup** -- the preprocess script (`set_llmdbench_environment.py`) runs inside each pod, extracts the pod's index from its hostname (via LeaderWorkerSet), selects the correct variant values, re-exports the env vars, and self-labels the pod using pykube
+
+The inference scheduler's `context-length-aware` plugin then reads the `llm-d.ai/context-length-range` label from each pod and routes requests accordingly.
+
+### Prerequisites
+
+- **Multinode (LeaderWorkerSet) must be enabled.** The per-pod index is derived from sequential pod names assigned by LWS (e.g., `decode-0`, `decode-1`). Without LWS, pods get random Deployment hash suffixes and the index cannot be determined.
+- **Kubeconfig secret must be mounted.** Pods need K8s API access to self-label. This is handled by mounting the `llmdbench-context` secret (created automatically by step 04).
+- **Preprocess script must be configured.** The `vllmCommon.preprocessScript` must run `set_llmdbench_environment.py` and source the generated env file.
+
+### Scenario Configuration
+
+Add the following to your scenario YAML under the `decode` (or `prefill`) section:
+
+```yaml
+scenario:
+  - name: "my-context-aware-deployment"
+
+    # Enable multinode -- REQUIRED for per-pod variants
+    multinode:
+      enabled: true
+
+    modelservice:
+      enabled: true
+
+    decode:
+      replicas: 2
+
+      # Per-pod context-length-range labels.
+      # List length must match replicas.
+      # Each pod gets the label at its index (pod-0 gets first, pod-1 gets second).
+      contextLengthRanges:
+        - "0-8000"
+        - "8000-32768"
+
+      # Per-pod vllm parameter overrides (optional).
+      # Supported keys: maxModelLen, maxNumSeq, maxNumBatchedTokens
+      # List length must match replicas.
+      vllmVariants:
+        - maxModelLen: 8000
+          maxNumSeq: 64
+        - maxModelLen: 32768
+          maxNumSeq: 16
+
+      parallelism:
+        tensor: 4
+        data: 1
+        dataLocal: 1
+        workers: 1
+
+    # Configure the inference extension with context-length-aware plugin
+    inferenceExtension:
+      pluginsConfigFile: "context-length-aware-config.yaml"
+      sidecar:
+        enabled: true
+      pluginsCustomConfig:
+        context-length-aware-config.yaml: |
+          apiVersion: inference.networking.x-k8s.io/v1alpha1
+          kind: EndpointPickerConfig
+          plugins:
+            - type: tokenizer
+              parameters:
+                modelName: "${model.name}"
+                udsTokenizerConfig:
+                  socketFile: /tmp/tokenizer/tokenizer-uds.socket
+            - type: context-length-aware
+              parameters:
+                label: llm-d.ai/context-length-range
+                enableFiltering: true
+          schedulingProfiles:
+            - name: default
+              plugins:
+                - pluginRef: tokenizer
+                - pluginRef: context-length-aware
+
+    # Preprocess script and kubeconfig secret volume are required
+    vllmCommon:
+      preprocessScript: "python3 /setup/preprocess/set_llmdbench_environment.py && source $HOME/llmdbench_env.sh"
+      volumes:
+        - name: k8s-llmdbench-context
+          type: secret
+          secret:
+            secretName: llmdbench-context
+      volumeMounts:
+        - name: k8s-llmdbench-context
+          mountPath: /etc/kubeconfig
+          readOnly: true
+```
+
+### What Gets Generated
+
+Given the configuration above, the rendered pod template will contain:
+
+```yaml
+env:
+  - name: VLLM_MAX_MODEL_LEN
+    value: "8000,,32768"
+  - name: VLLM_MAX_NUM_SEQ
+    value: "64,,16"
+  - name: LLMDBENCH_POD_LABELS
+    value: "llm-d.ai/context-length-range_eq_0-8000,llm-d.ai/context-length-range_eq_8000-32768"
+```
+
+At pod startup, the preprocess script:
+- **Pod decode-0**: sets `VLLM_MAX_MODEL_LEN=8000`, `VLLM_MAX_NUM_SEQ=64`, labels itself with `llm-d.ai/context-length-range=0-8000`
+- **Pod decode-1**: sets `VLLM_MAX_MODEL_LEN=32768`, `VLLM_MAX_NUM_SEQ=16`, labels itself with `llm-d.ai/context-length-range=8000-32768`
+
+### Standalone Deployments
+
+Context-length-aware routing is **not applicable** to standalone deployments. Standalone mode has no inference extension (EPP) or routing layer, so there is nothing to route requests based on context length. The `contextLengthRanges`, `vllmVariants`, and `inferenceExtension` fields only apply to the modelservice deployment path.
+
+### Verifying the Setup
+
+After standup, verify the labels are applied:
+
+```bash
+kubectl get pods -l llm-d.ai/role=decode -n <namespace> --show-labels
+```
+
+You should see each pod with a distinct `llm-d.ai/context-length-range` label.
+
+Check the EPP logs for context-length-aware plugin activation:
+
+```bash
+kubectl logs <epp-pod> -c epp -n <namespace> | grep -i "context-length"
+```
+
+### Preprocess Script
+
+The preprocess script (`set_llmdbench_environment.py`) is required when using `contextLengthRanges` or `vllmVariants`. It runs inside each pod at startup and performs two tasks:
+
+1. **Splits `,,`-delimited env vars** -- when `vllmVariants` is configured, env vars like `VLLM_MAX_MODEL_LEN="8000,,32768"` are split by the pod's LWS index, so each pod gets its own value.
+2. **Self-labels pods** -- applies the `llm-d.ai/context-length-range` label to each pod via the K8s API, so the inference scheduler can route requests based on context length.
+
+The script requires:
+- `vllmCommon.preprocessScript` set to run the script and source the env file
+- The `preprocesses` ConfigMap volume mounted at `/setup/preprocess`
+- The `llmdbench-context` secret volume mounted at `/etc/kubeconfig` (for K8s API access)
+
+See the commented-out sections in the example scenarios for the exact configuration.
+
+### Reference
+
+- [llm-d inference scheduler architecture: context-length-aware](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md#contextlengthaware)
+- [GPU example scenario](scenarios/examples/gpu.yaml) -- contains commented-out `contextLengthRanges`, `vllmVariants`, and `inferenceExtension` configuration
+- [Spyre example scenario](scenarios/examples/spyre.yaml) -- contains commented-out `contextLengthRanges`, `vllmVariants`, and `inferenceExtension` configuration with Spyre-specific volumes
 
 ---
 

--- a/config/scenarios/examples/gpu.yaml
+++ b/config/scenarios/examples/gpu.yaml
@@ -81,6 +81,11 @@ scenario:
       # Corresponds to: LLMDBENCH_VLLM_COMMON_TENSOR_PARALLELISM (default 1)
       # tensorParallelism: 2
 
+      # Preprocess script -- required for context-length-aware routing.
+      # Splits ,,-delimited env vars by pod index and self-labels pods via K8s API.
+      # Uncomment when enabling contextLengthRanges or vllmVariants below.
+      # preprocessScript: "python3 /setup/preprocess/set_llmdbench_environment.py && source $HOME/llmdbench_env.sh"
+
       # These flags control the auto-generated vllm serve command.
       # Flags not listed here inherit from defaults.yaml (e.g. allowLongMaxModelLen, serverDevMode).
       # To use a fully custom command instead, set decode.vllm.customCommand.
@@ -90,11 +95,37 @@ scenario:
         disableUvicornAccessLog: true  # --disable-uvicorn-access-log
         noPrefixCaching: true        # --no-enable-prefix-caching
 
+      # Volumes required for preprocess script and kubeconfig (pod self-labeling).
+      # Uncomment when enabling context-length-aware routing.
+      # volumes:
+      #   - name: preprocesses
+      #     type: configMap
+      #     configMap:
+      #       name: llm-d-benchmark-preprocesses
+      #       defaultMode: 493  # 0755
+      #   - name: k8s-llmdbench-context
+      #     type: secret
+      #     secret:
+      #       secretName: llmdbench-context
+      #
+      # volumeMounts:
+      #   - name: preprocesses
+      #     mountPath: /setup/preprocess
+      #   - name: k8s-llmdbench-context
+      #     mountPath: /etc/kubeconfig
+      #     readOnly: true
+
     # =========================================================================
     # DEPLOYMENT METHOD -- Choose standalone or modelservice
     # =========================================================================
     modelservice:
       enabled: true
+
+    # Enable multinode (LeaderWorkerSet) for sequential pod naming.
+    # Required when using contextLengthRanges or vllmVariants.
+    # See config/README.md "Context-Length-Aware Routing" section for full setup guide.
+    # multinode:
+    #   enabled: true
 
     # =========================================================================
     # STANDALONE -- Only applies when standalone.enabled: true
@@ -137,6 +168,58 @@ scenario:
     # -------------------------------------------------------------------------
     decode:
       # replicas: 1  # default
+
+      # Context-length-aware routing: per-pod labels (one per replica).
+      # Requires multinode enabled (for LWS sequential pod naming) and
+      # kubeconfig secret mounted (see vllmCommon.volumes above).
+      # Also requires the preprocess script (vllmCommon.preprocessScript) for
+      # pod self-labeling and ,,-delimited env var splitting.
+      # See config/README.md "Context-Length-Aware Routing" section for full setup guide.
+      # contextLengthRanges:
+      #   - "0-8000"
+      #   - "8000-32768"
+
+      # Per-pod vllm parameter overrides (one per replica).
+      # Values are converted to ,,-delimited env vars; the preprocess script
+      # selects the right value based on pod index from LWS.
+      # vllmVariants:
+      #   - maxModelLen: 8000
+      #     maxNumSeq: 64
+      #   - maxModelLen: 32768
+      #     maxNumSeq: 16
+
+    # =========================================================================
+    # INFERENCE EXTENSION (EPP) -- Context-length-aware routing with UDS tokenizer
+    # Uncomment this section along with multinode, contextLengthRanges,
+    # preprocessScript, volumes/volumeMounts, and optionally vllmVariants
+    # above to enable context-length-aware routing.
+    # See config/README.md "Context-Length-Aware Routing" section for full setup guide.
+    # =========================================================================
+    # inferenceExtension:
+    #   pluginsConfigFile: "context-length-aware-config.yaml"
+    #   flags:
+    #     v: "2"  # use v: "4" for debugging, v: "1" or "2" for benchmarking
+    #   sidecar:
+    #     enabled: true
+    #   pluginsCustomConfig:
+    #     context-length-aware-config.yaml: |
+    #       apiVersion: inference.networking.x-k8s.io/v1alpha1
+    #       kind: EndpointPickerConfig
+    #       plugins:
+    #         - type: tokenizer
+    #           parameters:
+    #             modelName: "${model.name}"
+    #             udsTokenizerConfig:
+    #               socketFile: /tmp/tokenizer/tokenizer-uds.socket
+    #         - type: context-length-aware
+    #           parameters:
+    #             label: llm-d.ai/context-length-range
+    #             enableFiltering: true
+    #       schedulingProfiles:
+    #         - name: default
+    #           plugins:
+    #             - pluginRef: tokenizer
+    #             - pluginRef: context-length-aware
 
     # =========================================================================
     # WORKLOAD / HARNESS -- Benchmark execution configuration

--- a/config/scenarios/examples/spyre.yaml
+++ b/config/scenarios/examples/spyre.yaml
@@ -159,6 +159,12 @@ scenario:
     modelservice:
       enabled: true
 
+    # Enable multinode (LeaderWorkerSet) for sequential pod naming.
+    # Required when using contextLengthRanges or vllmVariants.
+    # See config/README.md "Context-Length-Aware Routing" section for full setup guide.
+    # multinode:
+    #   enabled: true
+
     # =========================================================================
     # STANDALONE -- Only applies when standalone.enabled: true
     # =========================================================================
@@ -262,6 +268,25 @@ scenario:
     decode:
       replicas: 2
 
+      # Context-length-aware routing: per-pod labels (one per replica).
+      # Requires multinode enabled (for LWS sequential pod naming) and
+      # kubeconfig secret mounted (see vllmCommon.volumes below).
+      # Also requires the preprocess script (vllmCommon.preprocessScript) for
+      # pod self-labeling and ,,-delimited env var splitting.
+      # See config/README.md "Context-Length-Aware Routing" section for full setup guide.
+      # contextLengthRanges:
+      #   - "0-8000"
+      #   - "8000-32768"
+
+      # Per-pod vllm parameter overrides (one per replica).
+      # Values are converted to ,,-delimited env vars; the preprocess script
+      # selects the right value based on pod index from LWS.
+      # vllmVariants:
+      #   - maxModelLen: 8000
+      #     maxNumSeq: 32
+      #   - maxModelLen: 32768
+      #     maxNumSeq: 32
+
       parallelism:
         tensor: 4
         data: 1
@@ -330,6 +355,38 @@ scenario:
           value: "1"
         - name: VLLM_DT_CHUNK_LEN
           value: "1024"
+
+    # =========================================================================
+    # INFERENCE EXTENSION (EPP) -- Context-length-aware routing with UDS tokenizer
+    # Uncomment this section along with multinode, contextLengthRanges, and
+    # vllmVariants above to enable context-length-aware routing.
+    # See config/README.md "Context-Length-Aware Routing" section for full setup guide.
+    # =========================================================================
+    # inferenceExtension:
+    #   pluginsConfigFile: "context-length-aware-config.yaml"
+    #   flags:
+    #     v: "2"  # use v: "4" for debugging, v: "1" or "2" for benchmarking
+    #   sidecar:
+    #     enabled: true
+    #   pluginsCustomConfig:
+    #     context-length-aware-config.yaml: |
+    #       apiVersion: inference.networking.x-k8s.io/v1alpha1
+    #       kind: EndpointPickerConfig
+    #       plugins:
+    #         - type: tokenizer
+    #           parameters:
+    #             modelName: "${model.name}"
+    #             udsTokenizerConfig:
+    #               socketFile: /tmp/tokenizer/tokenizer-uds.socket
+    #         - type: context-length-aware
+    #           parameters:
+    #             label: llm-d.ai/context-length-range
+    #             enableFiltering: true
+    #       schedulingProfiles:
+    #         - name: default
+    #           plugins:
+    #             - pluginRef: tokenizer
+    #             - pluginRef: context-length-aware
 
     # =========================================================================
     # WORKLOAD / HARNESS -- Benchmark execution configuration

--- a/config/templates/jinja/12_gaie-values.yaml.j2
+++ b/config/templates/jinja/12_gaie-values.yaml.j2
@@ -58,8 +58,15 @@ inferenceExtension:
     image: "{{ images.udsTokenizer.repository }}:{{ images.udsTokenizer.tag }}"
     imagePullPolicy: {{ inferenceExtension.sidecar.imagePullPolicy | default('IfNotPresent') }}
     name: {{ inferenceExtension.sidecar.name | default('tokenizer-uds') }}
-{% if inferenceExtension.sidecar.env is defined and inferenceExtension.sidecar.env %}
     env:
+{% if huggingface.enabled %}
+      - name: HF_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ huggingface.secretName }}
+            key: {{ huggingface.tokenKey }}
+{% endif %}
+{% if inferenceExtension.sidecar.env is defined and inferenceExtension.sidecar.env %}
 {% for env_var in inferenceExtension.sidecar.env %}
       - name: {{ env_var.name }}
         value: "{{ env_var.value }}"

--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -155,18 +155,33 @@
   value: "{{ config.vllm.port | default(vllmCommon.vllmPort) }}"
 - name: VLLM_BLOCK_SIZE
   value: "{{ model.blockSize | default(vllmCommon.blockSize | default('16')) }}"
+{% if config.vllmVariants is defined and config.vllmVariants | length > 0 -%}
+- name: VLLM_MAX_MODEL_LEN
+  value: "{{ config.vllmVariants | map(attribute='maxModelLen') | join(',,') }}"
+{% else -%}
 - name: VLLM_MAX_MODEL_LEN
   value: "{{ model.maxModelLen | default(vllmCommon.maxModelLen | default('4096')) }}"
+{% endif -%}
 - name: VLLM_LOAD_FORMAT
   value: "{{ vllmCommon.loadFormat | default('auto') }}"
 - name: VLLM_ACCELERATOR_MEM_UTIL
   value: "{{ model.gpuMemoryUtilization | default(vllmCommon.gpuMemoryUtilization | default('0.95')) }}"
+{% if config.vllmVariants is defined and config.vllmVariants | length > 0 and config.vllmVariants[0].maxNumSeq is defined -%}
+- name: VLLM_MAX_NUM_SEQ
+  value: "{{ config.vllmVariants | map(attribute='maxNumSeq') | join(',,') }}"
+{% else -%}
 - name: VLLM_MAX_NUM_SEQ
   value: "{{ model.maxNumSeq | default(vllmCommon.maxNumSeq | default('256')) }}"
+{% endif -%}
 - name: VLLM_TENSOR_PARALLELISM
   value: "{{ config.parallelism.tensor | default('1') }}"
+{% if config.vllmVariants is defined and config.vllmVariants | length > 0 and config.vllmVariants[0].maxNumBatchedTokens is defined -%}
+- name: VLLM_MAX_NUM_BATCHED_TOKENS
+  value: "{{ config.vllmVariants | map(attribute='maxNumBatchedTokens') | join(',,') }}"
+{% else -%}
 - name: VLLM_MAX_NUM_BATCHED_TOKENS
   value: "{{ model.maxNumBatchedTokens | default(vllmCommon.maxNumBatchedTokens | default('')) }}"
+{% endif -%}
 - name: VLLM_NIXL_SIDE_CHANNEL_HOST
   valueFrom:
     fieldRef:
@@ -186,9 +201,21 @@
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
+{% set has_kubeconfig_env = config.extraEnvVars is defined and config.extraEnvVars and config.extraEnvVars | selectattr('name', 'equalto', 'KUBECONFIG') | list | length > 0 -%}
 {% if config.podLabels is defined and config.podLabels -%}
 - name: LLMDBENCH_POD_LABELS
   value: "{{ config.podLabels }}"
+{% if not has_kubeconfig_env -%}
+- name: KUBECONFIG
+  value: "/etc/kubeconfig/{{ control.contextSecretName | default('llmdbench-context') }}"
+{% endif -%}
+{% elif config.contextLengthRanges is defined and config.contextLengthRanges | length > 0 -%}
+- name: LLMDBENCH_POD_LABELS
+  value: "{% for r in config.contextLengthRanges %}{% if not loop.first %},{% endif %}llm-d.ai/context-length-range_eq_{{ r }}{% endfor %}"
+{% if not has_kubeconfig_env -%}
+- name: KUBECONFIG
+  value: "/etc/kubeconfig/{{ control.contextSecretName | default('llmdbench-context') }}"
+{% endif -%}
 {% endif -%}
 {% if config.extraEnvVars is defined and config.extraEnvVars %}
 {% for env in config.extraEnvVars %}

--- a/llmdbenchmark/parser/config_schema.py
+++ b/llmdbenchmark/parser/config_schema.py
@@ -216,6 +216,9 @@ class DeploymentBaseConfig(BaseModel):
     initContainers: list[Any]
     monitoring: DeploymentMonitoringConfig
 
+    contextLengthRanges: list[str] = Field(default_factory=list)
+    vllmVariants: list[dict[str, Any]] = Field(default_factory=list)
+
     annotations: dict[str, str] | None = None
 
     hostIPC: bool | None = None

--- a/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
+++ b/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import subprocess
+import sys
 import ipaddress
 import os
 import json
@@ -484,8 +485,8 @@ for key in dict(os.environ).keys():
     if "VLLM_" in key:
         value = os.environ.get(key)
         if value.count(',,') :
-            if pod_index :
-                if len(value.split(',,')) >= pod_index :
+            if pod_index is not None :
+                if len(value.split(',,')) > pod_index :
                     newvalue = value.split(',,')[pod_index]
                 else :
                     newvalue = value.split(',,')[0]
@@ -494,41 +495,92 @@ for key in dict(os.environ).keys():
             print(f"INFO: Variable \"{key}\" with value \"{value}\" will be re-exported with \"{newvalue}\" ({pod_index})")
             env_file_contents.append(f"export {key}={newvalue}")
 
-if pod_labels.count(',') and kubeconfig_path :
+if pod_labels.count('_eq_') and kubeconfig_path :
     try:
-        import pykube
-        from pykube.exceptions import PyKubeError, ObjectDoesNotExist
-    except ModuleNotFoundError as e:
-        print("DEBUG: Attempting to install pykube")
-        try :
-            result = subprocess.run(['pip', 'install', 'pykube'], capture_output=True, text=True, check=True)
-            import pykube
-            from pykube.exceptions import PyKubeError, ObjectDoesNotExist
-        except subprocess.CalledProcessError as e:
-            print(f"ERROR: Unable to install pykube: {e}")
-            sys.exit(1)
-
-    try:
-        #config = pykube.KubeConfig.from_service_account()
-        config = pykube.KubeConfig.from_file(kubeconfig_path)
-        api = pykube.HTTPClient(config)
-
-        pod = pykube.Pod.objects(api).filter(namespace=pod_namespace).get(name=pod_name)
-        if "labels" not in pod.obj["metadata"]:
-            pod.obj["metadata"]["labels"] = {}
-
-        if len(pod_labels.split(',')) >= pod_index :
-            pod_label = pod_labels.split(',')[pod_index]
+        labels_list = pod_labels.split(',')
+        if pod_index is not None and len(labels_list) > pod_index :
+            pod_label = labels_list[pod_index]
         else :
-            pod_label = pod_labels.split(',')[0]
+            pod_label = labels_list[0]
         pod_label_name, pod_label_value = pod_label.split("_eq_")
-        pod.obj["metadata"]["labels"][pod_label_name] = pod_label_value
-        pod.update()
-        print(f"INFO: Added label \"{pod_label_name}={pod_label_value}\" to this pod")
 
-    except ObjectDoesNotExist:
-        print(f"ERROR: Pod {pod_name} not found in namespace {pod_namespace}")
-        sys.exit(1)
+        # Try kubectl first (available in some images)
+        kubectl_bin = shutil.which("kubectl")
+        if kubectl_bin:
+            result = subprocess.run(
+                [kubectl_bin, "--kubeconfig", kubeconfig_path,
+                 "label", "pod", pod_name,
+                 "--namespace", pod_namespace,
+                 f"{pod_label_name}={pod_label_value}", "--overwrite"],
+                capture_output=True, text=True
+            )
+            if result.returncode == 0:
+                print(f"INFO: Added label \"{pod_label_name}={pod_label_value}\" to this pod (via kubectl)")
+            else:
+                raise RuntimeError(f"kubectl label failed: {result.stderr}")
+        else:
+            # Fall back to K8s API via urllib (stdlib, no pip needed)
+            import urllib.request
+            import ssl
+            import yaml
+
+            with open(kubeconfig_path, 'r') as f:
+                kubeconfig = yaml.safe_load(f)
+
+            # Extract server and credentials from kubeconfig
+            cluster = kubeconfig['clusters'][0]['cluster']
+            user = kubeconfig['users'][0]['user']
+            server = cluster['server'].rstrip('/')
+
+            ssl_ctx = ssl.create_default_context()
+            if 'certificate-authority-data' in cluster:
+                import base64, tempfile
+                ca_data = base64.b64decode(cluster['certificate-authority-data'])
+                ca_file = tempfile.NamedTemporaryFile(delete=False, suffix='.crt')
+                ca_file.write(ca_data)
+                ca_file.close()
+                ssl_ctx.load_verify_locations(ca_file.name)
+            elif 'certificate-authority' in cluster:
+                ssl_ctx.load_verify_locations(cluster['certificate-authority'])
+            else:
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+
+            if 'client-certificate-data' in user and 'client-key-data' in user:
+                import base64, tempfile
+                cert_data = base64.b64decode(user['client-certificate-data'])
+                key_data = base64.b64decode(user['client-key-data'])
+                cert_file = tempfile.NamedTemporaryFile(delete=False, suffix='.crt')
+                cert_file.write(cert_data)
+                cert_file.close()
+                key_file = tempfile.NamedTemporaryFile(delete=False, suffix='.key')
+                key_file.write(key_data)
+                key_file.close()
+                ssl_ctx.load_cert_chain(cert_file.name, key_file.name)
+
+            headers = {"Content-Type": "application/merge-patch+json"}
+            if 'token' in user:
+                headers["Authorization"] = f"Bearer {user['token']}"
+
+            patch_url = f"{server}/api/v1/namespaces/{pod_namespace}/pods/{pod_name}"
+            patch_body = json.dumps({
+                "metadata": {
+                    "labels": {
+                        pod_label_name: pod_label_value
+                    }
+                }
+            }).encode('utf-8')
+
+            req = urllib.request.Request(patch_url, data=patch_body, headers=headers, method='PATCH')
+            resp = urllib.request.urlopen(req, context=ssl_ctx)
+            if resp.status == 200:
+                print(f"INFO: Added label \"{pod_label_name}={pod_label_value}\" to this pod (via K8s API)")
+            else:
+                raise RuntimeError(f"K8s API returned status {resp.status}")
+
+    except Exception as e:
+        print(f"WARNING: Pod self-labeling failed (non-fatal): {e}")
+        print("WARNING: Context-length-aware routing will not work without pod labels.")
 
 
 env_file_contents.append("echo \"Defined NCCL environment variables\"")

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -397,6 +397,7 @@ def capture_label_logs(
         "logs",
         "--tail=-1",
         "--prefix=true",
+        "--all-containers=true",
         "-l", label,
         "--namespace", namespace,
         check=False,


### PR DESCRIPTION
1. Add context-length-aware routing for both `gpu.yaml` and `spyre.yaml`
2. Add `contextLengthRanges` and `vllmVariants` so decode/prefill pods can handle different context length ranges and different vllm parameters like `maxModelLen`, `maxNumSeq`, `maxNumBatchedTokens`.
3. Fix the bug in preprocess script for the standard vllm images where they don't have pykube or pip 
4. Add documentation for the added feature
5. Add `--all-containers` so we capture full epp pod logs for debug purposes 