### PR TITLE
Monitor startup time and replicas

### DIFF
--- a/llmdbenchmark/analysis/benchmark_report/br_v0_2_example.yaml
+++ b/llmdbenchmark/analysis/benchmark_report/br_v0_2_example.yaml
@@ -410,99 +410,513 @@ results:
             p90: 0.04262634576298297
             p95: 0.045246614259667695
 
-  # NOTE: Observability data is likely to be replaced with links to the actual data
   observability:
-    scrape_info:
-      interval_seconds: 15
-      method: pull
-      source: prom-sd
-      errors: []
+    # Per-component observability metrics
+    # Each entry references a component_label from scenario.stack[].metadata.label
+    components:
+      - component_label: vllm-svc-0  # References scenario.stack[0].metadata.label
+        aggregate:
+          kv_cache_usage:
+            units: percent
+            mean: 42.5
+            min: 12.3
+            p50: 41.8
+            p75: 52.1
+            p90: 63.4
+            p95: 71.2
+            p99: 85.6
+            max: 92.1
+          gpu_cache_usage:
+            units: percent
+            mean: 38.2
+            min: 10.1
+            p50: 37.5
+            p90: 58.7
+            p99: 78.3
+            max: 84.0
+          gpu_memory_usage:
+            units: GiB
+            mean: 62.4
+            min: 58.1
+            p50: 62.0
+            p90: 66.8
+            p99: 71.2
+            max: 73.5
+          gpu_utilization:
+            units: percent
+            mean: 76.0
+            min: 45.2
+            p50: 78.9
+            p90: 89.3
+            p99: 94.1
+            max: 96.8
+          running_requests:
+            units: count
+            mean: 24.6
+            min: 1.0
+            p50: 23.0
+            p90: 42.0
+            p99: 56.0
+            max: 62.0
+          waiting_requests:
+            units: count
+            mean: 3.2
+            min: 0.0
+            p50: 2.0
+            p90: 8.0
+            p99: 18.0
+            max: 25.0
+        time_series:
+          kv_cache_usage:
+            units: percent
+            series:
+              - ts: 2025-11-05T18:05:00Z
+                mean: 35.2
+                p90: 48.1
+                p99: 62.5
+              - ts: 2025-11-05T18:10:00Z
+                mean: 52.8
+                p90: 71.3
+                p99: 85.6
+          gpu_utilization:
+            units: percent
+            series:
+              - ts: 2025-11-05T18:05:00Z
+                mean: 73.2
+                p90: 85.4
+              - ts: 2025-11-05T18:10:00Z
+                mean: 78.9
+                p90: 91.2
 
-    metrics:
-      - name: series.tokens_total.vllm0                # 1) unique per file
-        metric_ref:                                    # 3) explicit type; registry ref is optional and can be omitted everywhere
-          id: tokens_total
-          version: 1
-        component_id: vllm-svc-0
-        type: counter
-        unit: token                                    # 4) unit separate
-        description: "Cumulative count of prompt and generated tokens processed."
-        labels:                                        # 2) series-level labels
-          model_id: Qwen/Qwen3-7B
-          precision: FP8
-        samples:
-          - ts: 2025-11-05T18:05:00Z
-            value: 12400321
+      - component_label: epp-0  # References scenario.stack[1].metadata.label
+        aggregate:
+          cpu_utilization:
+            units: percent
+            mean: 18.4
+            min: 5.2
+            p50: 17.1
+            p90: 28.9
+            p99: 35.6
+            max: 42.0
+          cpu_memory_usage:
+            units: GiB
+            mean: 2.8
+            min: 1.2
+            p50: 2.6
+            p90: 4.1
+            p99: 5.3
+            max: 5.8
+          running_requests:
+            units: count
+            mean: 12.3
+            min: 0.0
+            p50: 11.0
+            p90: 22.0
+            p99: 34.0
+            max: 40.0
+          waiting_requests:
+            units: count
+            mean: 1.5
+            min: 0.0
+            p50: 1.0
+            p90: 4.0
+            p99: 9.0
+            max: 12.0
 
-      - name: series.gpu_util.vllm0.gpu0
-        metric_ref:
-          id: gpu_utilization
-          version: 1
-        component_id: vllm-svc-0
-        type: gauge
-        unit: percent
-        description: "Instantaneous streaming multiprocessor utilization reported by DCGM."
-        labels: { gpu: "0", uuid: "GPU-1111" }
-        samples:
-          - ts: 2025-11-05T18:05:00Z
-            value: 73.2
-          - ts: 2025-11-05T18:05:15Z
-            value: 78.9
+    # Request drop rate across the system
+    drop_rate:
+      units: percent
+      mean: 0.02
+      min: 0.0
+      p50: 0.0
+      p90: 0.05
+      p99: 0.12
+      max: 0.18
 
-      - name: series.ttft.gateway0
-        metric_ref:
-          id: ttft_seconds
-          version: 1
-        component_id: gateway-0
-        type: histogram
-        unit: second
-        description: "Distribution of time to first generated token observed at the gateway."
-        labels:
-          route: /v1/chat/completions
-          scheduler: prefix-cache
-        histogram:
-          ts: 2025-11-05T18:10:00Z
-          buckets:
-            - { le: 0.05,  count: 1305 }
-            - { le: 0.10,  count: 9120 }
-            - { le: 0.20,  count: 20155 }
-            - { le: 0.50,  count: 28990 }
-            - { le: 1.00,  count: 30112 }
-            - { le: "+Inf", count: 30120 }
-          sum: 12145.7
-          count: 30120
+    # Pod startup times (creation to Ready, per pod)
+    # Collected continuously — new pods from autoscaling are detected each interval
+    pod_startup_times:
+      collected_at: '2025-11-05T18:17:00Z'
+      pods:
+        - name: qwen3-0p6b-decode-pod-1
+          model: Qwen/Qwen3-0.6B
+          role: decode
+          node: gpu-node-01
+          creation_timestamp: '2025-11-05T17:55:00Z'
+          ready_timestamp: '2025-11-05T17:56:12Z'
+          startup_seconds: 72.0
+        - name: qwen3-0p6b-decode-pod-2
+          model: Qwen/Qwen3-0.6B
+          role: decode
+          node: gpu-node-02
+          creation_timestamp: '2025-11-05T17:55:00Z'
+          ready_timestamp: '2025-11-05T17:56:25Z'
+          startup_seconds: 85.0
+        - name: qwen3-0p6b-decode-pod-3
+          model: Qwen/Qwen3-0.6B
+          role: decode
+          node: gpu-node-03
+          creation_timestamp: '2025-11-05T18:08:00Z'
+          ready_timestamp: '2025-11-05T18:09:35Z'
+          startup_seconds: 95.0
+      # Aggregate statistics across all pod startups
+      aggregate:
+        units: s
+        mean: 84.0
+        min: 72.0
+        p50: 85.0
+        p90: 93.0
+        p99: 94.8
+        max: 95.0
+      graph_path: metrics/graphs/pod_startup_times.png
 
-      - name: series.latency.gateway0
-        metric_ref:
-          id: request_latency_seconds
-          version: 1
-        component_id: "gateway-0"
-        type: summary
-        unit: second
-        description: "End-to-end request latency seen by the gateway."
-        labels:
-          route: /v1/chat/completions
-          scheduler: prefix-cache
-        summary:
-          ts: 2025-11-05T18:10:00Z
-          quantiles:
-            - { q: 0.5, value: 0.21 }
-            - { q: 0.9, value: 0.48 }
-            - { q: 0.99, value: 0.93 }
-          sum: 15822.3
-          count: 40211
+    # Replica status — polled every 15s during experiment
+    replica_status:
+      namespace: benchmark-ns
+      timestamp: '2025-11-05T18:17:00Z'
+      # Latest snapshot
+      controllers:
+        - kind: Deployment
+          name: qwen3-0p6b-decode
+          model: Qwen/Qwen3-0.6B
+          role: decode
+          desired_replicas: 3
+          available_replicas: 3
+          ready_replicas: 3
+          updated_replicas: 3
+        - kind: Deployment
+          name: qwen3-0p6b-prefill
+          model: Qwen/Qwen3-0.6B
+          role: prefill
+          desired_replicas: 0
+          available_replicas: 0
+          ready_replicas: 0
+          updated_replicas: 0
+      # Time series of snapshots
+      time_series:
+        - timestamp: '2025-11-05T18:00:40Z'
+          namespace: benchmark-ns
+          controllers:
+            - kind: Deployment
+              name: qwen3-0p6b-decode
+              model: Qwen/Qwen3-0.6B
+              role: decode
+              desired_replicas: 2
+              available_replicas: 2
+              ready_replicas: 2
+              updated_replicas: 2
+        - timestamp: '2025-11-05T18:08:10Z'
+          namespace: benchmark-ns
+          controllers:
+            - kind: Deployment
+              name: qwen3-0p6b-decode
+              model: Qwen/Qwen3-0.6B
+              role: decode
+              desired_replicas: 3
+              available_replicas: 2
+              ready_replicas: 2
+              updated_replicas: 2
+        - timestamp: '2025-11-05T18:09:40Z'
+          namespace: benchmark-ns
+          controllers:
+            - kind: Deployment
+              name: qwen3-0p6b-decode
+              model: Qwen/Qwen3-0.6B
+              role: decode
+              desired_replicas: 3
+              available_replicas: 3
+              ready_replicas: 3
+              updated_replicas: 3
+      # Aggregate ready replicas over time
+      aggregate_ready_replicas:
+        units: count
+        mean: 2.4
+        min: 2
+        p50: 2
+        p90: 3
+        p99: 3
+        max: 3
+      graph_path: metrics/graphs/replica_status.png
 
-      # Optional inline metric (no registry), still follows the same shape.
-      - name: series.vram.vllm0.gpu0
-        component_id: vllm-svc-0
-        type: gauge
-        unit: byte
-        description: "Allocated device memory as reported by the runtime."
-        labels:
-          gpu: "0"
-        samples:
-          - ts: 2025-11-05T18:05:00Z
-            value: 6.72e10
+    # -----------------------------------------------------------------------
+    # Ad-hoc per-metric entries (produced by metrics_processor.py)
+    # These are not yet formalized in the schema and pass via extra="allow".
+    # They document what real benchmark reports look like in practice.
+    # -----------------------------------------------------------------------
+
+    # vLLM metrics — KV cache and scheduling
+    vllm_kv_cache_usage_perc:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 42.5
+            p50: 41.8
+            p99: 85.6
+            stddev: 15.2
+            units: percent
+            graph_path: metrics/graphs/vllm_kv_cache_usage_perc.png
+      # Aggregated across all pods
+      aggregated:
+        mean: 40.3
+        p50: 39.8
+        p99: 82.1
+        stddev: 14.8
+        units: percent
+    vllm_num_requests_running:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 24.6
+            p50: 23.0
+            p99: 56.0
+            stddev: 12.1
+            units: count
+            graph_path: metrics/graphs/vllm_num_requests_running.png
+      # Aggregated across all pods (present when multiple pods exist)
+      aggregated:
+        mean: 23.8
+        p50: 22.0
+        p99: 54.0
+        stddev: 11.5
+        units: count
+    vllm_num_requests_waiting:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 3.2
+            p50: 2.0
+            p99: 18.0
+            stddev: 4.5
+            units: count
+            graph_path: metrics/graphs/vllm_num_requests_waiting.png
+    vllm_num_preemptions_total:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 0.5
+            p50: 0.0
+            p99: 3.0
+            stddev: 0.8
+            units: count
+            graph_path: metrics/graphs/vllm_num_preemptions_total.png
+
+    # vLLM metrics — Prefix cache
+    vllm_prefix_cache_hits_total:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 12500.0
+            p50: 12400.0
+            p99: 14200.0
+            stddev: 850.0
+            units: tokens
+            graph_path: metrics/graphs/vllm_prefix_cache_hits_total.png
+    vllm_prefix_cache_queries_total:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 19100.0
+            p50: 19000.0
+            p99: 21500.0
+            stddev: 1200.0
+            units: tokens
+            graph_path: metrics/graphs/vllm_prefix_cache_queries_total.png
+    vllm_prefix_cache_hit_rate:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 65.3
+            p50: 68.1
+            p99: 92.4
+            stddev: 18.7
+            units: percent
+            graph_path: metrics/graphs/vllm_prefix_cache_hit_rate.png
+
+    # vLLM metrics — External prefix cache
+    vllm_external_prefix_cache_hits_total:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 8200.0
+            p50: 8100.0
+            p99: 9500.0
+            stddev: 620.0
+            units: tokens
+            graph_path: metrics/graphs/vllm_external_prefix_cache_hits_total.png
+    vllm_external_prefix_cache_queries_total:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 19100.0
+            p50: 19000.0
+            p99: 21500.0
+            stddev: 1200.0
+            units: tokens
+            graph_path: metrics/graphs/vllm_external_prefix_cache_queries_total.png
+    vllm_external_prefix_cache_hit_rate:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 42.9
+            p50: 44.2
+            p99: 68.5
+            stddev: 14.3
+            units: percent
+            graph_path: metrics/graphs/vllm_external_prefix_cache_hit_rate.png
+
+    # vLLM metrics — NIXL KV transfer
+    vllm_nixl_xfer_time_seconds_sum:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 0.0045
+            p50: 0.0042
+            p99: 0.0098
+            stddev: 0.0015
+            units: seconds
+            graph_path: metrics/graphs/vllm_nixl_xfer_time_seconds_sum.png
+    vllm_nixl_xfer_time_seconds_count:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 450.0
+            p50: 440.0
+            p99: 520.0
+            stddev: 35.0
+            units: count
+            graph_path: metrics/graphs/vllm_nixl_xfer_time_seconds_count.png
+    vllm_nixl_bytes_transferred_sum:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 1.25e+09
+            p50: 1.22e+09
+            p99: 1.48e+09
+            stddev: 8.5e+07
+            units: bytes
+            graph_path: metrics/graphs/vllm_nixl_bytes_transferred_sum.png
+    vllm_nixl_bytes_transferred_count:
+      components:
+        - component_id: decode-engine
+          pod: qwen3-0p6b-decode-pod-1
+          role: decode
+          statistics:
+            mean: 450.0
+            p50: 440.0
+            p99: 520.0
+            stddev: 35.0
+            units: count
+            graph_path: metrics/graphs/vllm_nixl_bytes_transferred_count.png
+
+    # EPP (inference scheduler) Prometheus metrics — pool-level gauges
+    # These are pre-aggregated by the EPP across all endpoints.
+    # Scraped from EPP pod's /metrics endpoint (port 9090).
+    epp_pool_avg_kv_cache_utilization:
+      components:
+        - component_id: epp-0
+          pod: qwen3-0p6b-epp-pod-1
+          role: epp
+          statistics:
+            mean: 40.3
+            p50: 39.8
+            p99: 82.1
+            stddev: 14.8
+            units: percent
+            graph_path: metrics/graphs/epp_pool_avg_kv_cache_utilization.png
+    epp_pool_avg_queue_size:
+      components:
+        - component_id: epp-0
+          pod: qwen3-0p6b-epp-pod-1
+          role: epp
+          statistics:
+            mean: 4.7
+            p50: 3.0
+            p99: 22.0
+            stddev: 5.8
+            units: count
+            graph_path: metrics/graphs/epp_pool_avg_queue_size.png
+    epp_pool_avg_running_requests:
+      components:
+        - component_id: epp-0
+          pod: qwen3-0p6b-epp-pod-1
+          role: epp
+          statistics:
+            mean: 36.9
+            p50: 35.0
+            p99: 68.0
+            stddev: 16.2
+            units: count
+            graph_path: metrics/graphs/epp_pool_avg_running_requests.png
+    epp_pool_ready_pods:
+      components:
+        - component_id: epp-0
+          pod: qwen3-0p6b-epp-pod-1
+          role: epp
+          statistics:
+            mean: 2.4
+            p50: 2.0
+            p99: 3.0
+            stddev: 0.5
+            units: count
+            graph_path: metrics/graphs/epp_pool_ready_pods.png
+
+    # EPP (inference scheduler) log-derived metrics
+    epp_dispatch_latency:
+      statistics:
+        mean: 0.0012
+        p50: 0.0010
+        p99: 0.0035
+        stddev: 0.0008
+        units: seconds
+        graph_path: metrics/graphs/epp_dispatch_latency.png
+    epp_endpoint_scores:
+      components:
+        - component_id: qwen3-0p6b-decode-pod-1
+          statistics:
+            mean: 0.82
+            p50: 0.85
+            p99: 0.95
+            stddev: 0.08
+            units: score
+            graph_path: metrics/graphs/epp_endpoint_scores.png
+    epp_request_distribution:
+      components:
+        - component_id: qwen3-0p6b-decode-pod-1
+          statistics:
+            count: 245
+            units: count
+            graph_path: metrics/graphs/epp_request_distribution.png
+        - component_id: qwen3-0p6b-decode-pod-2
+          statistics:
+            count: 255
+            units: count
+            graph_path: metrics/graphs/epp_request_distribution.png
 
   profiling:
     anything_goes: 5 # The schema under profiling is currently open-ended

--- a/llmdbenchmark/analysis/benchmark_report/br_v0_2_json_schema.json
+++ b/llmdbenchmark/analysis/benchmark_report/br_v0_2_json_schema.json
@@ -502,6 +502,89 @@
       "title": "ComponentObservability",
       "type": "object"
     },
