### PR TITLE
feat: Add Check for PVC Creation Instead of Timing Out Only

### DIFF
--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -430,6 +430,7 @@ def _do_standup(args, logger, render_plan_errors):
         standalone_deploy_timeout=int(getattr(args, "standalone_deploy_timeout", 900) or 900),
         gateway_deploy_timeout=int(getattr(args, "gateway_deploy_timeout", 120) or 120),
         modelservice_deploy_timeout=int(getattr(args, "modelservice_deploy_timeout", 1500) or 1500),
+        pvc_bind_timeout=int(getattr(args, "pvc_bind_timeout", 240) or 240),
     )
 
     _check_model_access(context, all_stacks_info, logger)
@@ -1262,6 +1263,7 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT": ("standalone_deploy_timeout", "--standalone-deploy-timeout"),
         "LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT": ("gateway_deploy_timeout", "--gateway-deploy-timeout"),
         "LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT": ("modelservice_deploy_timeout", "--modelservice-deploy-timeout"),
+        "LLMDBENCH_PVC_BIND_TIMEOUT": ("pvc_bind_timeout", "--pvc-bind-timeout"),
     }
 
     active = {k: v for k, v in os.environ.items() if k in _ENV_TO_CLI}

--- a/llmdbenchmark/executor/command.py
+++ b/llmdbenchmark/executor/command.py
@@ -506,13 +506,31 @@ class CommandExecutor:
         poll_interval: int = 10,
         description: str = "",
     ) -> CommandResult:
-        """Poll a PVC until it reaches Bound phase, showing live progress."""
+        """Poll a PVC until it reaches Bound phase, showing live progress.
+
+        Short-circuits to success when the resolved StorageClass uses
+        ``volumeBindingMode: WaitForFirstConsumer`` (e.g. Kind's local-path
+        provisioner). Such PVCs intentionally stay ``Pending`` until a
+        consumer pod is scheduled, so blocking on Bound here would deadlock
+        standup before the consumer pod ever gets a chance to apply. Real
+        provisioning failures still surface as a pod-readiness or
+        download-job timeout downstream.
+        """
         desc = description or f"pvc/{pvc_name}"
         kc_args = " ".join(self._kubeconfig_args())
         cmd_repr = f'{self._kube_bin} {kc_args} wait --for=jsonpath={{.status.phase}}=Bound pvc/{pvc_name} --namespace {namespace} --timeout={timeout}s'.replace("  ", " ")
 
         if self.dry_run:
             return self._handle_dry_run(cmd_repr, int(time.time() * 1e9))
+
+        binding_mode = self._resolve_pvc_binding_mode(pvc_name, namespace)
+        if binding_mode == "WaitForFirstConsumer":
+            self.logger.log_info(
+                f"⏭️  {desc}: StorageClass uses WaitForFirstConsumer "
+                "-- PVC will bind when its consumer pod schedules; "
+                "skipping bind wait."
+            )
+            return CommandResult(command=cmd_repr, exit_code=0)
 
         start = time.time()
         last_status_line = ""
@@ -568,6 +586,51 @@ class CommandExecutor:
             self._print_progress(status_line, last_status_line)
             last_status_line = status_line
             time.sleep(poll_interval)
+
+    def _resolve_pvc_binding_mode(
+        self, pvc_name: str, namespace: str
+    ) -> str | None:
+        """Return the volumeBindingMode of the StorageClass that backs *pvc_name*.
+
+        Reads the PVC's ``spec.storageClassName`` (i.e. exactly what the
+        scenario config rendered into the manifest) and queries that
+        class's ``.volumeBindingMode``. Returns ``None`` when the PVC has
+        no explicit storageClassName -- in that case the caller falls
+        through to a normal Bound wait, which will fail with a clear hint
+        telling the user to set storageClassName explicitly rather than
+        rely on cluster defaults.
+        """
+        sc_name = self._jsonpath(
+            ["get", "pvc", pvc_name, "--namespace", namespace],
+            "{.spec.storageClassName}",
+        )
+        if not sc_name:
+            return None
+
+        mode = self._jsonpath(
+            ["get", "storageclass", sc_name],
+            "{.volumeBindingMode}",
+        )
+        return mode or "Immediate"
+
+    def _jsonpath(self, kube_args: list[str], jsonpath: str) -> str:
+        """Run a kubectl/oc query and return the trimmed jsonpath output."""
+        parts = [self._kube_bin]
+        parts.extend(self._kubeconfig_args())
+        parts.extend(kube_args)
+        # Single-quote the jsonpath so shell=True doesn't eat the
+        # backslashes used to escape dots in annotation keys.
+        parts.extend(["-o", f"'jsonpath={jsonpath}'"])
+        try:
+            result = subprocess.run(
+                " ".join(parts), shell=True, capture_output=True,
+                text=True, check=False, executable="/bin/bash",
+            )
+            if result.returncode != 0:
+                return ""
+            return result.stdout.strip()
+        except OSError:
+            return ""
 
     def _get_pod_statuses(
         self, label: str, namespace: str

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -96,6 +96,8 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     gateway_deploy_timeout: int = 120
     modelservice_deploy_timeout: int = 1500
 
+    pvc_bind_timeout: int = 240
+
     # Run-only mode (existing-stack)
     endpoint_url: str | None = None
     run_config_file: str | None = None

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -80,6 +80,7 @@ Provisions model infrastructure from a specification. Implicitly generates a pla
 | `--standalone-deploy-timeout` | `LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT` | Seconds to wait for the vLLM pods to deploy during standup in standalone mode. |
 | `--gateway-deploy-timeout` | `LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT` | Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice. |
 | `--modelservice-deploy-timeout` | `LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT` | Seconds to wait for decode, prefill and inference pool pods to deploy during standup with modelservice (Generic timeout for Step 9). |
+| `--pvc-bind-timeout` | `LLMDBENCH_PVC_BIND_TIMEOUT` | Seconds to wait for each PVC (workload, model, extra) to reach the Bound phase during standup. Fails fast on missing default StorageClass instead of masking as a downstream pod/job timeout. Default: 240 (some dynamic provisioners take 1-3 minutes per volume). |
 
 ### smoketest (`smoketest.py`)
 

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -112,3 +112,13 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env_int("LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT"),
         help="Seconds to wait for decode, prefill and inference pool pods to deploy during standup with modelservice.",
     )
