### PR TITLE
[Standup] Ensure `simulated-accelerators` is in sync with guides

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -91,8 +91,8 @@ RUN cd vllm; VLLM_TARGET_DEVICE=empty pip install -e . --no-build-isolation
 
 # GuideLLM also requires torch, installed above
 ARG GUIDELLM_REPO=https://github.com/vllm-project/guidellm.git
-ARG GUIDELLM_BRANCH=v0.5.3
-ARG GUIDELLM_COMMIT=v0.5.3
+ARG GUIDELLM_BRANCH=v0.5.4
+ARG GUIDELLM_COMMIT=v0.5.4
 RUN git clone --branch ${GUIDELLM_BRANCH} ${GUIDELLM_REPO}
 RUN cd guidellm; \
     git checkout ${GUIDELLM_COMMIT}; \

--- a/config/scenarios/guides/simulated-accelerators.yaml
+++ b/config/scenarios/guides/simulated-accelerators.yaml
@@ -2,7 +2,14 @@
 # Based on https://github.com/llm-d/llm-d/blob/dev/guides/simulated-accelerators/README.md
 #
 # Uses llm-d-inference-sim image to simulate inference without real GPUs.
-# Deploys facebook/opt-125m with 0 GPU accelerators on CPU-only nodes.
+# Deploys a "random" model with 0 GPU accelerators on CPU-only nodes.
+#
+# Key changes from upstream guide:
+#   - Uses hf://random as model URI (modelservice chart handles this)
+#   - Decode: 3 replicas with uds-tokenizer init container
+#   - Prefill: 1 replica with uds-tokenizer init container
+#   - Routing proxy enabled with nixlv2 connector
+#   - Pod monitoring enabled for both decode and prefill
 
 scenario:
   - name: simulated-accelerators
@@ -11,123 +18,322 @@ scenario:
     # COMMON -- Applies to all deployment methods
     # =========================================================================
 
-    # Model configuration
+    # -------------------------------------------------------------------------
+    # Model Configuration
+    # Uses "random" as a lightweight simulated model
+    # -------------------------------------------------------------------------
     model:
-      name: facebook/opt-125m
-      shortName: facebook-opt-125m
-      path: models/facebook/opt-125m
-      huggingfaceId: facebook/opt-125m
+      name: random
+      shortName: random
+      path: models/random
+      huggingfaceId: random
       gpuMemoryUtilization: 0
+      size: 5Mi
 
-    # =========================================================================
-    # STANDALONE -- Only applies when standalone.enabled: true
-    # =========================================================================
+    # -------------------------------------------------------------------------
+    # Model Artifacts
+    # The upstream guide uses hf://random with custom labels
+    # -------------------------------------------------------------------------
+    modelArtifacts:
+      extraLabels:
+        llm-d.ai/guide: "simulated-accelerators"
+        llm-d.ai/accelerator-variant: "cpu"
 
-    # Standalone deployment with simulated accelerators
-    # Disabled by default -- use modelservice. Enable with --methods standalone
-    standalone:
-      enabled: false
-      replicas: 1
+    storage:
+      modelPvc:
+        size: 5Mi
 
-      image:
-        repository: ghcr.io/llm-d/llm-d-inference-sim
-        tag: latest
-        pullPolicy: Always
-
-      # No GPU resources needed
-      resources:
-        limits:
-          memory: 4Gi
-          cpu: "4"
-        requests:
-          memory: 4Gi
-          cpu: "4"
-
-      # No GPU parallelism
-      parallelism:
-        tensor: 0
-
-      # CPU-only affinity
-      nodeSelector: {}
-
-      vllm:
-        port: 8000
-        # Custom command -- sim image uses /app/llm-d-inference-sim, not vllm serve.
-        # Note: model name is hardcoded here. Update if model.name changes.
-        customCommand: "/app/llm-d-inference-sim --model /model-cache/${model.path} --port $VLLM_INFERENCE_PORT --served-model-name ${model.name}"
-
-    # =========================================================================
-    # COMMON -- Applies to all deployment methods (continued)
-    # =========================================================================
-
+    # -------------------------------------------------------------------------
     # Affinity / Node Selection