+    "ControllerReplicaStatus": {
+      "additionalProperties": false,
+      "description": "Replica status for a single controller (Deployment or StatefulSet).",
+      "properties": {
+        "kind": {
+          "description": "Controller kind (e.g., Deployment, StatefulSet).",
+          "title": "Kind",
+          "type": "string"
+        },
+        "name": {
+          "description": "Controller name.",
+          "title": "Name",
+          "type": "string"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Model identifier.",
+          "title": "Model"
+        },
+        "role": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Role (e.g., prefill, decode).",
+          "title": "Role"
+        },
+        "desired_replicas": {
+          "description": "Number of desired replicas.",
+          "minimum": 0,
+          "title": "Desired Replicas",
+          "type": "integer"
+        },
+        "available_replicas": {
+          "description": "Number of available replicas.",
+          "minimum": 0,
+          "title": "Available Replicas",
+          "type": "integer"
+        },
+        "ready_replicas": {
+          "description": "Number of ready replicas.",
+          "minimum": 0,
+          "title": "Ready Replicas",
+          "type": "integer"
+        },
+        "updated_replicas": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Number of updated replicas.",
+          "title": "Updated Replicas"
+        }
+      },
+      "required": [
+        "kind",
+        "name",
+        "desired_replicas",
+        "available_replicas",
+        "ready_replicas"
+      ],
+      "title": "ControllerReplicaStatus",
+      "type": "object"
+    },
     "Distribution": {
       "description": "Distribution type.\n\nAttributes\n    FIXED: str\n        Length is a fixed value.\n    GAUSSIAN: str\n        Gaussian distribution, with a mean and standard deviation.\n    UNIFORM: str\n        Uniform distribution between a minimum and maximum value.\n    OTHER: str\n        An otherwise undefined distribution.",
       "enum": [
@@ -994,7 +1077,7 @@
       "type": "object"
     },
     "Observability": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "Observability metrics.",
       "properties": {
         "components": {
@@ -1024,9 +1107,193 @@
           ],
           "default": null,
           "description": "Request drop rate."
+        },
+        "pod_startup_times": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PodStartupTimes"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Pod startup times collected during or before the benchmark."
+        },
+        "replica_status": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReplicaStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Replica status across controllers at a point in time."
         }
       },
       "title": "Observability",
+      "type": "object"
+    },
+    "PodStartupInfo": {
+      "additionalProperties": false,
+      "description": "Startup timing information for a single pod.",
+      "properties": {
+        "name": {
+          "description": "Pod name.",
+          "title": "Name",
+          "type": "string"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Model identifier.",
+          "title": "Model"
+        },
+        "role": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Pod role (e.g., prefill, decode, aggregate).",
+          "title": "Role"
+        },
+        "node": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Node the pod was scheduled on.",
+          "title": "Node"
+        },
+        "creation_timestamp": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Timestamp when the pod was created.",
+          "title": "Creation Timestamp"
+        },
+        "ready_timestamp": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Timestamp when the pod became ready.",
+          "title": "Ready Timestamp"
+        },
+        "startup_seconds": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Time in seconds from creation to ready.",
+          "title": "Startup Seconds"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "PodStartupInfo",
+      "type": "object"
+    },
+    "PodStartupTimes": {
+      "additionalProperties": false,
+      "description": "Pod startup times collected during or before the benchmark.",
+      "properties": {
+        "collected_at": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Timestamp when startup times were collected.",
+          "title": "Collected At"
+        },
+        "pods": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/PodStartupInfo"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per-pod startup information.",
+          "title": "Pods"
+        },
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Statistics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Aggregate statistics (mean, p50, p99, etc.) across all pod startup times."
+        },
+        "graph_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to pod startup times visualization.",
+          "title": "Graph Path"
+        }
+      },
+      "title": "PodStartupTimes",
       "type": "object"
     },
     "ReplicaHealth": {
@@ -1083,6 +1350,149 @@
         "replica_id"
       ],
       "title": "ReplicaHealth",
+      "type": "object"
+    },
+    "ReplicaStatus": {
+      "additionalProperties": false,
+      "description": "Replica status across controllers, with optional time series and aggregate.",
+      "properties": {
+        "namespace": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Kubernetes namespace.",
+          "title": "Namespace"
+        },
+        "timestamp": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Timestamp of the latest snapshot.",
+          "title": "Timestamp"
+        },
+        "controllers": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ControllerReplicaStatus"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per-controller replica status (latest snapshot).",
+          "title": "Controllers"
+        },
+        "time_series": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ReplicaStatusSnapshot"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Time series of replica status snapshots collected during the benchmark.",
+          "title": "Time Series"
+        },
+        "aggregate_ready_replicas": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Statistics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Aggregate statistics (min, max, mean, etc.) of total ready replicas over time."
+        },
+        "graph_path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to replica status visualization.",
+          "title": "Graph Path"
+        }
+      },
+      "title": "ReplicaStatus",
+      "type": "object"
+    },
+    "ReplicaStatusSnapshot": {
+      "additionalProperties": false,
+      "description": "A single point-in-time replica status snapshot.",
+      "properties": {
+        "timestamp": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Timestamp when this snapshot was taken.",
+          "title": "Timestamp"
+        },
+        "namespace": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Kubernetes namespace.",
+          "title": "Namespace"
+        },
+        "controllers": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ControllerReplicaStatus"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per-controller replica status at this point in time.",
+          "title": "Controllers"
+        }
+      },
+      "title": "ReplicaStatusSnapshot",
       "type": "object"
     },
     "RequestPerformance": {
@@ -1276,6 +1686,18 @@
           ],
           "default": null,
           "description": "Number of swapped out requests."
+        },
+        "preemptions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Statistics"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Number of request preemptions due to memory pressure."
         }
       },
       "title": "ResourceMetrics",
@@ -1412,6 +1834,35 @@
           "default": null,
           "description": "Username that executed experiment.",
           "title": "User"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "User-provided description of the experiment.",
+          "title": "Description"
+        },
+        "keywords": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "User-provided keywords/tags for the experiment.",
+          "title": "Keywords"
         }
       },
       "required": [
@@ -1435,7 +1886,7 @@
             }
           ],
           "default": null,
-          "description": "ISO\u20118601 timestamp for experiment start.",
+          "description": "ISO-8601 timestamp for experiment start.",
           "title": "Start"
         },
         "end": {
@@ -1449,7 +1900,7 @@
             }
           ],
           "default": null,
-          "description": "ISO\u20118601 timestamp for experiment end.",
+          "description": "ISO-8601 timestamp for experiment end.",
           "title": "End"
         },
         "duration": {
@@ -1462,7 +1913,7 @@
             }
           ],
           "default": null,
-          "description": "ISO\u20118601 duration for experiment.",
+          "description": "ISO-8601 duration for experiment.",
           "title": "Duration"
         }
       },
@@ -1914,7 +2365,7 @@
       "description": "Time series data point.",
       "properties": {
         "ts": {
-          "description": "ISO\u20118601 timestamp.",
+          "description": "ISO-8601 timestamp.",
           "format": "date-time",
           "title": "Ts",
           "type": "string"

--- a/llmdbenchmark/analysis/benchmark_report/metrics_processor.py
+++ b/llmdbenchmark/analysis/benchmark_report/metrics_processor.py
@@ -59,6 +59,19 @@ GRAPHED_METRICS: dict[str, tuple[str, str, str]] = {
     'vllm:nixl_bytes_transferred_count': (
         'vllm_nixl_bytes_transferred_count', 'count',
         'vllm_nixl_bytes_transferred_count.png'),
+    # EPP (inference scheduler) Prometheus metrics — pool-level gauges
+    'inference_pool_average_kv_cache_utilization': (
+        'epp_pool_avg_kv_cache_utilization', 'percent',
+        'epp_pool_avg_kv_cache_utilization.png'),
+    'inference_pool_average_queue_size': (
+        'epp_pool_avg_queue_size', 'count',
+        'epp_pool_avg_queue_size.png'),
+    'inference_pool_average_running_requests': (
+        'epp_pool_avg_running_requests', 'count',
+        'epp_pool_avg_running_requests.png'),
+    'inference_pool_ready_pods': (
+        'epp_pool_ready_pods', 'count',
+        'epp_pool_ready_pods.png'),
 }
 
 
@@ -107,15 +120,30 @@ def load_epp_metrics_summary(metrics_dir: str) -> dict[str, Any]:
 
 
 def load_replica_status(metrics_dir: str) -> dict[str, Any]:
-    """Load the replica status JSON file."""
+    """Load the replica status JSON file.
+
+    Merges the latest snapshot with time series data if available.
+    """
     status_file = os.path.join(
         metrics_dir, 'processed', 'replica_status.json')
+    ts_file = os.path.join(
+        metrics_dir, 'processed', 'replica_status_timeseries.json')
 
     if not os.path.exists(status_file):
         return {}
 
     with open(status_file, 'r') as f:
-        return json.load(f)
+        result = json.load(f)
+
+    # Merge time series if available
+    if os.path.exists(ts_file):
+        with open(ts_file, 'r') as f:
+            ts_data = json.load(f)
+        snapshots = ts_data.get('snapshots', [])
+        if snapshots:
+            result['time_series'] = snapshots
+
+    return result
 
 
 def load_pod_startup_times(metrics_dir: str) -> dict[str, Any]:
@@ -141,7 +169,7 @@ def _make_stats_dict(metric_data: dict[str, Any], units: str,
         'units': units,
     }
     if graph_path:
-        stats['graphs'] = graph_path
+        stats['graph_path'] = graph_path
     return stats
 
 
@@ -205,7 +233,7 @@ def _build_epp_entries(
                 'p99': dl.get('p99', 0.0),
                 'stddev': dl.get('stddev', 0.0),
                 'units': dl.get('unit', 'seconds'),
-                'graphs': 'metrics/graphs/epp_dispatch_latency.png',
+                'graph_path': 'metrics/graphs/epp_dispatch_latency.png',
             }
         }
 
@@ -221,7 +249,7 @@ def _build_epp_entries(
                     'p99': score_data.get('p99', 0.0),
                     'stddev': score_data.get('stddev', 0.0),
                     'units': score_data.get('unit', 'score'),
-                    'graphs': 'metrics/graphs/epp_endpoint_scores.png',
+                    'graph_path': 'metrics/graphs/epp_endpoint_scores.png',
                 }
             })
         if components:
@@ -237,7 +265,7 @@ def _build_epp_entries(
                 'statistics': {
                     'count': dist_data.get('count', 0),
                     'units': 'count',
-                    'graphs': 'metrics/graphs/epp_request_distribution.png',
+                    'graph_path': 'metrics/graphs/epp_request_distribution.png',
                 }
             })
         if components:
