### PR TITLE
feat: Workload Variant Autoscaler Scenario and Infra Imeplementation

### DIFF
--- a/config/scenarios/guides/inference-scheduling-wva.yaml
+++ b/config/scenarios/guides/inference-scheduling-wva.yaml
@@ -1,0 +1,359 @@
+# INFERENCE SCHEDULING + WVA WELL LIT PATH for LLM-D Deployment
+#
+# Same base configuration as `inference-scheduling.yaml` (Qwen3-32B, 2 decode
+# pods, modelservice deployment) but with the Workload Variant Autoscaler
+# (WVA) explicitly enabled. All HPA / VariantAutoscaling knobs are listed
+# below even when they match defaults.yaml, so users can see the full
+# surface area in one place and tweak it per-scenario.
+#
+# Based on:
+#   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+#
+# Running:
+#
+#   llmdbenchmark --spec guides/inference-scheduling-wva standup -p <namespace>
+#
+# The `-u/--wva` CLI flag is NOT required with this scenario because
+# `wva.enabled: true` is already hard-coded below. Pass `-u` with the
+# plain `inference-scheduling` scenario if you want to toggle WVA on
+# without editing YAML.
+
+scenario:
+  # ============================================================================
+  # Inference Scheduling + WVA - Qwen3-32B with 2 decode pods, autoscaled
+  # ============================================================================
+  - name: "inference-scheduling-wva"
+
+    # =========================================================================
+    # MODEL CONFIGURATION
+    # =========================================================================
+    model:
+      name: Qwen/Qwen3-32B
+      shortName: qwen-qwen3-32b
+      path: models/Qwen/Qwen3-32B
+      huggingfaceId: Qwen/Qwen3-32B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+
+    # =========================================================================
+    # DEPLOYMENT METHOD
+    # =========================================================================
+    modelservice:
+      enabled: true
+
+    standalone:
+      enabled: false
+
+    # =========================================================================
+    # WVA CONFIGURATION
+    #
+    # Edit any field below to change WVA behavior for this scenario.
+    # Remove a field to fall back to its default.
+    # =========================================================================
+    wva:
+      enabled: true                  # master switch — same effect as `-u/--wva` on CLI
+
+      # Upstream well-lit-path tag. Becomes the `llm-d.ai/guide` label on the
+      # VariantAutoscaling so dashboards/queries can group by guide.
+      wellLitPath: inference-scheduling
+
+      # Where to install the WVA controller.
+      # Empty = use the deploy namespace (the first slot of `-p`). Override by
+      # passing `-p deploy,harness,wva` to put the controller elsewhere.
+      # NOTE: With namespaceScoped=true (below), the controller ONLY watches
+      # this namespace. Putting it in a different ns from your decode
+      # Deployment means it won't see your VariantAutoscaling.
+      namespace: ""
+
+      # Controller container image.
+      # Pin `tag` to a release version for reproducibility, or set to "auto"
+      # to let the version-resolver pick latest at plan time.
+      # NOTE: image tags use a leading "v" (v0.6.0), distinct from the
+      # helm chart version pinned in chartVersions.wva (which is bare 0.6.0).
+      # Available version tags can be listed with:
+      #   curl -sL "https://ghcr.io/token?scope=repository:llm-d/llm-d-workload-variant-autoscaler:pull" \
+      #     | jq -r .token | xargs -I{} curl -sH "Authorization: Bearer {}" \
+      #       https://ghcr.io/v2/llm-d/llm-d-workload-variant-autoscaler/tags/list
+      image:
+        repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+        tag: v0.6.0
+
+      replicaCount: 1                # WVA controller pod replicas (1 is the chart default)
+
+      # Disable to skip installing the controller but still render the VA
+      # + HPA (rare; useful when you reuse a cluster-wide controller
+      # installed elsewhere).
+      controller:
+        enabled: true
+
+      # Namespaced mode: controller only watches its own namespace. One WVA
+      # controller per unique wva.namespace across all rendered stacks.
+      # Set to false ONLY if you intend a single controller to manage
+      # multiple namespaces (cluster-scoped mode — discouraged on shared
+      # clusters because controllers from different tenants will race on
+      # the same VAs).
+      namespaceScoped: true
+
+      # Controller-side metrics endpoint (scraped by user-workload-monitoring).
+      # Don't change unless you have a port collision.
+      metrics:
+        enabled: true
+        port: 8443                   # /metrics port on the controller
+        secure: true                 # HTTPS + bearer-token auth
+
+      # Where the controller queries to read vLLM metrics for its scaling
+      # decisions. On OpenShift this is thanos-querier; on GKE point it at
+      # your kube-prometheus-stack Service URL.
+      prometheus:
+        baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+        port: 9091
+
+      # -----------------------------------------------------------------------
+      # VariantAutoscaling — per-model scaling intent
+      #
+      # Should match the HPA min/max below; the VA caps what the controller
+      # is willing to compute, the HPA caps what actually gets applied.
+      # -----------------------------------------------------------------------
+      variantAutoscaling:
+        enabled: true                # required for the VA to render at all
+        minReplicas: 1               # controller floor — never compute below this
+        maxReplicas: 10              # controller ceiling — never compute above this
+        # Relative GPU cost weight used by WVA's saturation solver to decide
+        # WHICH model to scale when several share GPU capacity. Higher =
+        # more expensive to scale up. Common tiering: H100=10, A100=8,
+        # L40S=5, MI300X=10. Tweak per stack to express your business priority.
+        variantCost: "10.0"
+        # SLO targets the controller tries to keep the variant within when
+        # computing desiredReplicas. Lower numbers = more aggressive scale-up
+        # under load.
+        slo:
+          tpot: 10                   # Time-Per-Output-Token target (ms)
+          ttft: 1000                 # Time-To-First-Token target (ms)
+
+      # -----------------------------------------------------------------------
+      # HorizontalPodAutoscaler — what actually changes the replica count
+      #
+      # The HPA reads `wva_desired_replicas` (emitted by the WVA controller
+      # via prometheus-adapter) and scales the decode Deployment between
+      # min/max.
+      # -----------------------------------------------------------------------
+      hpa:
+        enabled: true                # set false to render the VA only, no HPA
+        minReplicas: 1               # never scale below this — must be >= 1
+                                     # (HPA refuses to manage targets at 0)
+                                     # Keep aligned with variantAutoscaling.minReplicas above.
+        maxReplicas: 10              # safety ceiling — scale-up cap regardless
+                                     # of what the controller computes
+                                     # Keep aligned with variantAutoscaling.maxReplicas above.
+        targetAvgValue: 1            # target value the HPA tries to reach for
+                                     # `wva_desired_replicas` per pod.
+                                     # 1 = "match controller's desiredReplicas
+                                     # exactly". Don't change unless you
+                                     # understand HPA averaging math.
+
+        # Scaling behavior — how aggressively the HPA reacts. See:
+        #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+        behavior:
+          scaleUp:
+            # How long after a scale-up event before another one is allowed.
+            # Higher = smoother, less responsive. Lower = snappier but flappy.
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent        # alternative: "Pods" (absolute pod count)
+                value: 100           # 100% = double the current replica count per period
+                periodSeconds: 15    # how often this policy is evaluated
+          scaleDown:
+            # Larger window for scale-down avoids thrashing when load
+            # briefly dips. Bump to 300+ for batch workloads where transient
+            # idle is normal.
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100           # = halve the replica count per period
+                periodSeconds: 15
+
+      # vLLM *emulator* service — chart-internal feature for testing WVA
+      # without real vLLM pods. We deploy real vLLM via the modelservice
+      # chart, so we always disable this. Leave as-is.
+      vllmService:
+        enabled: false
+
+    # =========================================================================
+    # WVA-RELATED CHART VERSIONS
+    #
+    # Pins for the helm charts that step_03 installs as part of the WVA
+    # pipeline. Bump these to track upstream releases; align with what the
+    # upstream WVA guide currently calls for so the rule format and chart
+    # values stay compatible.
+    #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+    # =========================================================================
+    chartVersions:
+      # WVA controller chart (oci://ghcr.io/llm-d/workload-variant-autoscaler)
+      wva: 0.6.0
+      # prometheus-adapter chart (prometheus-community/prometheus-adapter).
+      # Pinned because newer releases have broken external-metric
+      # compatibility with the rule format the WVA chart emits.
+      # The upstream WVA README also pins this version.
+      prometheusAdapter: 5.2.0
+
+    # =========================================================================
+    # ROUTING / GAIE CONFIGURATION
+    # =========================================================================
+    inferenceExtension:
+      pluginsConfigFile: "default-plugins.yaml"
+
+    # =========================================================================
+    # PREFILL / DECODE CONFIGURATION (same as inference-scheduling.yaml)
+    # =========================================================================
+    prefill:
+      enabled: false
+      replicas: 0
+
+    decode:
+      replicas: 2
+
+      initContainers:
+        - name: preprocess
+          image: ghcr.io/llm-d/llm-d-benchmark:auto
+          imagePullPolicy: Always
+          command: ["set_llmdbench_environment.py", "-e", "/shared-config/llmdbench_env.sh", "-i"]
+          volumeMounts:
+            - name: shared-config
+              mountPath: /shared-config
+
+      parallelism:
+        tensor: 1
+        data: 1
+        dataLocal: 1
+        workers: 1
+
+      resources:
+        limits:
+          memory: 64Gi
+          cpu: "16"
+        requests:
+          memory: 64Gi
+          cpu: "16"
+
+      extraEnvVars: []
+
+      extraContainerConfig:
+        ports:
+          - containerPort: 5557  # NIXL side channel port
+            protocol: TCP
+          - containerPort: 8200  # Metrics port
+            name: metrics
+            protocol: TCP
+        securityContext:
+          capabilities:
+            add:
+              - "IPC_LOCK"
+              - "SYS_RAWIO"
+          runAsGroup: 0
+          runAsUser: 0
+        imagePullPolicy: Always
+
+      additionalVolumeMounts: []
+      additionalVolumes: []
+
+      # -----------------------------------------------------------------------
+      # Probes
+      #
+      # HTTP probes aligned with the upstream WVA well-lit-path guide
+      # (llm-d/guides/workload-autoscaling/ms-workload-autoscaling/values.yaml):
+      #   - startupProbe + readinessProbe use /v1/models — only returns 200
+      #     once vLLM has finished loading weights, so "Ready" truly means
+      #     "serving inference requests".
+      #   - livenessProbe uses /health — catches vLLM crash-loops (our
+      #     previous TCP-socket probe stayed green because the routing
+      #     sidecar stayed up while vLLM died).
+      #
+      # All probes target the routing sidecar port (8000 = servicePort),
+      # which proxies to vLLM on 8200. Probing 8000 exercises the full
+      # routing path end-to-end — the right signal for "benchmarking-ready".
+      # -----------------------------------------------------------------------
+      probes:
+        startup:
+          path: /v1/models
+          failureThreshold: 60
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+        liveness:
+          path: /health
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readiness:
+          path: /v1/models
+          failureThreshold: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+
+      # -----------------------------------------------------------------------
+      # PodMonitor (Prometheus scraping)
+      #
+      # Required for WVA: the WVA controller consumes vLLM metrics via
+      # prometheus-adapter; no PodMonitor → no metrics → HPA never sees a
+      # value for wva_desired_replicas → autoscaling silently broken.
+      # The `release: llmd` label is what user-workload-monitoring keys
+      # on for discovery, matching the upstream WVA guide's example.
+      # -----------------------------------------------------------------------
+      monitoring:
+        podmonitor:
+          enabled: true
+          portName: metrics
+          path: /metrics
+          interval: 30s
+          labels:
+            release: llmd
+
+    # =========================================================================
+    # VLLM COMMON CONFIGURATION
+    # =========================================================================
+    vllmCommon:
+      kvTransfer:
+        enabled: true
+        connector: NixlConnector
+        role: kv_both
+
+      flags:
+        enforceEager: true
+        disableLogRequests: true
+        disableUvicornAccessLog: true
+        allowLongMaxModelLen: "1"
+        serverDevMode: "1"
+
+      volumes:
+        - name: shared-config
+          type: emptyDir
+          emptyDir: {}
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: shared-config
+          mountPath: /shared-config
+
+    # =========================================================================
+    # STORAGE
+    # =========================================================================
+    storage:
+      modelPvc:
+        size: 1Ti
+
+    # =========================================================================
+    # WORKLOAD / HARNESS
+    # =========================================================================
+    workDir: "~/data/inference-scheduling-wva"
+
+    harness:
+      name: inference-perf
+      experimentProfile: shared_prefix_synthetic.yaml

--- a/config/specification/guides/inference-scheduling-wva.yaml.j2
+++ b/config/specification/guides/inference-scheduling-wva.yaml.j2
@@ -1,0 +1,19 @@
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/guides/inference-scheduling-wva.yaml
+
+# Experiment definitions are shared with the non-WVA inference-scheduling
+# scenario -- the workload shape is the same; only the infra scaling strategy
+# changes.

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -596,17 +596,17 @@ decode:
 {% if decode.monitoring.podmonitor.scrapeTimeout is defined %}
       scrapeTimeout: "{{ decode.monitoring.podmonitor.scrapeTimeout }}"
 {% endif %}
-{% if decode.monitoring.podmonitor.labels is defined %}
+{% if decode.monitoring.podmonitor.labels is defined and decode.monitoring.podmonitor.labels %}
       labels:
-{{ decode.monitoring.podmonitor.labels | toyaml | indent(8) }}
+{{ decode.monitoring.podmonitor.labels | toyaml(8) }}
 {% endif %}
-{% if decode.monitoring.podmonitor.annotations is defined %}
+{% if decode.monitoring.podmonitor.annotations is defined and decode.monitoring.podmonitor.annotations %}
       annotations:
-{{ decode.monitoring.podmonitor.annotations | toyaml | indent(8) }}
+{{ decode.monitoring.podmonitor.annotations | toyaml(8) }}
 {% endif %}
-{% if decode.monitoring.podmonitor.relabelings is defined %}
+{% if decode.monitoring.podmonitor.relabelings is defined and decode.monitoring.podmonitor.relabelings %}
       relabelings:
-{{ decode.monitoring.podmonitor.relabelings | toyaml | indent(8) }}
+{{ decode.monitoring.podmonitor.relabelings | toyaml(8) }}
 {% endif %}
 {% if decode.monitoring.podmonitor.metricRelabelings is defined %}
       metricRelabelings:

--- a/config/templates/jinja/19_wva-values.yaml.j2
+++ b/config/templates/jinja/19_wva-values.yaml.j2
@@ -1,55 +1,64 @@
 {# ============================================================================
    19_wva-values.yaml.j2
 
-   Helm values for the Workload Variant Autoscaler (WVA) chart.
-   Only rendered when wva.enabled is true.
+   Helm values for the Workload Variant Autoscaler (WVA) chart (v0.6.0).
 
-   Three values are runtime-computed and injected by step_09 at deploy time:
+   The controller is installed in namespaced mode (wva.namespaceScoped=true),
+   so the controller only watches the namespace it is deployed in.
+   VariantAutoscaling + HPA are rendered per-stack (see 27_wva-variantautoscaling
+   and 28_wva-hpa) and applied by step_09; the chart-embedded va/hpa/vllmService
+   resources are therefore disabled here.
+
+   One runtime-computed value is injected by step_02 at admin-install time:
      - wva.prometheus.caCert   (extracted from thanos-querier-tls secret)
-     - va.accelerator          (auto-detected from GPU affinity)
-     - vllmService.nodePort    (random available NodePort)
+
+   Only rendered when wva.enabled is true.
    ============================================================================ #}
 {% if wva is defined and wva.enabled | default(false) %}
-wva:
-  controllerInstance: {{ wva.namespace | default(namespace.name) }}
+controller:
   enabled: {{ wva.controller.enabled | default(true) | lower }}
+
+wva:
+  enabled: true
+  replicaCount: {{ wva.replicaCount | default(1) }}
   image:
     repository: {{ wva.image.repository }}
     tag: {{ wva.image.tag }}
+  imagePullPolicy: Always
+
+  namespaceScoped: {{ wva.namespaceScoped | default(true) | lower }}
+  controllerInstance: {{ wva.namespace | default(namespace.name, true) }}
+
   metrics:
     enabled: {{ wva.metrics.enabled | default(true) | lower }}
     port: {{ wva.metrics.port | default(8443) }}
     secure: {{ wva.metrics.secure | default(true) | lower }}
+
+  reconcileInterval: "60s"
+
   prometheus:
-    baseURL: "{{ wva.prometheus.baseUrl | default('https://thanos-querier.openshift-monitoring.svc.cluster.local') }}:{{ wva.prometheus.port | default(9091) }}"
-    caCert: ""
     monitoringNamespace: {{ openshiftMonitoring.userWorkloadMonitoringNamespace | default('openshift-user-workload-monitoring') }}
     serviceAccountName: prometheus-k8s
+    baseURL: "{{ wva.prometheus.baseUrl | default('https://thanos-querier.openshift-monitoring.svc.cluster.local') }}:{{ wva.prometheus.port | default(9091) }}"
     tls:
-      insecureSkipVerify: "true"
+      insecureSkipVerify: true
       caCertPath: /etc/ssl/certs/prometheus-ca.crt
-  reconcileInterval: "60s"
-  scaleToZero: "false"
+    caCert: ""
+
+  scaleToZero: false
 
 llmd:
   namespace: {{ namespace.name }}
   modelName: {{ model_id_label }}
   modelID: {{ model.name }}
 
+# VA/HPA/vllmService are rendered per-stack (27_wva-variantautoscaling,
+# 28_wva-hpa). Disable the chart-embedded versions so a single controller
+# can manage multiple models in the same namespace without collisions.
 va:
-  enabled: {{ wva.variantAutoscaling.enabled | default(true) | lower }}
-  accelerator: ""
-  sloTpot: {{ wva.variantAutoscaling.slo.tpot | default(10) }}
-  sloTtft: {{ wva.variantAutoscaling.slo.ttft | default(1000) }}
-
+  enabled: false
 hpa:
-  enabled: {{ wva.hpa.enabled | default(true) | lower }}
-  maxReplicas: {{ wva.hpa.maxReplicas | default(10) }}
-  targetAverageValue: {{ wva.hpa.targetAvgValue | default(1) }}
-
+  enabled: false
 vllmService:
-  enabled: {{ wva.vllmService.enabled | default(true) | lower }}
-  nodePort: 0
-  interval: {{ wva.vllmService.interval | default('15s') }}
-  scheme: {{ wva.vllmService.scheme | default('http') }}
+  enabled: false
 {% endif %}

--- a/config/templates/jinja/23_wva-namespace.yaml.j2
+++ b/config/templates/jinja/23_wva-namespace.yaml.j2
@@ -5,13 +5,17 @@
    This label is required so that user-workload-monitoring can discover
    and scrape WVA metrics in this namespace.
 
+   Namespaced-mode WVA uses `wva.namespace` (which defaults to the model
+   namespace). `kubectl apply` against this manifest is idempotent — if
+   the namespace already exists from step_05, the label is simply merged.
+
    Only rendered when wva.enabled is true.
    ============================================================================ #}
 {% if wva is defined and wva.enabled | default(false) %}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ wva.namespace | default(namespace.name) }}
+  name: {{ wva.namespace | default(namespace.name, true) }}
   labels:
     openshift.io/user-monitoring: "true"
 {% endif %}