-    # By default, affinity is disabled and pods schedule on any available node.
-    # Options:
-    #   1. Leave commented out -- no node selection constraint
-    #   2. Set nodeSelector to "auto" -- auto-detects GPU labels from the cluster
-    #   3. Set explicit labels -- pods only schedule on matching nodes
-    # This scenario overrides affinity for CPU-only nodes (no GPU required).
+    # CPU-only nodes (no GPU required)
+    # -------------------------------------------------------------------------
     affinity:
       enabled: true
       nodeSelector:
         kubernetes.io/os: linux
 
+    # -------------------------------------------------------------------------
+    # Accelerator Configuration -- no GPUs
+    # -------------------------------------------------------------------------
+    accelerator:
+      count: 0
+
+    # =========================================================================
+    # DEPLOYMENT METHOD
+    # =========================================================================
+    gateway:
+      className: agentgateway
+
+    # Use hf:// URI protocol so the modelservice chart handles model loading
+    # directly (no PVC download job needed)
+    modelservice:
+      enabled: true
+      uriProtocol: hf
+
+    standalone:
+      enabled: false
+
+    # =========================================================================
+    # MULTINODE -- disabled
+    # =========================================================================
+    multinode:
+      enabled: false
+
+    # =========================================================================
+    # ROUTING / PROXY CONFIGURATION
+    # Routing proxy enabled with nixlv2 connector (matches upstream guide)
+    # =========================================================================
+    routing:
+      servicePort: 8000
+      connector: nixlv2
+      secure: false
+      proxy:
+        enabled: true
+        image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+        connector: nixlv2
+        secure: false
+
+    # =========================================================================
+    # MODELSERVICE CONFIGURATION
+    # =========================================================================
+
     # Override images for simulation
     images:
       vllm:
         repository: ghcr.io/llm-d/llm-d-inference-sim
-        tag: latest
-        pullPolicy: Always
+        tag: v0.8.2
+        pullPolicy: IfNotPresent
+      routingSidecar:
+        repository: ghcr.io/llm-d/llm-d-routing-sidecar
+        tag: v0.7.1
 
-    # =========================================================================
-    # MODELSERVICE -- Only applies when modelservice.enabled: true
-    # The following sections configure the llm-d modelservice Helm chart
-    # deployment including decode pods, prefill pods, routing, and GAIE.
-    # =========================================================================
-
-    modelservice:
-      enabled: true
-
-    # Decode/prefill use image's default entrypoint (inference-sim)
-    # No customCommand -- the vLLM serve command is auto-generated
-    # from model.*, vllmCommon.flags.*, and decode.vllm.additionalFlags.
+    # -------------------------------------------------------------------------
+    # Decode Configuration -- 3 replicas with uds-tokenizer
+    # -------------------------------------------------------------------------
     decode:
       enabled: true
-      replicas: 1
+      replicas: 3
+
+      # Monitoring
+      monitoring:
+        podmonitor:
+          enabled: true
+          portName: "vllm"
+          path: "/metrics"
+          interval: "30s"
+
+      initContainers:
+        - name: uds-tokenizer
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          env:
+            - name: LOG_LEVEL
+              value: "DEBUG"
+            - name: PROBE_PORT
+              value: "8082"
+          ports:
+            - name: health
+              containerPort: 8082
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: uds-socket
+              mountPath: /tmp/tokenizer
+
       parallelism:
         tensor: 0
         data: 1
         dataLocal: 1
         workers: 1
+
       vllm:
         modelCommand: imageDefault
+        port: 8200
 