+    standup_parser.add_argument(
+        "--pvc-bind-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_PVC_BIND_TIMEOUT"),
+        help="Seconds to wait for each PVC (workload, model, extra) to reach "
+             "the Bound phase during standup. A PVC that never binds (e.g. no "
+             "default StorageClass on the cluster) fails fast instead of "
+             "masquerading as a downstream pod/job timeout. Default: 240 "
+             "(some dynamic provisioners take 1-3 minutes per volume).",
+    )

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -147,7 +147,7 @@ class ModelNamespaceStep(Step):
         bind_result = cmd.wait_for_pvc(
             pvc_name=pvc_name,
             namespace=namespace,
-            timeout=120,
+            timeout=context.pvc_bind_timeout,
             poll_interval=5,
             description=f'model PVC "{pvc_name}"',
         )
@@ -203,7 +203,7 @@ class ModelNamespaceStep(Step):
         bind_result = cmd.wait_for_pvc(
             pvc_name=pvc_name,
             namespace=namespace,
-            timeout=120,
+            timeout=context.pvc_bind_timeout,
             poll_interval=5,
             description=f'extra PVC "{pvc_name}"',
         )

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -129,14 +129,37 @@ class ModelNamespaceStep(Step):
         pvc_size = self._require_config(plan_config, "storage", "modelPvc", "size")
 
         namespace = context.require_namespace()
-        if not context.dry_run and self._check_existing_pvc(
-            cmd, context, pvc_name, pvc_size, namespace, errors
-        ):
-            return
+        already_exists = (
+            not context.dry_run and self._check_existing_pvc(
+                cmd, context, pvc_name, pvc_size, namespace, errors
+            )
+        )
+        if not already_exists:
+            result = cmd.kube("apply", "-f", str(pvc_yaml))
+            if not result.success and "AlreadyExists" not in result.stderr:
+                errors.append(f"Failed to create model PVC: {result.stderr}")
+                return
 
