### PR TITLE
deployment: add chat-template parameter

### DIFF
--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -157,6 +157,12 @@
 {%- if has_enable_prefix_caching %} \
   --enable-prefix-caching
 {%- endif %}
+{%- if vllmCommon.flags.chatTemplate is defined and vllmCommon.flags.chatTemplate %} \
+  --chat-template '{{ vllmCommon.flags.chatTemplate }}'
+{%- endif %}
+{%- if vllmCommon.flags.chatTemplateContentFormat is defined and vllmCommon.flags.chatTemplateContentFormat %} \
+  --chat-template-content-format {{ vllmCommon.flags.chatTemplateContentFormat }}
+{%- endif %}
 {%- if has_kv_transfer %} \
   --kv-transfer-config '{{ build_kv_transfer_config() }}'
 {%- endif %}
@@ -371,6 +377,12 @@
   --disable-uvicorn-access-log
 {%- endif %} \
   --model-loader-extra-config "$LLMDBENCH_VLLM_COMMON_MODEL_LOADER_EXTRA_CONFIG"
+{%- if vllmCommon.flags.chatTemplate is defined and vllmCommon.flags.chatTemplate %} \
+  --chat-template '{{ vllmCommon.flags.chatTemplate }}'
+{%- endif %}
+{%- if vllmCommon.flags.chatTemplateContentFormat is defined and vllmCommon.flags.chatTemplateContentFormat %} \
+  --chat-template-content-format {{ vllmCommon.flags.chatTemplateContentFormat }}
+{%- endif %}
 {%- if has_kv_transfer %} \
   --kv-transfer-config '{{ build_kv_transfer_config() }}'
 {%- endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -724,6 +724,8 @@ vllmCommon:
     disableUvicornAccessLog: true
     allowLongMaxModelLen: "1"
     serverDevMode: "1"
+    # chatTemplate: null
+    # chatTemplateContentFormat: null # Format for inline chat template: string, leave null for file
     # Additional vLLM flags (optional)
     # enableChunkedPrefill: false
     # maxNumBatchedTokens: null

--- a/llmdbenchmark/parser/config_schema.py
+++ b/llmdbenchmark/parser/config_schema.py
@@ -296,6 +296,8 @@ class VllmFlagsConfig(BaseModel):
     enablePrefixCaching: bool | None = None
     enableAutoToolChoice: bool | None = None
     toolCallParser: str | None = None
+    chatTemplate: str | None = None
+    chatTemplateContentFormat: str | None = None
 
 
 class VllmCommonConfig(BaseModel):


### PR DESCRIPTION
Some models (e.g. meta-llama) require a chat template to run "type: chat" inference.

This PR allows to set a chat-template for the vllm server guides/example deployments either as a file:

```
vllmCommon:
    flags:
        chatTemplate: /path/to/template
```

Or inline

```
vllmCommon:
    flags:
        chatTemplate: "{% for message in messages %}{{ message['role'] }}: {{ message['content'] }}\n{% endfor %}"
        chatTemplateContentFormat: string
```