+      # Decode container ports (vllm port)
+      ports:
+        - containerPort: 8200
+          name: vllm
+          protocol: TCP
+
+      # Extra container config for probes and volume mounts
+      extraContainerConfig:
+        imagePullPolicy: IfNotPresent
+
+      # Additional volume mounts for decode container
+      additionalVolumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+        - name: uds-socket
+          mountPath: /tmp/tokenizer
+
+      # Additional volumes for decode pods
+      additionalVolumes:
+        - name: metrics-volume
+          emptyDir: {}
+        - name: uds-socket
+          emptyDir: {}
+
+      # Custom probes matching upstream guide
+      probes:
+        startup:
+          path: /v1/models
+          port: 8200
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 60
+        liveness:
+          path: /health
+          port: 8200
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readiness:
+          path: /v1/models
+          port: 8200
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+
+    # -------------------------------------------------------------------------
+    # Prefill Configuration -- 1 replica with uds-tokenizer
+    # -------------------------------------------------------------------------
     prefill:
-      enabled: false
-      replicas: 0
+      enabled: true
+      replicas: 1
+
+      # Monitoring
+      monitoring:
+        podmonitor:
+          enabled: true
+          portName: "vllm"
+          path: "/metrics"
+          interval: "30s"
+
+      initContainers:
+        - name: uds-tokenizer
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          env:
+            - name: LOG_LEVEL
+              value: "DEBUG"
+            - name: PROBE_PORT
+              value: "8082"
+          ports:
+            - name: health
+              containerPort: 8082
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: uds-socket
+              mountPath: /tmp/tokenizer
+
       parallelism:
         tensor: 0
         data: 1
         dataLocal: 1
         workers: 1
+
       vllm:
         modelCommand: imageDefault
+        port: 8000
 
-    # Sim scenarios do not use the routing proxy sidecar
-    routing:
-      proxy:
-        enabled: false
+      # Prefill container ports
+      ports:
+        - containerPort: 8000
+          name: vllm
+          protocol: TCP
+
+      # Extra container config for probes and volume mounts
+      extraContainerConfig:
+        imagePullPolicy: IfNotPresent
+
+      # Additional volume mounts for prefill container
+      additionalVolumeMounts:
+        - name: metrics-volume
+          mountPath: /.config
+        - name: uds-socket
+          mountPath: /tmp/tokenizer
+
+      # Additional volumes for prefill pods
+      additionalVolumes:
+        - name: metrics-volume
+          emptyDir: {}
+        - name: uds-socket
+          emptyDir: {}
+
+      # Custom probes matching upstream guide
+      probes:
+        startup:
+          path: /v1/models
+          port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 60
+        liveness:
+          path: /health
+          port: 8000
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readiness:
+          path: /v1/models
+          port: 8000
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
+
+    # =========================================================================
+    # COMMON -- Applies to all deployment methods (continued)
+    # =========================================================================
+
+    # -------------------------------------------------------------------------
+    # vLLM Common Configuration
+    # -------------------------------------------------------------------------
+    vllmCommon:
+      shmMemory: 500Mi
+
+      volumes:
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 500Mi
+
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
 
     # =========================================================================
     # WORKLOAD / HARNESS -- Benchmark execution configuration
     # =========================================================================
 
-    # Harness configuration for simulated workloads
-    # Corresponds to: LLMDBENCH_CONTROL_WORK_DIR=~/data/simulated-accelerators
     workDir: "~/data/simulated-accelerators"
 
-    # Corresponds to: LLMDBENCH_HARNESS_NAME=vllm-benchmark
-    #                 LLMDBENCH_HARNESS_EXPERIMENT_PROFILE=random_concurrent.yaml
     harness:
       name: vllm-benchmark
       experimentProfile: random_concurrent.yaml

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -370,37 +370,9 @@ decode:
 {% if not ic_image or ic_image.endswith(':auto') %}
 {% set _ = ic.update({'image': images.benchmark.repository ~ ':' ~ images.benchmark.tag}) %}
 {% endif %}