-        result = cmd.kube("apply", "-f", str(pvc_yaml))
-        if not result.success and "AlreadyExists" not in result.stderr:
-            errors.append(f"Failed to create model PVC: {result.stderr}")
+        # Verify the PVC binds. Without this, a PVC stuck Pending (e.g.
+        # cluster has no default StorageClass and the manifest was rendered
+        # with storage_class=auto, which omits storageClassName) only
+        # surfaces as a silent download-job timeout further downstream.
+        bind_result = cmd.wait_for_pvc(
+            pvc_name=pvc_name,
+            namespace=namespace,
+            timeout=120,
+            poll_interval=5,
+            description=f'model PVC "{pvc_name}"',
+        )
+        if not bind_result.success:
+            errors.append(
+                f'Model PVC "{pvc_name}" did not bind: {bind_result.stderr}. '
+                "Common cause: cluster has no default StorageClass and "
+                'storage_class is "auto"/"default" (which omits storageClassName '
+                "so the cluster default is required). Run `kubectl get sc` to "
+                "verify, or set storage.modelPvc.storageClassName explicitly "
+                "in the scenario."
+            )
 
     def _create_extra_pvc(
         self, cmd: CommandExecutor, context: ExecutionContext, errors: list
@@ -162,14 +185,37 @@ class ModelNamespaceStep(Step):
             return
 
         namespace = context.require_namespace()
-        if not context.dry_run and self._check_existing_pvc(
-            cmd, context, pvc_name, pvc_size, namespace, errors
-        ):
-            return
+        already_exists = (
+            not context.dry_run and self._check_existing_pvc(
+                cmd, context, pvc_name, pvc_size, namespace, errors
+            )
+        )
+        if not already_exists:
+            result = cmd.kube("apply", "-f", str(extra_pvc_yaml))
+            if not result.success and "AlreadyExists" not in result.stderr:
+                errors.append(f"Failed to create extra PVC: {result.stderr}")
+                return
 
-        result = cmd.kube("apply", "-f", str(extra_pvc_yaml))
-        if not result.success and "AlreadyExists" not in result.stderr:
-            errors.append(f"Failed to create extra PVC: {result.stderr}")
+        # Verify the PVC binds. Without this, a PVC stuck Pending (e.g.
+        # cluster has no default StorageClass and the manifest was rendered
+        # with storage_class=auto, which omits storageClassName) only
+        # surfaces as a silent pod-readiness timeout further downstream.
+        bind_result = cmd.wait_for_pvc(
+            pvc_name=pvc_name,
+            namespace=namespace,
+            timeout=120,
+            poll_interval=5,
+            description=f'extra PVC "{pvc_name}"',
+        )
+        if not bind_result.success:
+            errors.append(
+                f'Extra PVC "{pvc_name}" did not bind: {bind_result.stderr}. '
+                "Common cause: cluster has no default StorageClass and "
+                'storage_class is "auto"/"default" (which omits storageClassName '
+                "so the cluster default is required). Run `kubectl get sc` to "
+                "verify, or set storage.extraPvc.storageClassName explicitly "
+                "in the scenario."
+            )
 
     def _add_context_secret(
         self, cmd: CommandExecutor, context: ExecutionContext,

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -73,7 +73,7 @@ class HarnessNamespaceStep(Step):
                 bind_result = cmd.wait_for_pvc(
                     pvc_name=pvc_name,
                     namespace=harness_ns,
-                    timeout=context.harness_data_access_timeout,
+                    timeout=context.pvc_bind_timeout,
                     poll_interval=5,
                     description=f'workload PVC "{pvc_name}"',
                 )

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -64,6 +64,40 @@ class HarnessNamespaceStep(Step):
                         f"Failed to create workload PVC: {result.stderr}"
                     )
 
+            # Verify the PVC binds before applying anything that mounts it.
+            # A PVC stuck Pending (e.g. cluster has no default StorageClass
+            # and the manifest was rendered with storage_class=auto, which
+            # omits storageClassName) would otherwise surface only as a
+            # silent pod-readiness timeout on the data-access pod below.
+            if not errors:
+                bind_result = cmd.wait_for_pvc(
+                    pvc_name=pvc_name,
+                    namespace=harness_ns,
+                    timeout=context.harness_data_access_timeout,
+                    poll_interval=5,
+                    description=f'workload PVC "{pvc_name}"',
+                )
+                if not bind_result.success:
+                    errors.append(
+                        f'Workload PVC "{pvc_name}" did not bind: '
+                        f"{bind_result.stderr}. Common cause: cluster has no "
+                        "default StorageClass and storage_class is "
+                        '"auto"/"default" (which omits storageClassName so '
+                        "the cluster default is required). Run "
+                        "`kubectl get sc` to verify, or set "
+                        "storage.workloadPvc.storageClassName explicitly in "
+                        "the scenario."
+                    )
+                    for err in errors:
+                        context.logger.log_error(f"    {err}")
+                    return StepResult(
+                        step_number=self.number,
+                        step_name=self.name,
+                        success=False,
+                        message="Workload PVC failed to bind -- aborting",
+                        errors=errors,
+                    )
+
         pod_yaml = self._find_rendered_yaml(
             context, "06_pod_access_to_harness_data"
         )


### PR DESCRIPTION
## Fail fast on PVC bind failures

Previously, a PVC stuck in `Pending` (e.g. cluster has no default `StorageClass` and the manifest was rendered with `storage_class: auto`, which omits `storageClassName`) would only surface as a silent pod-readiness or download-job timeout — with no clue why.

This change adds an explicit `wait_for_pvc(...)` Bound check + actionable hint right after each PVC is applied:


### Behavior
- After `kubectl apply` (or after detecting an existing PVC), poll `.status.phase` until `Bound`.
- On bind failure, append a clear error and abort the step with a hint:
  > Common cause: cluster has no default StorageClass and `storage_class` is `"auto"`/`"default"` (which omits `storageClassName` so the cluster default is required). Run `kubectl get sc` to verify, or set `storage.<pvc>.storageClassName` explicitly in the scenario.

### Why
Closes a long-standing UX gap where misconfigured storage produced opaque timeouts deep in standup. Users now get the failure pinpointed at the actual broken resource within ~120s, with the exact knob to fix it.

### Background
Top-level `storage_class:` and the per-PVC `storage.*.storageClassName:` fields are linked via a YAML anchor (`&storage_class` / `*storage_class`). Setting `storage_class: auto` cascades into all three PVCs unless overridden per-PVC....so a single missing default StorageClass on the cluster silently breaks all storage at once.