--- a/config/templates/jinja/27_wva-variantautoscaling.yaml.j2
+++ b/config/templates/jinja/27_wva-variantautoscaling.yaml.j2
@@ -1,0 +1,63 @@
+{# ============================================================================
+   27_wva-variantautoscaling.yaml.j2
+
+   Per-stack VariantAutoscaling resource. Targets the decode Deployment
+   created by the llm-d-modelservice chart (name = {model_id_label}-decode
+   per chart helper llm-d-modelservice.decodeName + fullnameOverride).
+
+   Labels follow the upstream well-lit-path example in
+   llm-d/guides/workload-autoscaling/inference-scheduling-autoscaling/va.yaml
+   with values parameterized so each stack emits its own VA regardless of
+   how many models share a namespace.
+
+   IMPORTANT: `wva.llmd.ai/controller-instance` label is required when the
+   chart is installed with a non-empty wva.controllerInstance. Per the
+   v0.6.0 controller's predicate (internal/controller/predicates.go):
+
+     - When CONTROLLER_INSTANCE env is set on the controller, it ONLY
+       reconciles VAs whose `wva.llmd.ai/controller-instance` label
+       matches that value. Without this label, the predicate returns
+       false and the controller silently skips the VA — it'll log
+       "No active VariantAutoscalings found" forever.
+
+   The value here MUST equal `wva.controllerInstance` from chart values
+   (which we set to wva.namespace | default(namespace.name)) and the
+   `controller_instance` label in the HPA selector — all three derive
+   from the same expression so they stay aligned.
+
+   The controller (installed once per namespace by step_02) watches this
+   namespace and reconciles every VariantAutoscaling resource in it
+   that bears the matching controller-instance label.
+
+   Only rendered when wva.enabled is true.
+   ============================================================================ #}
+{% if wva is defined and wva.enabled | default(false) %}
+{% set decode_cfg = decode if decode is defined else {} %}
+{% set accel_type = decode_cfg.acceleratorType | default({}) %}
+{% set accel_label = (accel_type.labelValues[0] if accel_type.labelValues is defined and accel_type.labelValues else accel_type.labelValue | default('')) %}
+{% set accel_name = 'H100' if 'H100' in accel_label
+                    else ('A100' if 'A100' in accel_label
+                    else ('L40S' if 'L40S' in accel_label
+                    else ('MI300X' if 'MI300X' in accel_label
+                    else ('G2' if 'G2' in accel_label
+                    else '')))) %}
+apiVersion: llmd.ai/v1alpha1
+kind: VariantAutoscaling
+metadata:
+  name: {{ model_id_label }}-decode
+  namespace: {{ wva.namespace | default(namespace.name, true) }}
+  labels:
+    inference.optimization/acceleratorName: "{{ accel_name }}"
+    llm-d.ai/model: "{{ model.shortName }}"
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/guide: "{{ wva.wellLitPath | default('inference-scheduling') }}"
+    wva.llmd.ai/controller-instance: "{{ wva.namespace | default(namespace.name, true) }}"
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: {{ model_id_label }}-decode
+  modelID: "{{ model.name }}"
+  variantCost: "{{ wva.variantAutoscaling.variantCost | default('10.0') }}"
+  minReplicas: {{ wva.variantAutoscaling.minReplicas | default(1) }}
+  maxReplicas: {{ wva.variantAutoscaling.maxReplicas | default(10) }}
+{% endif %}

--- a/config/templates/jinja/28_wva-hpa.yaml.j2
+++ b/config/templates/jinja/28_wva-hpa.yaml.j2
@@ -1,0 +1,57 @@
+{# ============================================================================
+   28_wva-hpa.yaml.j2
+
+   Per-stack HorizontalPodAutoscaler that consumes the wva_desired_replicas
+   external metric emitted by the WVA controller (via prometheus-adapter).
+
+   Selector labels:
+     - variant_name        — matches the VariantAutoscaling resource's
+                             metadata.name (emitted by WVA as va.Name).
+     - exported_namespace  — the VA resource's namespace; Prometheus
+                             renames WVA's `namespace` label to
+                             `exported_namespace` because Prometheus
+                             reserves `namespace` for the scraped pod's
+                             namespace.
+     - controller_instance — narrows the match to this namespace's
+                             controller in multi-controller setups so
+                             HPAs in different namespaces don't cross-talk.
+                             Currently optional in WVA chart v0.6.0 — the
+                             chart accepts wva.controllerInstance but
+                             doesn't yet plumb it through to the running
+                             controller, so emitted metrics may have an
+                             empty `controller_instance` label until
+                             upstream makes it non-optional.
+
+   Only rendered when wva.enabled is true.
+   ============================================================================ #}
+{% if wva is defined and wva.enabled | default(false) %}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ model_id_label }}-decode
+  namespace: {{ wva.namespace | default(namespace.name, true) }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ model_id_label }}-decode
+  minReplicas: {{ wva.hpa.minReplicas | default(1) }}
+  maxReplicas: {{ wva.hpa.maxReplicas | default(16) }}
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: wva_desired_replicas
+          selector:
+            matchLabels:
+              variant_name: {{ model_id_label }}-decode
+              exported_namespace: {{ wva.namespace | default(namespace.name, true) }}
+              controller_instance: {{ wva.namespace | default(namespace.name, true) }}
+        target:
+          type: AverageValue
+          averageValue: "{{ wva.hpa.targetAvgValue | default(1) }}"
+{% if wva.hpa.behavior is defined %}
+  behavior:
+{{ wva.hpa.behavior | toyaml | indent(4, first=True) }}
+{% endif %}
+{% endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -419,7 +419,11 @@ chartVersions:
   istiod: *istio_version
   llmDInfra: auto
   llmDModelservice: auto
-  wva: auto
+  wva: 0.6.0
+  # Pinned to match the upstream WVA README's prometheus-adapter install.
+  # Newer adapter versions have broken external-metric compatibility with
+  # the chart's rule format.
+  prometheusAdapter: 5.2.0
   inferencePool: *gaie_version
   agentgateway: *agentgateway_version
   lws: *lws_version
@@ -1285,17 +1289,27 @@ extraObjects: []
 
 # ============================================================================
 # WVA (Workload Variant Autoscaler)
+#
+# Installed in *namespaced* mode: the controller watches only the namespace
+# it is deployed in. One controller per unique wva.namespace across rendered
+# stacks. VariantAutoscaling + HPA are rendered per-stack so a single
+# controller can manage multiple models in the same namespace.
 # ============================================================================
 wva:
   enabled: false
   wellLitPath: inference-scheduling
-  namespace: ""  # defaults to common namespace
+  # When blank, resolves to namespace.name at render time. Overridable via
+  # the third component of `--namespace deploy,harness,wva`.
+  namespace: ""
   image:
     repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
     tag: auto
   replicaCount: 1
+  # Chart-level top-level switch (v0.6.0): enables the controller Deployment.
   controller:
     enabled: true
+  # When true, the controller only watches the namespace it runs in.
+  namespaceScoped: true
   metrics:
     enabled: true
     port: 8443
@@ -1305,13 +1319,28 @@ wva:
     port: 9091
   variantAutoscaling:
     enabled: true
+    variantCost: "10.0"
     slo:
       tpot: 10
       ttft: 1000
   hpa:
     enabled: true
-    maxReplicas: 10
+    minReplicas: 1
+    maxReplicas: 16
     targetAvgValue: 1
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 120
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+      scaleDown:
+        stabilizationWindowSeconds: 120
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
   vllmService:
     enabled: true
     nodePortMin: 30000

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-04-17 19:42:25` (UTC)
-- Generated against git ref: `412856cbfc27d73d258c9a5e8a164d47a1944372`
+- Generated at: `2026-04-22 18:07:40` (UTC)
+- Generated against git ref: `4871a20179248d93b1ecb1ede5a5cbc61fca82bd`
 
 ## System Tool Dependencies
 
@@ -41,14 +41,15 @@ OCI registry at generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **agentgateway** | `v1.0.1` | tag | `config/templates/values/defaults.yaml` line 424 (`chartVersions.agentgateway`) | [agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) (`oci://cr.agentgateway.dev/charts/`) |
-| **inferencePool** | `v1.4.0` | tag | `config/templates/values/defaults.yaml` line 423 (`chartVersions.inferencePool`) | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
+| **agentgateway** | `v1.0.1` | tag | `config/templates/values/defaults.yaml` line 428 (`chartVersions.agentgateway`) | [agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) (`oci://cr.agentgateway.dev/charts/`) |
+| **inferencePool** | `v1.4.0` | tag | `config/templates/values/defaults.yaml` line 427 (`chartVersions.inferencePool`) | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
 | **istioBase** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 418 (`chartVersions.istioBase`) | (unknown) |
 | **istiod** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 419 (`chartVersions.istiod`) | (unknown) |
 | **llmDInfra** | `v1.4.0` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 420 (`chartVersions.llmDInfra`) | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) (`https://llm-d-incubation.github.io/llm-d-infra/`) |
-| **llmDModelservice** | `v0.4.11` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 421 (`chartVersions.llmDModelservice`) | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) (`https://llm-d-incubation.github.io/llm-d-modelservice/`) |
-| **lws** | `0.8.0` | tag | `config/templates/values/defaults.yaml` line 425 (`chartVersions.lws`) | [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws) |
-| **wva** | `0.6.0` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 422 (`chartVersions.wva`) | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) (`oci://ghcr.io/llm-d/workload-variant-autoscaler`) |
+| **llmDModelservice** | `v0.4.12` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 421 (`chartVersions.llmDModelservice`) | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) (`https://llm-d-incubation.github.io/llm-d-modelservice/`) |
+| **lws** | `0.8.0` | tag | `config/templates/values/defaults.yaml` line 429 (`chartVersions.lws`) | [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws) |
+| **prometheusAdapter** | `5.2.0` | tag | `config/templates/values/defaults.yaml` line 426 (`chartVersions.prometheusAdapter`) | [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts) (`https://prometheus-community.github.io/helm-charts`) |
+| **wva** | `0.6.0` | tag | `config/templates/values/defaults.yaml` line 422 (`chartVersions.wva`) | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) (`oci://ghcr.io/llm-d/workload-variant-autoscaler`) |
 
 
 ## Container Image Dependencies
@@ -121,7 +122,7 @@ annotated with their `pyproject.toml` line.
 | **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
 | **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
 | **fastapi** | `0.136.0` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
-| **filelock** | `3.28.0` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
+| **filelock** | `3.29.0` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
 | **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
 | **fsspec** | `2026.3.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
 | **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
@@ -133,7 +134,7 @@ annotated with their `pyproject.toml` line.
 | **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
 | **huggingface_hub** | `1.11.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
 | **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
-| **idna** | `3.11` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
+| **idna** | `3.12` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
 | **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
 | **Jinja2** | `3.1.6` | version | `pyproject.toml` line 8 (direct) | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
 | **jiter** | `0.14.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |

--- a/docs/workload-variant-autoscaler.md
+++ b/docs/workload-variant-autoscaler.md
@@ -31,7 +31,7 @@ cd llm-d-benchmark
 ./install.sh
 
 # Or one-shot via curl, optionally pinning a branch:
-#   LLMDBENCH_BRANCH=wva_refactor \
+#   LLMDBENCH_BRANCH=<BRANCH_HERE> \
 #     curl -sSL https://raw.githubusercontent.com/llm-d/llm-d-benchmark/main/install.sh | bash
 # (the curl form clones into ./llm-d-benchmark/ for you)
 

--- a/docs/workload-variant-autoscaler.md
+++ b/docs/workload-variant-autoscaler.md
@@ -1,157 +1,470 @@
-# Workload Variant Autoscaler Integration
+# Workload Variant Autoscaler (WVA) Integration
 
-`llm-d-benchmark` provides the opportunity to deploy models with an autoscaler, called `workload-variant-autoscaler`.
-For information about *how* the autoscaler works, please be sure to visit their documentation found at the [workload-variant-autoscaler](https://github.com/llm-d-incubation/workload-variant-autoscaler) repo. In this document, we will refer to `workload-variant-autoscaler` as `WVA`.
+`llm-d-benchmark` integrates with the **Workload Variant Autoscaler (WVA)** so
+benchmarking scenarios can exercise model autoscaling end-to-end. This guide
+covers how WVA is wired in, how to enable it on a scenario, what each knob in
+the scenario YAML controls, what the smoketest validates, how to tear it down
+safely on a shared cluster, and how to debug the most common failure modes.
 
-## How to Deploy a Model with WVA
+For background on the autoscaler itself, see:
 
-The simplest way to deploy a model that takes advantage of `WVA` is through the flag `-u/--wva`.
+- [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) — the controller source
+- [llm-d well-lit-path WVA guide](https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md) — the upstream install reference our integration mirrors
 
-For example, we can easily standup a model that will take advantage of autoscaling via `WVA` by simply appending the aforementioned `WVA` flag:
-
-    - ./setup/standup.sh -p llm-d-test-exp -m Qwen/Qwen3-0.6B -c inference-scheduling --wva
-
-Here is a summary of what will occur in that command:
-
-- A model will be stood up and all underlying infra will be provisioned. In this case it is `Qwen/Qwen3-0.6B` - and it will be deployed via the `inference-scheduling` well-lit-path - this is something that is **not** unique, but business as usual.
-
-- `WVA` will either be *installed* or will be idempotent in the `WVA` *controller namespace*  (*llm-d-autoscaler* being the default) depending on if it already exists on the cluster. Do note, that it is actually possible to have multiple installations of `WVA` on a cluster in seperate namespaces - which one you target is dependent on the `namespace` that is configured within the `setup/env.sh`. As part of this process, we configure `Prometheus Adapters` to allow metrics from `model` to `WVA` controller to flow naturally.
-
-- `WVA` model specific components (hpa va servicemonitor vllm-service) will be created in the `model namespace` - in this case, `llm-d-test-exp`.
-
-## How to Undeploy a Model that uses WVA
-
-There is no difference here, simply run `teardown.sh` as per usual with no additional flags for `WVA`. But there a few things you should understand:
-
-- `teardown.sh` will remove all model specific resources, including the `WVA` model specific resources.
-- `teardown.sh` will NOT remove the `WVA` controller from the `llm-d-autoscaler` namespace (or from another namespace) - this is done purposefully as to not interrupt other jobs, since many models can target a single instance of the `WVA` controller.
-
-## How to Run Workloads on a Model that uses WVA
-
-There is no difference here, and there is no additional `WVA` information needed here. Simply run `run.sh` as per usual - with no additional flags for `WVA`. For an example benchmarking scenario see the below real usecase.
+> **Platform support:** WVA install is currently only verified on **OpenShift**.
+> On other platforms, every WVA-related step (install, smoketest, teardown) is
+> deliberately skipped — the scenario YAML can still render the WVA blocks, but
+> nothing is applied to the cluster.
 
 ---
 
-## Initial Benchmarking of WVA by Leveraging LLM-D-Benchmark
+## Quick start
 
-Benchmark tests have been conducted on an `H100`.
+End-to-end on a fresh machine, against a logged-in OpenShift cluster:
 
-## Reproducibility
+```bash
+# 1. Clone (replace the branch if you're targeting a specific one)
+git clone https://github.com/llm-d/llm-d-benchmark.git
+cd llm-d-benchmark
 
-To reproduce the experiments run during the intial benchmarking of `WVA` you may follow the below guide - although both sub-sections may look identical
-at first glance, but there are some subtleties. This guide assumes that you have cloned [llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) and have installed
-it on your local machine, or system you are *driving* the experiments.
+# 2. Install (creates .venv, installs the llmdbenchmark CLI + planner)
+./install.sh
 
-### Without WVA
+# Or one-shot via curl, optionally pinning a branch:
+#   LLMDBENCH_BRANCH=wva_refactor \
+#     curl -sSL https://raw.githubusercontent.com/llm-d/llm-d-benchmark/main/install.sh | bash
+# (the curl form clones into ./llm-d-benchmark/ for you)
 
-0. Create a namespace in where you wish to install the `llm-d` stack, we will use this namespace a lot throughout these steps.
+# 3. Activate the venv created by install.sh
+source .venv/bin/activate
 
-1. Deploy a full `llm-d` stack for a target model, in this case, `meta-llama/Llama-3.1-8B`, using the `inference-scheduling` well-lit-path.
+# 4. Confirm you're pointed at the right cluster + project
+oc whoami
+oc project   # or: oc new-project <namespace>
 