@@ -294,6 +322,19 @@ def add_metrics_to_benchmark_report(
         per_metric = _build_per_metric_entries(metrics_summary, graphs_dir)
         obs.update(per_metric)
 
+        # Cluster-wide aggregated metrics (from _aggregated key)
+        aggregated = metrics_summary.get('_aggregated', {}).get('metrics', {})
+        for prom_name, (report_key, units, _) in GRAPHED_METRICS.items():
+            if prom_name in aggregated:
+                agg_data = aggregated[prom_name]
+                if report_key in obs:
+                    obs[report_key]['aggregated'] = _make_stats_dict(
+                        agg_data, units)
+                else:
+                    obs[report_key] = {
+                        'aggregated': _make_stats_dict(agg_data, units)
+                    }
+
     # EPP metrics
     epp_summary = load_epp_metrics_summary(metrics_dir)
     if epp_summary:
@@ -303,11 +344,13 @@ def add_metrics_to_benchmark_report(
     # Replica status (desired vs ready vs available per controller/model)
     replica_status = load_replica_status(metrics_dir)
     if replica_status and replica_status.get('controllers'):
+        replica_status['graph_path'] = 'metrics/graphs/replica_status.png'
         obs['replica_status'] = replica_status
 
     # Pod startup times (creation to Ready, per node per replica)
     startup_times = load_pod_startup_times(metrics_dir)
     if startup_times and startup_times.get('pods'):
+        startup_times['graph_path'] = 'metrics/graphs/pod_startup_times.png'
         obs['pod_startup_times'] = startup_times
 
     return br_dict

--- a/llmdbenchmark/analysis/benchmark_report/metrics_processor.py
+++ b/llmdbenchmark/analysis/benchmark_report/metrics_processor.py
@@ -74,6 +74,19 @@ GRAPHED_METRICS: dict[str, tuple[str, str, str]] = {
         'epp_pool_ready_pods.png'),
 }
 
+# EPP log-derived metrics: summary_key -> (report_key, default_units, graph_file, per_component)
+_EPP_METRICS: dict[str, tuple[str, str, str, bool]] = {
+    'dispatch_latency': (
+        'epp_dispatch_latency', 'seconds',
+        'epp_dispatch_latency.png', False),
+    'endpoint_scores': (
+        'epp_endpoint_scores', 'score',
+        'epp_endpoint_scores.png', True),
+    'request_distribution': (
+        'epp_request_distribution', 'count',
+        'epp_request_distribution.png', True),
+}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -96,71 +109,17 @@ def _component_id(role: str) -> str:
     return 'inference-engine'
 
 
-def load_metrics_summary(metrics_dir: str) -> dict[str, Any]:
-    """Load the processed metrics summary JSON file."""
-    summary_file = os.path.join(
-        metrics_dir, 'processed', 'metrics_summary.json')
-
-    if not os.path.exists(summary_file):
+def _load_json(filepath: str) -> dict[str, Any]:
+    """Load a JSON file, returning {} if it doesn't exist."""
+    if not os.path.exists(filepath):
         return {}
-
-    with open(summary_file, 'r') as f:
-        return json.load(f)
-
-
-def load_epp_metrics_summary(metrics_dir: str) -> dict[str, Any]:
-    """Load the EPP metrics summary JSON file."""
-    summary_file = os.path.join(metrics_dir, 'epp_metrics_summary.json')
-
-    if not os.path.exists(summary_file):
-        return {}
-
-    with open(summary_file, 'r') as f:
-        return json.load(f)
-
-
-def load_replica_status(metrics_dir: str) -> dict[str, Any]:
-    """Load the replica status JSON file.
-
-    Merges the latest snapshot with time series data if available.
-    """
-    status_file = os.path.join(
-        metrics_dir, 'processed', 'replica_status.json')
-    ts_file = os.path.join(
-        metrics_dir, 'processed', 'replica_status_timeseries.json')
-
-    if not os.path.exists(status_file):
-        return {}
-
-    with open(status_file, 'r') as f:
-        result = json.load(f)
-
-    # Merge time series if available
-    if os.path.exists(ts_file):
-        with open(ts_file, 'r') as f:
-            ts_data = json.load(f)
-        snapshots = ts_data.get('snapshots', [])
-        if snapshots:
-            result['time_series'] = snapshots
-
-    return result
-
-
-def load_pod_startup_times(metrics_dir: str) -> dict[str, Any]:
-    """Load the pod startup times JSON file."""
-    status_file = os.path.join(
-        metrics_dir, 'processed', 'pod_startup_times.json')
-
-    if not os.path.exists(status_file):
-        return {}
-
-    with open(status_file, 'r') as f:
+    with open(filepath, 'r') as f:
         return json.load(f)
 
 
 def _make_stats_dict(metric_data: dict[str, Any], units: str,
                      graph_path: str | None = None) -> dict[str, Any]:
-    """Build a statistics dict from a metric_data entry (from metrics_summary)."""
+    """Build a statistics dict from a metric_data entry."""
     stats: dict[str, Any] = {
         'mean': metric_data.get('mean', 0.0),
         'p50': metric_data.get('p50', 0.0),
@@ -173,13 +132,17 @@ def _make_stats_dict(metric_data: dict[str, Any], units: str,
     return stats
 
 
+def _graph_path(graph_file: str) -> str:
+    """Return the relative graph path for a graph filename."""
+    return f'metrics/graphs/{graph_file}'
+
+
 # ---------------------------------------------------------------------------
-# Build per-metric observability entries
+# Build observability entries
 # ---------------------------------------------------------------------------
 
 def _build_per_metric_entries(
     metrics_summary: dict[str, Any],
-    graphs_dir: str,
 ) -> dict[str, Any]:
     """Build per-metric observability entries with per-component statistics.
 
@@ -199,15 +162,12 @@ def _build_per_metric_entries(
             if prom_name not in metrics:
                 continue
 
-            metric_data = metrics[prom_name]
-            graph_path = f'metrics/graphs/{graph_file}'
-
             component_entry = {
                 'component_id': comp_id,
                 'pod': pod_name,
                 'role': role,
                 'statistics': _make_stats_dict(
-                    metric_data, units, graph_path),
+                    metrics[prom_name], units, _graph_path(graph_file)),
             }
 
             if report_key not in entries:
@@ -217,75 +177,59 @@ def _build_per_metric_entries(
     return entries
 
 
+def _build_aggregated_entries(
+    metrics_summary: dict[str, Any],
+    obs: dict[str, Any],
+) -> None:
+    """Add cluster-wide aggregated stats to existing observability entries."""
+    aggregated = metrics_summary.get('_aggregated', {}).get('metrics', {})
+    for prom_name, (report_key, units, _) in GRAPHED_METRICS.items():
+        if prom_name not in aggregated:
+            continue
+        entry = obs.setdefault(report_key, {})
+        entry['aggregated'] = _make_stats_dict(aggregated[prom_name], units)
+
+
 def _build_epp_entries(
     epp_summary: dict[str, Any],
 ) -> dict[str, Any]:
-    """Build EPP metric entries for observability section."""
+    """Build EPP log-derived metric entries for observability section."""
     entries: dict[str, Any] = {}
 
-    # Dispatch latency
-    if 'dispatch_latency' in epp_summary:
-        dl = epp_summary['dispatch_latency']
-        entries['epp_dispatch_latency'] = {
-            'statistics': {
-                'mean': dl.get('mean', 0.0),
-                'p50': dl.get('p50', 0.0),
-                'p99': dl.get('p99', 0.0),
-                'stddev': dl.get('stddev', 0.0),
-                'units': dl.get('unit', 'seconds'),
-                'graph_path': 'metrics/graphs/epp_dispatch_latency.png',
+    for summary_key, (report_key, default_units, graph_file, per_component) in _EPP_METRICS.items():
+        data = epp_summary.get(summary_key)
+        if not data:
+            continue
+
+        gpath = _graph_path(graph_file)
+
+        if per_component and isinstance(data, dict):
+            components = [
+                {
+                    'component_id': comp_id,
+                    'statistics': _make_stats_dict(
+                        comp_data, comp_data.get('unit', default_units), gpath),
+                }
+                for comp_id, comp_data in data.items()
+                if isinstance(comp_data, dict)
+            ]
+            if components:
+                entries[report_key] = {'components': components}
+        elif isinstance(data, dict):
+            entries[report_key] = {
+                'statistics': _make_stats_dict(
+                    data, data.get('unit', default_units), gpath),
             }
-        }
 
-    # Endpoint scores
-    if 'endpoint_scores' in epp_summary:
-        components = []
-        for endpoint_id, score_data in epp_summary['endpoint_scores'].items():
-            components.append({
-                'component_id': endpoint_id,
-                'statistics': {
-                    'mean': score_data.get('mean', 0.0),
-                    'p50': score_data.get('p50', 0.0),
-                    'p99': score_data.get('p99', 0.0),
-                    'stddev': score_data.get('stddev', 0.0),
-                    'units': score_data.get('unit', 'score'),
-                    'graph_path': 'metrics/graphs/epp_endpoint_scores.png',
-                }
-            })
-        if components:
-            entries['epp_endpoint_scores'] = {'components': components}
-
-    # Request distribution
-    if 'request_distribution' in epp_summary:
-        components = []
-        for endpoint_id, dist_data in epp_summary[
-                'request_distribution'].items():
-            components.append({
-                'component_id': endpoint_id,
-                'statistics': {
-                    'count': dist_data.get('count', 0),
-                    'units': 'count',
-                    'graph_path': 'metrics/graphs/epp_request_distribution.png',
-                }
-            })
-        if components:
-            entries['epp_request_distribution'] = {'components': components}
-
-    # Plugin latencies
-    if 'plugin_latencies' in epp_summary:
-        for plugin_type, plugins in epp_summary['plugin_latencies'].items():
-            for plugin_name, latency_data in plugins.items():
-                key = f'epp_plugin_{plugin_type}_{plugin_name}'.replace(
-                    '/', '_').replace('-', '_')
-                entries[key] = {
-                    'statistics': {
-                        'mean': latency_data.get('mean', 0.0),
-                        'p50': latency_data.get('p50', 0.0),
-                        'p99': latency_data.get('p99', 0.0),
-                        'stddev': latency_data.get('stddev', 0.0),
-                        'units': latency_data.get('unit', 'seconds'),
-                    }
-                }
+    # Plugin latencies (dynamic keys)
+    for plugin_type, plugins in epp_summary.get('plugin_latencies', {}).items():
+        for plugin_name, latency_data in plugins.items():
+            key = f'epp_plugin_{plugin_type}_{plugin_name}'.replace(
+                '/', '_').replace('-', '_')
+            entries[key] = {
+                'statistics': _make_stats_dict(
+                    latency_data, latency_data.get('unit', 'seconds')),
+            }
 
     return entries
 
@@ -304,53 +248,42 @@ def add_metrics_to_benchmark_report(
     Populates per-metric entries (e.g. results.observability.vllm_kv_cache_usage_perc)
     with per-component statistics, role, graph paths, and EPP metrics.
     """
-    if 'results' not in br_dict:
-        br_dict['results'] = {}
-
-    if 'observability' not in br_dict['results']:
-        br_dict['results']['observability'] = {}
-
-    obs = br_dict['results']['observability']
+    obs = br_dict.setdefault('results', {}).setdefault('observability', {})
 
     # Remove legacy components/aggregate structure if present
     obs.pop('components', None)
 
-    # Per-metric entries from vLLM metrics
-    metrics_summary = load_metrics_summary(metrics_dir)
+    # Per-metric entries from vLLM and EPP Prometheus scrapes
+    metrics_summary = _load_json(
+        os.path.join(metrics_dir, 'processed', 'metrics_summary.json'))
     if metrics_summary:
-        graphs_dir = os.path.join(metrics_dir, 'graphs')
-        per_metric = _build_per_metric_entries(metrics_summary, graphs_dir)
-        obs.update(per_metric)
+        obs.update(_build_per_metric_entries(metrics_summary))
+        _build_aggregated_entries(metrics_summary, obs)
 
-        # Cluster-wide aggregated metrics (from _aggregated key)
-        aggregated = metrics_summary.get('_aggregated', {}).get('metrics', {})
-        for prom_name, (report_key, units, _) in GRAPHED_METRICS.items():
-            if prom_name in aggregated:
-                agg_data = aggregated[prom_name]
-                if report_key in obs:
-                    obs[report_key]['aggregated'] = _make_stats_dict(
-                        agg_data, units)
-                else:
-                    obs[report_key] = {
-                        'aggregated': _make_stats_dict(agg_data, units)
-                    }
-
-    # EPP metrics
-    epp_summary = load_epp_metrics_summary(metrics_dir)
+    # EPP log-derived metrics
+    epp_summary = _load_json(
+        os.path.join(metrics_dir, 'epp_metrics_summary.json'))
     if epp_summary:
-        epp_entries = _build_epp_entries(epp_summary)
-        obs.update(epp_entries)
+        obs.update(_build_epp_entries(epp_summary))
 
-    # Replica status (desired vs ready vs available per controller/model)
-    replica_status = load_replica_status(metrics_dir)
-    if replica_status and replica_status.get('controllers'):
-        replica_status['graph_path'] = 'metrics/graphs/replica_status.png'
+    # Replica status
+    replica_status = _load_json(
+        os.path.join(metrics_dir, 'processed', 'replica_status.json'))
+    if replica_status.get('controllers'):
+        # Merge time series if available
+        ts_data = _load_json(
+            os.path.join(metrics_dir, 'processed', 'replica_status_timeseries.json'))
+        snapshots = ts_data.get('snapshots', [])
+        if snapshots:
+            replica_status['time_series'] = snapshots
+        replica_status['graph_path'] = _graph_path('replica_status.png')
         obs['replica_status'] = replica_status
 
-    # Pod startup times (creation to Ready, per node per replica)
-    startup_times = load_pod_startup_times(metrics_dir)
-    if startup_times and startup_times.get('pods'):
-        startup_times['graph_path'] = 'metrics/graphs/pod_startup_times.png'
+    # Pod startup times
+    startup_times = _load_json(
+        os.path.join(metrics_dir, 'processed', 'pod_startup_times.json'))
+    if startup_times.get('pods'):
+        startup_times['graph_path'] = _graph_path('pod_startup_times.png')
         obs['pod_startup_times'] = startup_times
 
     return br_dict

--- a/llmdbenchmark/analysis/benchmark_report/schema_v0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/schema_v0_2.py
@@ -833,6 +833,107 @@ class ComponentObservability(BaseModel):
 
 
 # ------------------------------------------------------------------------------
+# Pod startup times
+# ------------------------------------------------------------------------------
+
+
+class PodStartupInfo(BaseModel):
+    """Startup timing information for a single pod."""
+
+    model_config = MODEL_CONFIG.copy()
+
+    name: str
+    """Pod name."""
+    model: str | None = None
+    """Model identifier."""
+    role: str | None = None
+    """Pod role (e.g., prefill, decode, aggregate)."""
+    node: str | None = None
+    """Node the pod was scheduled on."""
+    creation_timestamp: datetime.datetime | None = None
+    """Timestamp when the pod was created."""
+    ready_timestamp: datetime.datetime | None = None
+    """Timestamp when the pod became ready."""
+    startup_seconds: float | None = Field(None, ge=0)
+    """Time in seconds from creation to ready."""
+
+
+class PodStartupTimes(BaseModel):
+    """Pod startup times collected during or before the benchmark."""
+
+    model_config = MODEL_CONFIG.copy()
+
+    collected_at: datetime.datetime | None = None
+    """Timestamp when startup times were collected."""
+    pods: list[PodStartupInfo] | None = None
+    """Per-pod startup information."""
+    aggregate: Statistics | None = None
+    """Aggregate statistics (mean, p50, p99, etc.) across all pod startup times."""
+    graph_path: str | None = None
+    """Path to pod startup times visualization."""
+
+
+# ------------------------------------------------------------------------------
+# Replica status
+# ------------------------------------------------------------------------------
+
+
+class ControllerReplicaStatus(BaseModel):
+    """Replica status for a single controller (Deployment or StatefulSet)."""
+
+    model_config = MODEL_CONFIG.copy()
+
+    kind: str
+    """Controller kind (e.g., Deployment, StatefulSet)."""
+    name: str
+    """Controller name."""
+    model: str | None = None
+    """Model identifier."""
+    role: str | None = None
+    """Role (e.g., prefill, decode)."""
+    desired_replicas: int = Field(..., ge=0)
+    """Number of desired replicas."""
+    available_replicas: int = Field(..., ge=0)
+    """Number of available replicas."""
+    ready_replicas: int = Field(..., ge=0)
+    """Number of ready replicas."""
+    updated_replicas: int | None = Field(None, ge=0)
+    """Number of updated replicas."""
+
+
+class ReplicaStatusSnapshot(BaseModel):
+    """A single point-in-time replica status snapshot."""
+
+    model_config = MODEL_CONFIG.copy()
+
+    timestamp: datetime.datetime | None = None
+    """Timestamp when this snapshot was taken."""
+    namespace: str | None = None
+    """Kubernetes namespace."""
+    controllers: list[ControllerReplicaStatus] | None = None
+    """Per-controller replica status at this point in time."""
+
+
+class ReplicaStatus(BaseModel):
+    """Replica status across controllers, with optional time series and aggregate."""
+
+    model_config = MODEL_CONFIG.copy()
+
+    namespace: str | None = None
+    """Kubernetes namespace."""
+    timestamp: datetime.datetime | None = None
+    """Timestamp of the latest snapshot."""
+    controllers: list[ControllerReplicaStatus] | None = None
+    """Per-controller replica status (latest snapshot)."""
+    time_series: list[ReplicaStatusSnapshot] | None = None
+    """Time series of replica status snapshots collected during the benchmark."""
+    aggregate_ready_replicas: Statistics | None = None
+    """Aggregate statistics (min, max, mean, etc.) of total ready replicas over time."""
+    graph_path: str | None = None
+    """Path to replica status visualization."""
+
+
+# ------------------------------------------------------------------------------
 # Root for observability
 # ------------------------------------------------------------------------------
 
@@ -841,12 +942,18 @@ class Observability(BaseModel):
     """Observability metrics."""
 
     model_config = MODEL_CONFIG.copy()
-    # TODO keep as permissive until schema defined
+    # Keep permissive — real reports include ad-hoc metric keys
+    # (e.g. vllm_kv_cache_usage_perc, epp_dispatch_latency) that are
+    # not yet formalized in the schema.
     model_config["extra"] = "allow"
     components: list[ComponentObservability] | None = None
     """Per-component observability metrics."""
     drop_rate: Statistics | None = None
     """Request drop rate."""
+    pod_startup_times: PodStartupTimes | None = None
+    """Pod startup times collected during or before the benchmark."""
+    replica_status: ReplicaStatus | None = None
+    """Replica status across controllers at a point in time."""
 
     @model_validator(mode="after")
     def check_units(self):

--- a/llmdbenchmark/analysis/visualize_metrics.py
+++ b/llmdbenchmark/analysis/visualize_metrics.py
@@ -25,16 +25,61 @@ except ImportError:
     print("Warning: matplotlib not available. Install with: pip install matplotlib")
 
 
-def parse_prometheus_metrics_with_timestamp(file_path: str) -> tuple[str | None, str | None, dict[str, list[tuple[datetime, float]]]]:
+# Metrics that should include an aggregated mean line across pods
+AGGREGATE_METRICS = {
+    'vllm:kv_cache_usage_perc', 'vllm:num_requests_running',
+    'vllm:num_requests_waiting', 'vllm:num_preemptions_total',
+}
+
+# Metrics to visualize: prometheus_name -> (title, ylabel)
+METRICS_TO_PLOT = {
+    'vllm:kv_cache_usage_perc': ('KV Cache Usage', 'Usage (%)'),
+    'vllm:gpu_cache_usage_perc': ('GPU Cache Usage', 'Usage (%)'),
+    'vllm:cpu_cache_usage_perc': ('CPU Cache Usage', 'Usage (%)'),
+    'vllm:gpu_memory_usage_bytes': ('GPU Memory Usage', 'Memory (bytes)'),
+    'vllm:cpu_memory_usage_bytes': ('CPU Memory Usage', 'Memory (bytes)'),
+    'container_memory_usage_bytes': ('Container Memory Usage', 'Memory (bytes)'),
+    'DCGM_FI_DEV_GPU_UTIL': ('GPU Utilization', 'Utilization (%)'),
+    'DCGM_FI_DEV_POWER_USAGE': ('GPU Power Usage', 'Power (W)'),
+    'vllm:num_requests_running': ('Running Requests', 'Count'),
+    'vllm:num_requests_waiting': ('Waiting Requests', 'Count'),
+    'vllm:prefix_cache_hits_total': ('Prefix Cache Hits', 'Tokens'),
+    'vllm:prefix_cache_queries_total': ('Prefix Cache Queries', 'Tokens'),
+    'vllm:external_prefix_cache_hits_total': ('External Prefix Cache Hits (Cross-Instance)', 'Tokens'),
+    'vllm:external_prefix_cache_queries_total': ('External Prefix Cache Queries (Cross-Instance)', 'Tokens'),
+    'vllm:nixl_xfer_time_seconds_sum': ('NIXL KV Transfer Time', 'Time (s)'),
+    'vllm:nixl_xfer_time_seconds_count': ('NIXL KV Transfer Count', 'Count'),
+    'vllm:nixl_bytes_transferred_sum': ('NIXL Bytes Transferred', 'Bytes'),
+    'vllm:nixl_bytes_transferred_count': ('NIXL Transfers Count', 'Count'),
+    'vllm:num_preemptions_total': ('Request Preemptions', 'Count'),
+    # EPP (inference scheduler) pool-level metrics
+    'inference_pool_average_kv_cache_utilization': ('EPP Pool Avg KV Cache Utilization', 'Utilization (%)'),
+    'inference_pool_average_queue_size': ('EPP Pool Avg Queue Size', 'Count'),
+    'inference_pool_average_running_requests': ('EPP Pool Avg Running Requests', 'Count'),
+    'inference_pool_ready_pods': ('EPP Pool Ready Pods', 'Count'),
+}
+
+# Computed ratio metrics: (numerator, denominator, title, ylabel, output_name)
+RATIO_METRICS = [
+    ('vllm:prefix_cache_hits_total', 'vllm:prefix_cache_queries_total',
+     'Prefix Cache Hit Rate', 'Hit Rate (%)', 'vllm_prefix_cache_hit_rate'),
+    ('vllm:external_prefix_cache_hits_total', 'vllm:external_prefix_cache_queries_total',
+     'External Prefix Cache Hit Rate (Cross-Instance)', 'Hit Rate (%)', 'vllm_external_prefix_cache_hit_rate'),
+]
+
+
+# ---------------------------------------------------------------------------
+# Data collection
+# ---------------------------------------------------------------------------
+
+def parse_prometheus_metrics_with_timestamp(file_path):
     """Parse Prometheus metrics from a file with timestamps.
 
-    Args:
-        file_path: Path to metrics file
-
     Returns:
-        Tuple of (timestamp, pod_name, metrics_dict with timestamps)
+        Tuple of (timestamp_str, pod_name, metrics_dict)
+        where metrics_dict maps metric_name -> [(datetime, value), ...]
     """
-    metrics: dict[str, list[tuple[datetime, float]]] = {}
+    metrics = {}
     timestamp_str = None
     timestamp_dt = None
     pod_name = None
@@ -43,7 +88,6 @@ def parse_prometheus_metrics_with_timestamp(file_path: str) -> tuple[str | None,
         for line in f:
             line = line.strip()
 
-            # Extract timestamp
             if line.startswith('# Timestamp:'):
                 timestamp_str = line.split(':', 1)[1].strip()
                 try:
@@ -51,72 +95,77 @@ def parse_prometheus_metrics_with_timestamp(file_path: str) -> tuple[str | None,
                         timestamp_str.replace('Z', '+00:00'))
                 except ValueError:
                     pass
-
-            # Extract pod name
-            if line.startswith('# Pod:'):
+            elif line.startswith('# Pod:'):
                 pod_name = line.split(':', 1)[1].strip()
 
-            # Skip comments and empty lines
             if line.startswith('#') or not line:
                 continue
 
-            # Parse metric line
             match = re.match(
                 r'([a-zA-Z_:][a-zA-Z0-9_:]*(?:\{[^}]*\})?) ([\d.eE+-]+)', line)
             if match and timestamp_dt:
-                metric_name = match.group(1)
+                base_name = match.group(1).split('{')[0]
                 value = float(match.group(2))
-
-                # Extract base metric name (without labels)
-                base_name = metric_name.split('{')[0]
-
-                if base_name not in metrics:
-                    metrics[base_name] = []
-                metrics[base_name].append((timestamp_dt, value))
+                metrics.setdefault(base_name, []).append((timestamp_dt, value))
 
     return timestamp_str, pod_name, metrics
 
 
-def collect_time_series_data(metrics_dir: str) -> dict[str, dict[str, list[tuple[datetime, float]]]]:
+def collect_time_series_data(metrics_dir):
     """Collect time series data from all metric files.
 
-    Args:
-        metrics_dir: Directory containing metrics
-
     Returns:
-        Dictionary mapping pod names to their time series data
+        Dictionary mapping pod names to their time series data:
+        {pod_name: {metric_name: [(datetime, value), ...]}}
     """
     raw_dir = os.path.join(metrics_dir, 'raw')
-    pod_data: dict[str, dict[str, list[tuple[datetime, float]]]] = {}
+    pod_data = {}
 
     for file_path in glob.glob(os.path.join(raw_dir, '*.log')):
-        _, pod_name, metrics = parse_prometheus_metrics_with_timestamp(
-            file_path)
+        _, pod_name, metrics = parse_prometheus_metrics_with_timestamp(file_path)
 
         if pod_name:
-            if pod_name not in pod_data:
-                pod_data[pod_name] = {}
-
+            pod = pod_data.setdefault(pod_name, {})
             for metric_name, data_points in metrics.items():
-                if metric_name not in pod_data[pod_name]:
-                    pod_data[pod_name][metric_name] = []
-                pod_data[pod_name][metric_name].extend(data_points)
+                pod.setdefault(metric_name, []).extend(data_points)
 
-    # Sort time series data by timestamp
-    for pod_name in pod_data:
-        for metric_name in pod_data[pod_name]:
-            pod_data[pod_name][metric_name].sort(key=lambda x: x[0])
+    # Sort by timestamp
+    for pod in pod_data.values():
+        for metric_name in pod:
+            pod[metric_name].sort(key=lambda x: x[0])
 
     return pod_data
 
 
-def plot_metric_time_series(
-    pod_data: dict[str, dict[str, list[tuple[datetime, float]]]],
-    metric_name: str,
-    output_path: str,
-    title: str | None = None,
-    ylabel: str | None = None
-):
+# ---------------------------------------------------------------------------
+# Plot helpers
+# ---------------------------------------------------------------------------
+
+def _save_plot(fig, output_path):
+    """Format axes and save a plot to disk."""
+    for ax in fig.axes:
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    print(f"Saved plot: {output_path}")
+
+
+def _parse_ts(ts_str):
+    """Parse an ISO timestamp string to datetime, or None."""
+    try:
+        return datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Plot functions
+# ---------------------------------------------------------------------------
+
+def plot_metric_time_series(pod_data, metric_name, output_path,
+                            title=None, ylabel=None, show_aggregate=False):
     """Plot time series for a specific metric across all pods.
 
     Args:
@@ -125,70 +174,26 @@ def plot_metric_time_series(
         output_path: Path to save the plot
         title: Plot title (optional)
         ylabel: Y-axis label (optional)
-    """
-    if not MATPLOTLIB_AVAILABLE:
-        print(f"Skipping plot for {metric_name}: matplotlib not available")
-        return
-
-    fig, ax = plt.subplots(figsize=(12, 6))
-
-    for pod_name, metrics in pod_data.items():
-        if metric_name in metrics:
-            timestamps, values = zip(*metrics[metric_name])
-            ax.plot(timestamps, values, label=pod_name,
-                    marker='o', markersize=3)
-
-    ax.set_xlabel('Time')
-    ax.set_ylabel(ylabel or metric_name)
-    ax.set_title(title or f'{metric_name} Over Time')
-    ax.legend()
-    ax.grid(True, alpha=0.3)
-
-    # Format x-axis
-    ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
-    plt.xticks(rotation=45)
-
-    plt.tight_layout()
-    plt.savefig(output_path, dpi=150)
-    plt.close()
-
-    print(f"Saved plot: {output_path}")
-
-
-def plot_metric_time_series_with_aggregate(
-    pod_data: dict[str, dict[str, list[tuple[datetime, float]]]],
-    metric_name: str,
-    output_path: str,
-    title: str | None = None,
-    ylabel: str | None = None
-):
-    """Plot time series for a metric with an aggregated mean line across pods.
-
-    Args:
-        pod_data: Time series data for all pods
-        metric_name: Name of metric to plot
-        output_path: Path to save the plot
-        title: Plot title (optional)
-        ylabel: Y-axis label (optional)
+        show_aggregate: If True, add a dashed mean line across all pods
     """
     if not MATPLOTLIB_AVAILABLE:
         return
 
     fig, ax = plt.subplots(figsize=(12, 6))
-
-    # Collect all values by timestamp for aggregation
-    ts_values: dict[datetime, list[float]] = {}
+    ts_values = {} if show_aggregate else None
 
     for pod_name, metrics in pod_data.items():
-        if metric_name in metrics:
-            timestamps, values = zip(*metrics[metric_name])
-            ax.plot(timestamps, values, label=pod_name,
-                    marker='o', markersize=3, alpha=0.5)
+        if metric_name not in metrics:
+            continue
+        timestamps, values = zip(*metrics[metric_name])
+        alpha = 0.5 if show_aggregate else 1.0
+        ax.plot(timestamps, values, label=pod_name,
+                marker='o', markersize=3, alpha=alpha)
+        if show_aggregate:
             for ts, val in metrics[metric_name]:
                 ts_values.setdefault(ts, []).append(val)
 
-    # Plot aggregated mean line
-    if ts_values:
+    if show_aggregate and ts_values:
         sorted_ts = sorted(ts_values.keys())
         agg_means = [sum(ts_values[ts]) / len(ts_values[ts]) for ts in sorted_ts]
         ax.plot(sorted_ts, agg_means, label='Aggregated (mean)',
@@ -200,28 +205,19 @@ def plot_metric_time_series_with_aggregate(
     ax.set_title(title or f'{metric_name} Over Time')
     ax.legend()
     ax.grid(True, alpha=0.3)
-
-    ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
-    plt.xticks(rotation=45)
-    plt.tight_layout()
-    plt.savefig(output_path, dpi=150)
-    plt.close()
-
-    print(f"Saved plot: {output_path}")
+    _save_plot(fig, output_path)
 
 
-def plot_pod_startup_times(metrics_dir: str, output_path: str):
+def plot_pod_startup_times(metrics_dir, output_path):
     """Scatter plot of pod startup times.
 
     X-axis: ready_timestamp (when the pod became ready)
     Y-axis: startup_seconds (how long it took)
-    One dot per pod.
     """
     if not MATPLOTLIB_AVAILABLE:
         return
 
-    startup_file = os.path.join(
-        metrics_dir, 'processed', 'pod_startup_times.json')
+    startup_file = os.path.join(metrics_dir, 'processed', 'pod_startup_times.json')
     if not os.path.exists(startup_file):
         return
 
@@ -232,32 +228,22 @@ def plot_pod_startup_times(metrics_dir: str, output_path: str):
     if not pods:
         return
 
-    timestamps = []
-    startup_secs = []
-    labels = []
-
+    points = []
     for pod in pods:
-        ready_ts = pod.get('ready_timestamp', '')
+        ts = _parse_ts(pod.get('ready_timestamp', ''))
         secs = pod.get('startup_seconds')
-        if not ready_ts or secs is None:
-            continue
-        try:
-            ts = datetime.fromisoformat(ready_ts.replace('Z', '+00:00'))
-        except ValueError:
-            continue
-        timestamps.append(ts)
-        startup_secs.append(secs)
-        role = pod.get('role', '')
-        labels.append(f"{pod.get('name', '')}\n({role})")
+        if ts and secs is not None:
+            points.append((ts, secs))
 
-    if not timestamps:
+    if not points:
         return
 
-    fig, ax = plt.subplots(figsize=(12, 6))
-    scatter = ax.scatter(timestamps, startup_secs, s=80, c='steelblue',
-                         edgecolors='black', linewidths=0.5, zorder=5)
+    timestamps, startup_secs = zip(*points)
 
-    # Add aggregate line if stats available
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.scatter(timestamps, startup_secs, s=80, c='steelblue',
+               edgecolors='black', linewidths=0.5, zorder=5)
+
     agg = data.get('aggregate', {})
     if agg.get('mean'):
         ax.axhline(y=agg['mean'], color='orange', linestyle='--',
@@ -272,27 +258,15 @@ def plot_pod_startup_times(metrics_dir: str, output_path: str):
     ax.set_ylabel('Startup Time (seconds)')
     ax.set_title('Pod Startup Times')
     ax.grid(True, alpha=0.3)
-
-    ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
-    plt.xticks(rotation=45)
-    plt.tight_layout()
-    plt.savefig(output_path, dpi=150)
-    plt.close()
-
-    print(f"Saved plot: {output_path}")
+    _save_plot(fig, output_path)
 
 
-def plot_replica_status(metrics_dir: str, output_path: str):
-    """Line plot of replica counts over time.
-
-    X-axis: timestamp
-    Y-axis: total ready replicas (one line per role).
-    """
+def plot_replica_status(metrics_dir, output_path):
+    """Line plot of replica counts over time, one line per role."""
     if not MATPLOTLIB_AVAILABLE:
         return
 
-    ts_file = os.path.join(
-        metrics_dir, 'processed', 'replica_status_timeseries.json')
+    ts_file = os.path.join(metrics_dir, 'processed', 'replica_status_timeseries.json')
     if not os.path.exists(ts_file):
         return
 
@@ -303,23 +277,16 @@ def plot_replica_status(metrics_dir: str, output_path: str):
     if len(snapshots) < 2:
         return
 
-    # Build per-role time series: {role: [(timestamp, ready_count)]}
-    role_series: dict[str, list[tuple[datetime, int]]] = {}
-
+    # Build per-role time series
+    role_series = {}
     for snap in snapshots:
-        ts_str = snap.get('timestamp', '')
-        try:
-            ts = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
-        except ValueError:
+        ts = _parse_ts(snap.get('timestamp', ''))
+        if not ts:
             continue
-
-        role_counts: dict[str, int] = {}
+        role_counts = {}
         for ctrl in snap.get('controllers', []):
             role = ctrl.get('role', 'unknown')
-            role_counts[role] = (
-                role_counts.get(role, 0) + ctrl.get('ready_replicas', 0)
-            )
-
+            role_counts[role] = role_counts.get(role, 0) + ctrl.get('ready_replicas', 0)
         for role, count in role_counts.items():
             role_series.setdefault(role, []).append((ts, count))
 
@@ -327,7 +294,6 @@ def plot_replica_status(metrics_dir: str, output_path: str):
         return
 
     fig, ax = plt.subplots(figsize=(12, 6))
-
     for role, points in sorted(role_series.items()):
         points.sort(key=lambda x: x[0])
         timestamps, counts = zip(*points)
@@ -339,34 +305,23 @@ def plot_replica_status(metrics_dir: str, output_path: str):
     ax.legend()
     ax.grid(True, alpha=0.3)
     ax.yaxis.get_major_locator().set_params(integer=True)
-
-    ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
-    plt.xticks(rotation=45)
-    plt.tight_layout()
-    plt.savefig(output_path, dpi=150)
-    plt.close()
-
-    print(f"Saved plot: {output_path}")
+    _save_plot(fig, output_path)
 
 
-def generate_all_visualizations(metrics_dir: str, output_dir: str | None = None):
-    """Generate visualizations for all collected metrics.
+# ---------------------------------------------------------------------------
+# Main orchestration
+# ---------------------------------------------------------------------------
 
-    Args:
-        metrics_dir: Directory containing collected metrics
-        output_dir: Directory to save visualizations (default: metrics_dir/graphs)
-    """
+def generate_all_visualizations(metrics_dir, output_dir=None):
+    """Generate visualizations for all collected metrics."""
     if not MATPLOTLIB_AVAILABLE:
         print("Error: matplotlib is required for visualization")
-        print("Install with: pip install matplotlib")
         return
 
     if output_dir is None:
         output_dir = os.path.join(metrics_dir, 'graphs')
-
     os.makedirs(output_dir, exist_ok=True)
 
-    # Collect time series data
     print("Collecting time series data...")
     pod_data = collect_time_series_data(metrics_dir)
 
@@ -374,54 +329,19 @@ def generate_all_visualizations(metrics_dir: str, output_dir: str | None = None)
         print("No metrics data found")
         return
 
-    # Define metrics to visualize
-    metrics_to_plot = {
-        'vllm:kv_cache_usage_perc': ('KV Cache Usage', 'Usage (%)'),
-        'vllm:gpu_cache_usage_perc': ('GPU Cache Usage', 'Usage (%)'),
-        'vllm:cpu_cache_usage_perc': ('CPU Cache Usage', 'Usage (%)'),
-        'vllm:gpu_memory_usage_bytes': ('GPU Memory Usage', 'Memory (bytes)'),
-        'vllm:cpu_memory_usage_bytes': ('CPU Memory Usage', 'Memory (bytes)'),
-        'container_memory_usage_bytes': ('Container Memory Usage', 'Memory (bytes)'),
-        'DCGM_FI_DEV_GPU_UTIL': ('GPU Utilization', 'Utilization (%)'),
-        'DCGM_FI_DEV_POWER_USAGE': ('GPU Power Usage', 'Power (W)'),
-        'vllm:num_requests_running': ('Running Requests', 'Count'),
-        'vllm:num_requests_waiting': ('Waiting Requests', 'Count'),
-        'vllm:prefix_cache_hits_total': ('Prefix Cache Hits', 'Tokens'),
-        'vllm:prefix_cache_queries_total': ('Prefix Cache Queries', 'Tokens'),
-        'vllm:external_prefix_cache_hits_total': ('External Prefix Cache Hits (Cross-Instance)', 'Tokens'),
-        'vllm:external_prefix_cache_queries_total': ('External Prefix Cache Queries (Cross-Instance)', 'Tokens'),
-        'vllm:nixl_xfer_time_seconds_sum': ('NIXL KV Transfer Time', 'Time (s)'),
-        'vllm:nixl_xfer_time_seconds_count': ('NIXL KV Transfer Count', 'Count'),
-        'vllm:nixl_bytes_transferred_sum': ('NIXL Bytes Transferred', 'Bytes'),
-        'vllm:nixl_bytes_transferred_count': ('NIXL Transfers Count', 'Count'),
-        'vllm:num_preemptions_total': ('Request Preemptions', 'Count'),
-        # EPP (inference scheduler) pool-level metrics
-        'inference_pool_average_kv_cache_utilization': ('EPP Pool Avg KV Cache Utilization', 'Utilization (%)'),
-        'inference_pool_average_queue_size': ('EPP Pool Avg Queue Size', 'Count'),
-        'inference_pool_average_running_requests': ('EPP Pool Avg Running Requests', 'Count'),
-        'inference_pool_ready_pods': ('EPP Pool Ready Pods', 'Count'),
-    }
-
-    # Define computed ratio metrics: (numerator, denominator, title, ylabel, output_name)
-    ratio_metrics = [
-        ('vllm:prefix_cache_hits_total', 'vllm:prefix_cache_queries_total',
-         'Prefix Cache Hit Rate', 'Hit Rate (%)', 'vllm_prefix_cache_hit_rate'),
-        ('vllm:external_prefix_cache_hits_total', 'vllm:external_prefix_cache_queries_total',
-         'External Prefix Cache Hit Rate (Cross-Instance)', 'Hit Rate (%)', 'vllm_external_prefix_cache_hit_rate'),
-    ]
-
-    for numerator, denominator, title, ylabel, output_name in ratio_metrics:
+    # Ratio metrics (computed from pairs of counters)
+    for numerator, denominator, title, ylabel, output_name in RATIO_METRICS:
         ratio_data = {}
         for pod_name, metrics in pod_data.items():
             if numerator in metrics and denominator in metrics:
                 hits_by_ts = {ts: val for ts, val in metrics[numerator]}
                 queries_by_ts = {ts: val for ts, val in metrics[denominator]}
                 common_ts = sorted(set(hits_by_ts) & set(queries_by_ts))
-                ratio_points = []
-                for ts in common_ts:
-                    q = queries_by_ts[ts]
-                    rate = (hits_by_ts[ts] / q * 100) if q > 0 else 0.0
-                    ratio_points.append((ts, rate))
+                ratio_points = [
+                    (ts, (hits_by_ts[ts] / queries_by_ts[ts] * 100)
+                     if queries_by_ts[ts] > 0 else 0.0)
+                    for ts in common_ts
+                ]
                 if ratio_points:
                     ratio_data[pod_name] = {output_name: ratio_points}
         if ratio_data:
@@ -430,32 +350,20 @@ def generate_all_visualizations(metrics_dir: str, output_dir: str | None = None)
                 os.path.join(output_dir, f'{output_name}.png'),
                 title, ylabel)
 
-    # Metrics that should include an aggregated mean line across pods
-    aggregate_metrics = {
-        'vllm:kv_cache_usage_perc', 'vllm:num_requests_running',
-        'vllm:num_requests_waiting', 'vllm:num_preemptions_total',
-    }
-
-    # Generate line plots (time series)
-    for metric_name, (title, ylabel) in metrics_to_plot.items():
-        has_metric = any(
-            metric_name in metrics for metrics in pod_data.values())
-
+    # Standard time series plots
+    for metric_name, (title, ylabel) in METRICS_TO_PLOT.items():
+        has_metric = any(metric_name in m for m in pod_data.values())
         if has_metric:
             safe_name = metric_name.replace(':', '_')
-            out_path = os.path.join(output_dir, f'{safe_name}.png')
-            if metric_name in aggregate_metrics:
-                plot_metric_time_series_with_aggregate(
-                    pod_data, metric_name, out_path, title, ylabel)
-            else:
-                plot_metric_time_series(
-                    pod_data, metric_name, out_path, title, ylabel)
+            plot_metric_time_series(
+                pod_data, metric_name,
+                os.path.join(output_dir, f'{safe_name}.png'),
+                title, ylabel,
+                show_aggregate=(metric_name in AGGREGATE_METRICS))
 
-    # Pod startup times scatter plot
+    # Infrastructure plots
     plot_pod_startup_times(
         metrics_dir, os.path.join(output_dir, 'pod_startup_times.png'))
-
-    # Replica status line plot
     plot_replica_status(
         metrics_dir, os.path.join(output_dir, 'replica_status.png'))
 
@@ -489,5 +397,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-# Made with Bob

--- a/llmdbenchmark/analysis/visualize_metrics.py
+++ b/llmdbenchmark/analysis/visualize_metrics.py
@@ -155,6 +155,200 @@ def plot_metric_time_series(
     print(f"Saved plot: {output_path}")
 
 
+def plot_metric_time_series_with_aggregate(
+    pod_data: dict[str, dict[str, list[tuple[datetime, float]]]],
+    metric_name: str,
+    output_path: str,
+    title: str | None = None,
+    ylabel: str | None = None
+):
+    """Plot time series for a metric with an aggregated mean line across pods.
+
+    Args:
+        pod_data: Time series data for all pods
+        metric_name: Name of metric to plot
+        output_path: Path to save the plot
+        title: Plot title (optional)
+        ylabel: Y-axis label (optional)
+    """
+    if not MATPLOTLIB_AVAILABLE:
+        return
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    # Collect all values by timestamp for aggregation
+    ts_values: dict[datetime, list[float]] = {}
+
+    for pod_name, metrics in pod_data.items():
+        if metric_name in metrics:
+            timestamps, values = zip(*metrics[metric_name])
+            ax.plot(timestamps, values, label=pod_name,
+                    marker='o', markersize=3, alpha=0.5)
+            for ts, val in metrics[metric_name]:
+                ts_values.setdefault(ts, []).append(val)
+
+    # Plot aggregated mean line
+    if ts_values:
+        sorted_ts = sorted(ts_values.keys())
+        agg_means = [sum(ts_values[ts]) / len(ts_values[ts]) for ts in sorted_ts]
+        ax.plot(sorted_ts, agg_means, label='Aggregated (mean)',
+                color='black', linewidth=2, linestyle='--', marker='s',
+                markersize=4)
+
+    ax.set_xlabel('Time')
+    ax.set_ylabel(ylabel or metric_name)
+    ax.set_title(title or f'{metric_name} Over Time')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+
+    print(f"Saved plot: {output_path}")
+
+
+def plot_pod_startup_times(metrics_dir: str, output_path: str):
+    """Scatter plot of pod startup times.
+
+    X-axis: ready_timestamp (when the pod became ready)
+    Y-axis: startup_seconds (how long it took)
+    One dot per pod.
+    """
+    if not MATPLOTLIB_AVAILABLE:
+        return
+
+    startup_file = os.path.join(
+        metrics_dir, 'processed', 'pod_startup_times.json')
+    if not os.path.exists(startup_file):
+        return
+
+    with open(startup_file) as f:
+        data = json.load(f)
+
+    pods = data.get('pods', [])
+    if not pods:
+        return
+
+    timestamps = []
+    startup_secs = []
+    labels = []
+
+    for pod in pods:
+        ready_ts = pod.get('ready_timestamp', '')
+        secs = pod.get('startup_seconds')
+        if not ready_ts or secs is None:
+            continue
+        try:
+            ts = datetime.fromisoformat(ready_ts.replace('Z', '+00:00'))
+        except ValueError:
+            continue
+        timestamps.append(ts)
+        startup_secs.append(secs)
+        role = pod.get('role', '')
+        labels.append(f"{pod.get('name', '')}\n({role})")
+
+    if not timestamps:
+        return
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    scatter = ax.scatter(timestamps, startup_secs, s=80, c='steelblue',
+                         edgecolors='black', linewidths=0.5, zorder=5)
+
+    # Add aggregate line if stats available
+    agg = data.get('aggregate', {})
+    if agg.get('mean'):
+        ax.axhline(y=agg['mean'], color='orange', linestyle='--',
+                   linewidth=1.5, label=f"Mean: {agg['mean']:.1f}s")
+    if agg.get('p99'):
+        ax.axhline(y=agg['p99'], color='red', linestyle='--',
+                   linewidth=1, label=f"P99: {agg['p99']:.1f}s")
+    if agg.get('mean') or agg.get('p99'):
+        ax.legend()
+
+    ax.set_xlabel('Time (pod became Ready)')
+    ax.set_ylabel('Startup Time (seconds)')
+    ax.set_title('Pod Startup Times')
+    ax.grid(True, alpha=0.3)
+
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+
+    print(f"Saved plot: {output_path}")
+
+
+def plot_replica_status(metrics_dir: str, output_path: str):
+    """Line plot of replica counts over time.
+
+    X-axis: timestamp
+    Y-axis: total ready replicas (one line per role).
+    """
+    if not MATPLOTLIB_AVAILABLE:
+        return
+
+    ts_file = os.path.join(
+        metrics_dir, 'processed', 'replica_status_timeseries.json')
+    if not os.path.exists(ts_file):
+        return
+
+    with open(ts_file) as f:
+        ts_data = json.load(f)
+
+    snapshots = ts_data.get('snapshots', [])
+    if len(snapshots) < 2:
+        return
+
+    # Build per-role time series: {role: [(timestamp, ready_count)]}
+    role_series: dict[str, list[tuple[datetime, int]]] = {}
+
+    for snap in snapshots:
+        ts_str = snap.get('timestamp', '')
+        try:
+            ts = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
+        except ValueError:
+            continue
+
+        role_counts: dict[str, int] = {}
+        for ctrl in snap.get('controllers', []):
+            role = ctrl.get('role', 'unknown')
+            role_counts[role] = (
+                role_counts.get(role, 0) + ctrl.get('ready_replicas', 0)
+            )
+
+        for role, count in role_counts.items():
+            role_series.setdefault(role, []).append((ts, count))
+
+    if not role_series:
+        return
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    for role, points in sorted(role_series.items()):
+        points.sort(key=lambda x: x[0])
+        timestamps, counts = zip(*points)
+        ax.plot(timestamps, counts, label=role, marker='o', markersize=3)
+
+    ax.set_xlabel('Time')
+    ax.set_ylabel('Ready Replicas')
+    ax.set_title('Replica Count Over Time')
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+    ax.yaxis.get_major_locator().set_params(integer=True)
+
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+
+    print(f"Saved plot: {output_path}")
+
+
 def generate_all_visualizations(metrics_dir: str, output_dir: str | None = None):
     """Generate visualizations for all collected metrics.
 
@@ -201,6 +395,11 @@ def generate_all_visualizations(metrics_dir: str, output_dir: str | None = None)
         'vllm:nixl_bytes_transferred_sum': ('NIXL Bytes Transferred', 'Bytes'),
         'vllm:nixl_bytes_transferred_count': ('NIXL Transfers Count', 'Count'),
         'vllm:num_preemptions_total': ('Request Preemptions', 'Count'),
+        # EPP (inference scheduler) pool-level metrics
+        'inference_pool_average_kv_cache_utilization': ('EPP Pool Avg KV Cache Utilization', 'Utilization (%)'),
+        'inference_pool_average_queue_size': ('EPP Pool Avg Queue Size', 'Count'),
+        'inference_pool_average_running_requests': ('EPP Pool Avg Running Requests', 'Count'),
+        'inference_pool_ready_pods': ('EPP Pool Ready Pods', 'Count'),
     }
 
     # Define computed ratio metrics: (numerator, denominator, title, ylabel, output_name)
@@ -231,6 +430,12 @@ def generate_all_visualizations(metrics_dir: str, output_dir: str | None = None)
                 os.path.join(output_dir, f'{output_name}.png'),
                 title, ylabel)
 
+    # Metrics that should include an aggregated mean line across pods
+    aggregate_metrics = {
+        'vllm:kv_cache_usage_perc', 'vllm:num_requests_running',
+        'vllm:num_requests_waiting', 'vllm:num_preemptions_total',
+    }
+
     # Generate line plots (time series)
     for metric_name, (title, ylabel) in metrics_to_plot.items():
         has_metric = any(
@@ -238,10 +443,21 @@ def generate_all_visualizations(metrics_dir: str, output_dir: str | None = None)
 
         if has_metric:
             safe_name = metric_name.replace(':', '_')
-            plot_metric_time_series(
-                pod_data, metric_name,
-                os.path.join(output_dir, f'{safe_name}.png'),
-                title, ylabel)
+            out_path = os.path.join(output_dir, f'{safe_name}.png')
+            if metric_name in aggregate_metrics:
+                plot_metric_time_series_with_aggregate(
+                    pod_data, metric_name, out_path, title, ylabel)
+            else:
+                plot_metric_time_series(
+                    pod_data, metric_name, out_path, title, ylabel)
+
+    # Pod startup times scatter plot
+    plot_pod_startup_times(
+        metrics_dir, os.path.join(output_dir, 'pod_startup_times.png'))
+
+    # Replica status line plot
+    plot_replica_status(
+        metrics_dir, os.path.join(output_dir, 'replica_status.png'))
 
     print(f"\nAll visualizations saved to: {output_dir}")
 

--- a/workload/harnesses/collect_metrics.sh
+++ b/workload/harnesses/collect_metrics.sh
@@ -20,14 +20,15 @@ EPP_METRICS_PORT="${LLMDBENCH_EPP_METRICS_PORT:-9090}"  # EPP Prometheus metrics
 
 # Function to initialize metrics directory
 init_metrics_dir() {
-    mkdir -p "$METRICS_DIR"
-    mkdir -p "$METRICS_DIR/raw"
-    mkdir -p "$METRICS_DIR/processed"
+    mkdir -p "$METRICS_DIR/raw" "$METRICS_DIR/processed"
     echo "Metrics directory initialized: $METRICS_DIR"
 }
 
-# Function to get pod names and IPs for the deployment.
-# Uses the same label-based discovery as build/llm-d-benchmark.sh scrape_vllm_metrics.
+# ---------------------------------------------------------------------------
+# Pod discovery
+# ---------------------------------------------------------------------------
+
+# Get vLLM pod names and IPs.
 # Output: lines of "pod_name pod_ip" pairs.
 get_pod_info() {
     local namespace="$1"
@@ -67,8 +68,7 @@ get_pod_info() {
     echo "$pod_info"
 }
 
-# Function to get EPP (inference scheduler) pod names and IPs.
-# Discovers pods via the inferencepool label used by llm-d.
+# Get EPP (inference scheduler) pod names and IPs.
 # Output: lines of "pod_name pod_ip" pairs.
 get_epp_pod_info() {
     local namespace="$1"
@@ -99,15 +99,18 @@ get_epp_pod_info() {
     echo "$pod_info"
 }
 
-# Function to collect replica status (desired vs ready vs available) for all
-# vLLM-related Deployments and StatefulSets in the namespace.
-# Queries all controllers, then filters by pod-template label
-# llm-d.ai/inferenceServing=true so both modelservice and standalone are captured.
-# Writes the latest snapshot to $METRICS_DIR/processed/replica_status.json
-# and appends to $METRICS_DIR/processed/replica_status_timeseries.json.
+# ---------------------------------------------------------------------------
+# Replica status & pod startup times
+# ---------------------------------------------------------------------------
+
+# Collect replica status snapshot and append to time series.
+# Filters controllers to only include those matching the current benchmark's
+# model (via LLMDBENCH_HARNESS_STACK_NAME), so stale controllers from
+# previous runs in the same namespace are excluded.
 collect_replica_status() {
     local namespace="${LLMDBENCH_VLLM_COMMON_NAMESPACE:-default}"
     local kubectl_cmd="${KUBECTL_CMD:-kubectl}"
+    local model_filter="${LLMDBENCH_HARNESS_STACK_NAME:-}"
     local output_file="$METRICS_DIR/processed/replica_status.json"
     local timeseries_file="$METRICS_DIR/processed/replica_status_timeseries.json"
     local debug_log="$METRICS_DIR/raw/collection_debug.log"
@@ -117,13 +120,14 @@ collect_replica_status() {
     local all_json
     all_json=$($kubectl_cmd --namespace "$namespace" get deployments,statefulsets -o json 2>>"$debug_log") || all_json='{"items":[]}'
 
-    echo "$all_json" | _RS_NAMESPACE="$namespace" _RS_OUTPUT="$output_file" _RS_TS_OUTPUT="$timeseries_file" python3 -c '
+    echo "$all_json" | _RS_NAMESPACE="$namespace" _RS_OUTPUT="$output_file" _RS_TS_OUTPUT="$timeseries_file" _RS_MODEL_FILTER="$model_filter" python3 -c '
 import json, sys, os
 from datetime import datetime, timezone
 
 namespace = os.environ["_RS_NAMESPACE"]
 output_file = os.environ["_RS_OUTPUT"]
 ts_file = os.environ["_RS_TS_OUTPUT"]
+model_filter = os.environ.get("_RS_MODEL_FILTER", "")
 
 data = json.load(sys.stdin)
 snapshot = {
@@ -144,10 +148,15 @@ for item in data.get("items", []):
     if tmpl_labels.get("llm-d.ai/inferenceServing") != "true":
         continue
 
+    # Filter by model if LLMDBENCH_HARNESS_STACK_NAME is set
+    model = tmpl_labels.get("llm-d.ai/model", tmpl_labels.get("app", ""))
+    if model_filter and model != model_filter:
+        continue
+
     snapshot["controllers"].append({
         "name": metadata.get("name", ""),
         "kind": kind,
-        "model": tmpl_labels.get("llm-d.ai/model", tmpl_labels.get("app", "")),
+        "model": model,
         "role": tmpl_labels.get("llm-d.ai/role", "unknown"),
         "desired_replicas": spec.get("replicas", 0),
         "ready_replicas": status.get("readyReplicas", 0),
@@ -159,7 +168,7 @@ for item in data.get("items", []):
 with open(output_file, "w") as f:
     json.dump(snapshot, f, indent=2)
 
-# Append to time series
+# Append to time series only if replica counts changed
 ts_data = {"snapshots": []}
 if os.path.exists(ts_file):
     try:
@@ -167,23 +176,29 @@ if os.path.exists(ts_file):
             ts_data = json.load(f)
     except (json.JSONDecodeError, OSError):
         ts_data = {"snapshots": []}
-ts_data["snapshots"].append(snapshot)
-with open(ts_file, "w") as f:
-    json.dump(ts_data, f, indent=2)
 
-print("Replica status: %d controller(s), %d snapshots total" % (len(snapshot["controllers"]), len(ts_data["snapshots"])))
+changed = True
+if ts_data["snapshots"]:
+    prev = ts_data["snapshots"][-1]
+    prev_counts = {c["name"]: c.get("ready_replicas", 0) for c in prev.get("controllers", [])}
+    curr_counts = {c["name"]: c.get("ready_replicas", 0) for c in snapshot.get("controllers", [])}
+    changed = prev_counts != curr_counts
+
+if changed:
+    ts_data["snapshots"].append(snapshot)
+    with open(ts_file, "w") as f:
+        json.dump(ts_data, f, indent=2)
+
+print("Replica status: %d controller(s), %d snapshots%s" % (
+    len(snapshot["controllers"]), len(ts_data["snapshots"]),
+    "" if changed else " (unchanged)"))
 ' 2>>"$debug_log"
     if [[ $? -ne 0 ]]; then
         echo "Warning: Failed to collect replica status (see $debug_log)" >&2
     fi
 }
 
-# Function to collect pod startup times (creation to Ready) for all vLLM pods.
-# Uses the same label-based discovery as get_pod_info(), then extracts
-# creationTimestamp, conditions[Ready].lastTransitionTime, and spec.nodeName.
-# Called every collection interval to detect newly-scaled pods.
-# Incrementally appends new pods (not seen before) to
-# $METRICS_DIR/processed/pod_startup_times.json.
+# Collect pod startup times incrementally (detects newly-scaled pods).
 collect_pod_startup_times() {
     local namespace="${LLMDBENCH_VLLM_COMMON_NAMESPACE:-default}"
     local kubectl_cmd="${KUBECTL_CMD:-kubectl}"
@@ -279,15 +294,20 @@ if new_count > 0:
     fi
 }
 
-# Function to collect Prometheus metrics from a single pod via its IP.
-# Curls the pod IP directly from the benchmark pod instead of using kubectl exec,
-# so we don't compete for CPU inside the loaded vLLM container.
-# Writes curl output directly to file (matching the approach in build/llm-d-benchmark.sh).
-collect_prometheus_metrics_from_pod() {
+# ---------------------------------------------------------------------------
+# Prometheus metrics scraping
+# ---------------------------------------------------------------------------
+
+# Scrape Prometheus /metrics from a single pod.
+# Usage: _scrape_pod <pod_name> <pod_ip> <timestamp> <output_file> <port> <source_tag> [<fallback_port>]
+_scrape_pod() {
     local pod_name="$1"
     local pod_ip="$2"
     local timestamp="$3"
     local output_file="$4"
+    local port="$5"
+    local source_tag="$6"
+    local fallback_port="${7:-}"
     local debug_log="$METRICS_DIR/raw/collection_debug.log"
     local tmp_file="${output_file}.tmp"
 
@@ -296,12 +316,12 @@ collect_prometheus_metrics_from_pod() {
         echo "# Timestamp: $timestamp"
         echo "# Pod: $pod_name"
         echo "# PodIP: $pod_ip"
-        echo "# Source: prometheus_metrics"
+        echo "# Source: $source_tag"
         echo ""
     } > "$output_file"
 
-    # Try the configured metrics port — write directly to temp file
-    local url="http://${pod_ip}:${METRICS_PORT}${METRICS_PATH}"
+    # Try primary port
+    local url="http://${pod_ip}:${port}${METRICS_PATH}"
     local rc=0
     curl -sS --connect-timeout 5 --max-time "$METRICS_CURL_TIMEOUT" \
         "$url" > "$tmp_file" 2>>"$debug_log" || rc=$?
@@ -310,10 +330,10 @@ collect_prometheus_metrics_from_pod() {
         echo "  [$(date -u +%H:%M:%S)] curl failed (rc=$rc) for ${pod_name} ${url}" >> "$debug_log"
     fi
 
-    # If metrics port returned empty/failed, try inference port as fallback
-    if [[ ! -s "$tmp_file" && "$METRICS_PORT" != "$INFERENCE_PORT" ]]; then
-        url="http://${pod_ip}:${INFERENCE_PORT}${METRICS_PATH}"
-        echo "  [$(date -u +%H:%M:%S)] Retrying ${pod_name} on inference port: ${url}" >> "$debug_log"
+    # Try fallback port if primary failed/empty
+    if [[ ! -s "$tmp_file" && -n "$fallback_port" && "$port" != "$fallback_port" ]]; then
+        url="http://${pod_ip}:${fallback_port}${METRICS_PATH}"
+        echo "  [$(date -u +%H:%M:%S)] Retrying ${pod_name} on fallback port: ${url}" >> "$debug_log"
         rc=0
         curl -sS --connect-timeout 5 --max-time "$METRICS_CURL_TIMEOUT" \
             "$url" > "$tmp_file" 2>>"$debug_log" || rc=$?
@@ -322,18 +342,11 @@ collect_prometheus_metrics_from_pod() {
         fi
     fi
 
-    # Append whatever we got (or a warning if empty)
+    # Append content or warning
     if [[ -s "$tmp_file" ]]; then
         cat "$tmp_file" >> "$output_file"
     else
-        {
-            echo "# Warning: Failed to collect Prometheus metrics from pod $pod_name ($pod_ip)"
-            echo "# Attempted: ${pod_ip}:${METRICS_PORT}${METRICS_PATH}"
-            if [[ "$METRICS_PORT" != "$INFERENCE_PORT" ]]; then
-                echo "# Fallback: ${pod_ip}:${INFERENCE_PORT}${METRICS_PATH}"
-            fi
-            echo "# Debug log: $debug_log"
-        } >> "$output_file"
+        echo "# Warning: Failed to collect metrics from pod $pod_name ($pod_ip)" >> "$output_file"
     fi
     echo "" >> "$output_file"
 
@@ -341,49 +354,7 @@ collect_prometheus_metrics_from_pod() {
     return 0
 }
 
-# Function to collect Prometheus metrics from an EPP pod.
-# EPP exposes metrics on a different port (default 9090) than vLLM.
-collect_prometheus_metrics_from_epp_pod() {
-    local pod_name="$1"
-    local pod_ip="$2"
-    local timestamp="$3"
-    local output_file="$4"
-    local debug_log="$METRICS_DIR/raw/collection_debug.log"
-    local tmp_file="${output_file}.tmp"
-
-    # Write header
-    {
-        echo "# Timestamp: $timestamp"
-        echo "# Pod: $pod_name"
-        echo "# PodIP: $pod_ip"
-        echo "# Source: epp_prometheus_metrics"
-        echo ""
-    } > "$output_file"
-
-    local url="http://${pod_ip}:${EPP_METRICS_PORT}/metrics"
-    local rc=0
-    curl -sS --connect-timeout 5 --max-time "$METRICS_CURL_TIMEOUT" \
-        "$url" > "$tmp_file" 2>>"$debug_log" || rc=$?
-
-    if [[ $rc -ne 0 ]]; then
-        echo "  [$(date -u +%H:%M:%S)] curl failed (rc=$rc) for EPP ${pod_name} ${url}" >> "$debug_log"
-    fi
-
-    if [[ -s "$tmp_file" ]]; then
-        cat "$tmp_file" >> "$output_file"
-    else
-        {
-            echo "# Warning: Failed to collect EPP Prometheus metrics from pod $pod_name ($pod_ip)"
-            echo "# Attempted: ${url}"
-        } >> "$output_file"
-    fi
-    echo "" >> "$output_file"
-
-    rm -f "$tmp_file"
-    return 0
-}
-
-# Function to collect metrics snapshot from all pods
+# Collect metrics snapshot from all vLLM and EPP pods
 collect_metrics_snapshot() {
     local namespace="${LLMDBENCH_VLLM_COMMON_NAMESPACE:-default}"
     local timestamp=$(date +%s)
@@ -404,8 +375,9 @@ collect_metrics_snapshot() {
 
         echo "$pod_info" | while read -r pod_name pod_ip; do
             [[ -z "$pod_ip" || -z "$pod_name" ]] && continue
-            local pod_metrics_file="$METRICS_DIR/raw/${pod_name}_${timestamp}_metrics.log"
-            collect_prometheus_metrics_from_pod "$pod_name" "$pod_ip" "$iso_timestamp" "$pod_metrics_file" &
+            _scrape_pod "$pod_name" "$pod_ip" "$iso_timestamp" \
+                "$METRICS_DIR/raw/${pod_name}_${timestamp}_metrics.log" \
+                "$METRICS_PORT" "prometheus_metrics" "$INFERENCE_PORT" &
         done
     fi
 
@@ -419,8 +391,9 @@ collect_metrics_snapshot() {
 
         echo "$epp_info" | while read -r pod_name pod_ip; do
             [[ -z "$pod_ip" || -z "$pod_name" ]] && continue
-            local epp_metrics_file="$METRICS_DIR/raw/${pod_name}_${timestamp}_metrics.log"
-            collect_prometheus_metrics_from_epp_pod "$pod_name" "$pod_ip" "$iso_timestamp" "$epp_metrics_file" &
+            _scrape_pod "$pod_name" "$pod_ip" "$iso_timestamp" \
+                "$METRICS_DIR/raw/${pod_name}_${timestamp}_metrics.log" \
+                "$EPP_METRICS_PORT" "epp_prometheus_metrics" &
         done
     fi
 
@@ -428,7 +401,11 @@ collect_metrics_snapshot() {
     wait
 }
 
-# Function to start continuous collection in background
+# ---------------------------------------------------------------------------
+# Collection lifecycle
+# ---------------------------------------------------------------------------
+
+# Start continuous collection in background
 start_continuous_collection() {
     local duration="${1:-0}"  # 0 means run until stopped
 
@@ -466,7 +443,7 @@ start_continuous_collection() {
     rm -f "$METRICS_DIR/collector.pid"
 }
 
-# Function to stop continuous collection
+# Stop continuous collection
 stop_continuous_collection() {
     if [[ -f "$METRICS_DIR/collector.pid" ]]; then
         local pid=$(cat "$METRICS_DIR/collector.pid")
@@ -478,15 +455,10 @@ stop_continuous_collection() {
     fi
 }
 
-# Function to parse and aggregate collected logs
+# Parse and aggregate collected logs
 process_collected_metrics() {
     echo "Processing collected logs..."
-
-    # Get the directory where this script is located
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-    # Pass METRICS_DIR explicitly: it is a shell variable (not exported), so the
-    # subprocess would otherwise fall back to the relative default 'metrics'.
     METRICS_DIR="$METRICS_DIR" python3 "${SCRIPT_DIR}/process_metrics.py"
 }
 

--- a/workload/harnesses/collect_metrics.sh
+++ b/workload/harnesses/collect_metrics.sh
@@ -16,6 +16,7 @@ METRICS_PORT="${LLMDBENCH_VLLM_COMMON_METRICS_PORT:-${LLMDBENCH_VLLM_COMMON_INFE
 INFERENCE_PORT="${LLMDBENCH_VLLM_COMMON_INFERENCE_PORT:-8000}"
 METRICS_PATH="${LLMDBENCH_VLLM_MONITORING_METRICS_PATH:-/metrics}"
 METRICS_CURL_TIMEOUT="${METRICS_CURL_TIMEOUT:-30}"  # max-time for curl in seconds
+EPP_METRICS_PORT="${LLMDBENCH_EPP_METRICS_PORT:-9090}"  # EPP Prometheus metrics port
 
 # Function to initialize metrics directory
 init_metrics_dir() {
@@ -66,15 +67,49 @@ get_pod_info() {
     echo "$pod_info"
 }
 
+# Function to get EPP (inference scheduler) pod names and IPs.
+# Discovers pods via the inferencepool label used by llm-d.
+# Output: lines of "pod_name pod_ip" pairs.
+get_epp_pod_info() {
+    local namespace="$1"
+    local kubectl_cmd="${KUBECTL_CMD:-kubectl}"
+
+    # EPP pods are labeled with inferencepool=<name>
+    local pod_info
+    pod_info=$($kubectl_cmd --namespace "$namespace" get pods \
+        -l inferencepool \
+        --field-selector=status.phase=Running \
+        -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.podIP}{"\n"}{end}' 2>/dev/null || true)
+
+    # Fallback: match pods with "epp" in the name
+    if [[ -z "$pod_info" ]]; then
+        local pod_names
+        pod_names=$($kubectl_cmd get pods -n "$namespace" 2>/dev/null | grep -i "epp" | grep "Running" | awk '{print $1}')
+        if [[ -n "$pod_names" ]]; then
+            for pod in $pod_names; do
+                local ip
+                ip=$($kubectl_cmd get pod -n "$namespace" "$pod" -o jsonpath='{.status.podIP}' 2>/dev/null || true)
+                if [[ -n "$ip" ]]; then
+                    pod_info="${pod_info:+${pod_info}$'\n'}${pod} ${ip}"
+                fi
+            done
+        fi
+    fi
+
+    echo "$pod_info"
+}
+
 # Function to collect replica status (desired vs ready vs available) for all
 # vLLM-related Deployments and StatefulSets in the namespace.
 # Queries all controllers, then filters by pod-template label
 # llm-d.ai/inferenceServing=true so both modelservice and standalone are captured.
-# Writes a one-time snapshot to $METRICS_DIR/processed/replica_status.json.
+# Writes the latest snapshot to $METRICS_DIR/processed/replica_status.json
+# and appends to $METRICS_DIR/processed/replica_status_timeseries.json.
 collect_replica_status() {
     local namespace="${LLMDBENCH_VLLM_COMMON_NAMESPACE:-default}"
     local kubectl_cmd="${KUBECTL_CMD:-kubectl}"
     local output_file="$METRICS_DIR/processed/replica_status.json"
+    local timeseries_file="$METRICS_DIR/processed/replica_status_timeseries.json"
     local debug_log="$METRICS_DIR/raw/collection_debug.log"
 
     mkdir -p "$METRICS_DIR/processed" "$METRICS_DIR/raw"
@@ -82,15 +117,16 @@ collect_replica_status() {
     local all_json
     all_json=$($kubectl_cmd --namespace "$namespace" get deployments,statefulsets -o json 2>>"$debug_log") || all_json='{"items":[]}'
 
-    echo "$all_json" | _RS_NAMESPACE="$namespace" _RS_OUTPUT="$output_file" python3 -c '
+    echo "$all_json" | _RS_NAMESPACE="$namespace" _RS_OUTPUT="$output_file" _RS_TS_OUTPUT="$timeseries_file" python3 -c '
 import json, sys, os
 from datetime import datetime, timezone
 
 namespace = os.environ["_RS_NAMESPACE"]
 output_file = os.environ["_RS_OUTPUT"]
+ts_file = os.environ["_RS_TS_OUTPUT"]
 
 data = json.load(sys.stdin)
-result = {
+snapshot = {
     "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     "namespace": namespace,
     "controllers": [],
@@ -108,7 +144,7 @@ for item in data.get("items", []):
     if tmpl_labels.get("llm-d.ai/inferenceServing") != "true":
         continue
 
-    result["controllers"].append({
+    snapshot["controllers"].append({
         "name": metadata.get("name", ""),
         "kind": kind,
         "model": tmpl_labels.get("llm-d.ai/model", tmpl_labels.get("app", "")),
@@ -119,10 +155,23 @@ for item in data.get("items", []):
         "updated_replicas": status.get("updatedReplicas", 0),
     })
 
+# Write latest snapshot (backward compatible)
 with open(output_file, "w") as f:
-    json.dump(result, f, indent=2)
+    json.dump(snapshot, f, indent=2)
 
-print("Replica status: %d controller(s) written to %s" % (len(result["controllers"]), output_file))
+# Append to time series
+ts_data = {"snapshots": []}
+if os.path.exists(ts_file):
+    try:
+        with open(ts_file) as f:
+            ts_data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        ts_data = {"snapshots": []}
+ts_data["snapshots"].append(snapshot)
+with open(ts_file, "w") as f:
+    json.dump(ts_data, f, indent=2)
+
+print("Replica status: %d controller(s), %d snapshots total" % (len(snapshot["controllers"]), len(ts_data["snapshots"])))
 ' 2>>"$debug_log"
     if [[ $? -ne 0 ]]; then
         echo "Warning: Failed to collect replica status (see $debug_log)" >&2
@@ -132,7 +181,9 @@ print("Replica status: %d controller(s) written to %s" % (len(result["controller
 # Function to collect pod startup times (creation to Ready) for all vLLM pods.
 # Uses the same label-based discovery as get_pod_info(), then extracts
 # creationTimestamp, conditions[Ready].lastTransitionTime, and spec.nodeName.
-# Writes a one-time snapshot to $METRICS_DIR/processed/pod_startup_times.json.
+# Called every collection interval to detect newly-scaled pods.
+# Incrementally appends new pods (not seen before) to
+# $METRICS_DIR/processed/pod_startup_times.json.
 collect_pod_startup_times() {
     local namespace="${LLMDBENCH_VLLM_COMMON_NAMESPACE:-default}"
     local kubectl_cmd="${KUBECTL_CMD:-kubectl}"
@@ -164,13 +215,25 @@ from datetime import datetime, timezone
 output_file = os.environ["_ST_OUTPUT"]
 
 data = json.load(sys.stdin)
-result = {
-    "collected_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "pods": [],
-}
+
+# Load existing data to detect only new pods
+existing = {"collected_at": "", "pods": []}
+if os.path.exists(output_file):
+    try:
+        with open(output_file) as f:
+            existing = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        pass
+
+seen_names = {p["name"] for p in existing.get("pods", [])}
+new_count = 0
 
 for item in data.get("items", []):
     metadata = item.get("metadata", {})
+    pod_name = metadata.get("name", "")
+    if pod_name in seen_names:
+        continue
+
     spec = item.get("spec", {})
     status = item.get("status", {})
     labels = metadata.get("labels", {})
@@ -192,8 +255,8 @@ for item in data.get("items", []):
         except (ValueError, TypeError):
             pass
 
-    result["pods"].append({
-        "name": metadata.get("name", ""),
+    existing["pods"].append({
+        "name": pod_name,
         "node": spec.get("nodeName", ""),
         "model": labels.get("llm-d.ai/model", labels.get("app", "")),
         "role": labels.get("llm-d.ai/role", "unknown"),
@@ -201,11 +264,15 @@ for item in data.get("items", []):
         "ready_timestamp": ready_ts,
         "startup_seconds": startup_seconds,
     })
+    new_count += 1
+
+existing["collected_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 with open(output_file, "w") as f:
-    json.dump(result, f, indent=2)
+    json.dump(existing, f, indent=2)
 
-print("Pod startup times: %d pod(s) written to %s" % (len(result["pods"]), output_file))
+if new_count > 0:
+    print("Pod startup times: %d new pod(s) detected (%d total)" % (new_count, len(existing["pods"])))
 ' 2>>"$debug_log"
     if [[ $? -ne 0 ]]; then
         echo "Warning: Failed to collect pod startup times (see $debug_log)" >&2
@@ -274,6 +341,48 @@ collect_prometheus_metrics_from_pod() {
     return 0
 }
 
+# Function to collect Prometheus metrics from an EPP pod.
+# EPP exposes metrics on a different port (default 9090) than vLLM.
+collect_prometheus_metrics_from_epp_pod() {
+    local pod_name="$1"
+    local pod_ip="$2"
+    local timestamp="$3"
+    local output_file="$4"
+    local debug_log="$METRICS_DIR/raw/collection_debug.log"
+    local tmp_file="${output_file}.tmp"
+
+    # Write header
+    {
+        echo "# Timestamp: $timestamp"
+        echo "# Pod: $pod_name"
+        echo "# PodIP: $pod_ip"
+        echo "# Source: epp_prometheus_metrics"
+        echo ""
+    } > "$output_file"
+
+    local url="http://${pod_ip}:${EPP_METRICS_PORT}/metrics"
+    local rc=0
+    curl -sS --connect-timeout 5 --max-time "$METRICS_CURL_TIMEOUT" \
+        "$url" > "$tmp_file" 2>>"$debug_log" || rc=$?
+
+    if [[ $rc -ne 0 ]]; then
+        echo "  [$(date -u +%H:%M:%S)] curl failed (rc=$rc) for EPP ${pod_name} ${url}" >> "$debug_log"
+    fi
+
+    if [[ -s "$tmp_file" ]]; then
+        cat "$tmp_file" >> "$output_file"
+    else
+        {
+            echo "# Warning: Failed to collect EPP Prometheus metrics from pod $pod_name ($pod_ip)"
+            echo "# Attempted: ${url}"
+        } >> "$output_file"
+    fi
+    echo "" >> "$output_file"
+
+    rm -f "$tmp_file"
+    return 0
+}
+
 # Function to collect metrics snapshot from all pods
 collect_metrics_snapshot() {
     local namespace="${LLMDBENCH_VLLM_COMMON_NAMESPACE:-default}"
@@ -283,26 +392,37 @@ collect_metrics_snapshot() {
     echo "Collecting metrics at $iso_timestamp"
     echo "Namespace: $namespace"
 
+    # Collect vLLM pod metrics
     local pod_info
     pod_info=$(get_pod_info "$namespace")
 
     if [[ -z "$pod_info" ]]; then
-        echo "Warning: No running pods found in namespace $namespace" >&2
-        return 1
+        echo "Warning: No running vLLM pods found in namespace $namespace" >&2
+    else
+        echo "Found vLLM pods:"
+        echo "$pod_info"
+
+        echo "$pod_info" | while read -r pod_name pod_ip; do
+            [[ -z "$pod_ip" || -z "$pod_name" ]] && continue
+            local pod_metrics_file="$METRICS_DIR/raw/${pod_name}_${timestamp}_metrics.log"
+            collect_prometheus_metrics_from_pod "$pod_name" "$pod_ip" "$iso_timestamp" "$pod_metrics_file" &
+        done
     fi
 
-    echo "Found pods:"
-    echo "$pod_info"
+    # Collect EPP pod metrics
+    local epp_info
+    epp_info=$(get_epp_pod_info "$namespace")
 
-    # Collect from each pod in parallel, curling pod IPs directly
-    local pids=""
-    echo "$pod_info" | while read -r pod_name pod_ip; do
-        [[ -z "$pod_ip" || -z "$pod_name" ]] && continue
-        local pod_metrics_file="$METRICS_DIR/raw/${pod_name}_${timestamp}_metrics.log"
+    if [[ -n "$epp_info" ]]; then
+        echo "Found EPP pods:"
+        echo "$epp_info"
 
-        collect_prometheus_metrics_from_pod "$pod_name" "$pod_ip" "$iso_timestamp" "$pod_metrics_file" &
-        pids="$pids $!"
-    done
+        echo "$epp_info" | while read -r pod_name pod_ip; do
+            [[ -z "$pod_ip" || -z "$pod_name" ]] && continue
+            local epp_metrics_file="$METRICS_DIR/raw/${pod_name}_${timestamp}_metrics.log"
+            collect_prometheus_metrics_from_epp_pod "$pod_name" "$pod_ip" "$iso_timestamp" "$epp_metrics_file" &
+        done
+    fi
 
     # Wait for all background collections to finish
     wait
@@ -314,10 +434,6 @@ start_continuous_collection() {
 
     init_metrics_dir
 
-    # Collect one-time infrastructure snapshots
-    collect_replica_status
-    collect_pod_startup_times
-
     echo "Starting continuous metrics collection (interval: ${COLLECTION_INTERVAL}s)"
     echo $$ > "$METRICS_DIR/collector.pid"
 
@@ -325,6 +441,11 @@ start_continuous_collection() {
     local iterations=0
 
     while true; do
+        # Collect infrastructure state every iteration to track autoscaling
+        collect_replica_status
+        collect_pod_startup_times
+
+        # Collect Prometheus metrics from all pods
         collect_metrics_snapshot
         iterations=$((iterations + 1))
 
@@ -379,9 +500,9 @@ case "${1:-}" in
         ;;
     snapshot)
         init_metrics_dir
+        collect_metrics_snapshot
         collect_replica_status
         collect_pod_startup_times
-        collect_metrics_snapshot
         ;;
     process)
         process_collected_metrics

--- a/workload/harnesses/process_metrics.py
+++ b/workload/harnesses/process_metrics.py
@@ -191,6 +191,44 @@ def aggregate_metrics():
                     'unit': get_metric_unit(metric_name)
                 }
 
+    # Aggregate selected metrics across all pods
+    AGGREGATE_METRICS = {
+        'vllm:kv_cache_usage_perc', 'vllm:num_requests_running',
+        'vllm:num_requests_waiting', 'vllm:num_preemptions_total',
+        'vllm:prefix_cache_hit_rate', 'vllm:external_prefix_cache_hit_rate',
+        # EPP pool-level gauges (already aggregated by EPP across endpoints)
+        'inference_pool_average_kv_cache_utilization',
+        'inference_pool_average_queue_size',
+        'inference_pool_average_running_requests',
+        'inference_pool_ready_pods',
+    }
+    aggregated_values = defaultdict(list)
+    for pod_name, metrics in pod_metrics.items():
+        for metric_name, values in metrics.items():
+            if metric_name in AGGREGATE_METRICS and values:
+                aggregated_values[metric_name].extend(values)
+
+    if aggregated_values:
+        agg_metrics = {}
+        for metric_name, values in aggregated_values.items():
+            sorted_vals = sorted(values)
+            agg_metrics[metric_name] = {
+                'mean': statistics.mean(values),
+                'stddev': statistics.stdev(values) if len(values) > 1 else 0,
+                'min': min(values),
+                'p25': percentile(sorted_vals, 25),
+                'p50': percentile(sorted_vals, 50),
+                'p75': percentile(sorted_vals, 75),
+                'p90': percentile(sorted_vals, 90),
+                'p95': percentile(sorted_vals, 95),
+                'p99': percentile(sorted_vals, 99),
+                'max': max(values),
+                'count': len(values),
+                'unit': get_metric_unit(metric_name),
+            }
+        results['_aggregated'] = {'metrics': agg_metrics}
+        print(f"Aggregated {len(agg_metrics)} metrics across all pods")
+
     # Save aggregated results
     output_file = os.path.join(processed_dir, 'metrics_summary.json')
     with open(output_file, 'w') as f:
@@ -236,9 +274,117 @@ def get_metric_unit(metric_name):
         # Computed ratio metrics
         'vllm:prefix_cache_hit_rate': '%',
         'vllm:external_prefix_cache_hit_rate': '%',
+        # EPP (inference scheduler) Prometheus metrics
+        'inference_pool_average_kv_cache_utilization': '%',
+        'inference_pool_average_queue_size': 'count',
+        'inference_pool_average_running_requests': 'count',
+        'inference_pool_ready_pods': 'count',
+        'inference_extension_scheduler_e2e_duration_seconds_bucket': 'seconds',
+        'inference_extension_scheduler_e2e_duration_seconds_sum': 'seconds',
+        'inference_extension_scheduler_e2e_duration_seconds_count': 'count',
+        'inference_extension_plugin_duration_seconds_bucket': 'seconds',
+        'inference_extension_plugin_duration_seconds_sum': 'seconds',
+        'inference_extension_plugin_duration_seconds_count': 'count',
+        'inference_extension_request_duration_seconds_bucket': 'seconds',
+        'inference_extension_request_duration_seconds_sum': 'seconds',
+        'inference_extension_request_duration_seconds_count': 'count',
+        'inference_extension_request_ttft_duration_seconds_bucket': 'seconds',
+        'inference_extension_request_ttft_duration_seconds_sum': 'seconds',
+        'inference_extension_request_ttft_duration_seconds_count': 'count',
+        'inference_extension_input_tokens_bucket': 'tokens',
+        'inference_extension_output_tokens_bucket': 'tokens',
+        'inference_extension_normalized_time_per_output_token_bucket': 'seconds',
+        'inference_extension_prefix_indexer_hit_ratio_bucket': 'ratio',
+        'inference_extension_prefix_indexer_size': 'count',
+        'llm_d_inference_scheduler_pd_decision_total': 'count',
+        'llm_d_inference_scheduler_disagg_decision_total': 'count',
     }
     return units.get(metric_name, '')
 
 
+def aggregate_pod_startup_stats():
+    """Compute aggregate statistics for pod startup times."""
+    startup_file = os.path.join(processed_dir, 'pod_startup_times.json')
+    if not os.path.exists(startup_file):
+        return
+
+    with open(startup_file) as f:
+        data = json.load(f)
+
+    values = [
+        p['startup_seconds'] for p in data.get('pods', [])
+        if isinstance(p.get('startup_seconds'), (int, float))
+    ]
+    if not values:
+        return
+
+    sorted_vals = sorted(values)
+    data['aggregate'] = {
+        'units': 's',
+        'mean': statistics.mean(values),
+        'stddev': statistics.stdev(values) if len(values) > 1 else 0,
+        'min': min(values),
+        'p50': percentile(sorted_vals, 50),
+        'p90': percentile(sorted_vals, 90),
+        'p99': percentile(sorted_vals, 99),
+        'max': max(values),
+    }
+
+    with open(startup_file, 'w') as f:
+        json.dump(data, f, indent=2)
+
+    print(f"Pod startup stats: {len(values)} pods, "
+          f"mean={data['aggregate']['mean']:.1f}s")
+
+
+def aggregate_replica_stats():
+    """Compute aggregate statistics from replica status time series."""
+    ts_file = os.path.join(processed_dir, 'replica_status_timeseries.json')
+    status_file = os.path.join(processed_dir, 'replica_status.json')
+    if not os.path.exists(ts_file):
+        return
+
+    with open(ts_file) as f:
+        ts_data = json.load(f)
+
+    snapshots = ts_data.get('snapshots', [])
+    if not snapshots:
+        return
+
+    # Compute total ready replicas per snapshot
+    ready_counts = []
+    for snap in snapshots:
+        total_ready = sum(
+            c.get('ready_replicas', 0) for c in snap.get('controllers', [])
+        )
+        ready_counts.append(total_ready)
+
+    sorted_vals = sorted(ready_counts)
+    aggregate = {
+        'units': 'count',
+        'mean': statistics.mean(ready_counts),
+        'stddev': statistics.stdev(ready_counts) if len(ready_counts) > 1 else 0,
+        'min': min(ready_counts),
+        'p50': percentile(sorted_vals, 50),
+        'p90': percentile(sorted_vals, 90),
+        'p99': percentile(sorted_vals, 99),
+        'max': max(ready_counts),
+    }
+
+    # Write aggregate into the latest snapshot file for report integration
+    if os.path.exists(status_file):
+        with open(status_file) as f:
+            status_data = json.load(f)
+        status_data['aggregate_ready_replicas'] = aggregate
+        with open(status_file, 'w') as f:
+            json.dump(status_data, f, indent=2)
+
+    print(f"Replica stats: {len(snapshots)} snapshots, "
+          f"ready replicas min={aggregate['min']} max={aggregate['max']} "
+          f"mean={aggregate['mean']:.1f}")
+
+
 if __name__ == '__main__':
     aggregate_metrics()
+    aggregate_pod_startup_stats()
+    aggregate_replica_stats()

--- a/workload/harnesses/process_metrics.py
+++ b/workload/harnesses/process_metrics.py
@@ -19,6 +19,149 @@ metrics_dir = os.environ.get('METRICS_DIR', 'metrics')
 raw_dir = os.path.join(metrics_dir, 'raw')
 processed_dir = os.path.join(metrics_dir, 'processed')
 
+# Metrics to aggregate across all pods for cluster-wide stats
+AGGREGATE_METRICS = {
+    'vllm:kv_cache_usage_perc', 'vllm:num_requests_running',
+    'vllm:num_requests_waiting', 'vllm:num_preemptions_total',
+    'vllm:prefix_cache_hit_rate', 'vllm:external_prefix_cache_hit_rate',
+    # EPP pool-level gauges (already aggregated by EPP across endpoints)
+    'inference_pool_average_kv_cache_utilization',
+    'inference_pool_average_queue_size',
+    'inference_pool_average_running_requests',
+    'inference_pool_ready_pods',
+}
+
+# Ratio metrics: (output_name, numerator_metric, denominator_metric)
+RATIO_METRICS = [
+    ('vllm:prefix_cache_hit_rate',
+     'vllm:prefix_cache_hits_total', 'vllm:prefix_cache_queries_total'),
+    ('vllm:external_prefix_cache_hit_rate',
+     'vllm:external_prefix_cache_hits_total',
+     'vllm:external_prefix_cache_queries_total'),
+]
+
+# Metric name -> unit mapping
+METRIC_UNITS = {
+    # Cache metrics
+    'vllm:kv_cache_usage_perc': '%',
+    'vllm:gpu_cache_usage_perc': '%',
+    'vllm:cpu_cache_usage_perc': '%',
+    'vllm:prefix_cache_hits_total': 'tokens',
+    'vllm:prefix_cache_queries_total': 'tokens',
+    'vllm:external_prefix_cache_hits_total': 'tokens',
+    'vllm:external_prefix_cache_queries_total': 'tokens',
+    # Memory metrics
+    'vllm:gpu_memory_usage_bytes': 'bytes',
+    'DCGM_FI_DEV_FB_USED': 'bytes',
+    'vllm:cpu_memory_usage_bytes': 'bytes',
+    'container_memory_usage_bytes': 'bytes',
+    # Compute metrics
+    'DCGM_FI_DEV_GPU_UTIL': '%',
+    'container_cpu_usage_seconds_total': 'seconds',
+    # Performance metrics
+    'DCGM_FI_DEV_POWER_USAGE': 'watts',
+    # NIXL KV transfer metrics
+    'vllm:nixl_xfer_time_seconds_sum': 'seconds',
+    'vllm:nixl_xfer_time_seconds_count': 'count',
+    'vllm:nixl_bytes_transferred_sum': 'bytes',
+    'vllm:nixl_bytes_transferred_count': 'count',
+    # Preemption metrics
+    'vllm:num_preemptions_total': 'count',
+    # Queue metrics
+    'vllm:num_requests_running': 'count',
+    'vllm:num_requests_waiting': 'count',
+    'vllm:num_requests_swapped': 'count',
+    # Computed ratio metrics
+    'vllm:prefix_cache_hit_rate': '%',
+    'vllm:external_prefix_cache_hit_rate': '%',
+    # EPP (inference scheduler) Prometheus metrics
+    'inference_pool_average_kv_cache_utilization': '%',
+    'inference_pool_average_queue_size': 'count',
+    'inference_pool_average_running_requests': 'count',
+    'inference_pool_ready_pods': 'count',
+    'inference_extension_scheduler_e2e_duration_seconds_bucket': 'seconds',
+    'inference_extension_scheduler_e2e_duration_seconds_sum': 'seconds',
+    'inference_extension_scheduler_e2e_duration_seconds_count': 'count',
+    'inference_extension_plugin_duration_seconds_bucket': 'seconds',
+    'inference_extension_plugin_duration_seconds_sum': 'seconds',
+    'inference_extension_plugin_duration_seconds_count': 'count',
+    'inference_extension_request_duration_seconds_bucket': 'seconds',
+    'inference_extension_request_duration_seconds_sum': 'seconds',
+    'inference_extension_request_duration_seconds_count': 'count',
+    'inference_extension_request_ttft_duration_seconds_bucket': 'seconds',
+    'inference_extension_request_ttft_duration_seconds_sum': 'seconds',
+    'inference_extension_request_ttft_duration_seconds_count': 'count',
+    'inference_extension_input_tokens_bucket': 'tokens',
+    'inference_extension_output_tokens_bucket': 'tokens',
+    'inference_extension_normalized_time_per_output_token_bucket': 'seconds',
+    'inference_extension_prefix_indexer_hit_ratio_bucket': 'ratio',
+    'inference_extension_prefix_indexer_size': 'count',
+    'llm_d_inference_scheduler_pd_decision_total': 'count',
+    'llm_d_inference_scheduler_disagg_decision_total': 'count',
+}
+
+# Byte-unit conversions applied during parsing
+_BYTE_CONVERSIONS = {
+    'container_memory_usage_bytes': (1024**3, '_bytes', '_gb'),
+    'container_memory_working_set_bytes': (1024**3, '_bytes', '_gb'),
+    'container_network_receive_bytes_total': (1024**2, '_bytes_total', '_mb_total'),
+    'container_network_transmit_bytes_total': (1024**2, '_bytes_total', '_mb_total'),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_json(filepath):
+    """Load a JSON file, returning {} if it doesn't exist."""
+    if not os.path.exists(filepath):
+        return {}
+    with open(filepath, 'r') as f:
+        return json.load(f)
+
+
+def _save_json(filepath, data):
+    """Save data to a JSON file."""
+    with open(filepath, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def percentile(sorted_values, p):
+    """Calculate the p-th percentile from a sorted list using linear interpolation."""
+    n = len(sorted_values)
+    if n == 0:
+        return None
+    if n == 1:
+        return sorted_values[0]
+    k = (n - 1) * p / 100.0
+    f = int(k)
+    c = min(f + 1, n - 1)
+    return sorted_values[f] + (k - f) * (sorted_values[c] - sorted_values[f])
+
+
+def _compute_stats(values, unit=''):
+    """Compute statistics dict from a list of numeric values."""
+    sorted_vals = sorted(values)
+    return {
+        'mean': statistics.mean(values),
+        'stddev': statistics.stdev(values) if len(values) > 1 else 0,
+        'min': min(values),
+        'p25': percentile(sorted_vals, 25),
+        'p50': percentile(sorted_vals, 50),
+        'p75': percentile(sorted_vals, 75),
+        'p90': percentile(sorted_vals, 90),
+        'p95': percentile(sorted_vals, 95),
+        'p99': percentile(sorted_vals, 99),
+        'max': max(values),
+        'count': len(values),
+        'unit': unit,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
 
 def parse_prometheus_metrics(file_path):
     """Parse Prometheus metrics from a file."""
@@ -26,7 +169,6 @@ def parse_prometheus_metrics(file_path):
     timestamp = None
     pod_name = None
     namespace = None
-    source = None
 
     with open(file_path, 'r') as f:
         for line in f:
@@ -39,74 +181,42 @@ def parse_prometheus_metrics(file_path):
                 pod_name = line.split(':', 1)[1].strip()
             elif line.startswith('# Namespace:'):
                 namespace = line.split(':', 1)[1].strip()
-            elif line.startswith('# Source:'):
-                source = line.split(':', 1)[1].strip()
 
-            # Skip other comments and empty lines
+            # Skip comments and empty lines
             if line.startswith('#') or not line:
                 continue
 
-            # Parse Prometheus metric line: metric_name{labels} value timestamp
-            # Example: vllm:kv_cache_usage_perc 45.2
-            # Or cluster metrics: container_memory_usage_bytes{...} 1234567890 1234567890
             match = re.match(
                 r'([a-zA-Z_:][a-zA-Z0-9_:]*(?:\{[^}]*\})?) ([\d.eE+-]+)(?:\s+\d+)?', line)
             if match:
-                metric_name = match.group(1)
+                base_name = match.group(1).split('{')[0]
                 value = float(match.group(2))
 
-                # Extract base metric name (without labels)
-                base_name = metric_name.split('{')[0]
-
-                # For cluster metrics, convert bytes to GB for readability
-                if base_name in ['container_memory_usage_bytes', 'container_memory_working_set_bytes']:
-                    value = value / (1024**3)  # Convert to GB
-                    base_name = base_name.replace('_bytes', '_gb')
-                elif base_name in ['container_network_receive_bytes_total', 'container_network_transmit_bytes_total']:
-                    value = value / (1024**2)  # Convert to MB
-                    base_name = base_name.replace('_bytes_total', '_mb_total')
+                # Apply byte-unit conversions
+                if base_name in _BYTE_CONVERSIONS:
+                    divisor, old_suffix, new_suffix = _BYTE_CONVERSIONS[base_name]
+                    value = value / divisor
+                    base_name = base_name.replace(old_suffix, new_suffix)
 
                 metrics[base_name].append(value)
 
     return timestamp, pod_name, namespace, dict(metrics)
 
 
-def percentile(sorted_values, p):
-    """Calculate the p-th percentile from a sorted list using linear interpolation.
-
-    Args:
-        sorted_values: Sorted list of numeric values
-        p: Percentile (0-100)
-
-    Returns:
-        Interpolated percentile value
-    """
-    n = len(sorted_values)
-    if n == 0:
-        return None
-    if n == 1:
-        return sorted_values[0]
-    k = (n - 1) * p / 100.0
-    f = int(k)
-    c = f + 1
-    if c >= n:
-        return sorted_values[f]
-    return sorted_values[f] + (k - f) * (sorted_values[c] - sorted_values[f])
-
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
 
 def aggregate_metrics():
     """Aggregate metrics from all collected files."""
-    # Structure: {pod_name: {metric_name: [values]}}
     pod_metrics = defaultdict(lambda: defaultdict(list))
     pod_metadata = {}
 
-    # Process all raw metric files
     all_files = glob.glob(os.path.join(raw_dir, '*_metrics.log'))
 
     if not all_files:
         print("Warning: No raw files found to process")
         print(f"Checked directory: {raw_dir}")
-        # Create an informative empty result
         results = {
             '_info': {
                 'status': 'no_data',
@@ -120,10 +230,8 @@ def aggregate_metrics():
                 ]
             }
         }
-        output_file = os.path.join(processed_dir, 'metrics_summary.json')
-        with open(output_file, 'w') as f:
-            json.dump(results, f, indent=2)
-        print(f"Empty metrics summary saved to: {output_file}")
+        _save_json(os.path.join(processed_dir, 'metrics_summary.json'), results)
+        print(f"Empty metrics summary saved")
         return results
 
     print(f"Processing {len(all_files)} files...")
@@ -140,176 +248,58 @@ def aggregate_metrics():
             for metric_name, values in metrics.items():
                 pod_metrics[pod_name][metric_name].extend(values)
 
-    # Compute ratio metrics per-file before aggregation
-    # Structure: {pod_name: {ratio_metric_name: [per-file ratio values]}}
-    ratio_definitions = [
-        ('vllm:prefix_cache_hit_rate', 'vllm:prefix_cache_hits_total',
-         'vllm:prefix_cache_queries_total'),
-        ('vllm:external_prefix_cache_hit_rate',
-         'vllm:external_prefix_cache_hits_total',
-         'vllm:external_prefix_cache_queries_total'),
-    ]
+    # Compute ratio metrics per-pod before aggregation
     for pod_name, metrics in pod_metrics.items():
-        for ratio_name, num_metric, den_metric in ratio_definitions:
+        for ratio_name, num_metric, den_metric in RATIO_METRICS:
             if num_metric in metrics and den_metric in metrics:
                 num_vals = metrics[num_metric]
                 den_vals = metrics[den_metric]
-                # Values are collected in file order; pair by index
-                ratio_vals = []
-                for i in range(min(len(num_vals), len(den_vals))):
-                    if den_vals[i] > 0:
-                        ratio_vals.append(
-                            num_vals[i] / den_vals[i] * 100)
-                    else:
-                        ratio_vals.append(0.0)
+                ratio_vals = [
+                    (num_vals[i] / den_vals[i] * 100) if den_vals[i] > 0 else 0.0
+                    for i in range(min(len(num_vals), len(den_vals)))
+                ]
                 if ratio_vals:
                     metrics[ratio_name] = ratio_vals
 
-    # Calculate statistics for each metric
+    # Per-pod statistics
     results = {}
     for pod_name, metrics in pod_metrics.items():
         results[pod_name] = {
             'metadata': pod_metadata.get(pod_name, {}),
-            'metrics': {}
+            'metrics': {
+                name: _compute_stats(values, METRIC_UNITS.get(name, ''))
+                for name, values in metrics.items()
+                if values
+            }
         }
 
-        for metric_name, values in metrics.items():
-            if values:
-                sorted_vals = sorted(values)
-                results[pod_name]['metrics'][metric_name] = {
-                    'mean': statistics.mean(values),
-                    'stddev': statistics.stdev(values) if len(values) > 1 else 0,
-                    'min': min(values),
-                    'p25': percentile(sorted_vals, 25),
-                    'p50': percentile(sorted_vals, 50),
-                    'p75': percentile(sorted_vals, 75),
-                    'p90': percentile(sorted_vals, 90),
-                    'p95': percentile(sorted_vals, 95),
-                    'p99': percentile(sorted_vals, 99),
-                    'max': max(values),
-                    'count': len(values),
-                    'unit': get_metric_unit(metric_name)
-                }
-
-    # Aggregate selected metrics across all pods
-    AGGREGATE_METRICS = {
-        'vllm:kv_cache_usage_perc', 'vllm:num_requests_running',
-        'vllm:num_requests_waiting', 'vllm:num_preemptions_total',
-        'vllm:prefix_cache_hit_rate', 'vllm:external_prefix_cache_hit_rate',
-        # EPP pool-level gauges (already aggregated by EPP across endpoints)
-        'inference_pool_average_kv_cache_utilization',
-        'inference_pool_average_queue_size',
-        'inference_pool_average_running_requests',
-        'inference_pool_ready_pods',
-    }
+    # Cluster-wide aggregated statistics
     aggregated_values = defaultdict(list)
-    for pod_name, metrics in pod_metrics.items():
-        for metric_name, values in metrics.items():
-            if metric_name in AGGREGATE_METRICS and values:
-                aggregated_values[metric_name].extend(values)
+    for metrics in pod_metrics.values():
+        for name, values in metrics.items():
+            if name in AGGREGATE_METRICS and values:
+                aggregated_values[name].extend(values)
 
     if aggregated_values:
-        agg_metrics = {}
-        for metric_name, values in aggregated_values.items():
-            sorted_vals = sorted(values)
-            agg_metrics[metric_name] = {
-                'mean': statistics.mean(values),
-                'stddev': statistics.stdev(values) if len(values) > 1 else 0,
-                'min': min(values),
-                'p25': percentile(sorted_vals, 25),
-                'p50': percentile(sorted_vals, 50),
-                'p75': percentile(sorted_vals, 75),
-                'p90': percentile(sorted_vals, 90),
-                'p95': percentile(sorted_vals, 95),
-                'p99': percentile(sorted_vals, 99),
-                'max': max(values),
-                'count': len(values),
-                'unit': get_metric_unit(metric_name),
+        results['_aggregated'] = {
+            'metrics': {
+                name: _compute_stats(values, METRIC_UNITS.get(name, ''))
+                for name, values in aggregated_values.items()
             }
-        results['_aggregated'] = {'metrics': agg_metrics}
-        print(f"Aggregated {len(agg_metrics)} metrics across all pods")
+        }
+        print(f"Aggregated {len(aggregated_values)} metrics across all pods")
 
-    # Save aggregated results
     output_file = os.path.join(processed_dir, 'metrics_summary.json')
-    with open(output_file, 'w') as f:
-        json.dump(results, f, indent=2)
-
+    _save_json(output_file, results)
     print(f"Metrics summary saved to: {output_file}")
     print(f"Processed metrics from {len(results)} pods")
     return results
 
 
-def get_metric_unit(metric_name):
-    """Get the unit for a metric."""
-    units = {
-        # Cache metrics
-        'vllm:kv_cache_usage_perc': '%',
-        'vllm:gpu_cache_usage_perc': '%',
-        'vllm:cpu_cache_usage_perc': '%',
-        'vllm:prefix_cache_hits_total': 'tokens',
-        'vllm:prefix_cache_queries_total': 'tokens',
-        'vllm:external_prefix_cache_hits_total': 'tokens',
-        'vllm:external_prefix_cache_queries_total': 'tokens',
-        # Memory metrics
-        'vllm:gpu_memory_usage_bytes': 'bytes',
-        'DCGM_FI_DEV_FB_USED': 'bytes',
-        'vllm:cpu_memory_usage_bytes': 'bytes',
-        'container_memory_usage_bytes': 'bytes',
-        # Compute metrics
-        'DCGM_FI_DEV_GPU_UTIL': '%',
-        'container_cpu_usage_seconds_total': 'seconds',
-        # Performance metrics
-        'DCGM_FI_DEV_POWER_USAGE': 'watts',
-        # NIXL KV transfer metrics
-        'vllm:nixl_xfer_time_seconds_sum': 'seconds',
-        'vllm:nixl_xfer_time_seconds_count': 'count',
-        'vllm:nixl_bytes_transferred_sum': 'bytes',
-        'vllm:nixl_bytes_transferred_count': 'count',
-        # Preemption metrics
-        'vllm:num_preemptions_total': 'count',
-        # Queue metrics
-        'vllm:num_requests_running': 'count',
-        'vllm:num_requests_waiting': 'count',
-        'vllm:num_requests_swapped': 'count',
-        # Computed ratio metrics
-        'vllm:prefix_cache_hit_rate': '%',
-        'vllm:external_prefix_cache_hit_rate': '%',
-        # EPP (inference scheduler) Prometheus metrics
-        'inference_pool_average_kv_cache_utilization': '%',
-        'inference_pool_average_queue_size': 'count',
-        'inference_pool_average_running_requests': 'count',
-        'inference_pool_ready_pods': 'count',
-        'inference_extension_scheduler_e2e_duration_seconds_bucket': 'seconds',
-        'inference_extension_scheduler_e2e_duration_seconds_sum': 'seconds',
-        'inference_extension_scheduler_e2e_duration_seconds_count': 'count',
-        'inference_extension_plugin_duration_seconds_bucket': 'seconds',
-        'inference_extension_plugin_duration_seconds_sum': 'seconds',
-        'inference_extension_plugin_duration_seconds_count': 'count',
-        'inference_extension_request_duration_seconds_bucket': 'seconds',
-        'inference_extension_request_duration_seconds_sum': 'seconds',
-        'inference_extension_request_duration_seconds_count': 'count',
-        'inference_extension_request_ttft_duration_seconds_bucket': 'seconds',
-        'inference_extension_request_ttft_duration_seconds_sum': 'seconds',
-        'inference_extension_request_ttft_duration_seconds_count': 'count',
-        'inference_extension_input_tokens_bucket': 'tokens',
-        'inference_extension_output_tokens_bucket': 'tokens',
-        'inference_extension_normalized_time_per_output_token_bucket': 'seconds',
-        'inference_extension_prefix_indexer_hit_ratio_bucket': 'ratio',
-        'inference_extension_prefix_indexer_size': 'count',
-        'llm_d_inference_scheduler_pd_decision_total': 'count',
-        'llm_d_inference_scheduler_disagg_decision_total': 'count',
-    }
-    return units.get(metric_name, '')
-
-
 def aggregate_pod_startup_stats():
     """Compute aggregate statistics for pod startup times."""
     startup_file = os.path.join(processed_dir, 'pod_startup_times.json')
-    if not os.path.exists(startup_file):
-        return
-
-    with open(startup_file) as f:
-        data = json.load(f)
+    data = _load_json(startup_file)
 
     values = [
         p['startup_seconds'] for p in data.get('pods', [])
@@ -318,70 +308,35 @@ def aggregate_pod_startup_stats():
     if not values:
         return
 
-    sorted_vals = sorted(values)
-    data['aggregate'] = {
-        'units': 's',
-        'mean': statistics.mean(values),
-        'stddev': statistics.stdev(values) if len(values) > 1 else 0,
-        'min': min(values),
-        'p50': percentile(sorted_vals, 50),
-        'p90': percentile(sorted_vals, 90),
-        'p99': percentile(sorted_vals, 99),
-        'max': max(values),
-    }
-
-    with open(startup_file, 'w') as f:
-        json.dump(data, f, indent=2)
-
+    data['aggregate'] = _compute_stats(values, 's')
+    _save_json(startup_file, data)
     print(f"Pod startup stats: {len(values)} pods, "
           f"mean={data['aggregate']['mean']:.1f}s")
 
 
 def aggregate_replica_stats():
     """Compute aggregate statistics from replica status time series."""
-    ts_file = os.path.join(processed_dir, 'replica_status_timeseries.json')
-    status_file = os.path.join(processed_dir, 'replica_status.json')
-    if not os.path.exists(ts_file):
-        return
-
-    with open(ts_file) as f:
-        ts_data = json.load(f)
-
+    ts_data = _load_json(
+        os.path.join(processed_dir, 'replica_status_timeseries.json'))
     snapshots = ts_data.get('snapshots', [])
     if not snapshots:
         return
 
-    # Compute total ready replicas per snapshot
-    ready_counts = []
-    for snap in snapshots:
-        total_ready = sum(
-            c.get('ready_replicas', 0) for c in snap.get('controllers', [])
-        )
-        ready_counts.append(total_ready)
+    ready_counts = [
+        sum(c.get('ready_replicas', 0) for c in snap.get('controllers', []))
+        for snap in snapshots
+    ]
 
-    sorted_vals = sorted(ready_counts)
-    aggregate = {
-        'units': 'count',
-        'mean': statistics.mean(ready_counts),
-        'stddev': statistics.stdev(ready_counts) if len(ready_counts) > 1 else 0,
-        'min': min(ready_counts),
-        'p50': percentile(sorted_vals, 50),
-        'p90': percentile(sorted_vals, 90),
-        'p99': percentile(sorted_vals, 99),
-        'max': max(ready_counts),
-    }
-
-    # Write aggregate into the latest snapshot file for report integration
-    if os.path.exists(status_file):
-        with open(status_file) as f:
-            status_data = json.load(f)
-        status_data['aggregate_ready_replicas'] = aggregate
-        with open(status_file, 'w') as f:
-            json.dump(status_data, f, indent=2)
+    status_file = os.path.join(processed_dir, 'replica_status.json')
+    status_data = _load_json(status_file)
+    if status_data:
+        status_data['aggregate_ready_replicas'] = _compute_stats(
+            ready_counts, 'count')
+        _save_json(status_file, status_data)
 
     print(f"Replica stats: {len(snapshots)} snapshots, "
-          f"ready replicas min={aggregate['min']} max={aggregate['max']} "
-          f"mean={aggregate['mean']:.1f}")
+          f"ready replicas min={min(ready_counts)} max={max(ready_counts)} "
+          f"mean={statistics.mean(ready_counts):.1f}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Address #991 by adding time series for pod startup time and replicas with both stats and graphs.  
Example of benchmark report `v0.2`: 
```yaml
results:
  observability:
    pod_startup_times:
      aggregate:
        count: 5
        max: 64.0
        mean: 63.4
        min: 62.0
        p25: 63.0
        p50: 64.0
        p75: 64.0
        p90: 64.0
        p95: 64.0
        p99: 64.0
        stddev: 0.8944271909999159
        unit: s
      collected_at: '2026-04-23T01:05:32Z'
      graph_path: metrics/graphs/pod_startup_times.png
      pods:
      - creation_timestamp: '2026-04-23T01:02:15Z'
        model: facebook-b12e756d-opt-125m
        name: facebook-b12e756d-opt-125m-decode-bfbb4f646-2ll66
        node: pokprod-b93r44s1
        ready_timestamp: '2026-04-23T01:03:18Z'
        role: decode
        startup_seconds: 63.0
      - creation_timestamp: '2026-04-23T00:58:39Z'
        model: facebook-b12e756d-opt-125m
        name: facebook-b12e756d-opt-125m-decode-bfbb4f646-bd85f
        node: pokprod-b93r43s0
        ready_timestamp: '2026-04-23T00:59:41Z'
        role: decode
        startup_seconds: 62.0
      - creation_timestamp: '2026-04-23T00:58:39Z'
        model: facebook-b12e756d-opt-125m
        name: facebook-b12e756d-opt-125m-decode-bfbb4f646-qzsth
        node: pokprod-b93r38s0
        ready_timestamp: '2026-04-23T00:59:43Z'
        role: decode
        startup_seconds: 64.0
      - creation_timestamp: '2026-04-23T00:58:39Z'
        model: facebook-b12e756d-opt-125m
        name: facebook-b12e756d-opt-125m-prefill-7bc65cd7c5-lc55p
        node: pokprod-b93r43s3
        ready_timestamp: '2026-04-23T00:59:43Z'
        role: prefill
        startup_seconds: 64.0
      - creation_timestamp: '2026-04-23T00:58:39Z'
        model: facebook-b12e756d-opt-125m
        name: facebook-b12e756d-opt-125m-prefill-7bc65cd7c5-pzbtx
        node: pokprod-b93r38s0
        ready_timestamp: '2026-04-23T00:59:43Z'
        role: prefill
        startup_seconds: 64.0
    replica_status:
      aggregate_ready_replicas:
        count: 1
        max: 5
        mean: 5
        min: 5
        p25: 5
        p50: 5
        p75: 5
        p90: 5
        p95: 5
        p99: 5
        stddev: 0
        unit: count
      controllers:
      - available_replicas: 3
        desired_replicas: 3
        kind: Deployment
        model: facebook-b12e756d-opt-125m
        name: facebook-b12e756d-opt-125m-decode
        ready_replicas: 3
        role: decode
        updated_replicas: 3
      - available_replicas: 2
        desired_replicas: 2
        kind: Deployment
        model: facebook-b12e756d-opt-125m
        name: facebook-b12e756d-opt-125m-prefill
        ready_replicas: 2
        role: prefill
        updated_replicas: 2
      graph_path: metrics/graphs/replica_status.png
      namespace: mye
      time_series:
      - controllers:
        - available_replicas: 3
          desired_replicas: 3
          kind: Deployment
          model: facebook-b12e756d-opt-125m
          name: facebook-b12e756d-opt-125m-decode
          ready_replicas: 3
          role: decode
          updated_replicas: 3
        - available_replicas: 2
          desired_replicas: 2
          kind: Deployment
          model: facebook-b12e756d-opt-125m
          name: facebook-b12e756d-opt-125m-prefill
          ready_replicas: 2
          role: prefill
          updated_replicas: 2
        namespace: mye
        timestamp: '2026-04-23T01:05:01Z'
      timestamp: '2026-04-23T01:05:32Z'
```