### PR TITLE
⚠️ Switch OCP nightly benchmark runners from platform-eval to pokprod01

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-ocp.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp.yaml
@@ -39,7 +39,7 @@ jobs:
 
   benchmark-standalone:
     name: Benchmark - Standalone (OCP)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, openshift, pok-prod]
     needs: build-image
     timeout-minutes: 240
 
@@ -61,13 +61,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-
-      - name: Set up kubeconfig from secret
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_DATA }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
-        shell: bash
 
       - name: Install llmdbenchmark
         run: |
@@ -174,7 +167,7 @@ jobs:
 
   benchmark-modelservice:
     name: Benchmark - ModelService (OCP)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, openshift, pok-prod]
     needs: build-image
     timeout-minutes: 240
 
@@ -196,13 +189,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-
-      - name: Set up kubeconfig from secret
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KUBECONFIG_DATA }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
-        shell: bash
 
       - name: Install llmdbenchmark
         run: |


### PR DESCRIPTION
## Summary

Switch the OCP nightly benchmark workflow to use self-hosted `pok-prod` runners instead of GitHub-hosted `ubuntu-latest` runners with a kubeconfig secret pointing at platform-eval.

### Changes
- **`runs-on`**: `ubuntu-latest` → `[self-hosted, openshift, pok-prod]`  for both `benchmark-standalone` and `benchmark-modelservice` jobs
- **Removed** kubeconfig secret setup steps — self-hosted runners already have cluster access via their pre-configured kubeconfig
- **`build-image`** job remains on `ubuntu-latest` (only builds/pushes container images, no cluster access needed)

### Notes
- Runner label pattern `[self-hosted, openshift, pok-prod]` matches the convention used in `llm-d-infra` reusable nightly workflows
- Verify that `config/scenarios/cicd/ocp.yaml` GPU labels (`NVIDIA-L40S`), storage class (`ocs-storagecluster-cephfs`), and priority class (`nightly-gpu-critical`) are valid on pokprod01 — adjust if hardware differs