-    - Template Command: `./setup/standup.sh -p <namespace> -m <model id> -c <well-lit-path>`
-
-        - Example Populated Command: `./setup/standup.sh -p llm-d-vezio -m meta-llama/Llama-3.1-8B -c inference-scheduling`
-
-2. Run a workload using the `guidellm` `harness`  and `chatbot_synthetic` `workload profile` against an existing `llm-d` stack, using the `inference-scheduling` well-lit-path.
-
-    - Template Command: `./run.sh -l <harness> -w <workload profile> -p llm-d-vezio  -m <model id> -c <well-lit-path>`
-
-        - Example Populated Command: `./run.sh -l guidellm -w chatbot_synthetic -p llm-d-vezio -m meta-llama/Llama-3.1-8B -c inference-scheduling`
-
-3. Repeat `Step 2` to rerun a workload, in our case we reran `Step 2`, a total of 4 times.
-
-4. Collect results from the `analysis` directory that is provided in the logs of the `run.sh` command. You can see a detailed and granular report in the `results` directory if needed.
-
-    - Make sure you seperate these results into a seperate directory from the WVA experiment - they are not the best named - we will change this - otherwise it will be hard to tell what is what!
-
-5. Tear down the infrastructure (this will not delete the namespace, but will completely purge *all* resources for the model, effectively leaving an empty namespace - it will NOT touch cluster-wide resources.)
-
-    - Template Command: `./setup/teardown.sh -p <namespace> -d -c <well-lit-path>`
-
-        - Example Populated Command: `./setup/teardown.sh -p llm-d-vezio -d -c inference-scheduling`
-
-### With WVA
-
-0. Create a namespace (OR reuse the now *cleaned* namespace from the previous experiment) where you wish to install the `llm-d` stack, we will use this namespace a lot throughout these steps.
-
-1. Deploy a full `llm-d` stack for a target model, that will be scaled by `WVA`, in this case, `meta-llama/Llama-3.1-8B`, using the `inference-scheduling` well-lit-path.
-
-    - Template Command: `./setup/standup.sh -p <namespace> -m <model id> -c <well-lit-path> --wva`
-
-        - Example Populated Command: `./setup/standup.sh -p llm-d-vezio -m meta-llama/Llama-3.1-8B -c inference-scheduling --wva`
-
-2. Run a workload using the `guidellm` `harness`  and `chatbot_synthetic` `workload profile` against an existing `llm-d` stack, using the `inference-scheduling` well-lit-path.
-
-    - Template Command: `./run.sh -l <harness> -w <workload profile> -p llm-d-vezio  -m <model id> -c <well-lit-path>`
-
-        - Example Populated Command: `./run.sh -l guidellm -w chatbot_synthetic -p llm-d-vezio -m meta-llama/Llama-3.1-8B -c inference-scheduling`
-
-3. Repeat `Step 2` to rerun a workload, in our case we reran `Step 2`, a total of 4 times.
-
-4. Collect results from the `analysis` directory that is provided in the logs of the `run.sh` command. You can see a detailed and granular report in the `results` directory if needed.
-
-    - Make sure you seperate these results into a seperate directory from the non WVA experiment - they are not the best named - we will change this - otherwise it will be hard to tell what is what!
-
-5. Tear down the infrastructure (this will not delete the namespace, but will completely purge *all* resources for the model, including the `wva` variant resources, effectively leaving an empty namespace - it will NOT touch cluster-wide resources.)
-
-    - Template Command: `./setup/teardown.sh -p <namespace> -d -c <well-lit-path>`
-
-        - Example Populated Command: `./setup/teardown.sh -p llm-d-vezio -d -c inference-scheduling`
-
-### Where is the Guidellm chatbot_synthetic Workload Profile Defined?
-
-You can find the actual location of the `chatbot_synthetic` workload profile in [chatbot_synthetic.yaml.in](https://github.com/llm-d/llm-d-benchmark/blob/main/workload/profiles/guidellm/chatbot_synthetic.yaml.in) -
-as well as the Guidellm [documentation](https://github.com/vllm-project/guidellm/tree/7666c658460bc34abe3cc821d3ca072cfd39074a).
-
-For your convenience I have copied the profile below - notice, our automation will autopopulate the `target` and `model` fields:
-
-```yaml
-target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
-model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
-request_type: text_completions
-profile: constant
-rate: [1,2,4,8]
-max_seconds: 120
-data:
-prompt_tokens_min: 10
-prompt_tokens_max: 8192
-prompt_tokens: 4096
-prompt_tokens_stdev: 2048
-output_tokens_min: 10
-output_tokens_max: 2048
-output_tokens: 1024
-output_tokens_stdev: 512
-samples: 1000
+# 5. Standup the WVA-enabled scenario (substitute your namespace)
+llmdbenchmark --spec guides/inference-scheduling-wva standup -p <namespace>
 ```
 
-This will workload profile will generate synthetic data - there is still a PR open describing a feature to support the ability to supply the ShareGPT dataset directly, that is currently not functional, [source here](https://github.com/vllm-project/guidellm/pull/305).
+When standup completes, the smoketest will have already verified the full
+WVA pipeline (controller, prometheus-adapter, VA, HPA, end-to-end metric
+flow). The HPA's `TARGETS` column should read a numeric value
+(e.g. `500m/1`) rather than `<unknown>`:
 
-### What the Commands Do
+```bash
+oc get hpa -n <namespace>
+```
 
-#### Standup
+To redeploy after editing the scenario YAML, plain teardown then standup:
 
-- For all options see the `manual` via `-h/--help`
-- Ensures gateway provider is installed, otherwise it will install it (`istio` is the default, and what is used here in the experiments (1.29.1))
-- Ensures workload monitoring is prepared and configured
-- Ensures the model namespace is prepared and configured
-- Ensures harness namespace is prepared and configured
-- Ensures infra-llmdbench and modelservice are deployed, (and configures WVA if and only if it is enabled)
-- Runs a smoketest against the exposed model inference service
+```bash
+llmdbenchmark --spec guides/inference-scheduling-wva teardown -p <namespace>
+llmdbenchmark --spec guides/inference-scheduling-wva standup  -p <namespace>
+```
 
-#### Run
+The shared cluster-wide infrastructure (`prometheus-adapter`, ClusterRole,
+prometheus-ca ConfigMap) survives teardown automatically — see
+[Section 4](#4-cluster-wide-vs-per-tenant-resources--teardown-semantics)
+for the full preservation policy.
 
-- For all options see the `manual` via `-h/--help`
-- Automatically detects the `llm-d stack entrypoint`, for example, `"http://infra-llmdbench-inference-gateway-istio.llm-d-vezio.svc.cluster.local:80"`
-- Renders workload profile templates
-- Starts a harness pod for the target model
-- Runs workload via the harness pod using the endpoint automatically discovered
-- Copies the results and analysis from the pod to your local machine, or system you are driving the experiments
-- Cleans up and removes harness pod
+---
 
-Tear down the infrastructure (this will not delete the namespace, but will completely purge *all* resources for the model, including the `wva` variant resources, effectively leaving an empty namespace - it will NOT touch cluster-wide resources.)
+## 1. Architecture at a glance
 
-#### Teardown
+When a scenario has `wva.enabled: true` and the cluster is OpenShift, standup
+provisions the following resources, in this order:
 
-- For all options see the `manual` via `-h/--help`
-- Tears down model infrastructure of a given namespace - but it will *not* delete the namespace
-- Removes all model resources in the namespace provided, including the `wva` variant resources
+```
+cluster-wide / shared
+    prometheus-adapter      v5.2.0, in openshift-user-workload-monitoring
+                            serves wva_desired_replicas via external-metrics API
+    prometheus-ca           ConfigMap, same ns — CA cert for thanos-querier auth
+    allow-thanos-querier-api-access
+                            ClusterRole granting prometheus-adapter access
+                            to OCP's monitoring stack
+
+  <wva namespace>           = deploy namespace by default
+      workload-variant-autoscaler   Helm chart v0.6.0, namespaced mode
+                                    (reconciles only VAs in this namespace)
+
+      per stack (per model)
+          VariantAutoscaling/{model_id_label}-decode
+              labels:
+                  wva.llmd.ai/controller-instance = <wva.namespace>
+              spec.scaleTargetRef -> Deployment/{model_id_label}-decode
+
+          HorizontalPodAutoscaler/{model_id_label}-decode
+              spec.scaleTargetRef -> Deployment/{model_id_label}-decode
+              metric.selector.matchLabels:
+                  variant_name        = {model_id_label}-decode
+                  exported_namespace  = <wva.namespace>
+                  controller_instance = <wva.namespace>
+```
+
+**The data flow** that turns this into actual pod scaling:
+
+1. WVA controller reconciles each `VariantAutoscaling` it owns and
+   queries thanos-querier for that variant's vLLM saturation metrics.
+2. The controller emits `wva_desired_replicas` on its `:8443/metrics`
+   endpoint (Prometheus scrapes via the chart's ServiceMonitor).
+3. `prometheus-adapter` discovers `wva_desired_replicas` from
+   user-workload-monitoring Prometheus and exposes it via the
+   `external.metrics.k8s.io/v1beta1` API.
+4. The `HorizontalPodAutoscaler` polls that external-metrics API,
+   matches its `selector.matchLabels`, and scales the decode Deployment
+   between `spec.minReplicas` and `spec.maxReplicas`.
+
+Our integration ensures **every join along that chain is byte-aligned**
+(`controllerInstance` value, VA label, HPA selector). Misalignment in any
+one of them surfaces as `TARGETS: <unknown>` on the HPA — see the
+[smoketest validations](#5-smoketest-checks) for what catches each case.
+
+---
+
+## 2. Two ways to enable WVA on a scenario
+
+| Method | When to use |
+|---|---|
+| `-u / --wva` CLI flag on any existing scenario | Quick toggle without editing files; uses defaults from `config/templates/values/defaults.yaml` |
+| `--spec guides/inference-scheduling-wva` | Dedicated scenario where every WVA knob is spelled out inline so you can tweak them per-experiment |
+
+### 2a. Via the CLI flag
+
+```bash
+llmdbenchmark --spec guides/inference-scheduling standup -p <namespace> --wva
+```
+
+That sets `wva.enabled: true` at render time. All other WVA settings come from
+defaults — fine for a quick test, but you can't tweak per-experiment HPA
+behavior without editing the defaults file.
+
+### 2b. Via the dedicated `inference-scheduling-wva` scenario
+
+```bash
+llmdbenchmark --spec guides/inference-scheduling-wva standup -p <namespace>
+```
+
+Same model and inference setup as `inference-scheduling`, plus a fully spelled-out
+`wva:` block in the scenario YAML. The `-u/--wva` flag is **not required** here
+because `wva.enabled: true` is already set in the file.
+
+You'd choose this scenario when you want to:
+
+- See/tweak every HPA knob in one place
+- Override the controller image tag, prometheus-adapter version, etc.
+- Author a DoE experiment that sweeps over `wva.hpa.maxReplicas` or
+  `wva.variantAutoscaling.variantCost`
+
+---
+
+## 3. The WVA knobs in the scenario YAML
+
+All settings live under the `wva:` block in
+[`config/scenarios/guides/inference-scheduling-wva.yaml`](../config/scenarios/guides/inference-scheduling-wva.yaml).
+Each is documented inline in the file too. Below is what each does and the
+typical reasons you'd touch it.
+
+### 3.1 Top-level WVA controller settings
+
+```yaml
+wva:
+  enabled: true                  # master switch (same as -u/--wva on CLI)
+  wellLitPath: inference-scheduling   # surfaced as `llm-d.ai/guide` label on the VA
+  namespace: ""                  # empty = use the deploy namespace from -p
+  replicaCount: 1                # WVA controller pod replicas
+
+  controller:
+    enabled: true                # disable to render VA+HPA without installing the controller
+
+  namespaceScoped: true          # controller watches only its own ns; one per ns
+
+  image:
+    repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+    tag: v0.6.0                  # NOTE: image tags use a leading "v"
+
+  metrics:
+    enabled: true
+    port: 8443                   # /metrics port the controller exposes
+    secure: true                 # HTTPS + bearer-token auth
+
+  prometheus:
+    baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+    port: 9091
+```
+
+**Image tag note:** the *helm chart* version is bare semver (`chartVersions.wva: 0.6.0`),
+the *container image* tag uses a leading `v` (`v0.6.0`). They're set independently.
+
+### 3.2 VariantAutoscaling spec — per-model scaling intent
+
+```yaml
+wva:
+  variantAutoscaling:
+    enabled: true
+    minReplicas: 1               # controller floor
+    maxReplicas: 10              # controller ceiling
+    variantCost: "10.0"          # relative GPU cost weight (H100=10, A100=8, L40S=5)
+    slo:
+      tpot: 10                   # Time-Per-Output-Token target (ms)
+      ttft: 1000                 # Time-To-First-Token target (ms)
+```
+
+`variantCost` is what the WVA saturation solver uses to decide which model to
+scale when several share GPU capacity. Lower `slo.tpot`/`slo.ttft` = more
+aggressive scale-up under load.
+
+### 3.3 HorizontalPodAutoscaler spec — what actually changes the replica count
+
+```yaml
+wva:
+  hpa:
+    enabled: true
+    minReplicas: 1               # never scale below this; must be ≥ 1
+    maxReplicas: 10              # safety ceiling regardless of controller computation
+    targetAvgValue: 1            # 1 = "match controller's desiredReplicas exactly"
+
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 120
+        policies:
+          - type: Percent
+            value: 100           # 100% per period = double replicas
+            periodSeconds: 15
+      scaleDown:
+        stabilizationWindowSeconds: 120
+        policies:
+          - type: Percent
+            value: 100           # 100% per period = halve replicas
+            periodSeconds: 15
+```
+
+Keep `wva.hpa.{min,max}Replicas` aligned with `wva.variantAutoscaling.{min,max}Replicas`
+— the VA caps what the controller is willing to compute, the HPA caps what
+actually gets applied to the Deployment.
+
+For more `behavior` tuning options:
+[Kubernetes HPA: configurable scaling behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior).
+
+### 3.4 Chart version pins
+
+```yaml
+chartVersions:
+  wva: 0.6.0                     # WVA controller chart (oci://ghcr.io/llm-d/workload-variant-autoscaler)
+  prometheusAdapter: 5.2.0       # bumped charts have broken external-metric rule format
+```
+
+---
+
+## 4. Cluster-wide vs per-tenant resources & teardown semantics
+
+WVA installs a mix of cluster-wide and per-tenant resources. To keep
+multi-tenant clusters healthy, our standup and teardown follow this policy:
+
+| Resource | Scope | Standup | Plain teardown | `teardown -d/--deep` |
+|---|---|---|---|---|
+| `prometheus-adapter` | `openshift-user-workload-monitoring` (shared) | install if absent; reuse if any tenant already installed it | preserved | **preserved** |
+| `prometheus-ca` ConfigMap | shared monitoring ns | created | preserved | **preserved** |
+| `allow-thanos-querier-api-access` ClusterRole | cluster-scoped | applied | preserved | **preserved** |
+| WVA controller helm release | per-namespace | installed | preserved | uninstalled |
+| `VariantAutoscaling` for this stack | namespace-local | applied | **removed** | removed |
+| `HorizontalPodAutoscaler` for this stack | namespace-local | applied | **removed** | removed |
+
+**The principle:** `--deep` only removes resources that live in the target namespace.
+Cluster-shared infrastructure (`prometheus-adapter` + its supporting CRBs/CMs)
+is **never** removed by us — it's used by every WVA tenant in the cluster, so
+its lifecycle belongs to the platform admin, not to a per-tenant teardown.
+
+If you need to fully remove the shared adapter, do it explicitly:
+
+```bash
+helm uninstall -n openshift-user-workload-monitoring prometheus-adapter
+oc delete clusterrole allow-thanos-querier-api-access
+oc delete configmap -n openshift-user-workload-monitoring prometheus-ca
+```
+
+---
+
+## 5. Smoketest checks
+
+When `wva.enabled: true`, the smoketest runs eight extra checks beyond the
+standard pod/inference validation. Each one tells you exactly what it's
+verifying so a failure points at the broken link rather than a vague
+"WVA is sad" symptom.
+
+| Check | What it verifies | Failure means |
+|---|---|---|
+| `wva_platform_gate` | Cluster is OpenShift (or stack is correctly skipped on other platforms) | informational only |
+| `wva_controller_deployment` | Polls `Deployment/workload-variant-autoscaler-controller-manager` until `Available` with all replicas Ready (≤180s). **Fails fast** if the manager container's `restartCount` grows mid-wait | controller pod is crash-looping; check `oc logs -n <ns> deploy/workload-variant-autoscaler-controller-manager --previous` |
+| `wva_prometheus_adapter` | `Deployment/prometheus-adapter` in the user-workload monitoring ns is `Available` | adapter wasn't installed, or another tenant's broken install is squatting the cluster role |
+| `wva_variantautoscaling` | The per-stack `VariantAutoscaling/{model_id_label}-decode` exists | step_09 didn't apply the rendered VA |
+| `wva_va_controller_instance_label` | The VA carries `wva.llmd.ai/controller-instance=<value>` matching the controller's `CONTROLLER_INSTANCE` | the controller's predicate filters out the VA → "No active VariantAutoscalings found" loop, no metric ever emitted. **The most subtle WVA gate.** |
+| `wva_hpa_target` | The HPA's `scaleTargetRef.name` equals `{model_id_label}-decode` | template drift between VA and HPA |
+| `wva_hpa_selector_alignment` | The HPA's `metric.selector.matchLabels` has all three of `variant_name`, `exported_namespace`, `controller_instance` matching what the controller emits | HPA selector misalignment — controller's metric is in Prometheus but the HPA's selector matches zero rows |
+| `wva_hpa_able_to_scale` (best-effort) | HPA's `AbleToScale` condition is `True` | HPA hasn't initialized yet, or scale subresource lookup failed |
+| `wva_hpa_targets_resolved` | Polls the HPA's `.status.currentMetrics[*].external.current` until the value resolves from `<unknown>` to a number (≤180s). Includes the most recent `ScalingActive=False` reason in the failure message if it times out | full pipeline isn't producing a metric value — could be controller not reconciling, Prometheus not scraping, adapter rule missing, or selector mismatch |
+
+All polling timeouts are constants at the top of
+[`llmdbenchmark/smoketests/validators/wva.py`](../llmdbenchmark/smoketests/validators/wva.py)
+(`_WVA_CONTROLLER_TIMEOUT_SECS`, `_HPA_TARGETS_TIMEOUT_SECS`). Bump them if
+your cluster is unusually slow.
+
+### Replica-count check (in `BaseSmoketest.validate_role_pods`)
+
+The standard `decode_replicas` check is HPA-aware: when WVA is enabled and
+the role is HPA-managed (currently only `decode`), the check passes if the
+actual pod count is within `[wva.hpa.minReplicas, wva.hpa.maxReplicas]`,
+not just strictly equal to `decode.replicas`. Without this relaxation, an
+idle stack at `minReplicas: 1` would falsely fail when `decode.replicas: 2`.
+
+The role allow-list lives at module top in
+[`llmdbenchmark/smoketests/base.py`](../llmdbenchmark/smoketests/base.py)
+as `_WVA_HPA_MANAGED_ROLES = frozenset({"decode"})` — extend it if upstream
+WVA grows native prefill autoscaling.
+
+---
+
+## 6. Quick verification commands
+
+After a successful standup with WVA, these one-liners confirm the full chain
+is up. Run them in order; each one verifies a downstream link in the pipeline.
+
+```bash
+# 1. Controller pod is Available, no recent restarts
+oc get pod -n <ns> -l control-plane=controller-manager -o wide
+
+# 2. The VA is reconciled (METRICSREADY=True, OPTIMIZED=<a number>)
+oc get va -n <ns>
+
+# 3. The VA has the controller-instance label
+oc get va -n <ns> <model-id>-decode -o jsonpath='{.metadata.labels}'
+
+# 4. The controller actually emits the metric
+oc -n openshift-user-workload-monitoring exec -c prometheus prometheus-user-workload-0 -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=wva_desired_replicas{controller_instance="<ns>"}' \
+  | jq '.data.result'
+
+# 5. prometheus-adapter exposes it via the external-metrics API
+oc get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<ns>/wva_desired_replicas" | jq
+
+# 6. The HPA's TARGETS shows a numeric value (no longer <unknown>)
+oc get hpa -n <ns>
+```
+
+If 1–3 are green but 4 is empty → controller isn't reconciling (most likely
+`wva.llmd.ai/controller-instance` label mismatch — check #3 against the
+controller's `CONTROLLER_INSTANCE` env var).
+
+If 4 has a value but 5 is empty → prometheus-adapter doesn't have the rule
+(install was wrong namespace, or rule values file wasn't applied).
+
+If 5 has a value but 6 is `<unknown>` → HPA selector doesn't match the
+metric's labels.
+
+---
+
+## 7. Common failure modes & fixes
+
+### "No active VariantAutoscalings found" loop in controller logs
+
+Controller is running but says it sees no VAs to reconcile, even though one
+exists in the watched namespace.
+
+**Cause:** the VA is missing the `wva.llmd.ai/controller-instance` label
+(or it doesn't match the controller's `CONTROLLER_INSTANCE` env). The
+controller's predicate silently filters it out.
+
+**Fix:**
+
+```bash
+oc label va -n <ns> <model-id>-decode \
+  wva.llmd.ai/controller-instance=<controller-instance> --overwrite
+```
+
+…or re-run standup so the rendered template (which already includes the
+label) is applied.
+
+### HPA shows `TARGETS: <unknown>` indefinitely
+
+Something in the metric pipeline isn't lining up. Walk the chain in
+[Section 6](#6-quick-verification-commands) to find which link is broken.
+
+### `release: already exists` when installing prometheus-adapter
+
+Another tenant installed `prometheus-adapter` in their *own* namespace
+(not `openshift-user-workload-monitoring`). The chart's cluster-scoped
+`prometheus-adapter-resource-reader` ClusterRole is helm-owned by their
+release, blocking ours.
+
+**Fix:** ask that tenant to `helm uninstall -n <their-ns> prometheus-adapter`.
+Once the ClusterRole is freed, re-run our standup and we'll install it
+into the correct namespace per the upstream WVA guide.
+
+### Controller pod CrashLoopBackOff with `context deadline exceeded` in logs
+
+The controller can't reach the Kubernetes API server reliably (leader-election
+lease renewal times out). This is a **cluster network / CNI** issue, not a
+WVA bug. Verify:
+
+```bash
+oc get clusteroperator network -o yaml | yq '.status.conditions'
+oc get nodes -o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status'
+```
+
+If the network operator is `Degraded=True` or any node is `Ready=False`,
+escalate to the cluster admin.
+
+### Image pull fails with `manifest unknown`
+
+The image tag doesn't exist. Check what's actually published:
+
+```bash
+TOKEN=$(curl -sL "https://ghcr.io/token?scope=repository:llm-d/llm-d-workload-variant-autoscaler:pull" \
+  | jq -r .token)
+curl -sH "Authorization: Bearer $TOKEN" \
+  https://ghcr.io/v2/llm-d/llm-d-workload-variant-autoscaler/tags/list | jq
+```
+
+Note that **chart versions are bare semver** (`0.6.0`) but **image tags use
+a leading `v`** (`v0.6.0`). Mixing them up is a common source of pull failures.
+
+---
+
+## 8. Multi-tenant cluster considerations
+
+On a shared cluster, multiple groups may run their own WVA controllers and
+HPAs. Our integration is designed to coexist:
+
+- **Namespaced mode** (`wva.namespaceScoped: true`) keeps each controller
+  scoped to its own namespace, so different tenants' controllers don't race
+  on each other's `VariantAutoscaling` resources.
+- **`controllerInstance` label** + matching VA label + HPA selector ensures
+  a tenant's HPA only consumes metrics from their own controller, even if
+  another tenant's controller is incidentally watching the same namespace.
+- **Shared `prometheus-adapter`** is installed once and reused. Our standup
+  detects an existing install (via the `prometheus-adapter-resource-reader`
+  ClusterRole's helm-owner annotation) and skips re-installing.
+
+Tenants who run a *cluster-scoped* WVA controller (i.e., `namespaceScoped: false`)
+will reconcile other tenants' VAs too. The `controllerInstance` label gate
+on the HPA selector prevents their emitted metrics from ever satisfying our
+HPA, but it's still considered cluster-hygiene rude to run cluster-scoped.
+
+---
+
+## 9. Where each piece lives in the repo
+
+| Artifact | File |
+|---|---|
+| Chart values rendered into the helm install | [`config/templates/jinja/19_wva-values.yaml.j2`](../config/templates/jinja/19_wva-values.yaml.j2) |
+| WVA namespace label patch | [`config/templates/jinja/23_wva-namespace.yaml.j2`](../config/templates/jinja/23_wva-namespace.yaml.j2) |
+| Per-stack `VariantAutoscaling` | [`config/templates/jinja/27_wva-variantautoscaling.yaml.j2`](../config/templates/jinja/27_wva-variantautoscaling.yaml.j2) |
+| Per-stack `HorizontalPodAutoscaler` | [`config/templates/jinja/28_wva-hpa.yaml.j2`](../config/templates/jinja/28_wva-hpa.yaml.j2) |
+| `prometheus-adapter` values | [`config/templates/jinja/21_prometheus-adapter-values.yaml.j2`](../config/templates/jinja/21_prometheus-adapter-values.yaml.j2) |
+| `allow-thanos-querier-api-access` ClusterRole | [`config/templates/jinja/22_prometheus-rbac.yaml.j2`](../config/templates/jinja/22_prometheus-rbac.yaml.j2) |
+| Cluster-wide WVA defaults (chart version, image, monitoring URL) | [`config/templates/values/defaults.yaml`](../config/templates/values/defaults.yaml) (`wva:` and `chartVersions.wva` blocks) |
+| Standup admin install (controller + adapter) | [`llmdbenchmark/standup/steps/step_03_workload_monitoring.py`](../llmdbenchmark/standup/steps/step_03_workload_monitoring.py) |
+| Standup per-stack VA/HPA apply | [`llmdbenchmark/standup/steps/step_09_deploy_modelservice.py`](../llmdbenchmark/standup/steps/step_09_deploy_modelservice.py) |
+| Shared install/teardown helpers | [`llmdbenchmark/standup/wva.py`](../llmdbenchmark/standup/wva.py) |
+| Teardown logic | [`llmdbenchmark/teardown/steps/step_01_uninstall_helm.py`](../llmdbenchmark/teardown/steps/step_01_uninstall_helm.py) |
+| Smoketest WVA mixin | [`llmdbenchmark/smoketests/validators/wva.py`](../llmdbenchmark/smoketests/validators/wva.py) |
+| WVA-enabled scenario (the one to copy/edit for new experiments) | [`config/scenarios/guides/inference-scheduling-wva.yaml`](../config/scenarios/guides/inference-scheduling-wva.yaml) |

--- a/docs/workload-variant-autoscaler.md
+++ b/docs/workload-variant-autoscaler.md
@@ -38,24 +38,23 @@ cd llm-d-benchmark
 # 3. Activate the venv created by install.sh
 source .venv/bin/activate
 
-# 4. Confirm you're pointed at the right cluster + project
+# 4. Confirm you're pointed at the right cluster
 oc whoami
-oc project   # or: oc new-project <namespace>
 
 # 5. Standup the WVA-enabled scenario (substitute your namespace)
 llmdbenchmark --spec guides/inference-scheduling-wva standup -p <namespace>
 ```
 
 When standup completes, the smoketest will have already verified the full
-WVA pipeline (controller, prometheus-adapter, VA, HPA, end-to-end metric
+*Namespaced* WVA pipeline (controller, prometheus-adapter, VA, HPA, end-to-end metric
 flow). The HPA's `TARGETS` column should read a numeric value
-(e.g. `500m/1`) rather than `<unknown>`:
+(e.g. `q/1`) rather than `<unknown>`:
 
 ```bash
 oc get hpa -n <namespace>
 ```
 
-To redeploy after editing the scenario YAML, plain teardown then standup:
+To redeploy after editing the scenario YAML, please teardown then standup:
 
 ```bash
 llmdbenchmark --spec guides/inference-scheduling-wva teardown -p <namespace>

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -115,6 +115,7 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
             cli_model=getattr(args, "models", None),
             cli_methods=getattr(args, "methods", None),
             cli_monitoring=getattr(args, "monitoring", False),
+            cli_wva=getattr(args, "wva", False),
         ).eval()
 
         try:
@@ -973,6 +974,7 @@ def _render_plans_for_experiment(args, logger, setup_overrides=None):
         cli_model=getattr(args, "models", None),
         cli_methods=getattr(args, "methods", None),
         cli_monitoring=getattr(args, "monitoring", False),
+        cli_wva=getattr(args, "wva", False),
         setup_overrides=setup_overrides,
     ).eval()
 
@@ -1474,6 +1476,8 @@ def cli() -> None:
         args.skip = env_bool("LLMDBENCH_SKIP")
     if hasattr(args, "debug") and not args.debug:
         args.debug = env_bool("LLMDBENCH_DEBUG")
+    if hasattr(args, "wva") and not args.wva:
+        args.wva = env_bool("LLMDBENCH_WVA")
 
     # Convert relative/~ paths to absolute
     args.base_dir = get_absolute_path(args.base_dir)

--- a/llmdbenchmark/executor/command.py
+++ b/llmdbenchmark/executor/command.py
@@ -12,6 +12,44 @@ from llmdbenchmark.exceptions.exceptions import ExecutionError
 from llmdbenchmark.utilities.kube_helpers import CRASH_STATES
 
 
+def _summarize_container_status(not_ready: list[dict]) -> str:
+    """Return the 'worst' container state among *not_ready*.
+
+    Priority: terminated with a CRASH_STATES reason > any terminated >
+    waiting with a CRASH_STATES reason > any waiting > "NotReady".
+
+    This is what surfaces to ``wait_for_pods``' crash detector, so
+    pushing crash reasons to the front means a CrashLoopBackOff on one
+    container of a multi-container pod aborts the wait immediately
+    instead of getting masked by a "Waiting" sibling.
+    """
+    if not not_ready:
+        return "NotReady"
+
+    def _state_reason(cs: dict, key: str) -> str:
+        return (cs.get("state", {}).get(key) or {}).get("reason", "") or ""
+
+    # Terminal crash states first.
+    for cs in not_ready:
+        reason = _state_reason(cs, "terminated")
+        if reason in CRASH_STATES:
+            return reason
+
+    # Waiting with a crash reason (e.g. CrashLoopBackOff, ImagePullBackOff).
+    for cs in not_ready:
+        reason = _state_reason(cs, "waiting")
+        if reason in CRASH_STATES:
+            return reason
+
+    # Non-terminal but informative.
+    for cs in not_ready:
+        reason = _state_reason(cs, "waiting") or _state_reason(cs, "terminated")
+        if reason:
+            return reason
+
+    return "NotReady"
+
+
 @dataclass
 class CommandResult:
     """Result of a shell command execution."""
@@ -562,18 +600,26 @@ class CommandExecutor:
                     "containerStatuses", []
                 )
                 if container_statuses:
-                    cs = container_statuses[0]
-                    if cs.get("ready"):
+                    # A pod is Ready only when ALL of its containers are
+                    # Ready. Previously we only looked at containerStatuses[0]
+                    # which, for multi-container pods (e.g. modelservice's
+                    # decode pod with its routing sidecar), could show
+                    # "Ready" while the actual serving container was in
+                    # CrashLoopBackOff — causing step_09's wait to return
+                    # success on a broken deployment.
+                    if all(cs.get("ready", False) for cs in container_statuses):
                         ready = True
                         status = "Ready"
-                    elif cs.get("state", {}).get("waiting"):
-                        status = cs["state"]["waiting"].get(
-                            "reason", "Waiting"
-                        )
-                    elif cs.get("state", {}).get("terminated"):
-                        status = cs["state"]["terminated"].get(
-                            "reason", "Terminated"
-                        )
+                    else:
+                        # Surface the worst-looking not-ready container so the
+                        # caller can match against CRASH_STATES. Prefer a
+                        # crashing/terminated container over a merely-waiting
+                        # one so terminal failures bubble up first.
+                        not_ready = [
+                            cs for cs in container_statuses
+                            if not cs.get("ready", False)
+                        ]
+                        status = _summarize_container_status(not_ready)
                 elif phase == "Pending":
                     conditions = item.get("status", {}).get("conditions", [])
                     for cond in conditions:

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -65,8 +65,9 @@ def add_subcommands(parser: argparse._SubParsersAction):
     standup_parser.add_argument(
         "-u",
         "--wva",
-        default=env("LLMDBENCH_WVA"),
-        help="Enable Workload Variant Autoscaler.",
+        action="store_true",
+        default=False,
+        help="Enable Workload Variant Autoscaler (WVA) for this standup.",
     )
     standup_parser.add_argument(
         "-f",

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -47,6 +47,7 @@ class RenderPlans:
         cli_model: str | None = None,
         cli_methods: str | None = None,
         cli_monitoring: bool = False,
+        cli_wva: bool = False,
         setup_overrides: dict | None = None,
     ):
         self.template_dir = Path(template_dir)
@@ -59,6 +60,7 @@ class RenderPlans:
         self.cli_model = cli_model
         self.cli_methods = cli_methods
         self.cli_monitoring = cli_monitoring
+        self.cli_wva = cli_wva
         self.setup_overrides = setup_overrides
 
         self.logger = logger or get_logger(
@@ -420,6 +422,18 @@ class RenderPlans:
         self.logger.log_info(
             "Monitoring enabled from CLI: PodMonitor + metrics scraping"
         )
+        return result
+
+    def _resolve_wva(self, values: dict) -> dict:
+        """Enable the Workload Variant Autoscaler when ``-u/--wva`` is set."""
+        if not self.cli_wva:
+            return values
+
+        result = deepcopy(values)
+        wva_config = result.setdefault("wva", {})
+        wva_config["enabled"] = True
+
+        self.logger.log_info("Workload Variant Autoscaler enabled from CLI")
         return result
 
     def _resolve_deploy_method(self, values: dict) -> dict:
@@ -794,6 +808,7 @@ class RenderPlans:
         self._warn_custom_command_conflicts(merged_values)
         merged_values = self._resolve_deploy_method(merged_values)
         merged_values = self._resolve_monitoring(merged_values)
+        merged_values = self._resolve_wva(merged_values)
         merged_values = self._resolve_hf_token(merged_values)
         merged_values = self._resolve_model_id_label(merged_values)
         merged_values = self._resolve_inference_pool_host(merged_values)

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -20,6 +20,16 @@ from llmdbenchmark.utilities.endpoint import (
 
 _RETRYABLE_INDICATORS = ("502", "503", "504", "ServiceUnavailable", "not ready")
 
+# Roles whose pod count is HPA-managed when WVA is enabled. The replica
+# count check relaxes from strict equality (== <role>.replicas) to
+# range-membership (within wva.hpa.[min,max]Replicas) for these roles only.
+#
+# Currently only `decode` because the per-stack HPA template
+# (28_wva-hpa.yaml.j2) only targets the decode Deployment. If the WVA
+# chart grows native prefill autoscaling and we render a second HPA,
+# add "prefill" here and the relaxation kicks in automatically.
+_WVA_HPA_MANAGED_ROLES: frozenset[str] = frozenset({"decode"})
+
 
 def _is_retryable(text: str) -> bool:
     return any(ind in text for ind in _RETRYABLE_INDICATORS) if text else False
@@ -679,16 +689,54 @@ class BaseSmoketest:
                 f"{p.get('metadata', {}).get('name', '?')}@{p.get('spec', {}).get('nodeName', '?')}"
                 for p in pods
             ) or "none"
-            report.add(CheckResult(
-                f"{prefix}_replicas",
-                len(pods) == expected_pods,
-                expected=str(expected_pods),
-                actual=str(len(pods)),
-                message=(
-                    f"{role} pods in ns/{namespace}: "
-                    f"{len(pods)} (expected {expected_pods}) [{pod_details}]"
-                ),
-            ))
+
+            # If WVA + HPA owns the replica count for this role, the
+            # actual pod count is HPA-driven and may legitimately differ
+            # from the scenario's static `<role>.replicas` (e.g. with
+            # `decode.replicas: 2` and `wva.hpa.minReplicas: 1`, an idle
+            # cluster ends up at 1 pod, which is correct, not a regression).
+            #
+            # In that case we relax the check to "actual count is within
+            # the HPA's [minReplicas, maxReplicas] window" and surface
+            # both the scenario value and the HPA bounds in the message
+            # so a reader can still tell what's happening.
+            #
+            # Multinode (LWS) deployments scale via LeaderWorkerSet, not
+            # HPA, so the relaxation must not apply to them — keep strict
+            # equality there.
+            hpa_managed = (
+                _nested_get(config, "wva", "enabled")
+                and _nested_get(config, "wva", "hpa", "enabled")
+                and role in _WVA_HPA_MANAGED_ROLES
+                and not multinode_enabled
+            )
+            if hpa_managed:
+                hpa_min = int(_nested_get(config, "wva", "hpa", "minReplicas") or 1)
+                hpa_max = int(_nested_get(config, "wva", "hpa", "maxReplicas") or expected_pods)
+                in_range = hpa_min <= len(pods) <= hpa_max
+                report.add(CheckResult(
+                    f"{prefix}_replicas",
+                    in_range,
+                    expected=f"{hpa_min}..{hpa_max} (HPA window)",
+                    actual=str(len(pods)),
+                    message=(
+                        f"{role} pods in ns/{namespace}: "
+                        f"{len(pods)} (HPA min={hpa_min} max={hpa_max}, "
+                        f"scenario.{role}.replicas={expected_pods}) "
+                        f"[{pod_details}]"
+                    ),
+                ))
+            else:
+                report.add(CheckResult(
+                    f"{prefix}_replicas",
+                    len(pods) == expected_pods,
+                    expected=str(expected_pods),
+                    actual=str(len(pods)),
+                    message=(
+                        f"{role} pods in ns/{namespace}: "
+                        f"{len(pods)} (expected {expected_pods}) [{pod_details}]"
+                    ),
+                ))
 
         if not pods:
             return pods

--- a/llmdbenchmark/smoketests/validators/__init__.py
+++ b/llmdbenchmark/smoketests/validators/__init__.py
@@ -26,6 +26,7 @@ from llmdbenchmark.smoketests.validators.wide_ep_lws import (
 from llmdbenchmark.smoketests.validators.simulated_accelerators import (
     SimulatedAcceleratorsValidator,
 )
+from llmdbenchmark.smoketests.validators.wva import WvaValidator
 
 # Examples
 from llmdbenchmark.smoketests.validators.cpu import CpuValidator
@@ -38,9 +39,14 @@ VALIDATORS: dict[str, type] = {
     "pd-disaggregation": PdDisaggregationValidator,
     "precise-prefix-cache-aware": PrecisePrefixCacheAwareValidator,
     "inference-scheduling": InferenceSchedulingValidator,
+    # inference-scheduling-wva reuses the inference-scheduling validator;
+    # the WvaSmoketestMixin auto-activates its extra checks when the
+    # stack's config has wva.enabled: true.
+    "inference-scheduling-wva": InferenceSchedulingValidator,
     "tiered-prefix-cache": TieredPrefixCacheValidator,
     "wide-ep-lws": WideEpLwsValidator,
     "simulated-accelerators": SimulatedAcceleratorsValidator,
+    "wva": WvaValidator,
     # Examples
     "cpu-example-ms": CpuValidator,
     "gpu-example": GpuValidator,

--- a/llmdbenchmark/smoketests/validators/inference_scheduling.py
+++ b/llmdbenchmark/smoketests/validators/inference_scheduling.py
@@ -5,10 +5,16 @@ from pathlib import Path
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.smoketests.base import BaseSmoketest, _load_config, _nested_get
 from llmdbenchmark.smoketests.report import CheckResult, SmoketestReport
+from llmdbenchmark.smoketests.validators.wva import WvaSmoketestMixin
 
 
-class InferenceSchedulingValidator(BaseSmoketest):
-    """Validates inference scheduling scenario."""
+class InferenceSchedulingValidator(WvaSmoketestMixin, BaseSmoketest):
+    """Validates inference scheduling scenario.
+
+    Also runs WVA resource checks (controller, prometheus-adapter, VA, HPA)
+    when the rendered stack has ``wva.enabled: true``; the mixin is a no-op
+    for non-WVA stacks.
+    """
 
     def run_config_validation(
         self, context: ExecutionContext, stack_path: Path,
@@ -72,5 +78,8 @@ class InferenceSchedulingValidator(BaseSmoketest):
                     "dshm" in volumes,
                     message=f"Shared memory volume 'dshm' {'present' if 'dshm' in volumes else 'not found'}",
                 ))
+
+        # WVA checks are a no-op unless the stack has wva.enabled: true
+        self.run_wva_checks(context, stack_path, report)
 
         return report

--- a/llmdbenchmark/smoketests/validators/wva.py
+++ b/llmdbenchmark/smoketests/validators/wva.py
@@ -1,0 +1,675 @@
+"""WVA smoketest checks: controller + prometheus-adapter + per-stack VA & HPA.
+
+This is a *mixin* rather than a top-level validator so scenario-specific
+validators (e.g. inference-scheduling) can layer it on without having to
+duplicate its logic. A concrete validator exists too
+(:class:`WvaValidator`) for scenarios whose only WVA concerns are the
+baseline controller + per-stack VA/HPA checks.
+
+Activation gate: the mixin runs only when BOTH ``wva.enabled: true`` is
+present in the rendered stack config AND the cluster is OpenShift. WVA's
+install path (prometheus-adapter, thanos-querier integration, user-workload
+monitoring) is currently only verified on OpenShift; on other platforms
+standup deliberately skips the install, so the smoketest must skip the
+checks too.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from llmdbenchmark.executor.command import CommandExecutor
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.smoketests.base import BaseSmoketest, _load_config, _nested_get
+from llmdbenchmark.smoketests.report import CheckResult, SmoketestReport
+
+
+# How long to poll the WVA controller Deployment waiting for it to become
+# Available with all replicas Ready. Pod scheduling + image pull + leader
+# election typically take 30-60s on a healthy cluster.
+_WVA_CONTROLLER_TIMEOUT_SECS = 180
+_WVA_CONTROLLER_POLL_SECS = 5
+
+# How long to poll the HPA waiting for its TARGETS / currentMetrics field
+# to resolve from <unknown> to a real number. Default is generous because
+# the full pipeline (controller reconcile → Prometheus scrape →
+# prometheus-adapter discovery → HPA poll) can take 90–120 s end-to-end
+# even on a healthy cluster.
+_HPA_TARGETS_TIMEOUT_SECS = 180
+_HPA_TARGETS_POLL_SECS = 5
+
+
+class WvaSmoketestMixin:
+    """Adds WVA-specific checks to any scenario validator.
+
+    Subclasses (or concrete validators) call :meth:`run_wva_checks` from
+    their ``run_config_validation`` method. Safe to call unconditionally —
+    it returns immediately when WVA is not enabled on this stack.
+    """
+
+    def run_wva_checks(
+        self,
+        context: ExecutionContext,
+        stack_path: Path,
+        report: SmoketestReport,
+    ) -> None:
+        """Append WVA resource health checks to *report*.
+
+        Validates:
+          1. WVA controller Deployment becomes Available with all replicas
+             Ready in the WVA namespace (polling — fails fast if the
+             container starts crash-looping mid-wait).
+          2. prometheus-adapter Deployment exists and is Available in the
+             user-workload-monitoring namespace.
+          3. The per-stack VariantAutoscaling resource exists with the
+             expected name ({model_id_label}-decode).
+          4. The VariantAutoscaling carries the `wva.llmd.ai/controller-instance`
+             label matching the controller's `CONTROLLER_INSTANCE` env (when
+             set). Without this label the controller's predicate silently
+             skips the VA — the most subtle WVA misconfiguration.
+          5. The per-stack HPA exists and references the decode Deployment.
+          6. The HPA's external-metric selector matches what WVA actually
+             emits: `variant_name`, `exported_namespace`, and
+             `controller_instance` all aligned with the rendered VA + chart
+             values. Catches selector drift before it manifests as
+             `TARGETS: <unknown>`.
+          7. (optional) HPA has an ``AbleToScale`` condition, meaning
+             prometheus-adapter is serving ``wva_desired_replicas`` for it.
+          8. The HPA's TARGETS / currentMetrics field has resolved from
+             <unknown> to a numeric value — proves the full pipeline
+             (controller → Prometheus → adapter → HPA) is end-to-end live.
+        """
+        config = _load_config(stack_path)
+        if not (_nested_get(config, "wva", "enabled") or False):
+            return
+
+        # Standup also gates WVA install on OpenShift (see step_03 +
+        # step_09); the smoketest must mirror that gate or every check
+        # below would fail with "not found" against a cluster that
+        # never had WVA installed in the first place.
+        if not context.is_openshift:
+            report.add(CheckResult(
+                "wva_platform_gate",
+                True,
+                message=(
+                    f"WVA enabled in scenario but platform is "
+                    f"{context.platform_type}, not OpenShift -- skipping "
+                    "WVA smoketest checks (matches standup behavior)."
+                ),
+            ))
+            return
+
+        cmd = context.require_cmd()
+        namespace = context.require_namespace()
+
+        if context.dry_run:
+            report.add(CheckResult(
+                "wva_dry_run", True,
+                message="[DRY RUN] WVA smoketest skipped",
+            ))
+            return
+
+        wva_ns = _nested_get(config, "wva", "namespace") or namespace
+        monitoring_ns = (
+            _nested_get(config, "openshiftMonitoring", "userWorkloadMonitoringNamespace")
+            or "openshift-user-workload-monitoring"
+        )
+        model_id_label = (
+            config.get("model_id_label", "")
+            or _nested_get(config, "model", "shortName")
+            or ""
+        )
+        va_name = f"{model_id_label}-decode"
+        decode_deployment = f"{model_id_label}-decode"
+
+        # Expected `controller_instance` value -- derived the same way the
+        # 19_/27_/28_ templates do, so an empty `wva.namespace` falls back
+        # to the deploy namespace.
+        expected_controller_instance = (
+            _nested_get(config, "wva", "namespace") or namespace
+        )
+
+        self._check_wva_controller(
+            cmd, wva_ns, report,
+            timeout=_WVA_CONTROLLER_TIMEOUT_SECS,
+            poll_interval=_WVA_CONTROLLER_POLL_SECS,
+            logger=context.logger,
+        )
+        self._check_prometheus_adapter(cmd, monitoring_ns, report)
+        self._check_variant_autoscaling(
+            cmd, wva_ns, va_name, expected_controller_instance, report,
+        )
+        self._check_hpa(
+            cmd, wva_ns, va_name, decode_deployment,
+            expected_controller_instance, wva_ns, report,
+        )
+        self._wait_for_hpa_targets(
+            cmd, wva_ns, va_name, report,
+            timeout=_HPA_TARGETS_TIMEOUT_SECS,
+            poll_interval=_HPA_TARGETS_POLL_SECS,
+            logger=context.logger,
+        )
+
+    # --- individual checks ------------------------------------------------
+
+    @staticmethod
+    def _check_wva_controller(
+        cmd: CommandExecutor,
+        wva_ns: str,
+        report: SmoketestReport,
+        timeout: int = _WVA_CONTROLLER_TIMEOUT_SECS,
+        poll_interval: int = _WVA_CONTROLLER_POLL_SECS,
+        logger=None,
+    ) -> None:
+        """Wait for the WVA controller Deployment to become Available.
+
+        Polls ``oc get deployment workload-variant-autoscaler-controller-manager``
+        until the Deployment reports ``Available=True`` with all replicas Ready
+        (covers pod scheduling, image pull, container startup, health
+        probes, and leader election). Fails immediately — without waiting
+        the full timeout — if the manager container's restart count grows
+        mid-wait, since that signals a crash-loop that won't self-recover.
+        """
+        start = time.time()
+        baseline_restarts: int | None = None
+        last_state = "(deployment not found)"
+
+        while True:
+            elapsed = time.time() - start
+
+            result = cmd.kube(
+                "get", "deployment", "workload-variant-autoscaler-controller-manager",
+                "--namespace", wva_ns,
+                "-o", "json",
+                check=False,
+            )
+
+            if result.success:
+                try:
+                    dep = json.loads(result.stdout) if result.stdout else {}
+                except (json.JSONDecodeError, ValueError):
+                    dep = {}
+
+                available = _deployment_is_available(dep)
+                ready = dep.get("status", {}).get("readyReplicas", 0) or 0
+                desired = dep.get("spec", {}).get("replicas", 0) or 0
+
+                # Sample container restart count from any pod owned by
+                # this Deployment, to spot crash-loops without waiting
+                # for the full timeout.
+                restarts = _wva_controller_restart_count(cmd, wva_ns)
+                if baseline_restarts is None and restarts is not None:
+                    baseline_restarts = restarts
+
+                # Pod-restart growth during the wait → crash loop, fail fast.
+                if (
+                    baseline_restarts is not None
+                    and restarts is not None
+                    and restarts > baseline_restarts
+                ):
+                    report.add(CheckResult(
+                        "wva_controller_deployment",
+                        False,
+                        expected=f"Available, {desired}/{desired} ready, no restarts",
+                        actual=(
+                            f"Available={available}, {ready}/{desired} ready, "
+                            f"restarts={restarts} (was {baseline_restarts})"
+                        ),
+                        message=(
+                            f"WVA controller in ns/{wva_ns} is restarting "
+                            f"(restartCount {baseline_restarts}→{restarts} "
+                            f"during {int(elapsed)}s wait). Likely crash-loop; "
+                            f"check `oc logs -n {wva_ns} "
+                            f"deploy/workload-variant-autoscaler-controller-manager "
+                            f"--previous` for the failure cause."
+                        ),
+                    ))
+                    return
+
+                if available and desired > 0 and ready == desired:
+                    report.add(CheckResult(
+                        "wva_controller_deployment",
+                        True,
+                        expected=f"Available, {desired}/{desired} ready",
+                        actual=f"Available, {ready}/{desired} ready",
+                        message=(
+                            f"WVA controller in ns/{wva_ns}: "
+                            f"Available, {ready}/{desired} ready "
+                            f"after {int(elapsed)}s"
+                        ),
+                    ))
+                    return
+
+                last_state = f"Available={available}, {ready}/{desired} ready"
+            else:
+                last_state = (
+                    f"deployment lookup failed: "
+                    f"{result.stderr.strip()[:200]}"
+                )
+
+            if elapsed >= timeout:
+                report.add(CheckResult(
+                    "wva_controller_deployment",
+                    False,
+                    expected=f"Available, all replicas ready within {timeout}s",
+                    actual=last_state,
+                    message=(
+                        f"WVA controller in ns/{wva_ns} did not become "
+                        f"ready within {timeout}s. Last state: {last_state}"
+                    ),
+                ))
+                return
+
+            if logger is not None and int(elapsed) % 30 == 0 and int(elapsed) > 0:
+                logger.log_info(
+                    f"⏳ Waiting for WVA controller in ns/{wva_ns} to become "
+                    f"Ready ({int(elapsed)}/{timeout}s) -- {last_state}"
+                )
+
+            time.sleep(poll_interval)
+
+    @staticmethod
+    def _check_prometheus_adapter(
+        cmd: CommandExecutor, monitoring_ns: str, report: SmoketestReport
+    ) -> None:
+        """Verify prometheus-adapter Deployment is Available."""
+        result = cmd.kube(
+            "get", "deployment", "prometheus-adapter",
+            "--namespace", monitoring_ns,
+            "-o", "json",
+            check=False,
+        )
+        if not result.success:
+            report.add(CheckResult(
+                "wva_prometheus_adapter", False,
+                message=(
+                    f"prometheus-adapter Deployment not found in "
+                    f"ns/{monitoring_ns}: {result.stderr.strip()[:200]}"
+                ),
+            ))
+            return
+
+        try:
+            dep = json.loads(result.stdout) if result.stdout else {}
+        except (json.JSONDecodeError, ValueError):
+            dep = {}
+
+        available = _deployment_is_available(dep)
+        replicas = dep.get("status", {}).get("readyReplicas", 0) or 0
+        desired = dep.get("spec", {}).get("replicas", 0) or 0
+        report.add(CheckResult(
+            "wva_prometheus_adapter",
+            available and replicas == desired and desired > 0,
+            expected=f"Available, {desired}/{desired} ready",
+            actual=f"Available={available}, {replicas}/{desired} ready",
+            message=(
+                f"prometheus-adapter in ns/{monitoring_ns}: "
+                f"Available={available}, ready={replicas}/{desired}"
+            ),
+        ))
+
+    @staticmethod
+    def _check_variant_autoscaling(
+        cmd: CommandExecutor,
+        wva_ns: str,
+        va_name: str,
+        expected_controller_instance: str,
+        report: SmoketestReport,
+    ) -> None:
+        """Verify the per-stack VariantAutoscaling exists AND carries the
+        ``wva.llmd.ai/controller-instance`` label that matches the
+        controller's ``CONTROLLER_INSTANCE`` env.
+
+        The label check is the most subtle of the WVA gates: the v0.6.0
+        controller's predicate filters out any in-namespace VA that
+        doesn't carry this label when ``CONTROLLER_INSTANCE`` is set.
+        Without it, the VA shows up in ``oc get va`` but the controller
+        silently never reconciles it ("No active VariantAutoscalings
+        found" log loop forever) → no metric → HPA stuck at <unknown>.
+        """
+        result = cmd.kube(
+            "get", "variantautoscaling.llmd.ai", va_name,
+            "--namespace", wva_ns,
+            "-o", "json",
+            check=False,
+        )
+        if not result.success:
+            report.add(CheckResult(
+                "wva_variantautoscaling",
+                False,
+                expected=f"{va_name} present in ns/{wva_ns}",
+                actual="missing",
+                message=(
+                    f"VariantAutoscaling/{va_name} in ns/{wva_ns}: "
+                    f"{result.stderr.strip()[:200]}"
+                ),
+            ))
+            return
+
+        try:
+            va = json.loads(result.stdout) if result.stdout else {}
+        except (json.JSONDecodeError, ValueError):
+            va = {}
+
+        report.add(CheckResult(
+            "wva_variantautoscaling",
+            True,
+            expected=f"{va_name} present in ns/{wva_ns}",
+            actual="present",
+            message=f"VariantAutoscaling/{va_name} in ns/{wva_ns}: present",
+        ))
+
+        # Critical alignment check: VA label must match controller's instance.
+        labels = va.get("metadata", {}).get("labels", {}) or {}
+        actual_label = labels.get("wva.llmd.ai/controller-instance", "")
+        label_ok = actual_label == expected_controller_instance
+        report.add(CheckResult(
+            "wva_va_controller_instance_label",
+            label_ok,
+            expected=(
+                f"wva.llmd.ai/controller-instance="
+                f"{expected_controller_instance}"
+            ),
+            actual=(
+                f"wva.llmd.ai/controller-instance={actual_label or '(missing)'}"
+            ),
+            message=(
+                f"VariantAutoscaling/{va_name} controller-instance label: "
+                f"{actual_label or '(missing)'} "
+                f"(expected {expected_controller_instance}). "
+                "Without a matching label, the controller's predicate "
+                "skips this VA and never emits wva_desired_replicas."
+                if not label_ok
+                else
+                f"VariantAutoscaling/{va_name} carries the matching "
+                f"wva.llmd.ai/controller-instance={expected_controller_instance} "
+                "label — controller will reconcile it."
+            ),
+        ))
+
+    @staticmethod
+    def _check_hpa(
+        cmd: CommandExecutor,
+        wva_ns: str,
+        hpa_name: str,
+        expected_target: str,
+        expected_controller_instance: str,
+        expected_exported_namespace: str,
+        report: SmoketestReport,
+    ) -> None:
+        """Verify the per-stack HPA exists, targets the decode Deployment,
+        carries a metric selector aligned with what the WVA controller
+        actually emits, and (best-effort) has an ``AbleToScale`` condition.
+        """
+        result = cmd.kube(
+            "get", "hpa", hpa_name,
+            "--namespace", wva_ns,
+            "-o", "json",
+            check=False,
+        )
+        if not result.success:
+            report.add(CheckResult(
+                "wva_hpa", False,
+                message=(
+                    f"HPA/{hpa_name} not found in ns/{wva_ns}: "
+                    f"{result.stderr.strip()[:200]}"
+                ),
+            ))
+            return
+
+        try:
+            hpa = json.loads(result.stdout) if result.stdout else {}
+        except (json.JSONDecodeError, ValueError):
+            hpa = {}
+
+        scale_target = hpa.get("spec", {}).get("scaleTargetRef", {}).get("name", "")
+        report.add(CheckResult(
+            "wva_hpa_target",
+            scale_target == expected_target,
+            expected=expected_target,
+            actual=scale_target,
+            message=(
+                f"HPA/{hpa_name} scaleTargetRef.name={scale_target} "
+                f"(expected {expected_target})"
+            ),
+        ))
+
+        # Selector alignment check. The metric labels the controller
+        # actually emits are: variant_name (= VA's name), exported_namespace
+        # (= VA's namespace; renamed by Prometheus from `namespace`), and
+        # controller_instance (= chart's wva.controllerInstance, when set).
+        # The HPA's matchLabels must equal these or the external-metrics
+        # API will return zero items and the HPA stays <unknown>.
+        match_labels = (
+            hpa.get("spec", {}).get("metrics", [{}])[0]
+            .get("external", {}).get("metric", {})
+            .get("selector", {}).get("matchLabels", {})
+        ) or {}
+        expected_selector = {
+            "variant_name": expected_target,
+            "exported_namespace": expected_exported_namespace,
+            "controller_instance": expected_controller_instance,
+        }
+        mismatches = [
+            f"{k}={match_labels.get(k, '(missing)')}≠{v}"
+            for k, v in expected_selector.items()
+            if match_labels.get(k) != v
+        ]
+        report.add(CheckResult(
+            "wva_hpa_selector_alignment",
+            not mismatches,
+            expected=", ".join(f"{k}={v}" for k, v in expected_selector.items()),
+            actual=", ".join(f"{k}={v}" for k, v in match_labels.items()) or "(empty)",
+            message=(
+                f"HPA/{hpa_name} metric selector aligned with WVA-emitted "
+                f"labels — controller→adapter→HPA path will match."
+                if not mismatches
+                else
+                f"HPA/{hpa_name} metric selector mismatch: {', '.join(mismatches)}. "
+                "These three labels (variant_name, exported_namespace, "
+                "controller_instance) must equal what the WVA controller "
+                "emits or no metric row will match."
+            ),
+        ))
+
+        # Surface the AbleToScale condition when it's present -- it's the
+        # signal that prometheus-adapter is actually serving the
+        # wva_desired_replicas external metric to the HPA. Missing
+        # condition isn't a hard failure (HPA may still be initializing).
+        conditions = hpa.get("status", {}).get("conditions", []) or []
+        able = next(
+            (c for c in conditions if c.get("type") == "AbleToScale"),
+            None,
+        )
+        if able is not None:
+            is_true = able.get("status") == "True"
+            report.add(CheckResult(
+                "wva_hpa_able_to_scale",
+                is_true,
+                expected="True",
+                actual=able.get("status", "Unknown"),
+                message=(
+                    f"HPA/{hpa_name} AbleToScale={able.get('status')} "
+                    f"reason={able.get('reason', '')}"
+                ),
+            ))
+
+    @staticmethod
+    def _wait_for_hpa_targets(
+        cmd: CommandExecutor,
+        wva_ns: str,
+        hpa_name: str,
+        report: SmoketestReport,
+        timeout: int = _HPA_TARGETS_TIMEOUT_SECS,
+        poll_interval: int = _HPA_TARGETS_POLL_SECS,
+        logger=None,
+    ) -> None:
+        """Poll the HPA until its TARGETS / currentMetrics resolves to a value.
+
+        ``oc get hpa`` shows ``<unknown>`` for an external metric until the
+        full pipeline is live: WVA controller has reconciled the VA,
+        emitted ``wva_desired_replicas`` to its ``/metrics`` endpoint,
+        Prometheus has scraped it, prometheus-adapter has discovered the
+        rule, and the HPA controller has polled the external-metrics API.
+        End-to-end latency on a healthy cluster is typically 60–120 s.
+
+        We poll the HPA's ``.status.currentMetrics[*].external.current``
+        block (the source of the TARGETS column) until any external metric
+        on this HPA reports a value, or *timeout* expires.
+        """
+        start = time.time()
+        last_state = "<unknown>"
+        last_able_to_scale_reason = ""
+
+        while True:
+            elapsed = time.time() - start
+
+            result = cmd.kube(
+                "get", "hpa", hpa_name,
+                "--namespace", wva_ns,
+                "-o", "json",
+                check=False,
+            )
+            if result.success:
+                try:
+                    hpa = json.loads(result.stdout) if result.stdout else {}
+                except (json.JSONDecodeError, ValueError):
+                    hpa = {}
+
+                value = _hpa_first_external_metric_value(hpa)
+                if value is not None:
+                    target = _hpa_first_external_metric_target(hpa)
+                    target_str = f"/{target}" if target else ""
+                    report.add(CheckResult(
+                        "wva_hpa_targets_resolved",
+                        True,
+                        expected="<numeric>",
+                        actual=str(value),
+                        message=(
+                            f"HPA/{hpa_name} TARGETS resolved: "
+                            f"{value}{target_str} after "
+                            f"{int(elapsed)}s — full WVA pipeline live"
+                        ),
+                    ))
+                    return
+
+                # Capture the reason from AbleToScale for the eventual
+                # failure message, if present.
+                for c in (hpa.get("status", {}).get("conditions", []) or []):
+                    if c.get("type") == "ScalingActive" and c.get("status") == "False":
+                        last_able_to_scale_reason = (
+                            c.get("reason", "") + ": " + c.get("message", "")
+                        )[:240]
+                        break
+
+                last_state = "<unknown>"
+
+            if elapsed >= timeout:
+                report.add(CheckResult(
+                    "wva_hpa_targets_resolved",
+                    False,
+                    expected="<numeric>",
+                    actual=last_state,
+                    message=(
+                        f"HPA/{hpa_name} TARGETS did not resolve within "
+                        f"{timeout}s. Most recent ScalingActive=False reason: "
+                        f"{last_able_to_scale_reason or '(none reported)'}"
+                    ),
+                ))
+                return
+
+            if logger is not None and int(elapsed) % 30 == 0 and int(elapsed) > 0:
+                logger.log_info(
+                    f"⏳ Waiting for HPA/{hpa_name} TARGETS to resolve "
+                    f"({int(elapsed)}/{timeout}s)..."
+                )
+
+            time.sleep(poll_interval)
+
+
+def _hpa_first_external_metric_value(hpa: dict):
+    """Return the numeric value of the first external metric on the HPA, or None.
+
+    The HPA's TARGETS column is rendered from
+    ``.status.currentMetrics[*].external.current.{value,averageValue}``.
+    Either field may be set depending on the metric's targetType.
+    """
+    for m in (hpa.get("status", {}).get("currentMetrics", []) or []):
+        external = m.get("external") or {}
+        current = external.get("current") or {}
+        for key in ("value", "averageValue"):
+            v = current.get(key)
+            if v is not None and str(v) != "":
+                return v
+    return None
+
+
+def _hpa_first_external_metric_target(hpa: dict) -> str:
+    """Return the spec-side target value (denominator in TARGETS), or ''.
+
+    Used purely for logging — e.g. ``500m/1`` shows "500m" current and
+    "1" target.
+    """
+    for m in (hpa.get("spec", {}).get("metrics", []) or []):
+        target = (m.get("external") or {}).get("target") or {}
+        for key in ("value", "averageValue"):
+            v = target.get(key)
+            if v is not None and str(v) != "":
+                return str(v)
+    return ""
+
+
+def _wva_controller_restart_count(
+    cmd: CommandExecutor, wva_ns: str
+) -> int | None:
+    """Sum the manager-container restart counts across all controller pods.
+
+    Used to detect crash-loops mid-wait without parsing logs. Returns
+    None if pods can't be queried (don't treat that as a regression —
+    skip the crash-loop check that round).
+    """
+    result = cmd.kube(
+        "get", "pods",
+        "--namespace", wva_ns,
+        "-l", "control-plane=controller-manager",
+        "-o", "json",
+        check=False,
+    )
+    if not result.success:
+        return None
+    try:
+        data = json.loads(result.stdout) if result.stdout else {}
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    total = 0
+    for pod in data.get("items", []) or []:
+        for cs in pod.get("status", {}).get("containerStatuses", []) or []:
+            if cs.get("name") == "manager":
+                total += int(cs.get("restartCount", 0) or 0)
+    return total
+
+
+def _deployment_is_available(dep: dict) -> bool:
+    """Return True when the Deployment has an Available=True condition."""
+    for cond in dep.get("status", {}).get("conditions", []) or []:
+        if cond.get("type") == "Available" and cond.get("status") == "True":
+            return True
+    return False
+
+
+class WvaValidator(WvaSmoketestMixin, BaseSmoketest):
+    """Minimal standalone validator for WVA-only scenarios (e.g. inference-scheduling-wva).
+
+    Runs the base infrastructure smoketest plus the WVA-specific checks
+    (controller, prometheus-adapter, VariantAutoscaling, HPA).
+    """
+
+    def run_config_validation(
+        self, context: ExecutionContext, stack_path: Path,
+    ) -> SmoketestReport:
+        report = SmoketestReport()
+        self.run_wva_checks(context, stack_path, report)
+        return report

--- a/llmdbenchmark/smoketests/validators/wva.py
+++ b/llmdbenchmark/smoketests/validators/wva.py
@@ -40,6 +40,14 @@ _WVA_CONTROLLER_POLL_SECS = 5
 _HPA_TARGETS_TIMEOUT_SECS = 180
 _HPA_TARGETS_POLL_SECS = 5
 
+# How long to wait for the HPA's current replica count to converge to its
+# minReplicas (the expected idle steady-state when no traffic is hitting
+# the deployment). Includes the scaleDown stabilization window
+# (typically 120s) plus the time for the actual scale-down to complete,
+# so allow at least 2x the stabilization window.
+_HPA_CONVERGED_TIMEOUT_SECS = 300
+_HPA_CONVERGED_POLL_SECS = 10
+
 
 class WvaSmoketestMixin:
     """Adds WVA-specific checks to any scenario validator.
@@ -80,6 +88,15 @@ class WvaSmoketestMixin:
           8. The HPA's TARGETS / currentMetrics field has resolved from
              <unknown> to a numeric value — proves the full pipeline
              (controller → Prometheus → adapter → HPA) is end-to-end live.
+          9. The HPA's REPLICAS column converges to its MINPODS (idle
+             steady-state). With no traffic hitting the deployment, the
+             controller computes desiredReplicas=minReplicas and the HPA
+             scales the Deployment down to match — confirms the HPA is
+             not just receiving the metric but actually acting on it.
+         10. End-state snapshot of the VA + HPA (always passes if the
+             resources can be queried) so the smoketest log captures
+             the final cluster state without needing a follow-up
+             ``oc describe`` call to debug.
         """
         config = _load_config(stack_path)
         if not (_nested_get(config, "wva", "enabled") or False):
@@ -151,6 +168,13 @@ class WvaSmoketestMixin:
             poll_interval=_HPA_TARGETS_POLL_SECS,
             logger=context.logger,
         )
+        self._wait_for_hpa_converged(
+            cmd, wva_ns, va_name, report,
+            timeout=_HPA_CONVERGED_TIMEOUT_SECS,
+            poll_interval=_HPA_CONVERGED_POLL_SECS,
+            logger=context.logger,
+        )
+        self._log_va_hpa_state(cmd, wva_ns, va_name, report)
 
     # --- individual checks ------------------------------------------------
 
@@ -587,6 +611,145 @@ class WvaSmoketestMixin:
                 )
 
             time.sleep(poll_interval)
+
+    @staticmethod
+    def _wait_for_hpa_converged(
+        cmd: CommandExecutor,
+        wva_ns: str,
+        hpa_name: str,
+        report: SmoketestReport,
+        timeout: int = _HPA_CONVERGED_TIMEOUT_SECS,
+        poll_interval: int = _HPA_CONVERGED_POLL_SECS,
+        logger=None,
+    ) -> None:
+        """Wait for the HPA's REPLICAS to converge to its MINPODS.
+
+        At smoketest time the deployment has no traffic, so the WVA
+        controller computes ``desiredReplicas == minReplicas`` and the
+        HPA scales the Deployment down to that floor. If this never
+        happens, either:
+          - the HPA is receiving the metric but failing to scale (RBAC
+            or scale-subresource issue), or
+          - the controller is computing ``desiredReplicas > minReplicas``
+            for a still-loading deployment, or
+          - we're inside a still-active scaleDown stabilization window
+            and timeout was set too tight.
+        """
+        start = time.time()
+        last_state = "(hpa not found)"
+
+        while True:
+            elapsed = time.time() - start
+
+            result = cmd.kube(
+                "get", "hpa", hpa_name,
+                "--namespace", wva_ns,
+                "-o", "json",
+                check=False,
+            )
+
+            if result.success:
+                try:
+                    hpa = json.loads(result.stdout) if result.stdout else {}
+                except (json.JSONDecodeError, ValueError):
+                    hpa = {}
+
+                spec_min = int(hpa.get("spec", {}).get("minReplicas", 1) or 1)
+                spec_max = int(hpa.get("spec", {}).get("maxReplicas", 0) or 0)
+                current = hpa.get("status", {}).get("currentReplicas")
+                desired = hpa.get("status", {}).get("desiredReplicas")
+
+                last_state = (
+                    f"current={current} desired={desired} "
+                    f"min={spec_min} max={spec_max}"
+                )
+
+                if (
+                    current is not None
+                    and int(current) == spec_min
+                    and (desired is None or int(desired) == spec_min)
+                ):
+                    report.add(CheckResult(
+                        "wva_hpa_converged",
+                        True,
+                        expected=f"REPLICAS={spec_min} (=MINPODS)",
+                        actual=f"REPLICAS={current}",
+                        message=(
+                            f"HPA/{hpa_name} converged on idle steady-state "
+                            f"({last_state}) after {int(elapsed)}s"
+                        ),
+                    ))
+                    return
+
+            if elapsed >= timeout:
+                report.add(CheckResult(
+                    "wva_hpa_converged",
+                    False,
+                    expected="REPLICAS == MINPODS",
+                    actual=last_state,
+                    message=(
+                        f"HPA/{hpa_name} did not converge to MINPODS within "
+                        f"{timeout}s. Last state: {last_state}. "
+                        "Likely causes: scaleDown stabilization window still "
+                        "active (bump _HPA_CONVERGED_TIMEOUT_SECS), HPA can't "
+                        "patch the Deployment scale subresource, or controller "
+                        "computed desiredReplicas > minReplicas."
+                    ),
+                ))
+                return
+
+            if logger is not None and int(elapsed) % 30 == 0 and int(elapsed) > 0:
+                logger.log_info(
+                    f"⏳ Waiting for HPA/{hpa_name} REPLICAS to converge "
+                    f"({int(elapsed)}/{timeout}s) -- {last_state}"
+                )
+
+            time.sleep(poll_interval)
+
+    @staticmethod
+    def _log_va_hpa_state(
+        cmd: CommandExecutor,
+        wva_ns: str,
+        resource_name: str,
+        report: SmoketestReport,
+    ) -> None:
+        """Capture the current `oc get` output of the VA + HPA into the
+        smoketest report so the log alone tells the operator what state
+        each resource ended up in (TARGETS, MIN, MAX, REPLICAS, etc.)
+        without requiring a follow-up ``oc describe``.
+
+        Always passes when both resources can be queried; failure to
+        query is informational, not blocking.
+        """
+        va_result = cmd.kube(
+            "get", "variantautoscaling.llmd.ai", resource_name,
+            "--namespace", wva_ns,
+            check=False,
+        )
+        hpa_result = cmd.kube(
+            "get", "hpa", resource_name,
+            "--namespace", wva_ns,
+            check=False,
+        )
+
+        va_text = va_result.stdout.strip() if va_result.success else (
+            f"(failed: {va_result.stderr.strip()[:200]})"
+        )
+        hpa_text = hpa_result.stdout.strip() if hpa_result.success else (
+            f"(failed: {hpa_result.stderr.strip()[:200]})"
+        )
+
+        report.add(CheckResult(
+            "wva_va_hpa_state",
+            va_result.success and hpa_result.success,
+            message=(
+                f"End-state of WVA resources in ns/{wva_ns}:\n"
+                f"  VariantAutoscaling:\n    "
+                + va_text.replace("\n", "\n    ")
+                + "\n  HorizontalPodAutoscaler:\n    "
+                + hpa_text.replace("\n", "\n    ")
+            ),
+        ))
 
 
 def _hpa_first_external_metric_value(hpa: dict):

--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.executor.command import CommandExecutor
+from llmdbenchmark.standup import wva as wva_mod
 from llmdbenchmark.utilities.capacity_validator import run_capacity_planner
 
 
@@ -502,8 +503,6 @@ class WorkloadMonitoringStep(Step):
         The chart itself brings its own RBAC (``templates/rbac/*``), CRD
         (``llmd.ai/variantautoscaling``), ServiceMonitor, and ConfigMaps.
         """
-        from llmdbenchmark.standup import wva as wva_mod
-
         pairs = wva_mod.stacks_enabling_wva(context.rendered_stacks or [])
         if not pairs:
             return

--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -471,5 +471,92 @@ class WorkloadMonitoringStep(Step):
         result = cmd.kube("apply", "-f", str(monitoring_yaml))
         if not result.success:
             errors.append(f"Failed to apply monitoring configuration: {result.stderr}")
+            return
+        context.logger.log_info("User workload monitoring configured")
+
+        # WVA admin install MUST run after the ClusterMonitoringConfig is
+        # applied above — the prometheus-adapter is installed into the
+        # user-workload-monitoring namespace which is only created once
+        # UWM is enabled. Any rendered stack with wva.enabled: true
+        # triggers the install; one WVA controller per unique wva.namespace.
+        self._install_wva_if_enabled(cmd, context, errors)
+
+    def _install_wva_if_enabled(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        errors: list,
+    ) -> None:
+        """Install WVA controller + prometheus-adapter once per unique namespace.
+
+        Runs only when at least one rendered stack has ``wva.enabled: true``
+        and the platform is OpenShift. Provisions:
+
+        1. prometheus-adapter helm chart + prometheus-ca ConfigMap in the
+           user-workload monitoring namespace (cluster-scoped dependency,
+           installed once regardless of how many WVA namespaces exist).
+        2. The thanos-querier ClusterRole (from rendered 22_prometheus-rbac).
+        3. The WVA namespace label (from rendered 23_wva-namespace).
+        4. The WVA controller helm chart into each unique wva.namespace.
+
+        The chart itself brings its own RBAC (``templates/rbac/*``), CRD
+        (``llmd.ai/variantautoscaling``), ServiceMonitor, and ConfigMaps.
+        """
+        from llmdbenchmark.standup import wva as wva_mod
+
+        pairs = wva_mod.stacks_enabling_wva(context.rendered_stacks or [])
+        if not pairs:
+            return
+
+        if not context.is_openshift:
+            context.logger.log_info(
+                "ℹ️  WVA is enabled but platform is not OpenShift -- "
+                "skipping WVA admin install (not yet verified on non-OCP)"
+            )
+            return
+
+        # prometheus-adapter + ClusterRole: cluster-wide, install once
+        # from the first stack's rendered templates.
+        first_stack, first_cfg = pairs[0]
+        monitoring_ns = (
+            first_cfg.get("openshiftMonitoring", {})
+            .get("userWorkloadMonitoringNamespace", "openshift-user-workload-monitoring")
+        )
+
+        prom_ca_cert = wva_mod.extract_prometheus_ca_cert(cmd, context.logger)
+        if not prom_ca_cert:
+            context.logger.log_warning(
+                "Could not extract a Prometheus CA cert. Skipping "
+                "prometheus-adapter install -- the WVA controller will still "
+                "run (TLS insecureSkipVerify=true) but the HPA will not "
+                "receive metrics, so auto-scaling is disabled.\n"
+                "  To fix, ensure either:\n"
+                "    1) `oc get secret thanos-querier-tls -n openshift-monitoring` "
+                "returns the secret (needs cluster-admin on most clusters), or\n"
+                "    2) `oc get cm openshift-service-ca.crt` works in the "
+                "deploy namespace (this is the built-in fallback; any "
+                "authenticated user has access)."
+            )
         else:
-            context.logger.log_info("User workload monitoring configured")
+            wva_mod.install_prometheus_adapter(
+                cmd=cmd,
+                context=context,
+                plan_config=first_cfg,
+                stack_path=first_stack,
+                monitoring_ns=monitoring_ns,
+                prom_ca_cert=prom_ca_cert,
+                errors=errors,
+            )
+
+        # One WVA controller per unique wva.namespace.
+        for wva_ns, (stack_path, plan_config) in wva_mod.unique_wva_namespaces(pairs).items():
+            wva_mod.apply_wva_namespace_label(cmd, stack_path, wva_ns)
+            wva_mod.install_wva_for_namespace(
+                cmd=cmd,
+                context=context,
+                plan_config=plan_config,
+                stack_path=stack_path,
+                wva_namespace=wva_ns,
+                prom_ca_cert=prom_ca_cert,
+                errors=errors,
+            )

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -1,19 +1,10 @@
 """Step 09 -- Deploy the model via the llm-d modelservice Helm chart."""
 
-import base64
-import random
-import tempfile
 from pathlib import Path
-
-import yaml
 
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.executor.command import CommandExecutor
-
-
-# Known GPU accelerator prefixes for WVA auto-detection
-_ACCELERATOR_PREFIXES = ["G2", "A100", "H100", "L40S", "MI300X"]
 
 
 class DeployModelserviceStep(Step):
@@ -273,14 +264,13 @@ class DeployModelserviceStep(Step):
                 f"service/{route_service}:80"
             )
 
+        # WVA controller + prometheus-adapter are installed up-front by
+        # step_02 (admin prerequisites). Here we only apply this stack's
+        # VariantAutoscaling + HPA resources so the (already-running)
+        # controller can manage THIS model's decode deployment.
         wva_config = plan_config.get("wva", {})
         if wva_config.get("enabled", False) and context.is_openshift:
-            self._install_wva(cmd, context, plan_config, stack_path, errors)
-        elif wva_config.get("enabled", False) and not context.is_openshift:
-            context.logger.log_info(
-                "ℹ️  WVA is enabled but platform is not OpenShift -- "
-                "skipping WVA installation (not yet verified on non-OCP)"
-            )
+            self._apply_wva_stack_resources(cmd, stack_path, errors)
 
         self._propagate_standup_parameters(cmd, context, plan_config)
 
@@ -463,288 +453,26 @@ class DeployModelserviceStep(Step):
                         log_file = logs_dir / f"{pod_name}.log"
                         log_file.write_text(log_result.stdout, encoding="utf-8")
 
-    def _install_wva(  # pylint: disable=too-many-arguments,too-many-locals
+    def _apply_wva_stack_resources(
         self,
         cmd: CommandExecutor,
-        context: ExecutionContext,
-        plan_config: dict,
         stack_path: Path,
         errors: list,
-    ):
-        """Install WVA and prometheus-adapter, patching runtime values into rendered templates."""
-        namespace = context.require_namespace()
-        wva_cfg = plan_config.get("wva", {})
+    ) -> None:
+        """Apply this stack's VariantAutoscaling + HPA to the WVA namespace.
 
-        wva_namespace = context.wva_namespace or wva_cfg.get("namespace") or namespace
-
-        monitoring_ns = self._require_config(
-            plan_config, "openshiftMonitoring", "userWorkloadMonitoringNamespace"
-        )
-
-        ns_yaml = self._find_yaml(stack_path, "23_wva-namespace")
-        if ns_yaml and self._has_yaml_content(ns_yaml):
-            cmd.kube("apply", "-f", str(ns_yaml), check=False)
-        else:
-            context.logger.log_warning(
-                "WVA namespace template (23_wva-namespace) not found -- "
-                "creating namespace inline"
-            )
-            cmd.kube(
-                "create",
-                "namespace",
-                wva_namespace,
-                check=False,
-            )
-
-        wva_values_yaml = self._find_yaml(stack_path, "19_wva-values")
-        if not wva_values_yaml:
-            errors.append(
-                "WVA values template (19_wva-values) not found -- " "cannot install WVA"
-            )
-            return
-
-        wva_config = yaml.safe_load(wva_values_yaml.read_text(encoding="utf-8"))
-        if not wva_config:
-            errors.append("WVA values template rendered empty -- is wva.enabled set?")
-            return
-
-        prom_ca_cert = self._extract_prometheus_ca_cert(cmd, context)
-        if not prom_ca_cert:
-            context.logger.log_warning(
-                "Could not extract Prometheus CA cert from "
-                "thanos-querier-tls secret -- WVA may not connect to Prometheus"
-            )
-        if prom_ca_cert and "wva" in wva_config and "prometheus" in wva_config["wva"]:
-            wva_config["wva"]["prometheus"]["caCert"] = prom_ca_cert
-
-        affinity_str = ""
-        decode_cfg = plan_config.get("decode", {})
-        accel_types = decode_cfg.get("acceleratorType", {})
-        if accel_types:
-            label_values = accel_types.get("labelValues", [])
-            if label_values:
-                affinity_str = str(label_values[0])
-            elif accel_types.get("labelValue"):
-                affinity_str = str(accel_types["labelValue"])
-        accelerator_type = self._find_accelerator_prefix(affinity_str) or ""
-        if "va" in wva_config:
-            wva_config["va"]["accelerator"] = accelerator_type
-
-        vllm_svc_cfg = wva_cfg.get("vllmService", {})
-        node_port_min = int(self._require_config(plan_config, "wva", "vllmService", "nodePortMin"))
-        node_port_max = int(self._require_config(plan_config, "wva", "vllmService", "nodePortMax"))
-        node_port = self._get_random_node_port(
-            cmd, namespace, node_port_min, node_port_max
-        )
-        if "vllmService" in wva_config:
-            wva_config["vllmService"]["nodePort"] = node_port
-
-        tmp_dir = Path(tempfile.mkdtemp())
-        wva_values_path = tmp_dir / "wva_config.yaml"
-        wva_values_path.write_text(
-            yaml.dump(wva_config, sort_keys=False), encoding="utf-8"
-        )
-
-        wva_chart = plan_config.get("helmRepositories", {}).get("wva", {})
-        chart_url = wva_chart.get("url", "")
-        chart_version = plan_config.get("chartVersions", {}).get("wva", "")
-
-        if chart_url and chart_version:
-            result = cmd.helm(
-                "upgrade",
-                "--install",
-                "workload-variant-autoscaler",
-                chart_url,
-                "--version",
-                chart_version,
-                "--namespace",
-                wva_namespace,
-                "-f",
-                str(wva_values_path),
-            )
+        The WVA controller + prometheus-adapter were already installed by
+        step_02 once per unique wva.namespace. Here we only kubectl apply
+        the per-stack resources so a single controller can manage multiple
+        models.
+        """
+        for stem in ("27_wva-variantautoscaling", "28_wva-hpa"):
+            yaml_path = self._find_yaml(stack_path, stem)
+            if not (yaml_path and self._has_yaml_content(yaml_path)):
+                continue
+            result = cmd.kube("apply", "-f", str(yaml_path))
             if not result.success:
-                errors.append(f"Failed to install WVA: {result.stderr}")
-        else:
-            errors.append(
-                "WVA chart URL or version not configured -- "
-                "check helmRepositories.wva and chartVersions.wva"
-            )
-
-        if prom_ca_cert:
-            self._install_prometheus_adapters(
-                cmd,
-                context,
-                plan_config=plan_config,
-                stack_path=stack_path,
-                monitoring_ns=monitoring_ns,
-                prom_ca_cert=prom_ca_cert,
-                tmp_dir=tmp_dir,
-                errors=errors,
-            )
-        else:
-            context.logger.log_warning(
-                "Skipping prometheus-adapter install -- no CA cert available"
-            )
-
-    def _install_prometheus_adapters(
-        self,
-        cmd: CommandExecutor,
-        context: ExecutionContext,
-        plan_config: dict,
-        stack_path: Path,
-        monitoring_ns: str,
-        prom_ca_cert: str,
-        tmp_dir: Path,
-        errors: list,
-    ):
-        """Install prometheus-adapter using pre-rendered templates."""
-        cert_path = tmp_dir / "prometheus-ca.crt"
-        cert_path.write_text(prom_ca_cert, encoding="utf-8")
-
-        result = cmd.kube(
-            "create",
-            "configmap",
-            "prometheus-ca",
-            f"--from-file=ca.crt={cert_path}",
-            "--dry-run=client",
-            "-o",
-            "yaml",
-            namespace=monitoring_ns,
-            check=False,
-        )
-        if result.success and result.stdout.strip():
-            cm_yaml_path = tmp_dir / "prometheus-ca-configmap.yaml"
-            cm_yaml_path.write_text(result.stdout, encoding="utf-8")
-            apply_result = cmd.kube(
-                "apply",
-                "-f",
-                str(cm_yaml_path),
-                namespace=monitoring_ns,
-                check=False,
-            )
-            if not apply_result.success:
-                context.logger.log_warning(
-                    f"prometheus-ca ConfigMap apply failed: {apply_result.stderr}"
-                )
-        elif not result.success:
-            context.logger.log_warning(
-                f"prometheus-ca ConfigMap creation failed: {result.stderr}"
-            )
-
-        # Read the prometheus-adapter helm repo from defaults.yaml so the
-        # URL has a single source of truth (helmRepositories.prometheusAdapter).
-        # Fail loudly if the entry is missing -- we'd rather surface the
-        # config gap than silently install from a stale hardcoded URL.
-        repo_url = self._require_config(
-            plan_config, "helmRepositories", "prometheusAdapter", "url",
-        )
-        chart_name = self._require_config(
-            plan_config, "helmRepositories", "prometheusAdapter", "name",
-        )
-        repo_alias = "prometheus-community"
-
-        cmd.helm("repo", "add", repo_alias, repo_url, check=False)
-        cmd.helm("repo", "update", check=False)
-
-        adapter_values = self._find_yaml(stack_path, "21_prometheus-adapter-values")
-        if adapter_values:
-            result = cmd.helm(
-                "upgrade",
-                "--install",
-                "prometheus-adapter",
-                f"{repo_alias}/{chart_name}",
-                "--namespace",
-                monitoring_ns,
-                "-f",
-                str(adapter_values),
-            )
-            if not result.success:
-                errors.append(f"Failed to install prometheus-adapter: {result.stderr}")
-        else:
-            errors.append(
-                "prometheus-adapter values template (21_prometheus-adapter-values) "
-                "not found"
-            )
-
-        rbac_yaml = self._find_yaml(stack_path, "22_prometheus-rbac")
-        if rbac_yaml and self._has_yaml_content(rbac_yaml):
-            result = cmd.kube("apply", "-f", str(rbac_yaml), check=False)
-            if not result.success:
-                context.logger.log_warning(
-                    f"ClusterRole creation failed (non-fatal): {result.stderr}"
-                )
-        else:
-            context.logger.log_warning(
-                "prometheus RBAC template (22_prometheus-rbac) not found"
-            )
-
-    def _extract_prometheus_ca_cert(
-        self, cmd: CommandExecutor, context: ExecutionContext
-    ) -> str | None:
-        """Extract Prometheus CA cert from thanos-querier-tls secret."""
-        result = cmd.kube(
-            "get",
-            "secret",
-            "thanos-querier-tls",
-            "--namespace",
-            "openshift-monitoring",
-            "-o",
-            "jsonpath={.data.tls\\.crt}",
-            check=False,
-        )
-        if not result.success or not result.stdout.strip():
-            return None
-
-        try:
-            cert_bytes = base64.b64decode(result.stdout.strip())
-            cert_str = cert_bytes.decode("utf-8")
-            if not cert_str.endswith("\n"):
-                cert_str += "\n"
-            return cert_str
-        except Exception as exc:
-            context.logger.log_warning(f"Failed to decode CA cert: {exc}")
-            return None
-
-    @staticmethod
-    def _find_accelerator_prefix(affinity_string: str) -> str | None:
-        """Find the first known accelerator prefix in the affinity string."""
-        if not affinity_string:
-            return None
-        for prefix in _ACCELERATOR_PREFIXES:
-            if prefix in affinity_string:
-                return prefix
-        return None
-
-    @staticmethod
-    def _get_random_node_port(
-        cmd: CommandExecutor,
-        namespace: str,
-        min_port: int = 30000,
-        max_port: int = 32767,
-    ) -> int:
-        """Return a random available NodePort in the given range."""
-        existing_ports: set[int] = set()
-        result = cmd.kube(
-            "get",
-            "services",
-            "--all-namespaces",
-            "-o",
-            "jsonpath={.items[*].spec.ports[*].nodePort}",
-            check=False,
-        )
-        if result.success and result.stdout.strip():
-            for port_str in result.stdout.strip().split():
-                try:
-                    existing_ports.add(int(port_str))
-                except ValueError:
-                    continue
-
-        for _ in range(100):
-            candidate = random.randint(min_port, max_port)
-            if candidate not in existing_ports:
-                return candidate
-
-        return random.randint(min_port, max_port)
+                errors.append(f"Failed to apply {stem}: {result.stderr}")
 
     def _propagate_standup_parameters(
         self, cmd: CommandExecutor, context: ExecutionContext, plan_config: dict

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -271,6 +271,7 @@ class DeployModelserviceStep(Step):
         wva_config = plan_config.get("wva", {})
         if wva_config.get("enabled", False) and context.is_openshift:
             self._apply_wva_stack_resources(cmd, stack_path, errors)
+            self._log_wva_stack_state(cmd, context, plan_config)
 
         self._propagate_standup_parameters(cmd, context, plan_config)
 
@@ -473,6 +474,52 @@ class DeployModelserviceStep(Step):
             result = cmd.kube("apply", "-f", str(yaml_path))
             if not result.success:
                 errors.append(f"Failed to apply {stem}: {result.stderr}")
+
+    def _log_wva_stack_state(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        plan_config: dict,
+    ) -> None:
+        """Log the current state of this stack's VariantAutoscaling + HPA.
+
+        Lets the standup output show what got created (VA OPTIMIZED, HPA
+        TARGETS / REPLICAS, etc.) without the operator needing a follow-up
+        ``oc get``. Best-effort — failures here don't fail step_09.
+        """
+        wva_cfg = plan_config.get("wva", {}) or {}
+        wva_ns = (
+            wva_cfg.get("namespace")
+            or plan_config.get("namespace", {}).get("name", "")
+        )
+        model_id_label = plan_config.get("model_id_label", "")
+        if not (wva_ns and model_id_label):
+            return
+
+        resource_name = f"{model_id_label}-decode"
+
+        for kind, label in (
+            ("variantautoscaling.llmd.ai", "VariantAutoscaling"),
+            ("hpa", "HorizontalPodAutoscaler"),
+        ):
+            result = cmd.kube(
+                "get", kind, resource_name,
+                "--namespace", wva_ns,
+                check=False,
+            )
+            if result.success and result.stdout.strip():
+                context.logger.log_info(
+                    f"📋 {label} state in ns/{wva_ns}:"
+                )
+                # Indent each line so it visually groups with the
+                # header above it in the standup log.
+                for line in result.stdout.rstrip().splitlines():
+                    context.logger.log_info(f"    {line}")
+            else:
+                context.logger.log_warning(
+                    f"Could not query {label}/{resource_name} for state log: "
+                    f"{result.stderr.strip()[:200] or '(empty)'}"
+                )
 
     def _propagate_standup_parameters(
         self, cmd: CommandExecutor, context: ExecutionContext, plan_config: dict

--- a/llmdbenchmark/standup/wva.py
+++ b/llmdbenchmark/standup/wva.py
@@ -1,0 +1,464 @@
+"""Shared helpers for installing the Workload Variant Autoscaler (WVA).
+
+The WVA controller and its runtime dependencies (prometheus-adapter,
+prometheus-ca ConfigMap, thanos-querier ClusterRole) are cluster/admin-scoped
+and must be provisioned *before* any per-stack work runs. These helpers are
+called from ``step_02_admin_prerequisites`` once per unique ``wva.namespace``
+across all rendered stacks. Per-stack resources (VariantAutoscaling + HPA)
+are rendered from ``27_wva-variantautoscaling.yaml.j2`` /
+``28_wva-hpa.yaml.j2`` and applied in ``step_09``.
+
+Helpers live in this module (rather than in a step class) so both the
+admin step and per-stack step can import them without a cyclic
+dependency.
+"""
+
+from __future__ import annotations
+
+import base64
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.executor.command import CommandExecutor
+from llmdbenchmark.executor.context import ExecutionContext
+
+
+def extract_prometheus_ca_cert(
+    cmd: CommandExecutor, logger
+) -> str | None:
+    """Extract the Prometheus CA cert from the OpenShift monitoring stack.
+
+    Tries (in order):
+      1. ``thanos-querier-tls`` — the main cert used by the upstream WVA guide.
+      2. The service-ca ConfigMap injected by OpenShift
+         (``openshift-service-ca.crt``) — always readable by any pod/user
+         with access to a namespace, so this is a safe fallback when
+         secret read is blocked by RBAC.
+
+    Returns the PEM-encoded cert, or ``None`` if nothing works. Logs the
+    concrete failure reason so RBAC vs. missing-resource vs. decode-error
+    can be told apart at the console.
+    """
+    # CommandExecutor.kube() concatenates argv with spaces and runs via
+    # shell=True, so any backslash in a jsonpath arg is eaten by the shell
+    # unless we single-quote the whole thing. `tls.crt` contains a literal
+    # dot, which kubectl's jsonpath needs escaped as `tls\.crt`; we wrap
+    # in single quotes so both the backslash and dot survive the shell.
+
+    # Try 1: thanos-querier-tls (same source the upstream guide uses)
+    result = cmd.kube(
+        "get",
+        "secret",
+        "thanos-querier-tls",
+        "--namespace",
+        "openshift-monitoring",
+        "-o",
+        r"'jsonpath={.data.tls\.crt}'",
+        check=False,
+    )
+    if result.success and result.stdout.strip():
+        try:
+            cert_bytes = base64.b64decode(result.stdout.strip())
+            return _ensure_trailing_newline(cert_bytes.decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 -- log and fall through
+            logger.log_warning(f"Failed to decode thanos-querier-tls CA cert: {exc}")
+    elif not result.success:
+        logger.log_debug(
+            f"Could not read secret/thanos-querier-tls in openshift-monitoring: "
+            f"{result.stderr.strip()[:300]}"
+        )
+
+    # Try 2: openshift-service-ca.crt ConfigMap (present in every namespace
+    # on OCP, contains the cluster service-ca used to sign internal certs
+    # including thanos-querier). Readable by any authenticated user with
+    # namespace access — no openshift-monitoring read permission needed.
+    result = cmd.kube(
+        "get",
+        "configmap",
+        "openshift-service-ca.crt",
+        "-o",
+        r"'jsonpath={.data.service-ca\.crt}'",
+        check=False,
+    )
+    if result.success and result.stdout.strip():
+        logger.log_info(
+            "Using openshift-service-ca.crt ConfigMap as Prometheus CA fallback "
+            "(thanos-querier-tls secret was not readable)"
+        )
+        return _ensure_trailing_newline(result.stdout)
+
+    logger.log_debug(
+        f"Could not read openshift-service-ca.crt ConfigMap: "
+        f"{result.stderr.strip()[:300]}"
+    )
+    return None
+
+
+def _ensure_trailing_newline(cert: str) -> str:
+    """Return *cert* with a trailing newline (PEM convention)."""
+    cert = cert.strip()
+    return cert + "\n" if cert else ""
+
+
+def install_wva_for_namespace(  # pylint: disable=too-many-arguments,too-many-locals
+    cmd: CommandExecutor,
+    context: ExecutionContext,
+    plan_config: dict,
+    stack_path: Path,
+    wva_namespace: str,
+    prom_ca_cert: str | None,
+    errors: list,
+) -> None:
+    """Install the WVA controller helm release into *wva_namespace*.
+
+    Loads the rendered ``19_wva-values.yaml`` from *stack_path*, patches
+    the runtime-computed ``caCert`` into it, and runs
+    ``helm upgrade --install workload-variant-autoscaler``. Idempotent
+    across calls (subsequent calls for the same namespace are a helm
+    upgrade).
+    """
+    wva_values_yaml = _find_yaml(stack_path, "19_wva-values")
+    if not wva_values_yaml:
+        errors.append(
+            "WVA values template (19_wva-values) not found -- cannot install WVA"
+        )
+        return
+
+    wva_config = yaml.safe_load(wva_values_yaml.read_text(encoding="utf-8"))
+    if not wva_config:
+        errors.append("WVA values template rendered empty -- is wva.enabled set?")
+        return
+
+    if prom_ca_cert and "wva" in wva_config and "prometheus" in wva_config["wva"]:
+        wva_config["wva"]["prometheus"]["caCert"] = prom_ca_cert
+
+    tmp_dir = Path(tempfile.mkdtemp())
+    wva_values_path = tmp_dir / "wva_config.yaml"
+    wva_values_path.write_text(
+        yaml.dump(wva_config, sort_keys=False), encoding="utf-8"
+    )
+
+    wva_chart = plan_config.get("helmRepositories", {}).get("wva", {})
+    chart_url = wva_chart.get("url", "")
+    chart_version = plan_config.get("chartVersions", {}).get("wva", "")
+
+    if not (chart_url and chart_version):
+        errors.append(
+            "WVA chart URL or version not configured -- "
+            "check helmRepositories.wva and chartVersions.wva"
+        )
+        return
+
+    context.logger.log_info(
+        f"📦 Installing WVA controller v{chart_version} into ns/{wva_namespace}"
+    )
+    result = cmd.helm(
+        "upgrade",
+        "--install",
+        "workload-variant-autoscaler",
+        chart_url,
+        "--version",
+        chart_version,
+        "--namespace",
+        wva_namespace,
+        "--create-namespace",
+        "-f",
+        str(wva_values_path),
+    )
+    if not result.success:
+        errors.append(f"Failed to install WVA: {result.stderr}")
+
+
+def install_prometheus_adapter(  # pylint: disable=too-many-arguments
+    cmd: CommandExecutor,
+    context: ExecutionContext,
+    plan_config: dict,
+    stack_path: Path,
+    monitoring_ns: str,
+    prom_ca_cert: str,
+    errors: list,
+) -> None:
+    """Install the prometheus-adapter helm chart + prometheus-ca ConfigMap.
+
+    Cluster-scoped dependency for WVA: runs once up front regardless of
+    how many model namespaces host WVA controllers.
+    """
+    tmp_dir = Path(tempfile.mkdtemp())
+    cert_path = tmp_dir / "prometheus-ca.crt"
+    cert_path.write_text(prom_ca_cert, encoding="utf-8")
+
+    # Create-or-update the prometheus-ca ConfigMap in the monitoring ns.
+    result = cmd.kube(
+        "create",
+        "configmap",
+        "prometheus-ca",
+        f"--from-file=ca.crt={cert_path}",
+        "--dry-run=client",
+        "-o",
+        "yaml",
+        namespace=monitoring_ns,
+        check=False,
+    )
+    if result.success and result.stdout.strip():
+        cm_yaml_path = tmp_dir / "prometheus-ca-configmap.yaml"
+        cm_yaml_path.write_text(result.stdout, encoding="utf-8")
+        apply_result = cmd.kube(
+            "apply",
+            "-f",
+            str(cm_yaml_path),
+            namespace=monitoring_ns,
+            check=False,
+        )
+        if not apply_result.success:
+            context.logger.log_warning(
+                f"prometheus-ca ConfigMap apply failed: {apply_result.stderr}"
+            )
+    elif not result.success:
+        context.logger.log_warning(
+            f"prometheus-ca ConfigMap creation failed: {result.stderr}"
+        )
+
+    # prometheus-adapter is a cluster-scoped install (it owns a ClusterRole
+    # `prometheus-adapter-resource-reader` that can only belong to a single
+    # helm release cluster-wide). If another tenant in the cluster already
+    # installed it — common on shared OCP clusters — we can't
+    # `helm upgrade --install` ours on top without stealing ownership of
+    # that ClusterRole.
+    #
+    # In that case we can only reuse their install IF they configured it
+    # with the WVA rule (`wva_desired_replicas` external metric). If they
+    # didn't, the adapter is live but our HPA will still get no metric —
+    # we surface that with a loud error so it's obvious what to do (either
+    # have them re-install with the WVA values file, or uninstall theirs
+    # and let us install ours).
+    existing_release, existing_ns = _find_existing_prometheus_adapter_release(cmd)
+    if existing_release:
+        has_rule = _external_metric_available(cmd, "wva_desired_replicas")
+        if has_rule:
+            context.logger.log_info(
+                f"ℹ️  prometheus-adapter is already installed cluster-wide "
+                f"(release={existing_release!r}, namespace={existing_ns!r}) "
+                "and serves wva_desired_replicas via the external-metrics API. "
+                "Reusing it."
+            )
+        else:
+            errors.append(
+                f"prometheus-adapter is already installed by another tenant "
+                f"(release={existing_release!r}, namespace={existing_ns!r}) "
+                "but the external-metrics API does NOT expose "
+                "wva_desired_replicas. Their install is missing the WVA "
+                "rule set, so the HPA cannot receive metrics.\n"
+                "  Fix by one of:\n"
+                "    1) Have that tenant re-install prometheus-adapter with "
+                "the WVA values file "
+                "(https://raw.githubusercontent.com/llm-d/llm-d-workload-variant-autoscaler/"
+                f"v{plan_config.get('chartVersions', {}).get('wva', '0.6.0')}/"
+                "config/samples/prometheus-adapter-values-ocp.yaml), or\n"
+                "    2) `helm uninstall` their release (ClusterRole ownership "
+                "then clears) and re-run this standup so we install with the "
+                "correct rules, or\n"
+                "    3) Patch their adapter ConfigMap to add the "
+                "wva_desired_replicas rule."
+            )
+    else:
+        repo_url = _require_config(
+            plan_config, "helmRepositories", "prometheusAdapter", "url",
+        )
+        chart_name = _require_config(
+            plan_config, "helmRepositories", "prometheusAdapter", "name",
+        )
+        repo_alias = "prometheus-community"
+
+        cmd.helm("repo", "add", repo_alias, repo_url, check=False)
+        cmd.helm("repo", "update", check=False)
+
+        adapter_values = _find_yaml(stack_path, "21_prometheus-adapter-values")
+        if not adapter_values:
+            errors.append(
+                "prometheus-adapter values template (21_prometheus-adapter-values) "
+                "not found"
+            )
+            return
+
+        # Pin prometheus-adapter chart version (from chartVersions.prometheusAdapter
+        # in defaults.yaml) so newer releases can't break the external-metric
+        # rule format the WVA chart emits. Upstream README uses this same pin.
+        adapter_version = plan_config.get("chartVersions", {}).get(
+            "prometheusAdapter", ""
+        )
+
+        context.logger.log_info(
+            f"📦 Installing prometheus-adapter"
+            f"{' v' + adapter_version if adapter_version else ''} "
+            f"into ns/{monitoring_ns}"
+        )
+        version_args = ("--version", adapter_version) if adapter_version else ()
+        result = cmd.helm(
+            "upgrade",
+            "--install",
+            "prometheus-adapter",
+            f"{repo_alias}/{chart_name}",
+            *version_args,
+            "--namespace",
+            monitoring_ns,
+            "--create-namespace",
+            "-f",
+            str(adapter_values),
+        )
+        if not result.success:
+            errors.append(f"Failed to install prometheus-adapter: {result.stderr}")
+
+    rbac_yaml = _find_yaml(stack_path, "22_prometheus-rbac")
+    if rbac_yaml and _has_yaml_content(rbac_yaml):
+        result = cmd.kube("apply", "-f", str(rbac_yaml), check=False)
+        if not result.success:
+            context.logger.log_warning(
+                f"ClusterRole creation failed (non-fatal): {result.stderr}"
+            )
+    else:
+        context.logger.log_warning(
+            "prometheus RBAC template (22_prometheus-rbac) not found"
+        )
+
+
+def apply_wva_namespace_label(
+    cmd: CommandExecutor, stack_path: Path, wva_namespace: str
+) -> None:
+    """Apply the rendered 23_wva-namespace YAML (Namespace + user-monitoring label)."""
+    ns_yaml = _find_yaml(stack_path, "23_wva-namespace")
+    if ns_yaml and _has_yaml_content(ns_yaml):
+        cmd.kube("apply", "-f", str(ns_yaml), check=False)
+
+
+def stacks_enabling_wva(rendered_stacks: list[Path]) -> list[tuple[Path, dict]]:
+    """Return (stack_path, plan_config) pairs for every rendered stack with wva.enabled."""
+    pairs: list[tuple[Path, dict]] = []
+    for stack_path in rendered_stacks:
+        cfg_file = stack_path / "config.yaml"
+        if not cfg_file.exists():
+            continue
+        try:
+            with open(cfg_file, encoding="utf-8") as fh:
+                cfg = yaml.safe_load(fh) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        if cfg.get("wva", {}).get("enabled", False):
+            pairs.append((stack_path, cfg))
+    return pairs
+
+
+def unique_wva_namespaces(
+    stacks: list[tuple[Path, dict]],
+) -> dict[str, tuple[Path, dict]]:
+    """Group stacks by their ``wva.namespace`` (falling back to ``namespace.name``).
+
+    Returns a mapping ``{wva_namespace: (first_stack_path, first_plan_config)}``
+    so the caller can install the controller once per namespace using that
+    stack's rendered values.
+    """
+    result: dict[str, tuple[Path, dict]] = {}
+    for stack_path, cfg in stacks:
+        wva_cfg = cfg.get("wva", {})
+        wva_ns = wva_cfg.get("namespace") or cfg.get("namespace", {}).get("name", "")
+        if not wva_ns:
+            continue
+        if wva_ns not in result:
+            result[wva_ns] = (stack_path, cfg)
+    return result
+
+
+# --- internal helpers ------------------------------------------------------
+
+
+def _external_metric_available(cmd: CommandExecutor, metric_name: str) -> bool:
+    """Return True iff *metric_name* is served by the external-metrics API.
+
+    We hit the API discovery endpoint rather than inspecting the adapter's
+    ConfigMap because the ConfigMap name/namespace varies by installer;
+    the API itself is the authoritative cluster-wide answer.
+    """
+    result = cmd.kube(
+        "get",
+        "--raw",
+        "/apis/external.metrics.k8s.io/v1beta1",
+        check=False,
+    )
+    if not result.success or not result.stdout.strip():
+        return False
+
+    import json as _json
+    try:
+        data = _json.loads(result.stdout)
+    except (ValueError, _json.JSONDecodeError):
+        return False
+
+    for resource in data.get("resources", []) or []:
+        if resource.get("name") == metric_name:
+            return True
+    return False
+
+
+def _find_existing_prometheus_adapter_release(
+    cmd: CommandExecutor,
+) -> tuple[str | None, str | None]:
+    """Return (release_name, release_namespace) if prometheus-adapter is
+    already installed *anywhere* in the cluster, else (None, None).
+
+    Uses the cluster-scoped ``prometheus-adapter-resource-reader``
+    ClusterRole as the probe — the chart always creates it with a unique
+    name, so its helm ownership annotations point at the one release that
+    currently owns the install. Any tenant that ran
+    ``helm install prometheus-adapter ...`` (including llm-d-slo-queueing-test,
+    kube-prometheus-stack subchart, etc.) will show up here.
+    """
+    result = cmd.kube(
+        "get",
+        "clusterrole",
+        "prometheus-adapter-resource-reader",
+        "-o",
+        "jsonpath="
+        "'{.metadata.annotations.meta\\.helm\\.sh/release-name}"
+        "|{.metadata.annotations.meta\\.helm\\.sh/release-namespace}'",
+        check=False,
+    )
+    if not result.success or not result.stdout.strip():
+        return None, None
+
+    payload = result.stdout.strip().strip("'")
+    release_name, _, release_ns = payload.partition("|")
+    release_name = release_name or None
+    release_ns = release_ns or None
+    return release_name, release_ns
+
+
+def _find_yaml(stack_path: Path, stem_prefix: str) -> Path | None:
+    """Locate a rendered YAML under *stack_path* by filename stem prefix."""
+    for candidate in stack_path.glob(f"{stem_prefix}*.yaml"):
+        return candidate
+    return None
+
+
+def _has_yaml_content(path: Path) -> bool:
+    """Return True if *path* contains any non-comment YAML content."""
+    if not path.exists():
+        return False
+    text = path.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        return True
+    return False
+
+
+def _require_config(cfg: dict, *keys: str):
+    """Navigate dotted config path, raising if any segment is missing."""
+    node = cfg
+    for key in keys:
+        if not isinstance(node, dict) or key not in node:
+            dotted = ".".join(keys)
+            raise KeyError(f"Required config key missing: {dotted}")
+        node = node[key]
+    return node

--- a/llmdbenchmark/standup/wva.py
+++ b/llmdbenchmark/standup/wva.py
@@ -16,6 +16,7 @@ dependency.
 from __future__ import annotations
 
 import base64
+import json
 import tempfile
 from pathlib import Path
 
@@ -169,6 +170,25 @@ def install_wva_for_namespace(  # pylint: disable=too-many-arguments,too-many-lo
     )
     if not result.success:
         errors.append(f"Failed to install WVA: {result.stderr}")
+        return
+
+    # Wait for the controller pod(s) to actually become Ready before
+    # returning, with live ⏳ progress output (same helper used by
+    # step_08 for gateway and step_09 for decode/prefill). Without this,
+    # step_03 returns success while the controller is still scheduling
+    # / pulling images, and downstream steps race against pod startup.
+    wait = cmd.wait_for_pods(
+        label="control-plane=controller-manager",
+        namespace=wva_namespace,
+        timeout=300,
+        poll_interval=5,
+        description=f"WVA controller in ns/{wva_namespace}",
+    )
+    if not wait.success:
+        errors.append(
+            f"WVA controller pods did not become Ready in ns/{wva_namespace}: "
+            f"{wait.stderr}"
+        )
 
 
 def install_prometheus_adapter(  # pylint: disable=too-many-arguments
@@ -309,6 +329,21 @@ def install_prometheus_adapter(  # pylint: disable=too-many-arguments
         )
         if not result.success:
             errors.append(f"Failed to install prometheus-adapter: {result.stderr}")
+        else:
+            # Live progress wait so we don't race step_03 ahead of the
+            # adapter actually serving the external-metrics API.
+            wait = cmd.wait_for_pods(
+                label="app.kubernetes.io/name=prometheus-adapter",
+                namespace=monitoring_ns,
+                timeout=300,
+                poll_interval=5,
+                description=f"prometheus-adapter in ns/{monitoring_ns}",
+            )
+            if not wait.success:
+                errors.append(
+                    f"prometheus-adapter pods did not become Ready in "
+                    f"ns/{monitoring_ns}: {wait.stderr}"
+                )
 
     rbac_yaml = _find_yaml(stack_path, "22_prometheus-rbac")
     if rbac_yaml and _has_yaml_content(rbac_yaml):
@@ -388,10 +423,9 @@ def _external_metric_available(cmd: CommandExecutor, metric_name: str) -> bool:
     if not result.success or not result.stdout.strip():
         return False
 
-    import json as _json
     try:
-        data = _json.loads(result.stdout)
-    except (ValueError, _json.JSONDecodeError):
+        data = json.loads(result.stdout)
+    except (ValueError, json.JSONDecodeError):
         return False
 
     for resource in data.get("resources", []) or []:

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -20,8 +20,30 @@ class UninstallHelmStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        return ("modelservice" not in context.deployed_methods and
-                "fma" not in context.deployed_methods)
+        # We still run for WVA-enabled stacks even when neither
+        # modelservice nor fma is in deployed_methods, so the VA+HPA
+        # resources get cleaned up.
+        if ("modelservice" in context.deployed_methods
+                or "fma" in context.deployed_methods):
+            return False
+        return not self._any_stack_has_wva(context)
+
+    @staticmethod
+    def _any_stack_has_wva(context: ExecutionContext) -> bool:
+        """Return True if any rendered stack has wva.enabled: true."""
+        import yaml as _yaml
+        for stack_path in context.rendered_stacks or []:
+            cfg_file = stack_path / "config.yaml"
+            if not cfg_file.exists():
+                continue
+            try:
+                with open(cfg_file, encoding="utf-8") as fh:
+                    cfg = _yaml.safe_load(fh) or {}
+            except (OSError, _yaml.YAMLError):
+                continue
+            if (cfg.get("wva", {}) or {}).get("enabled", False):
+                return True
+        return False
 
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
@@ -41,6 +63,11 @@ class UninstallHelmStep(Step):
             if not is_fma_enabled:
                 self._delete_openshift_routes(cmd, context, ns, release)
                 self._delete_download_job(cmd, context, ns)
+
+        # WVA teardown: always remove per-stack VA+HPA. Only uninstall the
+        # shared controller + prometheus-adapter when the user passed -d
+        # (context.deep_clean) -- other stacks may still be using them.
+        self._teardown_wva(cmd, context, errors)
 
         if errors:
             return StepResult(
@@ -131,6 +158,128 @@ class UninstallHelmStep(Step):
             if result.success:
                 context.logger.log_info(
                     f"  Deleted route/{route_name}", emoji="🗑️"
+                )
+
+    def _teardown_wva(
+        self, cmd: CommandExecutor, context: ExecutionContext, errors: list
+    ) -> None:
+        """Tear down WVA resources.
+
+        Always deletes the per-stack VariantAutoscaling + HPA so the model
+        no longer auto-scales after teardown. The (per-namespace) WVA
+        controller is preserved unless ``--deep`` (``deep_clean``) is set,
+        because other stacks in the same namespace may still depend on it.
+
+        prometheus-adapter and its supporting cluster-wide resources
+        (``allow-thanos-querier-api-access`` ClusterRole, ``prometheus-ca``
+        ConfigMap) are NEVER touched by teardown — not even with --deep.
+        They are shared cluster-wide infrastructure used by every WVA
+        tenant's HPA pipeline. Their lifecycle is managed once at the
+        cluster level (e.g. by a platform admin), and removing them on a
+        per-tenant teardown would silently break every other namespace's
+        autoscaling.
+
+        Skipped entirely on non-OpenShift platforms — standup gates the
+        WVA install on OpenShift (see step_03), so on other platforms
+        there's nothing for teardown to remove.
+        """
+        if not context.is_openshift:
+            context.logger.log_info(
+                f"WVA teardown skipped: platform is {context.platform_type}, "
+                "not OpenShift (matches standup behavior — WVA was never installed)."
+            )
+            return
+
+        import yaml as _yaml
+
+        wva_stacks: list[tuple[str, str]] = []  # (wva_namespace, model_id_label)
+        seen_ns: set[str] = set()
+
+        for stack_path in context.rendered_stacks or []:
+            cfg_file = stack_path / "config.yaml"
+            if not cfg_file.exists():
+                continue
+            try:
+                with open(cfg_file, encoding="utf-8") as fh:
+                    cfg = _yaml.safe_load(fh) or {}
+            except (OSError, _yaml.YAMLError):
+                continue
+            wva_cfg = cfg.get("wva", {}) or {}
+            if not wva_cfg.get("enabled", False):
+                continue
+            wva_ns = (
+                wva_cfg.get("namespace")
+                or cfg.get("namespace", {}).get("name", "")
+            )
+            model_id_label = cfg.get("model_id_label", "")
+            if wva_ns and model_id_label:
+                wva_stacks.append((wva_ns, model_id_label))
+                seen_ns.add(wva_ns)
+
+        if not wva_stacks:
+            return
+
+        # 1. Per-stack VariantAutoscaling + HPA: always delete.
+        for wva_ns, model_id_label in wva_stacks:
+            resource_name = f"{model_id_label}-decode"
+            for kind in ("hpa", "variantautoscaling.llmd.ai"):
+                context.logger.log_info(
+                    f"Deleting {kind}/{resource_name} from ns/{wva_ns}"
+                )
+                result = cmd.kube(
+                    "delete", kind, resource_name,
+                    "--namespace", wva_ns,
+                    "--ignore-not-found=true",
+                    check=False,
+                )
+                if result.success:
+                    context.logger.log_info(
+                        f"  Deleted {kind}/{resource_name}", emoji="🗑️"
+                    )
+
+        # 2. WVA controller(s): only on --deep. The controller is per-namespace
+        # (one per unique wva.namespace, all of which are target namespaces
+        # for this teardown), so removing it on --deep is in-scope.
+        #
+        # PRINCIPLE: --deep only removes resources that live in the target
+        # namespace(s). It MUST NOT touch cross-namespace or cluster-scoped
+        # resources -- doing so would silently break other tenants. That's
+        # why we explicitly do NOT remove on any teardown:
+        #   - prometheus-adapter (lives in openshift-user-workload-monitoring)
+        #   - prometheus-ca ConfigMap (lives in openshift-user-workload-monitoring)
+        #   - allow-thanos-querier-api-access ClusterRole (cluster-scoped)
+        # All three are shared infrastructure for every WVA tenant's HPA
+        # pipeline. Their lifecycle is managed once at the cluster level
+        # (e.g. by a platform admin). Our standup install is idempotent
+        # and skips when a cluster-wide install already exists, so leaving
+        # them in place across teardowns is always correct.
+        if not context.deep_clean:
+            context.logger.log_info(
+                "Preserving WVA controller (pass -d/--deep to uninstall). "
+                "prometheus-adapter and shared cluster-wide RBAC are always "
+                "preserved regardless of --deep -- other tenants depend on them."
+            )
+            return
+
+        context.logger.log_info(
+            "Deep clean: uninstalling WVA controller(s). "
+            "prometheus-adapter and shared cluster RBAC are kept intact."
+        )
+        for wva_ns in sorted(seen_ns):
+            context.logger.log_info(
+                f"Uninstalling helm release "
+                f"workload-variant-autoscaler from ns/{wva_ns}"
+            )
+            uninstall = cmd.helm(
+                "uninstall", "workload-variant-autoscaler",
+                "--namespace", wva_ns,
+                "--ignore-not-found",
+                check=False,
+            )
+            if not uninstall.success and "not found" not in (uninstall.stderr or "").lower():
+                errors.append(
+                    f"Failed to uninstall WVA controller in {wva_ns}: "
+                    f"{uninstall.stderr}"
                 )
 
     def _delete_download_job(

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import yaml
+
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.executor.command import CommandExecutor
@@ -31,15 +33,14 @@ class UninstallHelmStep(Step):
     @staticmethod
     def _any_stack_has_wva(context: ExecutionContext) -> bool:
         """Return True if any rendered stack has wva.enabled: true."""
-        import yaml as _yaml
         for stack_path in context.rendered_stacks or []:
             cfg_file = stack_path / "config.yaml"
             if not cfg_file.exists():
                 continue
             try:
                 with open(cfg_file, encoding="utf-8") as fh:
-                    cfg = _yaml.safe_load(fh) or {}
-            except (OSError, _yaml.YAMLError):
+                    cfg = yaml.safe_load(fh) or {}
+            except (OSError, yaml.YAMLError):
                 continue
             if (cfg.get("wva", {}) or {}).get("enabled", False):
                 return True
@@ -190,8 +191,6 @@ class UninstallHelmStep(Step):
             )
             return
 
-        import yaml as _yaml
-
         wva_stacks: list[tuple[str, str]] = []  # (wva_namespace, model_id_label)
         seen_ns: set[str] = set()
 
@@ -201,8 +200,8 @@ class UninstallHelmStep(Step):
                 continue
             try:
                 with open(cfg_file, encoding="utf-8") as fh:
-                    cfg = _yaml.safe_load(fh) or {}
-            except (OSError, _yaml.YAMLError):
+                    cfg = yaml.safe_load(fh) or {}
+            except (OSError, yaml.YAMLError):
                 continue
             wva_cfg = cfg.get("wva", {}) or {}
             if not wva_cfg.get("enabled", False):


### PR DESCRIPTION
# Add Workload Variant Autoscaler (WVA) integration

Wires the [Workload Variant Autoscaler v0.6.0](https://github.com/llm-d/llm-d-workload-variant-autoscaler) into `llm-d-benchmark` so scenarios can exercise model autoscaling end-to-end. Adds a dedicated `inference-scheduling-wva` scenario, a per-stack `VariantAutoscaling` + `HPA` rendering pipeline, an admin-level controller install, smoketest checks that catch every link in the metric chain, and teardown semantics that respect cluster-shared infrastructure on multi-tenant clusters.

## What this enables

```bash
# Toggle WVA on any existing scenario
llmdbenchmark --spec guides/inference-scheduling standup -p <ns> --wva

# Or use the dedicated scenario where every WVA/HPA/VA knob is spelled out inline
llmdbenchmark --spec guides/inference-scheduling-wva standup -p <ns>
```


## Highlights

### CLI / scenario authoring / Standup
- New `-u/--wva` boolean flag on `standup` (also via `LLMDBENCH_WVA` env var) — toggles `wva.enabled: true` at render time without editing scenario files.
- New scenario `config/scenarios/guides/inference-scheduling-wva.yaml` — same model + inference setup as `inference-scheduling`, plus a fully spelled-out `wva:` block with inline comments documenting each knob (HPA min/max, behavior windows, VA cost & SLO targets, controller image tag, namespaceScoped mode, etc.).
- Chart versions exposed in the scenario (`chartVersions.wva: 0.6.0`, `chartVersions.prometheusAdapter: 5.2.0`) so users don't have to dig into defaults to bump.

### Teardown
- **Cluster-shared infrastructure is NEVER removed**, even with `-d/--deep`. `prometheus-adapter`, the `allow-thanos-querier-api-access` ClusterRole, and the `prometheus-ca` ConfigMap are used by every WVA tenant in the cluster — their lifecycle belongs to the platform admin, not a per-tenant tool.
- Plain teardown removes the per-stack VA + HPA so the model stops autoscaling.
- `-d/--deep` additionally removes the per-namespace WVA controller helm release.
- Teardown is also gated on `is_openshift` to mirror standup behavior.

### Smoketest
New `WvaSmoketestMixin` (auto-applied to scenarios with `wva.enabled: true` on OpenShift) validates the full chain. Each check pinpoints exactly which link is broken on failure:

| Check | What it catches |
|---|---|
| `wva_platform_gate` | Skipped cleanly on non-OpenShift, no false alarms |
| `wva_controller_deployment` | Polls until Available + Ready (≤180s); **fails fast** if manager container restartCount grows mid-wait |
| `wva_prometheus_adapter` | Adapter Deployment Available in monitoring ns |
| `wva_variantautoscaling` | Per-stack VA exists |
| `wva_va_controller_instance_label` | VA carries the `wva.llmd.ai/controller-instance` label matching the controller's env — the most subtle WVA gate (without it, controller silently filters out the VA → "No active VariantAutoscalings found" loop) |
| `wva_hpa_target` | HPA's `scaleTargetRef.name` correct |
| `wva_hpa_selector_alignment` | HPA's `metric.selector.matchLabels` has all three of `variant_name`, `exported_namespace`, `controller_instance` matching what the controller actually emits |
| `wva_hpa_able_to_scale` | HPA `AbleToScale` condition (best-effort) |
| `wva_hpa_targets_resolved` | Polls HPA `currentMetrics` until `<unknown>` resolves to a numeric value (≤180s); includes most-recent `ScalingActive=False` reason in failure message |

### Standup base improvements (incidental but caught real bugs)
- `wait_for_pods` now requires **all** containers Ready, not just `containerStatuses[0]`. Previously a decode pod with a healthy routing-sidecar but crash-looping vLLM container was reported as Ready, masking real failures.
- Replica-count validation in `validate_role_pods` is now HPA-aware: when WVA is enabled, the decode replica check accepts any count within `[wva.hpa.minReplicas, wva.hpa.maxReplicas]` instead of strict equality with `decode.replicas`. Multinode/LWS still uses strict equality. Prefill is documented as future-extensible via a `_WVA_HPA_MANAGED_ROLES` allow-list.

## Documentation

- `docs/workload-variant-autoscaler.md` rewritten end-to-end. Sections: quick start, architecture diagram, two ways to enable WVA, every scenario knob explained, cluster-wide vs per-tenant resources & teardown semantics, all 9 smoketest checks tabulated, six-step verification command sequence, common failure modes & fixes (every issue we hit during integration), multi-tenant cluster considerations, and a file-location index for every artifact.

## Notes for reviewers

- The `wva.llmd.ai/controller-instance` label gate on the VA is the single most important alignment requirement since without it the controller silently does nothing, and the smoketest now explicitly verifies it.
- Image tags use `v` prefix (`v0.6.0`); helm chart versions are bare semver (`0.6.0`). The scenario YAML and inline doc comments call this out so it doesn't trip up the next user.


## Example Output from Real Standup (Majorly Truncated)

```
....
2026-04-22 14:45:54,479 - INFO    -     │ User workload monitoring configured
2026-04-22 14:45:55,926 - INFO    -     │ ℹ️  prometheus-adapter is already installed cluster-wide (release='prometheus-adapter', namespace='openshift-user-workload-monitoring') and serves wva_desired_replicas via the external-metrics API. Reusing it.
2026-04-22 14:45:56,743 - INFO    -     │ 📦 Installing WVA controller v0.6.0 into ns/tyler-wva
2026-04-22 14:46:10,057 - INFO    -     │ ✅ WVA controller in ns/tyler-wva: 1/1 Ready (00:00)
....
2026-04-22 14:54:07,587 - INFO    - Stack 'inference-scheduling-wva': starting 5 step(s)...
2026-04-22 14:54:07,587 - INFO    - -- [06] Stack 'inference-scheduling-wva': fma_deploy
2026-04-22 14:54:07,587 - INFO    - -- [06] Stack 'inference-scheduling-wva': standalone_deploy
2026-04-22 14:54:07,587 - INFO    - >> [07] Stack 'inference-scheduling-wva': Set up Helm repos and gateway infrastructure
2026-04-22 14:54:15,154 - INFO    - ✅ [07] Stack 'inference-scheduling-wva': Completed: deploy_setup
2026-04-22 14:54:15,154 - INFO    - >> [08] Stack 'inference-scheduling-wva': Deploy GAIE inference extension
2026-04-22 14:54:18,842 - INFO    -     │ ✅ gateway infra: 1/1 Ready (00:00)
2026-04-22 14:54:18,842 - INFO    -     │ GAIE deployed -- EPP pod will become Ready after model servers are deployed in step 09
2026-04-22 14:54:18,843 - INFO    - ✅ [08] Stack 'inference-scheduling-wva': Completed: deploy_gaie
2026-04-22 14:54:18,843 - INFO    - >> [09] Stack 'inference-scheduling-wva': Deploy model via modelservice Helm chart
2026-04-22 14:54:18,869 - INFO    -     │ Assigning anyuid/privileged SCCs to SA 'qwen-qwe-cefc1572-wen3-32b' in namespace tyler-wva
2026-04-22 14:54:22,694 - INFO    -     │ ✅ decode pods: 1/1 Ready (00:00)
2026-04-22 14:54:23,275 - INFO    -     │ ✅ inference pool: 1/1 Ready (00:00)
2026-04-22 14:54:25,210 - INFO    -     │ PodMonitor created for Prometheus scraping
2026-04-22 14:54:26,184 - INFO    -     │ OpenShift route 'llmdbench-inference-gateway-route' created to service/infra-llmdbench-inference-gateway-istio:80
2026-04-22 14:54:27,767 - INFO    -     │ 📋 VariantAutoscaling state in ns/tyler-wva:
2026-04-22 14:54:27,767 - INFO    -     │     NAME                                TARGET                              MODEL            MIN   MAX   OPTIMIZED   METRICSREADY   AGE
2026-04-22 14:54:27,767 - INFO    -     │     qwen-qwe-cefc1572-wen3-32b-decode   qwen-qwe-cefc1572-wen3-32b-decode   Qwen/Qwen3-32B   1     10    1           True           14m
2026-04-22 14:54:28,020 - INFO    -     │ 📋 HorizontalPodAutoscaler state in ns/tyler-wva:
2026-04-22 14:54:28,021 - INFO    -     │     NAME                                REFERENCE                                      TARGETS     MINPODS   MAXPODS   REPLICAS   AGE
2026-04-22 14:54:28,021 - INFO    -     │     qwen-qwe-cefc1572-wen3-32b-decode   Deployment/qwen-qwe-cefc1572-wen3-32b-decode   1/1 (avg)   1         10        1          14m
2026-04-22 14:54:28,486 - INFO    -     │ 📋 Deployment metadata to configmap/llm-d-benchmark-standup-parameters in ns/tyler-wva
2026-04-22 14:54:28,486 - INFO    -     │    oc get configmap llm-d-benchmark-standup-parameters -n tyler-wva -o yaml
2026-04-22 14:54:29,029 - INFO    - ✅ [09] Stack 'inference-scheduling-wva': Completed: deploy_modelservice
```