-{# Render init containers manually so we can inject shared env vars via macro #}
 {% endfor %}
 {% for ic in decode.initContainers %}
-  - name: {{ ic.name }}
-    image: {{ ic.image }}
-{% if ic.imagePullPolicy is defined %}
-    imagePullPolicy: {{ ic.imagePullPolicy }}
-{% endif %}
-{% if ic.command is defined %}
-    command:
-{{ ic.command | toyaml | indent(4, true) }}
-{% endif %}
-{% if ic.args is defined %}
-    args:
-{{ ic.args | toyaml | indent(4, true) }}
-{% endif %}
-{% if ic.env is defined and ic.env %}
-    env:
-{{ ic.env | toyaml | indent(4, true) }}
-{% else %}
-    env:
-{{ build_ms_env_vars('decode') | indent(4, true) }}
-{% endif %}
-{% if ic.volumeMounts is defined %}
-    volumeMounts:
-{{ ic.volumeMounts | toyaml | indent(4, true) }}
-{% endif %}
-{% if ic.securityContext is defined %}
-    securityContext:
-{{ ic.securityContext | toyaml | indent(6) }}
-{% endif %}
+{{ render_init_container(ic, 'decode') | indent(4, true) }}
 {% endfor %}
 {% endif %}
 
@@ -424,7 +396,7 @@ decode:
 {{ build_ms_env_vars('decode') | indent(6, true) }}
 {% if decode.ports is defined and decode.ports %}
     ports:
-{{ decode.ports | toyaml | indent(6) }}
+{{ decode.ports | toyaml | indent(6, true) }}
 {% elif decode.extraContainerConfig is defined and decode.extraContainerConfig.ports is defined %}
     ports:
 {% for port in decode.extraContainerConfig.ports %}
@@ -481,22 +453,34 @@ decode:
       startupProbe:
         httpGet:
           path: {{ decode.probes.startup.path }}
-          port: {{ decode_effective_port }}
+          port: {{ decode.probes.startup.port | default(decode_effective_port) }}
         failureThreshold: {{ decode.probes.startup.failureThreshold }}
         initialDelaySeconds: {{ decode.probes.startup.initialDelaySeconds }}
         periodSeconds: {{ decode.probes.startup.periodSeconds }}
         timeoutSeconds: {{ decode.probes.startup.timeoutSeconds }}
       livenessProbe:
+{% if decode.probes.liveness.path is defined and decode.probes.liveness.path %}
+        httpGet:
+          path: {{ decode.probes.liveness.path }}
+          port: {{ decode.probes.liveness.port | default(decode_effective_port) }}
+{% else %}
         tcpSocket:
-          port: {{ decode_effective_port }}
+          port: {{ decode.probes.liveness.port | default(decode_effective_port) }}
+{% endif %}
         failureThreshold: {{ decode.probes.liveness.failureThreshold }}
         periodSeconds: {{ decode.probes.liveness.periodSeconds }}
+{% if decode.probes.liveness.timeoutSeconds is defined %}
+        timeoutSeconds: {{ decode.probes.liveness.timeoutSeconds }}
+{% endif %}
       readinessProbe:
         httpGet:
           path: {{ decode.probes.readiness.path }}
-          port: {{ decode_effective_port }}
+          port: {{ decode.probes.readiness.port | default(decode_effective_port) }}
         failureThreshold: {{ decode.probes.readiness.failureThreshold }}
         periodSeconds: {{ decode.probes.readiness.periodSeconds }}
+{% if decode.probes.readiness.timeoutSeconds is defined %}
+        timeoutSeconds: {{ decode.probes.readiness.timeoutSeconds }}
+{% endif %}
 {% if decode.extraContainerConfig is defined and decode.extraContainerConfig %}
 {% set extra_config_without_ports = {} %}
 {% for k, v in decode.extraContainerConfig.items() if k != 'ports' %}
@@ -781,7 +765,7 @@ prefill:
   subGroupExclusiveTopology: {{ prefill.subGroupExclusiveTopology | lower }}
 {% endif %}
 
-{# Prefill init containers -- rendered manually with shared env var macro #}
+{# Prefill init containers -- rendered via shared macro #}
 {% if prefill.initContainers is defined and prefill.initContainers %}
   initContainers:
 {% for ic in prefill.initContainers %}
@@ -789,34 +773,9 @@ prefill:
 {% if not ic_image or ic_image.endswith(':auto') %}
 {% set _ = ic.update({'image': images.benchmark.repository ~ ':' ~ images.benchmark.tag}) %}
 {% endif %}
-  - name: {{ ic.name }}
-    image: {{ ic.image }}
-{% if ic.imagePullPolicy is defined %}
-    imagePullPolicy: {{ ic.imagePullPolicy }}
-{% endif %}
-{% if ic.command is defined %}
-    command:
-{{ ic.command | toyaml | indent(4, true) }}
-{% endif %}
-{% if ic.args is defined %}
-    args:
-{{ ic.args | toyaml | indent(4, true) }}
-{% endif %}
-{% if ic.env is defined and ic.env %}
-    env:
-{{ ic.env | toyaml | indent(4, true) }}
-{% else %}
-    env:
-{{ build_ms_env_vars('prefill') | indent(4, true) }}
-{% endif %}
-{% if ic.volumeMounts is defined %}
-    volumeMounts:
-{{ ic.volumeMounts | toyaml | indent(4, true) }}
-{% endif %}
-{% if ic.securityContext is defined %}
-    securityContext:
-{{ ic.securityContext | toyaml | indent(6) }}
-{% endif %}
+{% endfor %}
+{% for ic in prefill.initContainers %}
+{{ render_init_container(ic, 'prefill') | indent(4, true) }}
 {% endfor %}
 {% endif %}
 
@@ -840,7 +799,7 @@ prefill:
 {{ build_ms_env_vars('prefill') | indent(6, true) }}
 {% if prefill.ports is defined and prefill.ports %}
     ports:
-{{ prefill.ports | toyaml | indent(6) }}
+{{ prefill.ports | toyaml | indent(6, true) }}
 {% elif prefill.extraContainerConfig is defined and prefill.extraContainerConfig.ports is defined %}
     ports:
 {% for port in prefill.extraContainerConfig.ports %}
@@ -897,22 +856,34 @@ prefill:
       startupProbe:
         httpGet:
           path: {{ prefill.probes.startup.path }}
-          port: {{ prefill_effective_port }}
+          port: {{ prefill.probes.startup.port | default(prefill_effective_port) }}
         failureThreshold: {{ prefill.probes.startup.failureThreshold }}
         initialDelaySeconds: {{ prefill.probes.startup.initialDelaySeconds }}
         periodSeconds: {{ prefill.probes.startup.periodSeconds }}
         timeoutSeconds: {{ prefill.probes.startup.timeoutSeconds }}
       livenessProbe:
+{% if prefill.probes.liveness.path is defined and prefill.probes.liveness.path %}
+        httpGet:
+          path: {{ prefill.probes.liveness.path }}
+          port: {{ prefill.probes.liveness.port | default(prefill_effective_port) }}
+{% else %}
         tcpSocket:
-          port: {{ prefill_effective_port }}
+          port: {{ prefill.probes.liveness.port | default(prefill_effective_port) }}
+{% endif %}
         failureThreshold: {{ prefill.probes.liveness.failureThreshold }}
         periodSeconds: {{ prefill.probes.liveness.periodSeconds }}
+{% if prefill.probes.liveness.timeoutSeconds is defined %}
+        timeoutSeconds: {{ prefill.probes.liveness.timeoutSeconds }}
+{% endif %}
       readinessProbe:
         httpGet:
           path: {{ prefill.probes.readiness.path }}
-          port: {{ prefill_effective_port }}
+          port: {{ prefill.probes.readiness.port | default(prefill_effective_port) }}
         failureThreshold: {{ prefill.probes.readiness.failureThreshold }}
         periodSeconds: {{ prefill.probes.readiness.periodSeconds }}
+{% if prefill.probes.readiness.timeoutSeconds is defined %}
+        timeoutSeconds: {{ prefill.probes.readiness.timeoutSeconds }}
+{% endif %}
 {% if prefill.extraContainerConfig is defined and prefill.extraContainerConfig %}
 {% set extra_config_without_ports = {} %}
 {% for k, v in prefill.extraContainerConfig.items() if k != 'ports' %}

--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -1,3 +1,64 @@
+{# ======================================================================== #}
+{# Macro to render a single init container for modelservice pods.          #}
+{# Supports the full Kubernetes init container spec including the sidecar  #}
+{# pattern (restartPolicy: Always) used by uds-tokenizer and similar.     #}
+{# Fields not explicitly listed are passed through via toyaml.             #}
+{# mode: 'decode' or 'prefill' -- controls env var injection default.     #}
+{# ======================================================================== #}
+{% macro render_init_container(ic, mode='decode') -%}
+- name: {{ ic.name }}
+  image: {{ ic.image }}
+{% if ic.imagePullPolicy is defined %}
+  imagePullPolicy: {{ ic.imagePullPolicy }}
+{% endif %}
+{% if ic.restartPolicy is defined %}
+  restartPolicy: {{ ic.restartPolicy }}
+{% endif %}
+{% if ic.command is defined %}
+  command:
+{{ ic.command | toyaml | indent(2, true) }}
+{% endif %}
+{% if ic.args is defined %}
+  args:
+{{ ic.args | toyaml | indent(2, true) }}
+{% endif %}
+{% if ic.env is defined and ic.env %}
+  env:
+{{ ic.env | toyaml | indent(2, true) }}
+{% else %}
+  env:
+{{ build_ms_env_vars(mode) | indent(2, true) }}
+{% endif %}
+{% if ic.ports is defined and ic.ports %}
+  ports:
+{{ ic.ports | toyaml | indent(2, true) }}
+{% endif %}
+{% if ic.resources is defined %}
+  resources:
+{{ ic.resources | toyaml | indent(4, true) }}
+{% endif %}
+{% if ic.startupProbe is defined %}
+  startupProbe:
+{{ ic.startupProbe | toyaml | indent(4, true) }}
+{% endif %}
+{% if ic.livenessProbe is defined %}
+  livenessProbe:
+{{ ic.livenessProbe | toyaml | indent(4, true) }}
+{% endif %}
+{% if ic.readinessProbe is defined %}
+  readinessProbe:
+{{ ic.readinessProbe | toyaml | indent(4, true) }}
+{% endif %}
+{% if ic.volumeMounts is defined %}
+  volumeMounts:
+{{ ic.volumeMounts | toyaml | indent(2, true) }}
+{% endif %}
+{% if ic.securityContext is defined %}
+  securityContext:
+{{ ic.securityContext | toyaml | indent(4, true) }}
+{% endif %}
+{%- endmacro %}
+
 {# Macro to build kv-transfer-config JSON #}
 {% macro build_kv_transfer_config() -%}
 {% if vllmCommon.kvTransfer.extraConfig is defined and vllmCommon.kvTransfer.extraConfig -%}

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -18,7 +18,7 @@
 | **GAIE InferencePool** | `v1.3.1` | chart version | `setup/env.sh` (`LLMDBENCH_VLLM_GAIE_CHART_VERSION`) | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
 | **kgateway** | `v2.2.3` | chart version | `setup/env.sh` (`LLMDBENCH_GATEWAY_PROVIDER_KGATEWAY_CHART_VERSION`) | [kgateway-dev/kgateway](https://github.com/kgateway-dev/kgateway) |
 | **Istio** | `1.29.1` | chart version | `setup/env.sh` (`LLMDBENCH_GATEWAY_PROVIDER_ISTIO_CHART_VERSION`) | [istio/istio](https://github.com/istio/istio) |
-| **Workload Variant Autoscaler** | `0.5.1` | chart version | `setup/env.sh` (`LLMDBENCH_WVA_CHART_VERSION`) | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) |
+| **Workload Variant Autoscaler** | `0.6.0` | chart version | `setup/env.sh` (`LLMDBENCH_WVA_CHART_VERSION`) | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) |
 | **Gateway API CRDs** | `v1.4.0` | tag | `setup/env.sh` (`LLMDBENCH_GATEWAY_API_CRD_REVISION`) | [kubernetes-sigs/gateway-api](https://github.com/kubernetes-sigs/gateway-api) |
 
 ## Container Images
@@ -30,7 +30,7 @@
 | **llm-d-inference-scheduler** | `auto` | floating (image) | `setup/env.sh` (`LLMDBENCH_LLMD_INFERENCESCHEDULER_IMAGE_TAG`) | [llm-d/llm-d](https://github.com/llm-d/llm-d) |
 | **llm-d-routing-sidecar** | `auto` | floating (image) | `setup/env.sh` (`LLMDBENCH_LLMD_ROUTINGSIDECAR_IMAGE_TAG`) | [llm-d/llm-d](https://github.com/llm-d/llm-d) |
 | **vllm-openai** | `auto` | floating (image) | `setup/env.sh` (`LLMDBENCH_VLLM_STANDALONE_IMAGE_TAG`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) |
-| **llm-d-workload-variant-autoscaler** | `v0.5.1` | image tag | `setup/env.sh` (`LLMDBENCH_WVA_IMAGE_TAG`) | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) |
+| **llm-d-workload-variant-autoscaler** | `v0.6.0` | image tag | `setup/env.sh` (`LLMDBENCH_WVA_IMAGE_TAG`) | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) |
 
 ## Harness Tools (Dockerfile pins)
 
@@ -74,8 +74,8 @@ Installed via: `pip install git+https://github.com/llm-d-incubation/llm-d-planne
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |-----------|-------------|----------|---------------|---------------|
-| **yq** | `v4.52.4` | release tag | `setup/install_deps.sh` (`install_yq_linux`) | [mikefarah/yq](https://github.com/mikefarah/yq) |
-| **helmfile** | `v1.4.1` | release tag | `setup/install_deps.sh` (`install_helmfile_linux`) | [helmfile/helmfile](https://github.com/helmfile/helmfile) |
+| **yq** | `v4.52.5` | release tag | `setup/install_deps.sh` (`install_yq_linux`) | [mikefarah/yq](https://github.com/mikefarah/yq) |
+| **helmfile** | `v1.4.2` | release tag | `setup/install_deps.sh` (`install_helmfile_linux`) | [helmfile/helmfile](https://github.com/helmfile/helmfile) |
 | **helm** | `latest` | floating | `setup/install_deps.sh` (`install_helm_linux`) | [helm/helm](https://github.com/helm/helm) |
 | **kubectl** | `stable` | floating | `build/Dockerfile` | [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) |
 

--- a/llmdbenchmark/parser/config_schema.py
+++ b/llmdbenchmark/parser/config_schema.py
@@ -82,6 +82,10 @@ class ProbeConfig(BaseModel):
     model_config = STRICT_CONFIG
 
     path: str | None = None
+    # Optional explicit port (defaults to the role's effective vLLM port at
+    # render time). Set per-probe in the scenario when the probe needs to
+    # hit a non-default port (e.g. uds-tokenizer health on 8082).
+    port: int | str | None = None
     failureThreshold: int = Field(ge=1)
     initialDelaySeconds: int | None = Field(default=None, ge=0)
     periodSeconds: int = Field(ge=1)


### PR DESCRIPTION
The `simulated-accelerators` guide now includes an `initContainer` for UDS tokenizer

Additionally, updated the version for `GuideLLM` (to `v0.5.4`) and a couple of additional verisions on `upstream-versions.md`