### PR TITLE
fix the bugs for configMap under sidecar and preprocess script

### DIFF
--- a/config/templates/jinja/12_gaie-values.yaml.j2
+++ b/config/templates/jinja/12_gaie-values.yaml.j2
@@ -62,6 +62,9 @@ inferenceExtension:
     image: "{{ images.udsTokenizer.repository }}:{{ images.udsTokenizer.tag }}"
     imagePullPolicy: {{ inferenceExtension.sidecar.imagePullPolicy | default('IfNotPresent') }}
     name: {{ inferenceExtension.sidecar.name | default('tokenizer-uds') }}
+    configMap:
+      name: {{ model_id_label }}-gaie-sidecar-config
+      data: {}
     env:
 {% if huggingface.enabled %}
       - name: HF_TOKEN

--- a/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
+++ b/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
@@ -99,7 +99,7 @@ for dep in deps_present.keys() :
         deps_present[dep] = True
         executable_found_path=result.stdout.split('\n')[0]
         executable_found_name=executable_found_path.split('/')[-1]
-        shutil.copy2(executable_actual_path, f"{options.envdir}/{executable_actual_name}")
+        shutil.copy2(executable_found_path, f"{options.envdir}/{executable_found_name}")
     except subprocess.CalledProcessError as e:
         if os.access(executables_path, os.W_OK):
             print(f"WARNING: Dependency \"{dep}\" not available on the image: {e.cmd} returned {e.returncode}. Trying to obtain externally...")
@@ -113,7 +113,7 @@ for dep in deps_present.keys() :
         deps_present[dep] = True
         executable_found_path=result.stdout.split('\n')[0]
         executable_found_name=executable_found_path.split('/')[-1]
-        shutil.copy2(executable_actual_path, f"{options.envdir}/{executable_actual_name}")
+        shutil.copy2(executable_found_path, f"{options.envdir}/{executable_found_name}")
     except subprocess.CalledProcessError as e:
         print(f"WARNING: Dependency \"{dep}\" neither available on the image nor on the config map: {e.cmd} returned {e.returncode}.")
 


### PR DESCRIPTION
- When `sidecar.enabled: true`, the chart dereferences `.Values.inferenceExtension.sidecar.configMap.name` to create a Kubernetes `configMap`. If `configMap` is not in the values, Helm hits a nil pointer error:
```bash
Error: template: inferencepool/templates/inferenceextension.yaml:1:3: executing
  "inferencepool/templates/inferenceextension.yaml" at <include "inference-extension.config" .>: error calling include:
  template: inferencepool/charts/inferenceExtension/templates/_config.yaml:63:18: executing "inference-extension.config"
  at <.Values.inferenceExtension.sidecar.configMap.name>: nil pointer evaluating interface {}.name
```

- Fix the bug for the undefined var name - `executable_actual_path` in `llmdbenchmark/standup/preprocess/set_llmdbench_environment.py`

