### PR TITLE
feat: llm-d Multi Model + WVA Enablement per Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This repository provides an automated workflow for benchmarking LLM inference us
 > [!TIP]
 > We acknowledge many users are still utilizing our previous (now deprecated) library, and to make the transition easier, we still have that library available. It can be found in our [v0.5.2](https://github.com/llm-d/llm-d-benchmark/tree/v0.5.2) version tag.
 
-
 ### Main Goal
 
 Provide a single source of automation for repeatable and reproducible experiments and performance evaluation on `llm-d`:
@@ -26,7 +25,6 @@ For the client setup, the provided `install.sh` will install the necessary tools
 
 Deploying the llm-d stack requires **cluster-level admin** privileges, as you will be configuring cluster-level resources.
 However, the scripts can be executed by **namespace-level admin** users, as long as the [Kubernetes infrastructure components](https://github.com/llm-d-incubation/llm-d-infra) are configured and the **target namespace already exists**.
-
 
 ## Getting Started
 
@@ -90,6 +88,8 @@ Every command takes a `--spec` that selects the configuration for your cluster a
 ```bash
 --spec gpu                              # NVIDIA GPU setup (config/specification/examples/gpu.yaml.j2)
 --spec inference-scheduling             # inference scheduling guide
+--spec inference-scheduling-wva         # inference scheduling + WVA autoscaling
+--spec multi-model-wva                  # multi-model WVA: N pools, 1 gateway, 1 shared HTTPRoute
 --spec pd-disaggregation               # prefill-decode disaggregation guide
 ...
 --spec /full/path/to/my-spec.yaml.j2    # custom spec
@@ -120,6 +120,157 @@ llmdbenchmark --spec gpu teardown
 
 Each command renders Kubernetes manifests from your spec's templates and defaults, then applies them. The workspace directory captures rendered configs, manifests, and results for later inspection.
 
+### Deploy multiple models behind one gateway
+
+The `multi-model-wva` scenario deploys N models under a single gateway,
+each with its own EPP + InferencePool + VariantAutoscaling + HPA, sharing
+one WVA controller and one HTTPRoute with N backendRefs:
+
+```bash
+# Standup — renders two stacks (qwen3-06b, llama-31-8b), installs shared
+# infra once, deploys a per-model Helm release + VA + HPA for each.
+llmdbenchmark --spec guides/multi-model-wva standup -p my-namespace
+
+# Smoketest — runs stack-by-stack (sequential), hitting each pool at its
+# routing prefix (/qwen3-06b/v1/models, /llama-31-8b/v1/models).
+llmdbenchmark --spec guides/multi-model-wva smoketest -p my-namespace
+
+# Run — iterates every stack, each harness pod targets its own pool's endpoint.
+llmdbenchmark --spec guides/multi-model-wva run -p my-namespace
+
+# See what's deployed: list detected endpoints + copy-paste run commands.
+llmdbenchmark --spec guides/multi-model-wva run -p my-namespace --list-endpoints
+
+# Benchmark just one pool (no --endpoint-url needed — auto-resolves):
+llmdbenchmark --spec guides/multi-model-wva run -p my-namespace \
+  --stack qwen3-06b \
+  -l inference-perf -w sanity_random.yaml
+
+# Teardown — removes both stacks and the shared infra.
+llmdbenchmark --spec guides/multi-model-wva teardown -p my-namespace
+```
+
+Stack names (`qwen3-06b`, `llama-31-8b`) double as path prefixes on the
+shared HTTPRoute (`/qwen3-06b/v1/...`, `/llama-31-8b/v1/...`). Pick short
+descriptive names in your own scenario — `--list-endpoints` prints the
+rendered URLs so you rarely have to type them manually.
+
+#### Discovering what's deployed (`--list-endpoints`)
+
+After standup, `--list-endpoints` detects each pool's routing URL, prints a
+copy-paste-ready table, and exits without launching any harness pods:
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p my-namespace --list-endpoints
+```
+
+```
+📋 Detected endpoints:
+  STACK        MODEL                      ENDPOINT URL
+  -----------  -------------------------  ------------------------------
+  qwen3-06b    Qwen/Qwen3-0.6B            http://10.1.2.3:80/qwen3-06b
+  llama-31-8b  unsloth/Meta-Llama-3.1-8B  http://10.1.2.3:80/llama-31-8b
+
+💡 Copy-paste to benchmark one pool:
+
+  # qwen3-06b — Qwen/Qwen3-0.6B
+  llmdbenchmark --spec guides/multi-model-wva run \
+    --namespace my-namespace \
+    --endpoint-url http://10.1.2.3:80/qwen3-06b \
+    --model Qwen/Qwen3-0.6B \
+    -l <harness> -w <workload.yaml> -j <parallel-pods>
+  ...
+```
+
+#### Example Targeting a single pool (`--stack`)
+
+`--stack NAME` restricts any lifecycle command to one pool (or a
+comma-separated subset). Endpoint URL auto-resolves for the selected
+stack — no need to pass `--endpoint-url` manually:
+
+```bash
+# Benchmark qwen3-06b only with guidellm, two parallel harness pods
+llmdbenchmark --spec guides/multi-model-wva run -p my-namespace \
+  --stack qwen3-06b \
+  -l guidellm \
+  -w sanity_random.yaml \
+  -j 2
+```
+
+Breakdown of the Example:
+
+- `--stack qwen3-06b` filters per-stack steps to that pool. Endpoint
+  detection (step 03) runs only for that stack and auto-resolves to
+  `http://<gateway>:80/qwen3-06b` — including the routing prefix — so every
+  downstream step targets the qwen3-06b InferencePool.
+- `-l guidellm` selects the guidellm harness
+  ([workload/harnesses/guidellm-llm-d-benchmark.sh](workload/harnesses/guidellm-llm-d-benchmark.sh)).
+- `-j 2` launches two guidellm pods hitting the same endpoint. Both pods
+  run the same treatment (`-w`) but write to distinct result
+  subdirectories (`{experiment_id}_1`, `{experiment_id}_2`) on the
+  workload PVC.
+
+Want to compare pools side-by-side? Launch two invocations in parallel
+shells (different `--workspace` each):
+
+```bash
+# Terminal 1 — --workspace is a global option, placed before the subcommand
+llmdbenchmark --spec guides/multi-model-wva --workspace /tmp/run-qwen run -p my-namespace \
+  --stack qwen3-06b \
+  -l guidellm -w sanity_random.yaml -j 2 &
+
+# Terminal 2 (or same shell, backgrounded)
+llmdbenchmark --spec guides/multi-model-wva --workspace /tmp/run-llama run -p my-namespace \
+  --stack llama-31-8b \
+  -l guidellm -w sanity_random.yaml -j 2
+```
+
+`--stack` also works on `standup`, `smoketest`, and `teardown`. Same
+flag, same semantics — restrict execution to the named subset of stacks
+without editing the scenario YAML. Scenario-wide steps (namespace
+creation, admin prereqs, shared infra, WVA controller install) always
+run; only the per-stack steps (06+ for standup) are filtered.
+
+```bash
+# Standup only pool qwen3-06b from the multi-model scenario — shared
+# infra (istio, Gateway, WVA controller, model PVC) installs normally,
+# but only qwen3-06b's ms/gaie/VA/HPA resources get created.
+llmdbenchmark --spec guides/multi-model-wva standup -p my-namespace \
+  --stack qwen3-06b
+
+# Standup two named pools out of a larger scenario:
+llmdbenchmark --spec guides/multi-model-wva standup -p my-namespace \
+  --stack qwen3-06b,llama-31-8b
+
+# Tear down just one pool later, leaving the other running:
+llmdbenchmark --spec guides/multi-model-wva teardown -p my-namespace \
+  --stack qwen3-06b
+```
+
+Unknown stack names fail loudly with a list of valid ones.
+
+When `--stack NAME` selects exactly one stack, `-m/--models` scopes to
+that stack only — sibling stacks keep their scenario-defined models.
+Handy for "rerun pool A against a different model" without touching pool
+B:
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p my-namespace \
+  --stack qwen3-06b \
+  --model meta-llama/Llama-3.2-3B \
+  -l inference-perf -w sanity_random.yaml
+```
+
+Without `--stack`, `-m` applies to every stack and emits a warning.
+
+Add a third model by copying a stack block in
+[`config/scenarios/guides/multi-model-wva.yaml`](config/scenarios/guides/multi-model-wva.yaml)
+and changing `name` + `model`. Scenario-wide config (gateway class, WVA
+controller image, shared HTTPRoute, EPP plugin config) lives in the
+top-level `shared:` block and is inherited by every stack. See
+[Workload Variant Autoscaler](docs/workload-variant-autoscaler.md#2c-via-the-multi-model-wva-scenario-multiple-pools-one-wva-controller)
+for the full architecture.
+
 ### Benchmark an existing endpoint (run-only mode)
 
 Already have a model-serving endpoint running? Skip deployment entirely:
@@ -145,6 +296,8 @@ See [workload/README.md](workload/README.md) for the full experiment file format
 | Topic | Where to look |
 |-------|---------------|
 | Configuration system, defaults, scenarios, overrides | [config/README.md](config/README.md) |
+| Multi-model scenarios and the `shared:` block | [config/README.md](config/README.md#method-1-scenario-file-recommended-for-deployment-specific-config), [developer-guide](docs/developer-guide.md#multi-stack-scenarios-and-the-shared-block) |
+| Workload-variant-autoscaler, including multi-pool setup | [docs/workload-variant-autoscaler.md](docs/workload-variant-autoscaler.md) |
 | Workloads, harnesses, profiles, experiments | [workload/README.md](workload/README.md) |
 | Standup phase, deployment methods, step details | [llmdbenchmark/standup/README.md](llmdbenchmark/standup/README.md) |
 | Smoketests, per-scenario validation, adding validators | [llmdbenchmark/smoketests/README.md](llmdbenchmark/smoketests/README.md) |
@@ -258,6 +411,7 @@ llmdbenchmark --version
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
+| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict per-stack execution to the named subset. Useful in multi-stack scenarios (e.g. `guides/multi-model-wva`) to re-deploy a single pool without touching siblings. Unknown names fail loudly. |
 | `-f` / `--monitoring` | `LLMDBENCH_MONITORING` | Enable PodMonitor creation and EPP verbosity during standup |
 | `--skip-smoketest` | | Skip automatic smoketest after standup completes |
 | `--affinity` | `LLMDBENCH_AFFINITY` | Node affinity / tolerations label |
@@ -274,6 +428,7 @@ llmdbenchmark --version
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name (default: `llmdbench`) |
 | `-d` / `--deep` | `LLMDBENCH_DEEP_CLEAN` | Deep clean: delete ALL resources in both namespaces |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Comma-separated namespaces (model,harness) |
+| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict teardown to the named subset. Useful for removing one pool from a multi-stack scenario while leaving siblings in place. |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 
 ### Experiment Options
@@ -324,6 +479,8 @@ llmdbenchmark --version
 | `--analyze` | | Run local analysis on results after collection |
 | `-z` / `--skip` | `LLMDBENCH_SKIP` | Skip execution, only collect existing results |
 | `-d` / `--debug` | `LLMDBENCH_DEBUG` | Debug mode: start harness pods with sleep infinity |
+| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict the benchmark to the named subset of stacks. Endpoint URL auto-resolves for the selected stack — no need for `--endpoint-url`. When `--stack` selects exactly one stack, `-m/--models` scopes to that stack only. |
+| `--list-endpoints` | | Detect per-stack endpoint URLs, print a copy-paste table of `llmdbenchmark run` invocations, and exit without launching any harness pods. Useful after `standup` to discover what's deployed. |
 
 ### Smoketest Options
 
@@ -340,7 +497,8 @@ llmdbenchmark --spec gpu smoketest -p my-namespace -s 2   # config validation on
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment methods (standalone, modelservice, fma) |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
-| `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
+| `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4). Smoketest pins this to 1 regardless — parallel probes across stacks are confusing. |
+| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict smoketest to the named subset of stacks. |
 
 Smoketests also run automatically after `standup` unless `--skip-smoketest` is passed. See [llmdbenchmark/smoketests/README.md](llmdbenchmark/smoketests/README.md) for details on what each step validates.
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ The install script auto-detects if the repo is present -- if not, it clones it f
 
 Two supported entry points depending on what you have access to:
 
-**🖥️ No Accelerators  / No Cluster Access — Utilize a Kind Quickstart**
+**🖥️ No Accelerators  / No Cluster Access - Utilize a Kind Quickstart**
 
-Run the full `standup → smoketest → run → teardown` lifecycle on a local [Kind](https://kind.sigs.k8s.io/) cluster using a simulated inference engine. No accelerators, no cloud account, no cluster operator required. It uses the same `cicd/kind-sim` scenario that CI runs on every PR, so if it works locally it works in CI.
+Run the full `standup -> smoketest -> run -> teardown` lifecycle on a local [Kind](https://kind.sigs.k8s.io/) cluster using a simulated inference engine. No accelerators, no cloud account, no cluster operator required. It uses the same `cicd/kind-sim` scenario that CI runs on every PR, so if it works locally it works in CI.
 
 - **Requirements:** Docker (or Podman/Colima) with **4 CPUs / 8 GiB RAM** and Python 3.11+
 - **Continue with Quick Start Guide:** [Quickstart on Kind](docs/quickstart.md)
 
-**🚀 Access to Compute cluster with Accelerators — full pipeline**
+**🚀 Access to Compute cluster with Accelerators - full pipeline**
 
 Deploy against a Kubernetes cluster with Accelerators (OpenShift, GKE, EKS, CKS, etc.). Use one of the built-in specs or a well-lit path guide tuned for your hardware.
 
@@ -127,32 +127,32 @@ each with its own EPP + InferencePool + VariantAutoscaling + HPA, sharing
 one WVA controller and one HTTPRoute with N backendRefs:
 
 ```bash
-# Standup — renders two stacks (qwen3-06b, llama-31-8b), installs shared
+# Standup - renders two stacks (qwen3-06b, llama-31-8b), installs shared
 # infra once, deploys a per-model Helm release + VA + HPA for each.
 llmdbenchmark --spec guides/multi-model-wva standup -p my-namespace
 
-# Smoketest — runs stack-by-stack (sequential), hitting each pool at its
+# Smoketest - runs stack-by-stack (sequential), hitting each pool at its
 # routing prefix (/qwen3-06b/v1/models, /llama-31-8b/v1/models).
 llmdbenchmark --spec guides/multi-model-wva smoketest -p my-namespace
 
-# Run — iterates every stack, each harness pod targets its own pool's endpoint.
+# Run - iterates every stack, each harness pod targets its own pool's endpoint.
 llmdbenchmark --spec guides/multi-model-wva run -p my-namespace
 
 # See what's deployed: list detected endpoints + copy-paste run commands.
 llmdbenchmark --spec guides/multi-model-wva run -p my-namespace --list-endpoints
 
-# Benchmark just one pool (no --endpoint-url needed — auto-resolves):
+# Benchmark just one pool (no --endpoint-url needed - auto-resolves):
 llmdbenchmark --spec guides/multi-model-wva run -p my-namespace \
   --stack qwen3-06b \
   -l inference-perf -w sanity_random.yaml
 
-# Teardown — removes both stacks and the shared infra.
+# Teardown - removes both stacks and the shared infra.
 llmdbenchmark --spec guides/multi-model-wva teardown -p my-namespace
 ```
 
 Stack names (`qwen3-06b`, `llama-31-8b`) double as path prefixes on the
 shared HTTPRoute (`/qwen3-06b/v1/...`, `/llama-31-8b/v1/...`). Pick short
-descriptive names in your own scenario — `--list-endpoints` prints the
+descriptive names in your own scenario - `--list-endpoints` prints the
 rendered URLs so you rarely have to type them manually.
 
 #### Discovering what's deployed (`--list-endpoints`)
@@ -173,7 +173,7 @@ llmdbenchmark --spec guides/multi-model-wva run -p my-namespace --list-endpoints
 
 💡 Copy-paste to benchmark one pool:
 
-  # qwen3-06b — Qwen/Qwen3-0.6B
+  # qwen3-06b - Qwen/Qwen3-0.6B
   llmdbenchmark --spec guides/multi-model-wva run \
     --namespace my-namespace \
     --endpoint-url http://10.1.2.3:80/qwen3-06b \
@@ -186,7 +186,7 @@ llmdbenchmark --spec guides/multi-model-wva run -p my-namespace --list-endpoints
 
 `--stack NAME` restricts any lifecycle command to one pool (or a
 comma-separated subset). Endpoint URL auto-resolves for the selected
-stack — no need to pass `--endpoint-url` manually:
+stack - no need to pass `--endpoint-url` manually:
 
 ```bash
 # Benchmark qwen3-06b only with guidellm, two parallel harness pods
@@ -201,7 +201,7 @@ Breakdown of the Example:
 
 - `--stack qwen3-06b` filters per-stack steps to that pool. Endpoint
   detection (step 03) runs only for that stack and auto-resolves to
-  `http://<gateway>:80/qwen3-06b` — including the routing prefix — so every
+  `http://<gateway>:80/qwen3-06b` - including the routing prefix - so every
   downstream step targets the qwen3-06b InferencePool.
 - `-l guidellm` selects the guidellm harness
   ([workload/harnesses/guidellm-llm-d-benchmark.sh](workload/harnesses/guidellm-llm-d-benchmark.sh)).
@@ -214,7 +214,7 @@ Want to compare pools side-by-side? Launch two invocations in parallel
 shells (different `--workspace` each):
 
 ```bash
-# Terminal 1 — --workspace is a global option, placed before the subcommand
+# Terminal 1 - --workspace is a global option, placed before the subcommand
 llmdbenchmark --spec guides/multi-model-wva --workspace /tmp/run-qwen run -p my-namespace \
   --stack qwen3-06b \
   -l guidellm -w sanity_random.yaml -j 2 &
@@ -226,13 +226,13 @@ llmdbenchmark --spec guides/multi-model-wva --workspace /tmp/run-llama run -p my
 ```
 
 `--stack` also works on `standup`, `smoketest`, and `teardown`. Same
-flag, same semantics — restrict execution to the named subset of stacks
+flag, same semantics - restrict execution to the named subset of stacks
 without editing the scenario YAML. Scenario-wide steps (namespace
 creation, admin prereqs, shared infra, WVA controller install) always
 run; only the per-stack steps (06+ for standup) are filtered.
 
 ```bash
-# Standup only pool qwen3-06b from the multi-model scenario — shared
+# Standup only pool qwen3-06b from the multi-model scenario - shared
 # infra (istio, Gateway, WVA controller, model PVC) installs normally,
 # but only qwen3-06b's ms/gaie/VA/HPA resources get created.
 llmdbenchmark --spec guides/multi-model-wva standup -p my-namespace \
@@ -250,7 +250,7 @@ llmdbenchmark --spec guides/multi-model-wva teardown -p my-namespace \
 Unknown stack names fail loudly with a list of valid ones.
 
 When `--stack NAME` selects exactly one stack, `-m/--models` scopes to
-that stack only — sibling stacks keep their scenario-defined models.
+that stack only - sibling stacks keep their scenario-defined models.
 Handy for "rerun pool A against a different model" without touching pool
 B:
 
@@ -352,7 +352,7 @@ source .venv/bin/activate
 
 The install script:
 
-1. Creates a Python virtual environment at `.venv/` (via [uv](https://docs.astral.sh/uv/) or `python3 -m venv` — see [Install](#install))
+1. Creates a Python virtual environment at `.venv/` (via [uv](https://docs.astral.sh/uv/) or `python3 -m venv` - see [Install](#install))
 2. Validates Python 3.11+ and pip
 3. Checks for required system tools (curl, git, kubectl or oc, helm, helmfile, kustomize, jq, yq, skopeo, crane)
 4. Installs the `helm-diff` plugin (required by helmfile)
@@ -411,7 +411,7 @@ llmdbenchmark --version
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
-| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict per-stack execution to the named subset. Useful in multi-stack scenarios (e.g. `guides/multi-model-wva`) to re-deploy a single pool without touching siblings. Unknown names fail loudly. |
+| `--stack NAME[,NAME...]` | `LLMDBENCH_STACK` | Restrict per-stack execution to the named subset. Useful in multi-stack scenarios (e.g. `guides/multi-model-wva`) to re-deploy a single pool without touching siblings. Unknown names fail loudly. |
 | `-f` / `--monitoring` | `LLMDBENCH_MONITORING` | Enable PodMonitor creation and EPP verbosity during standup |
 | `--skip-smoketest` | | Skip automatic smoketest after standup completes |
 | `--affinity` | `LLMDBENCH_AFFINITY` | Node affinity / tolerations label |
@@ -428,7 +428,7 @@ llmdbenchmark --version
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name (default: `llmdbench`) |
 | `-d` / `--deep` | `LLMDBENCH_DEEP_CLEAN` | Deep clean: delete ALL resources in both namespaces |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Comma-separated namespaces (model,harness) |
-| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict teardown to the named subset. Useful for removing one pool from a multi-stack scenario while leaving siblings in place. |
+| `--stack NAME[,NAME...]` | `LLMDBENCH_STACK` | Restrict teardown to the named subset. Useful for removing one pool from a multi-stack scenario while leaving siblings in place. |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 
 ### Experiment Options
@@ -479,7 +479,7 @@ llmdbenchmark --version
 | `--analyze` | | Run local analysis on results after collection |
 | `-z` / `--skip` | `LLMDBENCH_SKIP` | Skip execution, only collect existing results |
 | `-d` / `--debug` | `LLMDBENCH_DEBUG` | Debug mode: start harness pods with sleep infinity |
-| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict the benchmark to the named subset of stacks. Endpoint URL auto-resolves for the selected stack — no need for `--endpoint-url`. When `--stack` selects exactly one stack, `-m/--models` scopes to that stack only. |
+| `--stack NAME[,NAME...]` | `LLMDBENCH_STACK` | Restrict the benchmark to the named subset of stacks. Endpoint URL auto-resolves for the selected stack - no need for `--endpoint-url`. When `--stack` selects exactly one stack, `-m/--models` scopes to that stack only. |
 | `--list-endpoints` | | Detect per-stack endpoint URLs, print a copy-paste table of `llmdbenchmark run` invocations, and exit without launching any harness pods. Useful after `standup` to discover what's deployed. |
 
 ### Smoketest Options
@@ -497,8 +497,8 @@ llmdbenchmark --spec gpu smoketest -p my-namespace -s 2   # config validation on
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment methods (standalone, modelservice, fma) |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
-| `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4). Smoketest pins this to 1 regardless — parallel probes across stacks are confusing. |
-| `--stack NAME[,NAME…]` | `LLMDBENCH_STACK` | Restrict smoketest to the named subset of stacks. |
+| `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4). Smoketest pins this to 1 regardless - parallel probes across stacks are confusing. |
+| `--stack NAME[,NAME...]` | `LLMDBENCH_STACK` | Restrict smoketest to the named subset of stacks. |
 
 Smoketests also run automatically after `standup` unless `--skip-smoketest` is passed. See [llmdbenchmark/smoketests/README.md](llmdbenchmark/smoketests/README.md) for details on what each step validates.
 

--- a/config/README.md
+++ b/config/README.md
@@ -103,6 +103,55 @@ scenario:
 
 Only the keys you specify are overridden. Everything else comes from `defaults.yaml`.
 
+**Multi-stack scenarios — the `shared:` block.** The scenario file also
+accepts an optional top-level `shared:` key that's merged into every stack
+before the per-stack overrides. Use it to lift scenario-wide config out of
+duplicated per-stack blocks. Per-stack still wins, so any stack can override
+a shared value:
+
+```yaml
+shared:
+  modelservice: { enabled: true }
+  wva:
+    enabled: true
+    image: { tag: v0.6.0 }
+  httpRoute:
+    mode: shared
+    name: multi-model-route
+    pathPrefix: /{stack.name}
+    rewriteTo: /
+
+scenario:
+  - name: pool-a
+    model: { name: Qwen/Qwen3-0.6B, ... }
+    decode: { replicas: 1 }
+  - name: pool-b
+    model: { name: unsloth/Meta-Llama-3.1-8B, ... }
+    decode: { replicas: 1 }
+```
+
+Render-time conveniences that activate only when `len(scenario) ≥ 2`:
+
+- `downloadJob.name` and `inferenceExtension.monitoring.secretName` are
+  auto-suffixed with each stack's `model_id_label` so parallel download
+  Jobs and sibling gaie Helm releases don't collide. Explicit overrides
+  (in `defaults.yaml`, `shared:`, or per-stack) are preserved.
+- `storage.modelPvc.name` is **not** suffixed — every stack writes weights
+  to a distinct `model.path` subdirectory on one shared PVC. This matches
+  how NVMe / local-directory storage classes are typically deployed and
+  lets cached weights be reused across runs without per-model duplication.
+- When `httpRoute.mode: shared`, [08_httproute.yaml.j2](templates/jinja/08_httproute.yaml.j2)
+  renders a single HTTPRoute in the first stack with one backendRef per
+  sibling stack; other stacks render an empty file.
+- Step 04 iterates `context.rendered_stacks` so every stack with
+  `modelservice.uriProtocol: pvc` (or standalone) runs a download Job
+  against the shared PVC. Downloads run in parallel — total wall time
+  ≈ slowest model, not sum.
+
+See [guides/multi-model-wva.yaml](scenarios/guides/multi-model-wva.yaml) for a
+complete example and the developer guide's [Multi-Stack Scenarios](../docs/developer-guide.md#multi-stack-scenarios-and-the-shared-block)
+section for the merge semantics.
+
 **Example: GPU scenario with a custom vLLM image**
 
 The GPU example uses standalone deployment, so the container image is set under `standalone.image` (not `images.vllm`, which is the fallback for modelservice deployments). See [Container Images](#container-images) for the full image config reference.

--- a/config/README.md
+++ b/config/README.md
@@ -103,7 +103,7 @@ scenario:
 
 Only the keys you specify are overridden. Everything else comes from `defaults.yaml`.
 
-**Multi-stack scenarios — the `shared:` block.** The scenario file also
+**Multi-stack scenarios - the `shared:` block.** The scenario file also
 accepts an optional top-level `shared:` key that's merged into every stack
 before the per-stack overrides. Use it to lift scenario-wide config out of
 duplicated per-stack blocks. Per-stack still wins, so any stack can override
@@ -130,13 +130,13 @@ scenario:
     decode: { replicas: 1 }
 ```
 
-Render-time conveniences that activate only when `len(scenario) ≥ 2`:
+Render-time conveniences that activate only when `len(scenario) >= 2`:
 
 - `downloadJob.name` and `inferenceExtension.monitoring.secretName` are
   auto-suffixed with each stack's `model_id_label` so parallel download
   Jobs and sibling gaie Helm releases don't collide. Explicit overrides
   (in `defaults.yaml`, `shared:`, or per-stack) are preserved.
-- `storage.modelPvc.name` is **not** suffixed — every stack writes weights
+- `storage.modelPvc.name` is **not** suffixed - every stack writes weights
   to a distinct `model.path` subdirectory on one shared PVC. This matches
   how NVMe / local-directory storage classes are typically deployed and
   lets cached weights be reused across runs without per-model duplication.
@@ -145,8 +145,8 @@ Render-time conveniences that activate only when `len(scenario) ≥ 2`:
   sibling stack; other stacks render an empty file.
 - Step 04 iterates `context.rendered_stacks` so every stack with
   `modelservice.uriProtocol: pvc` (or standalone) runs a download Job
-  against the shared PVC. Downloads run in parallel — total wall time
-  ≈ slowest model, not sum.
+  against the shared PVC. Downloads run in parallel - total wall time
+  ~ slowest model, not sum.
 
 See [guides/multi-model-wva.yaml](scenarios/guides/multi-model-wva.yaml) for a
 complete example and the developer guide's [Multi-Stack Scenarios](../docs/developer-guide.md#multi-stack-scenarios-and-the-shared-block)
@@ -343,12 +343,12 @@ Scenario files support `${dotted.path}` references that are resolved at render t
 
 ### Syntax
 
-Use `${section.key}` to reference any scalar value in the config. The path must contain at least one dot — this distinguishes config variables from shell variables, which are left untouched.
+Use `${section.key}` to reference any scalar value in the config. The path must contain at least one dot - this distinguishes config variables from shell variables, which are left untouched.
 
 | Pattern | Resolved? | Why |
 |---|---|---|
-| `${model.name}` | Yes | Dotted path → config lookup |
-| `${model.path}` | Yes | Dotted path → config lookup |
+| `${model.name}` | Yes | Dotted path -> config lookup |
+| `${model.path}` | Yes | Dotted path -> config lookup |
 
 ### Available variables
 
@@ -366,9 +366,9 @@ Any scalar value in the merged config (defaults + scenario) can be referenced. C
 
 Config variables work in any string field in the scenario YAML, including fields that are normally passed through as raw text:
 
-- `customCommand` — vLLM serve commands for decode/prefill/standalone
-- `extraEnvVars` — environment variable values
-- `pluginsCustomConfig` — inline EPP plugin configuration
+- `customCommand` - vLLM serve commands for decode/prefill/standalone
+- `extraEnvVars` - environment variable values
+- `pluginsCustomConfig` - inline EPP plugin configuration
 
 ### Example
 
@@ -405,7 +405,7 @@ Shell variables like `$VLLM_METRICS_PORT` are preserved for runtime resolution. 
 - Substitution runs after all resolvers (model, namespace, version, etc.) so all values are available.
 - If a reference cannot be resolved, it is left as-is and a warning is logged.
 - Non-string values (integers, booleans) are converted to strings when embedded.
-- The original config dict is not mutated — a deep copy is used.
+- The original config dict is not mutated - a deep copy is used.
 
 ## Model Artifact Protocol (`modelservice.uriProtocol`)
 
@@ -426,7 +426,7 @@ Controls how the modelservice Helm chart locates and loads model weights. Set vi
 4. Template 13 generates `modelArtifacts.uri: pvc://<pvc-name>/<model-path>`
 5. The modelservice Helm chart mounts the PVC and serves from it
 
-This is the recommended protocol for production — models are pre-cached and startup is fast.
+This is the recommended protocol for production - models are pre-cached and startup is fast.
 
 **`hf://` protocol:**
 
@@ -447,14 +447,14 @@ scenario:
       huggingfaceId: facebook/opt-125m
     modelservice:
       enabled: true
-      uriProtocol: hf     # No PVC, no download job — fetch at runtime
+      uriProtocol: hf     # No PVC, no download job - fetch at runtime
 ```
 
 ### Code path
 
-1. `llmdbenchmark/standup/steps/step_04_model_namespace.py` — `_requires_pvc_download()` returns `False` when `uriProtocol != "pvc"`
-2. `config/templates/jinja/13_ms-values.yaml.j2` — conditionally generates `hf://` or `pvc://` URI
-3. `config/templates/jinja/04_download_job.yaml.j2` — only rendered/applied when protocol is `pvc`
+1. `llmdbenchmark/standup/steps/step_04_model_namespace.py` - `_requires_pvc_download()` returns `False` when `uriProtocol != "pvc"`
+2. `config/templates/jinja/13_ms-values.yaml.j2` - conditionally generates `hf://` or `pvc://` URI
+3. `config/templates/jinja/04_download_job.yaml.j2` - only rendered/applied when protocol is `pvc`
 
 ## Chart Versions
 
@@ -475,7 +475,7 @@ Versions set to `auto` are resolved at plan time by `VersionResolver` using `hel
 
 ### Overriding versions in a scenario
 
-Add a `chartVersions` section to your scenario YAML. Only include the versions you want to change — the rest inherit from defaults:
+Add a `chartVersions` section to your scenario YAML. Only include the versions you want to change - the rest inherit from defaults:
 
 ```yaml
 scenario:

--- a/config/scenarios/guides/multi-model-wva.yaml
+++ b/config/scenarios/guides/multi-model-wva.yaml
@@ -1,0 +1,386 @@
+# MULTI-MODEL + WVA WELL LIT PATH for LLM-D Deployment
+#
+# Deploys N models under a single gateway, each with its own EPP +
+# InferencePool + VariantAutoscaling + HPA, managed by one shared WVA
+# controller, reachable through ONE HTTPRoute with N backendRefs.
+#
+# Topology (with N=2):
+#                        ┌──── Gateway (infra-llmdbench, shared) ──────┐
+#                        │     HTTPRoute multi-model-route (shared)    │
+#                        │     ├── /qwen3-06b/v1   → InferencePool A   │
+#                        │     └── /llama-31-8b/v1 → InferencePool B   │
+#                        └─────────────────────────────────────────────┘
+#                              │                          │
+#                      ┌───────┴────────┐         ┌───────┴────────┐
+#                      │ EPP qwen3-06b  │         │ EPP llama-31-8b│
+#                      │ + InferencePool│         │ + InferencePool│
+#                      └───────┬────────┘         └───────┬────────┘
+#                              │                          │
+#                      ┌───────┴────────┐         ┌───────┴────────┐
+#                      │ vLLM decode    │         │ vLLM decode    │
+#                      │ + VA + HPA     │         │ + VA + HPA     │
+#                      └────────────────┘         └────────────────┘
+#                                     ▲                  ▲
+#                                     └──── WVA (1) ─────┘
+#                                           controller
+#
+# Architecture:
+#
+#   - `shared:` block holds scenario-wide config (WVA controller,
+#     gateway, shared HTTPRoute, EPP plugin config, flowControl feature
+#     gate). It is merged into every stack's values in
+#     render_plans._process_stack BEFORE the per-stack overrides —
+#     per-stack always wins.
+#
+#   - `scenario:` is a list of N stacks. Each gets its own
+#     `{model_id_label}-ms` and `{model_id_label}-gaie` Helm releases,
+#     its own VA + HPA, and its own auto-named download Job + PVC.
+#
+#   - One WVA controller per wva.namespace (deduplicated by
+#     install_wva_for_namespace). Leaving wva.namespace empty in the
+#     shared block sends it to the deploy namespace → one controller.
+#
+# Stack naming convention:
+#
+#   Stack `name` values double as path prefixes in the shared HTTPRoute
+#   (`/{stack.name}/v1/...`). Pick short descriptive names that identify
+#   the model family + size (e.g. `qwen3-06b`, `llama-31-8b`) rather than
+#   opaque labels (`pool-a`). Keep them lowercase and URL-safe; no hard
+#   k8s limit on the name itself, but conventionally ≤30 chars.
+#   `--list-endpoints` prints the rendered URLs so users rarely have to
+#   type these manually.
+#
+# Based on:
+#   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+# and the WVA team's deploy/install-multi-model.sh orchestrator.
+#
+# Running:
+#
+#   llmdbenchmark --spec guides/multi-model-wva standup -p <namespace>
+#
+# To add a third model: copy one of the stack blocks, give it a unique
+# short descriptive `name` and a unique `model.*`. The parser auto-
+# derives unique `downloadJob.name` and
+# `inferenceExtension.monitoring.secretName` values from the model ID
+# label, so nothing else needs per-stack customization.
+
+# ============================================================================
+# SHARED - applied to every stack before per-stack overrides
+# ============================================================================
+shared:
+  # --------------------------------------------------------------------------
+  # DEPLOYMENT METHOD
+  # --------------------------------------------------------------------------
+  modelservice:
+    enabled: true
+  standalone:
+    enabled: false
+
+  # --------------------------------------------------------------------------
+  # WVA CONTROLLER - installed once per namespace. Per-stack scaling intent
+  # (variantAutoscaling, hpa) lives in each stack's `wva:` block below.
+  # --------------------------------------------------------------------------
+  wva:
+    enabled: true
+    # Tag VAs as part of the inference-scheduling guide so upstream
+    # dashboards group them together with single-model WVA scenarios —
+    # the underlying architecture (gateway + EPP + InferencePool + VA +
+    # HPA) is identical, only the number of pools differs.
+    wellLitPath: inference-scheduling
+    namespace: ""
+    image:
+      repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+      tag: v0.6.0
+    replicaCount: 1
+    controller:
+      enabled: true
+    namespaceScoped: true
+    metrics:
+      enabled: true
+      port: 8443
+      secure: true
+    prometheus:
+      baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+      port: 9091
+    vllmService:
+      enabled: false
+
+  chartVersions:
+    wva: 0.6.0
+    prometheusAdapter: 5.2.0
+
+  # --------------------------------------------------------------------------
+  # HTTPROUTE - one shared route with N URLRewrite rules, one per stack.
+  # Emitted only in the first stack's render (stackIndex == 1). Other stacks
+  # render an empty 08_httproute.yaml (step_09 skips empty files).
+  #
+  # pathPrefix is the whole client-side path segment; the gateway rewrites
+  # it to rewriteTo before the upstream pod sees the request. We route on
+  # `/{stack.name}` (e.g. `/pool-a`) rather than `/{stack.name}/v1` so the
+  # smoketest can probe both `/{stack.name}/health` and
+  # `/{stack.name}/v1/models` — the vLLM `/health` endpoint lives at the
+  # root, not under `/v1`, and a narrower prefix like `/pool-a/v1` would
+  # not match it.
+  # --------------------------------------------------------------------------
+  httpRoute:
+    mode: shared
+    name: multi-model-route
+    pathPrefix: /{stack.name}
+    rewriteTo: /
+
+  # --------------------------------------------------------------------------
+  # EPP PLUGIN CONFIG - same scheduling profile for all pools. Enabling the
+  # flowControl feature gate is required for WVA autoscaling (EPP queue
+  # depth drives the scaling signal).
+  # --------------------------------------------------------------------------
+  inferenceExtension:
+    pluginsConfigFile: "wva-plugins.yaml"
+    pluginsCustomConfig:
+      wva-plugins.yaml: |
+        apiVersion: inference.networking.x-k8s.io/v1alpha1
+        kind: EndpointPickerConfig
+        featureGates:
+          - flowControl
+        plugins:
+          - type: queue-scorer
+          - type: kv-cache-utilization-scorer
+          - type: prefix-cache-scorer
+        schedulingProfiles:
+          - name: default
+            plugins:
+              - pluginRef: queue-scorer
+                weight: 2
+              - pluginRef: kv-cache-utilization-scorer
+                weight: 2
+              - pluginRef: prefix-cache-scorer
+                weight: 3
+
+  # --------------------------------------------------------------------------
+  # VLLM COMMON - same across pools. Individual flags can be overridden
+  # per-stack below if a specific model needs different tuning.
+  # --------------------------------------------------------------------------
+  vllmCommon:
+    kvTransfer:
+      enabled: true
+      connector: NixlConnector
+      role: kv_both
+    flags:
+      enforceEager: true
+      disableLogRequests: true
+      disableUvicornAccessLog: true
+      allowLongMaxModelLen: "1"
+      serverDevMode: "1"
+    volumes:
+      - name: shared-config
+        type: emptyDir
+        emptyDir: {}
+      - name: dshm
+        type: emptyDir
+        emptyDir:
+          medium: Memory
+          sizeLimit: 8Gi
+    volumeMounts:
+      - name: dshm
+        mountPath: /dev/shm
+      - name: shared-config
+        mountPath: /shared-config
+
+  # --------------------------------------------------------------------------
+  # PREFILL / DECODE defaults shared across pools. Decode resources are
+  # overridden per-stack for model-specific sizing.
+  # --------------------------------------------------------------------------
+  prefill:
+    enabled: false
+    replicas: 0
+
+  decode:
+    initContainers:
+      - name: preprocess
+        image: ghcr.io/llm-d/llm-d-benchmark:auto
+        imagePullPolicy: Always
+        command: ["set_llmdbench_environment.py", "-e", "/shared-config/llmdbench_env.sh", "-i"]
+        volumeMounts:
+          - name: shared-config
+            mountPath: /shared-config
+    parallelism:
+      tensor: 1
+      data: 1
+      dataLocal: 1
+      workers: 1
+    extraEnvVars: []
+    extraContainerConfig:
+      ports:
+        - containerPort: 5557
+          protocol: TCP
+        - containerPort: 8200
+          name: metrics
+          protocol: TCP
+      securityContext:
+        capabilities:
+          add:
+            - "IPC_LOCK"
+            - "SYS_RAWIO"
+        runAsGroup: 0
+        runAsUser: 0
+      imagePullPolicy: Always
+    additionalVolumeMounts: []
+    additionalVolumes: []
+    probes:
+      startup:
+        path: /v1/models
+        failureThreshold: 60
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+      liveness:
+        path: /health
+        failureThreshold: 3
+        periodSeconds: 10
+        timeoutSeconds: 5
+      readiness:
+        path: /v1/models
+        failureThreshold: 3
+        periodSeconds: 5
+        timeoutSeconds: 2
+    monitoring:
+      podmonitor:
+        enabled: true
+        portName: metrics
+        path: /metrics
+        interval: 30s
+        labels:
+          release: llmd
+
+  # --------------------------------------------------------------------------
+  # HARNESS + WORKDIR - harness is single-instance per scenario, so it
+  # lives in `shared` (the workload PVC it writes to is scenario-wide).
+  # --------------------------------------------------------------------------
+  workDir: "~/data/multi-model-wva"
+  harness:
+    name: inference-perf
+    experimentProfile: shared_prefix_synthetic.yaml
+
+  # --------------------------------------------------------------------------
+  # STORAGE - ONE shared model PVC for the whole scenario.
+  # Every stack's weights live in a distinct subdirectory
+  # (`{modelPvc.mountPath}/{model.path}`) on the same volume, which is the
+  # right shape for NVMe / local-directory-backed storage classes and for
+  # reusing cached weights across runs. Size it for the sum of all models
+  # this scenario will ever load.
+  # --------------------------------------------------------------------------
+  storage:
+    modelPvc:
+      size: 100Gi
+
+
+# ============================================================================
+# SCENARIO - per-model stacks
+# ============================================================================
+scenario:
+  # --------------------------------------------------------------------------
+  # QWEN3-06B - Qwen/Qwen3-0.6B
+  # --------------------------------------------------------------------------
+  - name: "qwen3-06b"
+
+    model:
+      name: Qwen/Qwen3-0.6B
+      shortName: qwen-qwen3-0-6b
+      path: models/Qwen/Qwen3-0.6B
+      huggingfaceId: Qwen/Qwen3-0.6B
+      size: 8Gi
+      maxModelLen: 8192
+      blockSize: 64
+      gpuMemoryUtilization: 0.85
+
+    wva:
+      variantAutoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        variantCost: "10.0"
+        slo:
+          tpot: 10
+          ttft: 1000
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetAvgValue: 1
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+          scaleDown:
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+
+    decode:
+      replicas: 1
+      resources:
+        limits:
+          memory: 24Gi
+          cpu: "8"
+        requests:
+          memory: 24Gi
+          cpu: "8"
+
+
+  # --------------------------------------------------------------------------
+  # LLAMA-31-8B - unsloth/Meta-Llama-3.1-8B
+  # --------------------------------------------------------------------------
+  - name: "llama-31-8b"
+
+    model:
+      name: unsloth/Meta-Llama-3.1-8B
+      shortName: unsloth-meta-llama-3-1-8b
+      path: models/unsloth/Meta-Llama-3.1-8B
+      huggingfaceId: unsloth/Meta-Llama-3.1-8B
+      size: 32Gi
+      maxModelLen: 8192
+      blockSize: 64
+      gpuMemoryUtilization: 0.85
+
+    wva:
+      variantAutoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        variantCost: "10.0"
+        slo:
+          tpot: 10
+          ttft: 1000
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetAvgValue: 1
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+          scaleDown:
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+
+    decode:
+      replicas: 1
+      resources:
+        limits:
+          memory: 48Gi
+          cpu: "16"
+        requests:
+          memory: 48Gi
+          cpu: "16"
+

--- a/config/scenarios/guides/multi-model-wva.yaml
+++ b/config/scenarios/guides/multi-model-wva.yaml
@@ -5,23 +5,23 @@
 # controller, reachable through ONE HTTPRoute with N backendRefs.
 #
 # Topology (with N=2):
-#                        ┌──── Gateway (infra-llmdbench, shared) ──────┐
-#                        │     HTTPRoute multi-model-route (shared)    │
-#                        │     ├── /qwen3-06b/v1   → InferencePool A   │
-#                        │     └── /llama-31-8b/v1 → InferencePool B   │
-#                        └─────────────────────────────────────────────┘
-#                              │                          │
-#                      ┌───────┴────────┐         ┌───────┴────────┐
-#                      │ EPP qwen3-06b  │         │ EPP llama-31-8b│
-#                      │ + InferencePool│         │ + InferencePool│
-#                      └───────┬────────┘         └───────┬────────┘
-#                              │                          │
-#                      ┌───────┴────────┐         ┌───────┴────────┐
-#                      │ vLLM decode    │         │ vLLM decode    │
-#                      │ + VA + HPA     │         │ + VA + HPA     │
-#                      └────────────────┘         └────────────────┘
-#                                     ▲                  ▲
-#                                     └──── WVA (1) ─────┘
+#                        +---- Gateway (infra-llmdbench, shared) ------+
+#                        |     HTTPRoute multi-model-route (shared)    |
+#                        |     +-- /qwen3-06b/v1   -> InferencePool A   |
+#                        |     +-- /llama-31-8b/v1 -> InferencePool B   |
+#                        +---------------------------------------------+
+#                              |                          |
+#                      +-------+--------+         +-------+--------+
+#                      | EPP qwen3-06b  |         | EPP llama-31-8b|
+#                      | + InferencePool|         | + InferencePool|
+#                      +-------+--------+         +-------+--------+
+#                              |                          |
+#                      +-------+--------+         +-------+--------+
+#                      | vLLM decode    |         | vLLM decode    |
+#                      | + VA + HPA     |         | + VA + HPA     |
+#                      +----------------+         +----------------+
+#                                     ^                  ^
+#                                     +---- WVA (1) -----+
 #                                           controller
 #
 # Architecture:
@@ -29,7 +29,7 @@
 #   - `shared:` block holds scenario-wide config (WVA controller,
 #     gateway, shared HTTPRoute, EPP plugin config, flowControl feature
 #     gate). It is merged into every stack's values in
-#     render_plans._process_stack BEFORE the per-stack overrides —
+#     render_plans._process_stack BEFORE the per-stack overrides -
 #     per-stack always wins.
 #
 #   - `scenario:` is a list of N stacks. Each gets its own
@@ -38,7 +38,7 @@
 #
 #   - One WVA controller per wva.namespace (deduplicated by
 #     install_wva_for_namespace). Leaving wva.namespace empty in the
-#     shared block sends it to the deploy namespace → one controller.
+#     shared block sends it to the deploy namespace -> one controller.
 #
 # Stack naming convention:
 #
@@ -46,7 +46,7 @@
 #   (`/{stack.name}/v1/...`). Pick short descriptive names that identify
 #   the model family + size (e.g. `qwen3-06b`, `llama-31-8b`) rather than
 #   opaque labels (`pool-a`). Keep them lowercase and URL-safe; no hard
-#   k8s limit on the name itself, but conventionally ≤30 chars.
+#   k8s limit on the name itself, but conventionally <=30 chars.
 #   `--list-endpoints` prints the rendered URLs so users rarely have to
 #   type these manually.
 #
@@ -83,7 +83,7 @@ shared:
   wva:
     enabled: true
     # Tag VAs as part of the inference-scheduling guide so upstream
-    # dashboards group them together with single-model WVA scenarios —
+    # dashboards group them together with single-model WVA scenarios -
     # the underlying architecture (gateway + EPP + InferencePool + VA +
     # HPA) is identical, only the number of pools differs.
     wellLitPath: inference-scheduling
@@ -118,7 +118,7 @@ shared:
   # it to rewriteTo before the upstream pod sees the request. We route on
   # `/{stack.name}` (e.g. `/pool-a`) rather than `/{stack.name}/v1` so the
   # smoketest can probe both `/{stack.name}/health` and
-  # `/{stack.name}/v1/models` — the vLLM `/health` endpoint lives at the
+  # `/{stack.name}/v1/models` - the vLLM `/health` endpoint lives at the
   # root, not under `/v1`, and a narrower prefix like `/pool-a/v1` would
   # not match it.
   # --------------------------------------------------------------------------

--- a/config/specification/guides/multi-model-wva.yaml.j2
+++ b/config/specification/guides/multi-model-wva.yaml.j2
@@ -14,5 +14,5 @@ template_dir:
 scenario_file:
   path: {{ base_dir }}/config/scenarios/guides/multi-model-wva.yaml
 
-# Experiment definitions are shared with inference-scheduling — the workload
+# Experiment definitions are shared with inference-scheduling - the workload
 # shape is the same, only the number of models/pools differs.

--- a/config/specification/guides/multi-model-wva.yaml.j2
+++ b/config/specification/guides/multi-model-wva.yaml.j2
@@ -1,0 +1,18 @@
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/guides/multi-model-wva.yaml
+
+# Experiment definitions are shared with inference-scheduling — the workload
+# shape is the same, only the number of models/pools differs.

--- a/config/templates/jinja/04_download_job.yaml.j2
+++ b/config/templates/jinja/04_download_job.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: download-model
+  name: {{ downloadJob.name }}
   namespace: {{ namespace.name }}
 spec:
   backoffLimit: {{ downloadJob.backoffLimit }}

--- a/config/templates/jinja/08_httproute.yaml.j2
+++ b/config/templates/jinja/08_httproute.yaml.j2
@@ -1,12 +1,12 @@
-{# HTTPRoute rendering — two modes:
+{# HTTPRoute rendering - two modes:
 
-   1. per-stack  (default): emit one HTTPRoute per stack, one backendRef →
+   1. per-stack  (default): emit one HTTPRoute per stack, one backendRef ->
       this stack's {model_id_label}-gaie InferencePool. This is the single-
       model behavior the repo has always had.
 
    2. shared:     emit ONE HTTPRoute in stack index 1 only, with one
       backendRef per sibling stack. Each sibling becomes its own rule with
-      its own PathPrefix → InferencePool routing. Other stacks render empty.
+      its own PathPrefix -> InferencePool routing. Other stacks render empty.
       Gives multi-model scenarios a single-gateway / many-pool frontend.
 
    `httpRoute.mode: shared` is the opt-in; scenarios without the key keep
@@ -14,7 +14,7 @@
 
    Knobs for shared mode (all optional, sensible defaults shown):
      httpRoute.name         (default: "multi-model-route")
-     httpRoute.pathPrefix   (default: "/{stack.name}/v1")  — `{stack.name}`
+     httpRoute.pathPrefix   (default: "/{stack.name}/v1")  - `{stack.name}`
                              is substituted per sibling; if the prefix has
                              no substitution token the stacks will collide
      httpRoute.rewriteTo    (default: "/v1")

--- a/config/templates/jinja/08_httproute.yaml.j2
+++ b/config/templates/jinja/08_httproute.yaml.j2
@@ -1,4 +1,71 @@
+{# HTTPRoute rendering — two modes:
+
+   1. per-stack  (default): emit one HTTPRoute per stack, one backendRef →
+      this stack's {model_id_label}-gaie InferencePool. This is the single-
+      model behavior the repo has always had.
+
+   2. shared:     emit ONE HTTPRoute in stack index 1 only, with one
+      backendRef per sibling stack. Each sibling becomes its own rule with
+      its own PathPrefix → InferencePool routing. Other stacks render empty.
+      Gives multi-model scenarios a single-gateway / many-pool frontend.
+
+   `httpRoute.mode: shared` is the opt-in; scenarios without the key keep
+   the per-stack behavior.
+
+   Knobs for shared mode (all optional, sensible defaults shown):
+     httpRoute.name         (default: "multi-model-route")
+     httpRoute.pathPrefix   (default: "/{stack.name}/v1")  — `{stack.name}`
+                             is substituted per sibling; if the prefix has
+                             no substitution token the stacks will collide
+     httpRoute.rewriteTo    (default: "/v1")
+
+   `siblingStacks` and `stackIndex` are injected by
+   llmdbenchmark.parser.render_plans._process_stack.
+#}
 {% if standalone.enabled is defined and not standalone.enabled %}
+{% set _mode = (httpRoute.mode if httpRoute is defined and httpRoute.mode is defined else 'per-stack') %}
+{% if _mode == 'shared' %}
+{% set _owner_index = sharedInfraStackIndex | default(1) | int %}
+{% set _modelservice_siblings = siblingStacks | selectattr('standalone', 'equalto', false) | list if siblingStacks else [] %}
+{% if stackIndex | default(1) | int == _owner_index and _modelservice_siblings | length > 0 %}
+{% set _name = (httpRoute.name if httpRoute is defined and httpRoute.name is defined else 'multi-model-route') %}
+{% set _prefix_tpl = (httpRoute.pathPrefix if httpRoute is defined and httpRoute.pathPrefix is defined else '/{stack.name}/v1') %}
+{% set _rewrite_to = (httpRoute.rewriteTo if httpRoute is defined and httpRoute.rewriteTo is defined else '/v1') %}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ _name }}
+  namespace: {{ gateway.namespace }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ gateway.name }}
+  rules:
+{% for sibling in _modelservice_siblings %}
+{% set _sibling_label = sibling.modelName | model_id_label(namespace.name) %}
+    - backendRefs:
+      - group: inference.networking.k8s.io
+        kind: InferencePool
+        name: {{ _sibling_label }}-gaie
+        port: {{ decode.vllm.servicePort }}
+        weight: 1
+      timeouts:
+        backendRequest: 0s
+        request: 300s
+      matches:
+        - path:
+            type: PathPrefix
+            value: {{ _prefix_tpl.replace('{stack.name}', sibling.name) }}
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: {{ _rewrite_to }}
+{% endfor %}
+{% endif %}
+{% elif httpRoute is not defined or httpRoute.enabled | default(true) %}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -39,4 +106,5 @@ spec:
       timeouts:
         backendRequest: 0s
         request: 0s
+{% endif %}
 {% endif %}

--- a/config/templates/jinja/09_helmfile-gateway-provider.yaml.j2
+++ b/config/templates/jinja/09_helmfile-gateway-provider.yaml.j2
@@ -15,7 +15,7 @@
 {# Gateway provider (istio / agentgateway control plane) is cluster-scoped
    and lives in a shared namespace (e.g. istio-system). In multi-stack
    scenarios, running `helmfile apply` for the same release concurrently
-   from multiple stacks races on the upgrade — stack 2 hits
+   from multiple stacks races on the upgrade - stack 2 hits
    "release: already exists" while stack 1's upgrade is still in flight.
    Render empty for stacks other than the scenario's shared-infra owner
    so only one install runs per scenario. The per-stack apply step treats

--- a/config/templates/jinja/09_helmfile-gateway-provider.yaml.j2
+++ b/config/templates/jinja/09_helmfile-gateway-provider.yaml.j2
@@ -12,6 +12,22 @@
   The agentgateway release layout mirrors the canonical upstream helmfile:
     https://raw.githubusercontent.com/llm-d-incubation/llm-d-infra/refs/heads/main/quickstart/gateway-control-plane-providers/agentgateway.helmfile.yaml
 #}
+{# Gateway provider (istio / agentgateway control plane) is cluster-scoped
+   and lives in a shared namespace (e.g. istio-system). In multi-stack
+   scenarios, running `helmfile apply` for the same release concurrently
+   from multiple stacks races on the upgrade — stack 2 hits
+   "release: already exists" while stack 1's upgrade is still in flight.
+   Render empty for stacks other than the scenario's shared-infra owner
+   so only one install runs per scenario. The per-stack apply step treats
+   an empty rendered file as a no-op via _has_yaml_content().
+
+   Ownership: `sharedInfraStackIndex` is the 1-indexed position of the
+   first non-standalone stack, computed in
+   `render_plans._resolve_shared_infra_stack_index`. This correctly
+   promotes ownership past any leading standalone stacks (which can't
+   install istio themselves). #}
+{% if stackIndex is defined and stackIndex | int != sharedInfraStackIndex | default(1) | int %}
+{% else %}
 {% set gw_class = gateway.className %}
 {% set gw_ns = gateway.providerNamespace %}
 {% if standalone.enabled is defined and not standalone.enabled and gw_class == 'istio' %}
@@ -93,4 +109,5 @@ releases:
     labels:
       type: gateway-provider
       kind: gateway-control-plane
+{% endif %}
 {% endif %}

--- a/config/templates/jinja/10_helmfile-main.yaml.j2
+++ b/config/templates/jinja/10_helmfile-main.yaml.j2
@@ -10,6 +10,20 @@ repositories:
     url: {{ helmRepositories.llmDInfra.url }}
 
 releases:
+{# `infra-llmdbench` (llm-d-infra chart → Gateway resource + CRDs) is scenario-
+   shared. In multi-stack scenarios, two parallel `helmfile apply` runs from
+   different stacks would both try to upgrade the same release and race on
+   helm's concurrency guard. Render it only in the shared-infra-owner stack;
+   other stacks rely on the owner having installed it and drop the release
+   from their helmfile entirely (along with any `needs:` references to it).
+
+   Owner is computed by render_plans._resolve_shared_infra_stack_index
+   (1-indexed position of the first non-standalone stack) so scenarios
+   that mix standalone + modelservice still install shared infra via the
+   first modelservice stack, not a leading standalone one that can't. #}
+{% set _is_shared_infra_owner = (stackIndex is not defined or stackIndex | int == sharedInfraStackIndex | default(1) | int) %}
+{% set _is_first_stack = _is_shared_infra_owner %}
+{% if _is_first_stack %}
   - name: infra-llmdbench
     namespace: {{ gateway.namespace }}
     chart: llm-d-infra/llm-d-infra
@@ -20,6 +34,7 @@ releases:
       kind: inference-stack
     values:
       - infra.yaml
+{% endif %}
 
   - name: {{ model_id_label }}-ms
     namespace: {{ gateway.namespace }}
@@ -27,7 +42,9 @@ releases:
     version: {{ chartVersions.llmDModelservice }}
     installed: true
     needs:
+{% if _is_first_stack %}
       - {{ gateway.namespace }}/infra-llmdbench
+{% endif %}
       - {{ gateway.namespace }}/{{ model_id_label }}-gaie
     values:
       - ms-values.yaml
@@ -39,8 +56,10 @@ releases:
     chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
     version: {{ chartVersions.inferencePool }}
     installed: true
+{% if _is_first_stack %}
     needs:
       - {{ gateway.namespace }}/infra-llmdbench
+{% endif %}
     values:
       - gaie-values.yaml
     labels:

--- a/config/templates/jinja/10_helmfile-main.yaml.j2
+++ b/config/templates/jinja/10_helmfile-main.yaml.j2
@@ -10,7 +10,7 @@ repositories:
     url: {{ helmRepositories.llmDInfra.url }}
 
 releases:
-{# `infra-llmdbench` (llm-d-infra chart → Gateway resource + CRDs) is scenario-
+{# `infra-llmdbench` (llm-d-infra chart -> Gateway resource + CRDs) is scenario-
    shared. In multi-stack scenarios, two parallel `helmfile apply` runs from
    different stacks would both try to upgrade the same release and race on
    helm's concurrency guard. Render it only in the shared-infra-owner stack;

--- a/config/templates/jinja/12_gaie-values.yaml.j2
+++ b/config/templates/jinja/12_gaie-values.yaml.j2
@@ -37,13 +37,17 @@ inferenceExtension:
 {% endfor %}
 {% endif %}
   monitoring:
-    secret:
-      name: {{ inferenceExtension.monitoring.secretName | default('inference-gateway-sa-metrics-reader-secret') }}
     interval: "{{ inferenceExtension.monitoring.interval | default('10s') }}"
     prometheus:
       enabled: {{ inferenceExtension.monitoring.prometheus.enabled | default(true) | lower }}
       auth:
         enabled: {{ inferenceExtension.monitoring.prometheus.auth.enabled | default(true) | lower }}
+        # Overridable Secret name for the Prometheus ServiceAccount token.
+        # The gaie (inferencepool) chart v1.4.0 uses this exact path; older
+        # templates wrote `monitoring.secret.name` which the chart silently
+        # ignored and fell back to its hardcoded default, causing
+        # cross-release Helm ownership conflicts in multi-stack scenarios.
+        secretName: {{ inferenceExtension.monitoring.secretName | default('inference-gateway-sa-metrics-reader-secret') }}
   flags:
 {% if inferenceExtension.flags is defined and inferenceExtension.flags %}
 {% for key, value in inferenceExtension.flags.items() %}

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -249,7 +249,7 @@ decode:
   priorityClassName: {{ decode_priority }}
 {% endif %}
 
-{# GPU count = accelerator.count if explicit, else tensor × dataLocal (each DP-local rank needs its own GPU) #}
+{# GPU count = accelerator.count if explicit, else tensor x dataLocal (each DP-local rank needs its own GPU) #}
 {% set decode_default_gpus = (decode.parallelism.tensor | int) * (decode.parallelism.dataLocal | int) %}
 {% set decode_accel_count = (decode.accelerator.count | default(decode_default_gpus) | int) if decode.accelerator is defined else decode_default_gpus %}
 {% if decode_accel_count > 0 %}
@@ -358,7 +358,7 @@ decode:
   subGroupExclusiveTopology: {{ decode.subGroupExclusiveTopology | lower }}
 {% endif %}
 
-{# Init containers — default image to images.benchmark if not specified or set to "auto".
+{# Init containers - default image to images.benchmark if not specified or set to "auto".
    Propagate core env vars so preprocess scripts have access to port numbers,
    model parameters, and parallelism settings. This was not done in the bash
    implementation but is needed for preprocess scripts that configure NCCL,
@@ -656,7 +656,7 @@ prefill:
   priorityClassName: {{ prefill_priority }}
 {% endif %}
 
-{# GPU count = accelerator.count if explicit, else tensor × dataLocal (each DP-local rank needs its own GPU) #}
+{# GPU count = accelerator.count if explicit, else tensor x dataLocal (each DP-local rank needs its own GPU) #}
 {% set prefill_default_gpus = (prefill.parallelism.tensor | int) * (prefill.parallelism.dataLocal | int) %}
 {% set prefill_accel_count = (prefill.accelerator.count | default(prefill_default_gpus) | int) if prefill.accelerator is defined else prefill_default_gpus %}
 {% if prefill_accel_count > 0 %}

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -1024,7 +1024,7 @@ prefill:
 {# -------------------------------------------------------------------------- #}
 {% if extraObjects is defined and extraObjects %}
 extraObjects:
-{{ extraObjects | toyaml | indent(2) }}
+{{ extraObjects | toyaml | indent(2, first=True) }}
 {% endif %}
 
 {% endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -286,7 +286,7 @@ storage:
       - ReadWriteMany
     storageClassName: *storage_class
 
-  # Extra PVC — only created when name is non-empty.
+  # Extra PVC - only created when name is non-empty.
   # Mirrors bash LLMDBENCH_VLLM_COMMON_EXTRA_PVC_NAME.
   # The PVC is NOT automatically mounted; scenarios must also add matching
   # entries to vllmCommon.volumes/volumeMounts to wire it into pods.
@@ -563,7 +563,7 @@ inferenceExtension:
   #       ...
   pluginsCustomConfig: {}
   verbosity: "1"
-  # UDS tokenizer sidecar — runs alongside EPP for precise-prefix-cache scoring.
+  # UDS tokenizer sidecar - runs alongside EPP for precise-prefix-cache scoring.
   # Enable in scenarios that use `precise-prefix-cache-scorer` with UDS tokenizer.
   sidecar:
     enabled: false
@@ -758,13 +758,13 @@ decode:
   # Scheduler name override global schedulerName (optional)
   # schedulerName: default-scheduler
 
-  # PriorityClassName override (optional — inherits from vllmCommon if not set)
+  # PriorityClassName override (optional - inherits from vllmCommon if not set)
   # priorityClassName: ""
 
-  # Ephemeral storage override (optional — inherits from vllmCommon if not set)
+  # Ephemeral storage override (optional - inherits from vllmCommon if not set)
   # ephemeralStorage: ""
 
-  # Network resource override (optional — inherits from vllmCommon if not set)
+  # Network resource override (optional - inherits from vllmCommon if not set)
   # networkResource: ""
   # networkNr: ""
 
@@ -906,13 +906,13 @@ prefill:
   # Scheduler name override global schedulerName (optional)
   # schedulerName: default-scheduler
 
-  # PriorityClassName override (optional — inherits from vllmCommon if not set)
+  # PriorityClassName override (optional - inherits from vllmCommon if not set)
   # priorityClassName: ""
 
-  # Ephemeral storage override (optional — inherits from vllmCommon if not set)
+  # Ephemeral storage override (optional - inherits from vllmCommon if not set)
   # ephemeralStorage: ""
 
-  # Network resource override (optional — inherits from vllmCommon if not set)
+  # Network resource override (optional - inherits from vllmCommon if not set)
   # networkResource: ""
   # networkNr: ""
 
@@ -1035,13 +1035,13 @@ standalone:
   # Scheduler name override global schedulerName (optional)
   schedulerName: default-scheduler
 
-  # PriorityClassName override (optional — inherits from vllmCommon if not set)
+  # PriorityClassName override (optional - inherits from vllmCommon if not set)
   # priorityClassName: ""
 
-  # Ephemeral storage override (optional — inherits from vllmCommon if not set)
+  # Ephemeral storage override (optional - inherits from vllmCommon if not set)
   # ephemeralStorage: ""
 
-  # Network resource override (optional — inherits from vllmCommon if not set)
+  # Network resource override (optional - inherits from vllmCommon if not set)
   # networkResource: ""
   # networkNr: ""
 
@@ -1447,7 +1447,7 @@ openshiftMonitoring:
 
 # ============================================================================
 # IDLE CLEANUP (Experimental)
-# Automatic GPU reclamation — scales down idle model deployments to 0 replicas
+# Automatic GPU reclamation - scales down idle model deployments to 0 replicas
 # when no inference requests are observed over a configurable window.
 #
 # Deploys a namespace-scoped CronJob with its own ServiceAccount + RBAC.

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1261,6 +1261,11 @@ fma:
 # DOWNLOAD JOB CONFIGURATION
 # ============================================================================
 downloadJob:
+  # Job name. Multi-stack scenarios auto-suffix this with the model ID
+  # label (render_plans._resolve_per_stack_identity) so each stack gets
+  # its own download-{model_id_label} Job and the waits don't cross-talk.
+  # Set explicitly here to opt out of the auto-suffix.
+  name: download-model
   backoffLimit: 3
   mountPath: /cache
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -999,16 +999,16 @@ share a namespace, the render engine auto-suffixes a small set of shipped-defaul
 resource names with the stack's ``model_id_label`` so Helm releases and
 Kubernetes objects don't collide:
 
-| Default path | Rewritten to (N ≥ 2) |
+| Default path | Rewritten to (N >= 2) |
 |---|---|
 | `downloadJob.name` (`download-model`) | `download-model-{model_id_label}` |
-| `inferenceExtension.monitoring.secretName` | `…-sa-metrics-reader-secret-{model_id_label}` |
+| `inferenceExtension.monitoring.secretName` | `...-sa-metrics-reader-secret-{model_id_label}` |
 
 Explicit overrides (in `defaults.yaml`, `shared:`, or a stack) are preserved.
 Single-stack scenarios skip the rewrite entirely.
 
 **Model PVCs are shared, not per-stack.** `storage.modelPvc.name` deliberately
-is **not** in the auto-suffix list — every stack writes its weights to a
+is **not** in the auto-suffix list - every stack writes its weights to a
 distinct subdirectory on one shared PVC (keyed by `model.path`). That matches
 how NVMe-backed and local-directory storage classes are typically deployed
 (one volume with per-model subdirs, not N volumes), and avoids wasting
@@ -1020,14 +1020,14 @@ for the implementation and `_STACK_SCOPED_DEFAULTS` for the full list.
 
 **Shared HTTPRoute template.** When `httpRoute.mode: shared`, only the first
 stack's render of [`08_httproute.yaml.j2`](../config/templates/jinja/08_httproute.yaml.j2)
-emits a non-empty file — a single HTTPRoute with one backendRef per sibling
+emits a non-empty file - a single HTTPRoute with one backendRef per sibling
 stack. Sibling stacks are exposed to templates via the injected
 `siblingStacks` list and `stackIndex` variable (see
 [`_build_sibling_stacks`](../llmdbenchmark/parser/render_plans.py)). The same
-`stackIndex > 1 → empty` gate dedupes cluster-shared infra templates —
+`stackIndex > 1 -> empty` gate dedupes cluster-shared infra templates -
 [`09_helmfile-gateway-provider.yaml.j2`](../config/templates/jinja/09_helmfile-gateway-provider.yaml.j2)
 (istio control plane) and the `infra-llmdbench` release in
-[`10_helmfile-main.yaml.j2`](../config/templates/jinja/10_helmfile-main.yaml.j2) —
+[`10_helmfile-main.yaml.j2`](../config/templates/jinja/10_helmfile-main.yaml.j2) -
 so N stacks don't race on the same Helm release during parallel per-stack step
 execution.
 
@@ -1039,7 +1039,7 @@ execution.
    YAML and the scenario YAML. For each stack it applies a four-layer merge:
 
    ```
-   defaults.yaml  →  scenario.shared  →  stack config  →  CLI / setup overrides
+   defaults.yaml  ->  scenario.shared  ->  stack config  ->  CLI / setup overrides
    ```
 
    Each later layer wins over earlier ones; dicts deep-merge, lists replace

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -917,16 +917,137 @@ The deployment method must be exactly one of `standalone` or `modelservice`.
 Both `standalone.enabled` and `modelservice.enabled` must be explicitly set so
 that the rendered templates know which path to take.
 
+#### Multi-stack example
+
+When a scenario defines more than one stack (e.g. to run multiple models
+behind the same gateway), lift scenario-wide settings into the top-level
+`shared:` block and keep per-stack blocks to just the model-specific knobs.
+
+```yaml
+# config/scenarios/examples/my-two-model-scenario.yaml
+shared:
+  modelservice: { enabled: true }
+  standalone:   { enabled: false }
+  httpRoute:
+    mode: shared
+    name: multi-model-route
+    pathPrefix: /{stack.name}
+    rewriteTo: /
+  wva:
+    enabled: true
+    image: { tag: v0.6.0 }
+
+scenario:
+  - name: qwen3-06b
+    model: { name: Qwen/Qwen3-0.6B, ... }
+    decode: { replicas: 1 }
+    wva:
+      variantAutoscaling: { minReplicas: 1, maxReplicas: 4 }
+      hpa:                { minReplicas: 1, maxReplicas: 4 }
+  - name: llama-31-8b
+    model: { name: unsloth/Meta-Llama-3.1-8B, ... }
+    decode: { replicas: 1 }
+    wva:
+      variantAutoscaling: { minReplicas: 1, maxReplicas: 4 }
+      hpa:                { minReplicas: 1, maxReplicas: 4 }
+```
+
+See the next subsection for how `shared:` merges with per-stack and the
+render-time behavior (auto-named PVCs, shared HTTPRoute, stack-index guards).
+For a fully-annotated real scenario, see
+[`guides/multi-model-wva.yaml`](../config/scenarios/guides/multi-model-wva.yaml).
+
+### Multi-Stack Scenarios and the `shared:` Block
+
+The scenario file supports an optional top-level `shared:` block alongside the
+`scenario:` list. Values in `shared:` are merged into every stack *before* the
+per-stack overrides, letting you lift scenario-wide settings (gateway, WVA
+controller, shared HTTPRoute config, chart versions, plugin config) out of
+per-stack blocks. Per-stack always wins, so a stack can still opt out of any
+shared value by setting it explicitly.
+
+```yaml
+# config/scenarios/guides/multi-model-wva.yaml (abridged)
+shared:
+  modelservice: { enabled: true }
+  standalone:   { enabled: false }
+  wva:
+    enabled: true
+    image: { repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler, tag: v0.6.0 }
+  httpRoute:
+    mode: shared
+    name: multi-model-route
+    pathPrefix: /{stack.name}
+    rewriteTo: /
+  vllmCommon:
+    flags: { enforceEager: true }
+
+scenario:
+  - name: qwen3-06b
+    model: { name: Qwen/Qwen3-0.6B, ... }
+    decode: { replicas: 1, resources: { ... } }
+    wva:
+      variantAutoscaling: { minReplicas: 1, maxReplicas: 4 }
+      hpa:                { minReplicas: 1, maxReplicas: 4 }
+  - name: llama-31-8b
+    model: { name: unsloth/Meta-Llama-3.1-8B, ... }
+    # same shape
+```
+
+**Resource-name collision handling (multi-stack only).** When two or more stacks
+share a namespace, the render engine auto-suffixes a small set of shipped-default
+resource names with the stack's ``model_id_label`` so Helm releases and
+Kubernetes objects don't collide:
+
+| Default path | Rewritten to (N ≥ 2) |
+|---|---|
+| `downloadJob.name` (`download-model`) | `download-model-{model_id_label}` |
+| `inferenceExtension.monitoring.secretName` | `…-sa-metrics-reader-secret-{model_id_label}` |
+
+Explicit overrides (in `defaults.yaml`, `shared:`, or a stack) are preserved.
+Single-stack scenarios skip the rewrite entirely.
+
+**Model PVCs are shared, not per-stack.** `storage.modelPvc.name` deliberately
+is **not** in the auto-suffix list — every stack writes its weights to a
+distinct subdirectory on one shared PVC (keyed by `model.path`). That matches
+how NVMe-backed and local-directory storage classes are typically deployed
+(one volume with per-model subdirs, not N volumes), and avoids wasting
+pre-provisioned disk. Operators who genuinely need per-model volumes can
+override `storage.modelPvc.name` per-stack in the scenario.
+
+See [`_resolve_per_stack_identity`](../llmdbenchmark/parser/render_plans.py)
+for the implementation and `_STACK_SCOPED_DEFAULTS` for the full list.
+
+**Shared HTTPRoute template.** When `httpRoute.mode: shared`, only the first
+stack's render of [`08_httproute.yaml.j2`](../config/templates/jinja/08_httproute.yaml.j2)
+emits a non-empty file — a single HTTPRoute with one backendRef per sibling
+stack. Sibling stacks are exposed to templates via the injected
+`siblingStacks` list and `stackIndex` variable (see
+[`_build_sibling_stacks`](../llmdbenchmark/parser/render_plans.py)). The same
+`stackIndex > 1 → empty` gate dedupes cluster-shared infra templates —
+[`09_helmfile-gateway-provider.yaml.j2`](../config/templates/jinja/09_helmfile-gateway-provider.yaml.j2)
+(istio control plane) and the `infra-llmdbench` release in
+[`10_helmfile-main.yaml.j2`](../config/templates/jinja/10_helmfile-main.yaml.j2) —
+so N stacks don't race on the same Helm release during parallel per-stack step
+execution.
+
 ### How Templates Are Rendered
 
 1. `RenderSpecification` renders the `.yaml.j2` spec to resolve `base_dir`
    paths and writes the result as YAML.
 2. `RenderPlans` (in `llmdbenchmark/parser/render_plans.py`) loads the defaults
-   YAML and the scenario YAML, deep-merges them (scenario overrides defaults),
-   then renders each Jinja2 template in `config/templates/jinja/` with the
-   merged config values.
+   YAML and the scenario YAML. For each stack it applies a four-layer merge:
+
+   ```
+   defaults.yaml  →  scenario.shared  →  stack config  →  CLI / setup overrides
+   ```
+
+   Each later layer wins over earlier ones; dicts deep-merge, lists replace
+   wholesale. After merging, `RenderPlans` resolves model IDs, per-stack
+   identity names, and substitutes `${dotted.path}` references, then renders
+   each Jinja2 template in `config/templates/jinja/` with the final values.
 3. Output goes to one directory per stack under the plan directory (e.g.,
-   `plan/my-custom-deployment/`).
+   `plan/my-custom-deployment/`, or `plan/qwen3-06b/`, `plan/llama-31-8b/`, ...).
 
 ### Custom Jinja2 Templates
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -95,7 +95,7 @@ Smoketests include three steps:
 
 Well-lit-path scenarios (pd-disaggregation, precise-prefix-cache-aware, inference-scheduling, inference-scheduling-wva, tiered-prefix-cache, wide-ep-lws, simulated-accelerators) have dedicated validators with scenario-specific checks. Other scenarios (including multi-stack scenarios like `multi-model-wva`) run steps 00 and 01 only.
 
-Multi-stack scenarios run smoketest steps sequentially (one stack at a time) regardless of the `--parallel` flag — parallel probes of a shared gateway would be noisy and harder to debug. Each stack's `/health` and `/v1/models` requests are automatically prefixed with its routing path (e.g. `/qwen3-06b/...`) when the scenario uses a shared HTTPRoute.
+Multi-stack scenarios run smoketest steps sequentially (one stack at a time) regardless of the `--parallel` flag - parallel probes of a shared gateway would be noisy and harder to debug. Each stack's `/health` and `/v1/models` requests are automatically prefixed with its routing path (e.g. `/qwen3-06b/...`) when the scenario uses a shared HTTPRoute.
 
 #### Run
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -93,7 +93,9 @@ Smoketests include three steps:
 - **Step 01** -- Inference test: sends a sample `/v1/completions` request, logs generated text and a demo curl command
 - **Step 02** -- Config validation: per-scenario checks that compare deployed pod configuration against the rendered scenario config (resources, parallelism, env vars, probes, volumes, security, vLLM flags, etc.)
 
-Well-lit-path scenarios (pd-disaggregation, precise-prefix-cache-aware, inference-scheduling, tiered-prefix-cache, wide-ep-lws, simulated-accelerators) have dedicated validators with scenario-specific checks. Other scenarios run steps 00 and 01 only.
+Well-lit-path scenarios (pd-disaggregation, precise-prefix-cache-aware, inference-scheduling, inference-scheduling-wva, tiered-prefix-cache, wide-ep-lws, simulated-accelerators) have dedicated validators with scenario-specific checks. Other scenarios (including multi-stack scenarios like `multi-model-wva`) run steps 00 and 01 only.
+
+Multi-stack scenarios run smoketest steps sequentially (one stack at a time) regardless of the `--parallel` flag — parallel probes of a shared gateway would be noisy and harder to debug. Each stack's `/health` and `/v1/models` requests are automatically prefixed with its routing path (e.g. `/qwen3-06b/...`) when the scenario uses a shared HTTPRoute.
 
 #### Run
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -340,7 +340,8 @@ The workspace directory printed at the top of every run contains all rendered te
 You just ran the same lifecycle CI exercises every PR. From here, natural next steps are:
 
 - **Try a real GPU scenario**: see [`config/specification/examples/gpu.yaml.j2`](../config/specification/examples/gpu.yaml.j2) and run it against a cluster that has GPU nodes.
-- **Explore the well-lit paths**: [`config/specification/guides/`](../config/specification/guides/) has scenarios for `inference-scheduling`, `pd-disaggregation`, `precise-prefix-cache-aware`, `tiered-prefix-cache`, and `wide-ep-lws` — each worth a read even if you don't run them.
+- **Explore the well-lit paths**: [`config/specification/guides/`](../config/specification/guides/) has scenarios for `inference-scheduling`, `inference-scheduling-wva`, `multi-model-wva`, `pd-disaggregation`, `precise-prefix-cache-aware`, `tiered-prefix-cache`, and `wide-ep-lws` — each worth a read even if you don't run them.
+- **Try multi-model with WVA**: [`multi-model-wva`](../config/scenarios/guides/multi-model-wva.yaml) deploys two models behind one gateway with a single shared HTTPRoute and a single WVA controller autoscaling each pool independently. Standup: `llmdbenchmark --spec guides/multi-model-wva standup -p <namespace>`.
 - **Write a custom scenario**: see the [Developer Guide, Section 7](developer-guide.md#7-how-to-add-a-new-scenario-well-lit-path) — "How to Add a New Scenario".
 - **Add a new benchmark step**: see the [Developer Guide, Section 2](developer-guide.md#2-how-to-add-a-new-step) — "How to Add a New Step".
 - **Set up pre-commit** so your first PR passes CI on the first try: see [Local Development Checks in CONTRIBUTING.md](../CONTRIBUTING.md#local-development-checks-pre-commit).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This guide walks you through running your **first llm-d-benchmark deployment on a local [Kind](https://kind.sigs.k8s.io/) cluster** — no GPU required. By the end you will have stood up a simulated inference deployment, run a sanity benchmark workload against it, and torn everything down cleanly.
+This guide walks you through running your **first llm-d-benchmark deployment on a local [Kind](https://kind.sigs.k8s.io/) cluster** - no GPU required. By the end you will have stood up a simulated inference deployment, run a sanity benchmark workload against it, and torn everything down cleanly.
 
 This is the same scenario our CI runs on every PR (see [`ci-pr-benchmark.yaml`](../.github/workflows/ci-pr-benchmark.yaml)), so if the walkthrough works here it will work the same way in CI.
 
@@ -10,11 +10,11 @@ This is the same scenario our CI runs on every PR (see [`ci-pr-benchmark.yaml`](
 >
 > Kind is a local-Docker-in-Docker Kubernetes distribution. It is ideal for:
 >
-> - **First-time walkthroughs of the framework** — you can exercise the full `standup → smoketest → run → teardown` lifecycle without any cloud account, cluster access, or GPU hardware.
-> - **Iterating on framework code** — testing your changes to steps, templates, or scenarios locally in a fast feedback loop.
-> - **Reproducing CI failures** — the PR-benchmark workflow uses this exact `cicd/kind-sim` scenario on a Kind cluster, so a local repro is one `./util/test-scenarios.sh` invocation away.
+> - **First-time walkthroughs of the framework** - you can exercise the full `standup -> smoketest -> run -> teardown` lifecycle without any cloud account, cluster access, or GPU hardware.
+> - **Iterating on framework code** - testing your changes to steps, templates, or scenarios locally in a fast feedback loop.
+> - **Reproducing CI failures** - the PR-benchmark workflow uses this exact `cicd/kind-sim` scenario on a Kind cluster, so a local repro is one `./util/test-scenarios.sh` invocation away.
 >
-> Kind is **not** a benchmarking target. It runs a simulated inference engine (`llm-d-inference-sim`) on CPU, so any latency, throughput, or GPU-utilization numbers you collect here are meaningless as performance data. When you have access to a cluster with real accelerators, switch to one of the GPU-backed scenarios under [`config/specification/examples/gpu.yaml.j2`](../config/specification/examples/gpu.yaml.j2) or [`config/specification/guides/`](../config/specification/guides/) and skip steps 1 and 2 of this guide — jump straight to [step 3 (Install llmdbenchmark)](#3-install-llmdbenchmark) and use your existing kubeconfig.
+> Kind is **not** a benchmarking target. It runs a simulated inference engine (`llm-d-inference-sim`) on CPU, so any latency, throughput, or GPU-utilization numbers you collect here are meaningless as performance data. When you have access to a cluster with real accelerators, switch to one of the GPU-backed scenarios under [`config/specification/examples/gpu.yaml.j2`](../config/specification/examples/gpu.yaml.j2) or [`config/specification/guides/`](../config/specification/guides/) and skip steps 1 and 2 of this guide - jump straight to [step 3 (Install llmdbenchmark)](#3-install-llmdbenchmark) and use your existing kubeconfig.
 
 ## Table of Contents
 
@@ -35,8 +35,8 @@ This is the same scenario our CI runs on every PR (see [`ci-pr-benchmark.yaml`](
 |---|---|
 | Cluster | Kind (local Docker-in-Docker, CPU-only) |
 | Scenario | [`cicd/kind-sim`](../config/scenarios/cicd/kind-sim.yaml) |
-| Model | `facebook/opt-125m` (small — chosen so the quickstart works on a laptop) |
-| Inference engine | [`llm-d-inference-sim`](https://github.com/llm-d/llm-d-inference-sim) — fake inference, no GPU |
+| Model | `facebook/opt-125m` (small - chosen so the quickstart works on a laptop) |
+| Inference engine | [`llm-d-inference-sim`](https://github.com/llm-d/llm-d-inference-sim) - fake inference, no GPU |
 | Deploy methods | `modelservice` (default) or `standalone` |
 | Harness | `inference-perf` with the `sanity_random.yaml` workload profile |
 
@@ -55,7 +55,7 @@ You need these installed before starting:
 
 > **Resource note:** The `cicd/kind-sim` scenario deploys ~7 pods on a single Kind node. With the default 2 CPUs that Docker Desktop, Colima, and Podman ship with, the harness pod (and sometimes the gateway) cannot schedule due to `Insufficient cpu`. Bump your container runtime to **4 CPUs** before creating the Kind cluster. See [Troubleshooting](#pods-stuck-in-pending-during-standup-or-run) if you hit this.
 
-Everything else — `kubectl`, `helm`, `helmfile`, `kind`, `skopeo`, `crane`, `helm-diff`, `jq`, `yq`, `kustomize` — will be installed for you by `./install.sh` in [step 3](#3-install-llmdbenchmark), with one exception: `kind` itself, which we install first below because we want the cluster up before the installer runs.
+Everything else - `kubectl`, `helm`, `helmfile`, `kind`, `skopeo`, `crane`, `helm-diff`, `jq`, `yq`, `kustomize` - will be installed for you by `./install.sh` in [step 3](#3-install-llmdbenchmark), with one exception: `kind` itself, which we install first below because we want the cluster up before the installer runs.
 
 ## 1. Install Kind locally
 
@@ -95,7 +95,7 @@ If you prefer a different installation path or version manager, see the [upstrea
 
 ## 2. Create the Kind cluster
 
-Create a single-node cluster. The default Kind configuration is enough — we do **not** need any special port mappings, extra mounts, or registry config for `cicd/kind-sim`.
+Create a single-node cluster. The default Kind configuration is enough - we do **not** need any special port mappings, extra mounts, or registry config for `cicd/kind-sim`.
 
 ```bash
 kind create cluster --name llmd-quickstart
@@ -122,7 +122,7 @@ cd llm-d-benchmark
 source .venv/bin/activate
 ```
 
-We intentionally **do not** pass `-y` to `install.sh`. The `-y` flag forces the installer to use your system Python instead of creating a virtualenv, which is appropriate on CI runners (they are already isolated containers) but wrong for local development — it would pollute your system site-packages and skip the `.venv/` that `source .venv/bin/activate` on the next line expects. Always run `./install.sh` without flags on your laptop.
+We intentionally **do not** pass `-y` to `install.sh`. The `-y` flag forces the installer to use your system Python instead of creating a virtualenv, which is appropriate on CI runners (they are already isolated containers) but wrong for local development - it would pollute your system site-packages and skip the `.venv/` that `source .venv/bin/activate` on the next line expects. Always run `./install.sh` without flags on your laptop.
 
 Verify the CLI is on PATH:
 
@@ -136,7 +136,7 @@ You should see the `llmdbenchmark` help banner with `plan`, `standup`, `smoketes
 
 ## 4. First deployment: standup + smoketest + run (modelservice)
 
-Now we run the full four-phase lifecycle against the Kind cluster we created in [step 2](#2-create-the-kind-cluster). `modelservice` is the default deploy method — no `-t` flag needed.
+Now we run the full four-phase lifecycle against the Kind cluster we created in [step 2](#2-create-the-kind-cluster). `modelservice` is the default deploy method - no `-t` flag needed.
 
 Pick a namespace for your run. Anything unique is fine:
 
@@ -175,7 +175,7 @@ This sends a handful of real requests through the gateway, validates the respons
 
 ### 4c. Run the benchmark
 
-Now run the `inference-perf` harness with the `sanity_random.yaml` workload. This is the smallest benchmark profile we ship — perfect for a first run.
+Now run the `inference-perf` harness with the `sanity_random.yaml` workload. This is the smallest benchmark profile we ship - perfect for a first run.
 
 ```bash
 llmdbenchmark --spec cicd/kind-sim run -p "$NS" \
@@ -190,7 +190,7 @@ What to expect:
 - Per-request metrics are collected into a results directory printed at the end of the run.
 - The analysis phase generates summary CSVs and plots in that same directory.
 
-The results directory path is printed in the final log line — something like `/tmp/<user>-<timestamp>/<phase>/<stack>/results/`. You can open the plots with any image viewer or the CSVs with any spreadsheet.
+The results directory path is printed in the final log line - something like `/tmp/<user>-<timestamp>/<phase>/<stack>/results/`. You can open the plots with any image viewer or the CSVs with any spreadsheet.
 
 ## 5. Alternate path: standalone deployment
 
@@ -207,7 +207,7 @@ llmdbenchmark --spec cicd/kind-sim run       -p "$NS_SA" -t standalone \
     -l inference-perf -w sanity_random.yaml
 ```
 
-The `-t standalone` flag is the only difference from [step 4](#4-first-deployment-standup--smoketest--run-modelservice). Every other argument — spec, namespace, harness, workload — is identical.
+The `-t standalone` flag is the only difference from [step 4](#4-first-deployment-standup--smoketest--run-modelservice). Every other argument - spec, namespace, harness, workload - is identical.
 
 ## 6. Tear down
 
@@ -248,7 +248,7 @@ kind delete cluster --name llmd-quickstart
   **Check your current allocation:**
 
   ```bash
-  # Docker Desktop / Colima / Podman — any of these will work:
+  # Docker Desktop / Colima / Podman - any of these will work:
   docker info 2>/dev/null | grep -E "CPUs|Total Memory"
   podman info 2>/dev/null | grep -E "cpus|memTotal"
   colima status 2>/dev/null
@@ -257,11 +257,11 @@ kind delete cluster --name llmd-quickstart
   kubectl describe node | grep -A6 "Allocated resources"
   ```
 
-  **Fix — increase CPUs to at least 4 (8 GiB RAM recommended):**
+  **Fix - increase CPUs to at least 4 (8 GiB RAM recommended):**
 
   ```bash
   # Docker Desktop: Settings > Resources > CPUs: 4, Memory: 8 GiB
-  # (no CLI option — must be done through the GUI)
+  # (no CLI option - must be done through the GUI)
 
   # Colima
   colima stop && colima start --cpu 4 --memory 8
@@ -279,7 +279,7 @@ kind delete cluster --name llmd-quickstart
 
   Then re-run standup from scratch.
 
-- **PVC stuck**: `kubectl get pvc -n "$NS"` — the `standard` Kind storage class should provision immediately. If it does not, you're probably out of disk; see above.
+- **PVC stuck**: `kubectl get pvc -n "$NS"` - the `standard` Kind storage class should provision immediately. If it does not, you're probably out of disk; see above.
 - **Image pull backoff**: check `kubectl describe pod -n "$NS" <pod>` for the failing image and make sure your machine has network access to `ghcr.io`.
 - **Node selector mismatch**: if `kubectl describe pod -n "$NS" <pod>` shows `0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector`, print the node's labels with `kubectl get node -o jsonpath='{.items[0].metadata.labels}' | jq` and cross-check against the scenario's `affinity.nodeSelector` in `config/scenarios/cicd/kind-sim.yaml`. On a standard Kind cluster this should always match because `kubernetes.io/os=linux` is a well-known label the kubelet sets automatically.
 
@@ -300,7 +300,7 @@ source .venv/bin/activate
 ./install.sh
 ```
 
-(no `-y` — we want the `.venv/` path, not system Python)
+(no `-y` - we want the `.venv/` path, not system Python)
 
 ### Standup reports "Model download failed"
 
@@ -311,14 +311,14 @@ The `facebook/opt-125m` model is public and small. If the download fails, you mo
 
 ### Run phase hangs on `waiting for harness pod` or reports `No pods deployed`
 
-- `kubectl get pods -n "$NS"` — check if the harness pod is `Pending`. If `kubectl describe pod -n "$NS" <harness-pod>` shows `Insufficient cpu` or `Insufficient memory`, see [Pods stuck in Pending](#pods-stuck-in-pending-during-standup-or-run) above.
+- `kubectl get pods -n "$NS"` - check if the harness pod is `Pending`. If `kubectl describe pod -n "$NS" <harness-pod>` shows `Insufficient cpu` or `Insufficient memory`, see [Pods stuck in Pending](#pods-stuck-in-pending-during-standup-or-run) above.
 - If a previous run failed and left a stale harness pod, clean it up before retrying:
 
   ```bash
   kubectl delete pod -n "$NS" -l app=llmdbench-harness-launcher --ignore-not-found
   ```
 
-- If you edited `harness.resources` in your scenario to reduce requests, you must re-run `plan` before `run` (no standup needed — the cluster infra is unchanged):
+- If you edited `harness.resources` in your scenario to reduce requests, you must re-run `plan` before `run` (no standup needed - the cluster infra is unchanged):
 
   ```bash
   llmdbenchmark --spec cicd/kind-sim plan -p "$NS"
@@ -340,10 +340,10 @@ The workspace directory printed at the top of every run contains all rendered te
 You just ran the same lifecycle CI exercises every PR. From here, natural next steps are:
 
 - **Try a real GPU scenario**: see [`config/specification/examples/gpu.yaml.j2`](../config/specification/examples/gpu.yaml.j2) and run it against a cluster that has GPU nodes.
-- **Explore the well-lit paths**: [`config/specification/guides/`](../config/specification/guides/) has scenarios for `inference-scheduling`, `inference-scheduling-wva`, `multi-model-wva`, `pd-disaggregation`, `precise-prefix-cache-aware`, `tiered-prefix-cache`, and `wide-ep-lws` — each worth a read even if you don't run them.
+- **Explore the well-lit paths**: [`config/specification/guides/`](../config/specification/guides/) has scenarios for `inference-scheduling`, `inference-scheduling-wva`, `multi-model-wva`, `pd-disaggregation`, `precise-prefix-cache-aware`, `tiered-prefix-cache`, and `wide-ep-lws` - each worth a read even if you don't run them.
 - **Try multi-model with WVA**: [`multi-model-wva`](../config/scenarios/guides/multi-model-wva.yaml) deploys two models behind one gateway with a single shared HTTPRoute and a single WVA controller autoscaling each pool independently. Standup: `llmdbenchmark --spec guides/multi-model-wva standup -p <namespace>`.
-- **Write a custom scenario**: see the [Developer Guide, Section 7](developer-guide.md#7-how-to-add-a-new-scenario-well-lit-path) — "How to Add a New Scenario".
-- **Add a new benchmark step**: see the [Developer Guide, Section 2](developer-guide.md#2-how-to-add-a-new-step) — "How to Add a New Step".
+- **Write a custom scenario**: see the [Developer Guide, Section 7](developer-guide.md#7-how-to-add-a-new-scenario-well-lit-path) - "How to Add a New Scenario".
+- **Add a new benchmark step**: see the [Developer Guide, Section 2](developer-guide.md#2-how-to-add-a-new-step) - "How to Add a New Step".
 - **Set up pre-commit** so your first PR passes CI on the first try: see [Local Development Checks in CONTRIBUTING.md](../CONTRIBUTING.md#local-development-checks-pre-commit).
 
-If you hit anything that didn't work for you in this guide, please [open an issue](https://github.com/llm-d/llm-d-benchmark/issues) — that's the fastest way to get the guide improved for the next person.
+If you hit anything that didn't work for you in this guide, please [open an issue](https://github.com/llm-d/llm-d-benchmark/issues) - that's the fastest way to get the guide improved for the next person.

--- a/docs/run.md
+++ b/docs/run.md
@@ -36,21 +36,21 @@ A list of pre-defined profiles, each specific to particular harness, can be foun
 
 ```
 📦 workload
- ┣ 📂 profiles
- ┃ ┗ 📂 guidellm
- ┃ ┃ ┗ 📜 sanity_concurrent.yaml.in
- ┃ ┗ 📂 nop
- ┃ ┃ ┗ 📜 nop.yaml.in
- ┃ ┗ 📂 inference-perf
- ┃ ┃ ┣ 📜 sanity_random.yaml.in
- ┃ ┃ ┣ 📜 summarization_synthetic.yaml.in
- ┃ ┃ ┣ 📜 chatbot_sharegpt.yaml.in
- ┃ ┃ ┣ 📜 shared_prefix_synthetic.yaml.in
- ┃ ┃ ┣ 📜 chatbot_synthetic.yaml.in
- ┃ ┃ ┗ 📜 code_completion_synthetic.yaml.in
- ┃ ┗ 📂 vllm-benchmark
- ┃ ┃ ┣ 📜 sanity_random.yaml.in
- ┃ ┃ ┗ 📜 random_concurrent.yaml.in
+ + 📂 profiles
+ | + 📂 guidellm
+ | | + 📜 sanity_concurrent.yaml.in
+ | + 📂 nop
+ | | + 📜 nop.yaml.in
+ | + 📂 inference-perf
+ | | + 📜 sanity_random.yaml.in
+ | | + 📜 summarization_synthetic.yaml.in
+ | | + 📜 chatbot_sharegpt.yaml.in
+ | | + 📜 shared_prefix_synthetic.yaml.in
+ | | + 📜 chatbot_synthetic.yaml.in
+ | | + 📜 code_completion_synthetic.yaml.in
+ | + 📂 vllm-benchmark
+ | | + 📜 sanity_random.yaml.in
+ | | + 📜 random_concurrent.yaml.in
 ```
 What is shown here are the workload profile **templates** (hence, the `yaml.in`) and for each template, parameters which are specific for a particular standup are automatically replaced to generate a `yaml`. This rendered workload profile is then stored as a `configmap` on the target `Kubernetes` cluster. An illustrative example follows (`inference-perf/sanity_random.yaml.in`) :
 
@@ -146,14 +146,14 @@ The following table displays a comprehensive list of environment variables (and 
 
 When a scenario defines more than one stack (e.g.
 [`guides/multi-model-wva`](../config/scenarios/guides/multi-model-wva.yaml)),
-every per-stack step in the `run` phase executes once per rendered stack —
+every per-stack step in the `run` phase executes once per rendered stack -
 endpoint detection, model verification, profile rendering, configmap creation,
 harness deploy, wait, and collect. Each stack's results are collected into
 its own experiment-ID-keyed subdirectory under the workspace.
 
 **Per-stack endpoints.** For shared-HTTPRoute scenarios (`httpRoute.mode: shared`
 in the scenario file), step 03 `detect_endpoint` bakes the stack's path prefix
-into the detected URL — e.g. `http://gw:80/qwen3-06b` for stack `qwen3-06b`.
+into the detected URL - e.g. `http://gw:80/qwen3-06b` for stack `qwen3-06b`.
 Every downstream step treats the endpoint as an opaque base URL, so:
 
 - `test_model_serving` hits `http://gw:80/qwen3-06b/v1/models`.
@@ -161,10 +161,10 @@ Every downstream step treats the endpoint as an opaque base URL, so:
   `http://gw:80/qwen3-06b`; the harness script then calls
   `${endpoint_url}/v1/completions` which resolves to
   `http://gw:80/qwen3-06b/v1/completions`.
-- The shared HTTPRoute rewrites `/qwen3-06b/*` → `/*` so the upstream vLLM
+- The shared HTTPRoute rewrites `/qwen3-06b/*` -> `/*` so the upstream vLLM
   still sees `/v1/completions` and its friends.
 
-Nothing in the harness scripts changes — the routing prefix is invisible to them.
+Nothing in the harness scripts changes - the routing prefix is invisible to them.
 
 **Parallelism knobs.** `--parallel N` (default 4) caps how many stacks the
 executor runs per-stack steps for at once. Set `--parallel 1` to serialize
@@ -176,7 +176,7 @@ sequentially regardless of `--parallel`, since interleaved `/health` and
 ### Discovering deployed endpoints
 
 After standup, `--list-endpoints` prints a table of per-stack routing URLs
-and a copy-paste block of ready-to-run invocations — no harness pods
+and a copy-paste block of ready-to-run invocations - no harness pods
 launched:
 
 ```bash
@@ -192,7 +192,7 @@ any harness pods.
 ### Targeting a single pool (`--stack`)
 
 `--stack NAME` (or comma-separated list) restricts run execution to one
-stack. Endpoint URL auto-resolves for the selected stack — no need to
+stack. Endpoint URL auto-resolves for the selected stack - no need to
 pass `--endpoint-url` manually:
 
 ```bash
@@ -214,11 +214,11 @@ names fail loudly with a list of valid ones. Available via
 | `-t / --methods` | Applies to every stack. |
 | `-f / --monitoring` | Applies to every stack. |
 | `-u / --wva` | Applies to every stack. |
-| `-l / --harness`, `-w / --workload`, `-o / --overrides` | Applies to every stack's harness pod — all stacks run the same workload. |
-| `-j / --parallelism` | Applies to every stack — each stack launches N parallel harness pods. |
+| `-l / --harness`, `-w / --workload`, `-o / --overrides` | Applies to every stack's harness pod - all stacks run the same workload. |
+| `-j / --parallelism` | Applies to every stack - each stack launches N parallel harness pods. |
 | `--endpoint-url` | Single endpoint for run-only mode; bypasses auto-detect. In multi-stack, only meaningful when combined with `--stack` (otherwise every stack targets the same endpoint, which is rarely desired). |
-| `--stack NAME[,NAME…]` | Scopes every per-stack step to the named subset. |
-| **`-m / --models`** | **Scopes to the filter when `--stack NAME` names exactly one stack** — only that stack's model is overridden; siblings keep their scenario-defined models. Without `--stack` (or with a broader filter), `-m` applies to every stack and emits a warning — that collapses a multi-model scenario into N copies of one model, which is almost never desired. |
+| `--stack NAME[,NAME...]` | Scopes every per-stack step to the named subset. |
+| **`-m / --models`** | **Scopes to the filter when `--stack NAME` names exactly one stack** - only that stack's model is overridden; siblings keep their scenario-defined models. Without `--stack` (or with a broader filter), `-m` applies to every stack and emits a warning - that collapses a multi-model scenario into N copies of one model, which is almost never desired. |
 
 So the clean pattern for "rerun pool A against a different model":
 
@@ -234,12 +234,12 @@ The filter scopes `-m` to one stack; sibling stacks are left alone.
 The rule: anything that's inherently per-stack configuration (model name,
 path, shortName) is best edited in the scenario YAML, not overridden via
 CLI. CLI flags are designed to override *scenario-wide* knobs (namespace,
-harness, workload) uniformly across every stack — or, when combined with
+harness, workload) uniformly across every stack - or, when combined with
 `--stack`, to target a single stack without disturbing the others.
 
 ### Benchmarking a single stack from a multi-stack scenario
 
-Preferred — use `--stack`, endpoint auto-resolves:
+Preferred - use `--stack`, endpoint auto-resolves:
 
 ```bash
 # After standup of guides/multi-model-wva
@@ -248,7 +248,7 @@ llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
   -l inference-perf -w sanity_random.yaml
 ```
 
-Equivalent — pin `--endpoint-url` yourself (useful if the scenario file
+Equivalent - pin `--endpoint-url` yourself (useful if the scenario file
 isn't available locally):
 
 ```bash
@@ -259,7 +259,7 @@ llmdbenchmark run \
   -l inference-perf -w sanity_random.yaml
 ```
 
-Include the path prefix in the URL exactly as shown — the HTTPRoute
+Include the path prefix in the URL exactly as shown - the HTTPRoute
 rewrites it away before the request reaches vLLM.
 
 ## Harnesses

--- a/docs/run.md
+++ b/docs/run.md
@@ -142,6 +142,125 @@ The following table displays a comprehensive list of environment variables (and 
 > [!TIP]
 > In case the full path is ommited for the (workload) profile (either by setting `LLMDBENCH_HARNESS_EXPERIMENT_PROFILE` or CLI parameter `-w/--workload`), it is assumed that the file exists inside the `workload/profiles/<harness name>` folder
 
+## Multi-Stack Runs
+
+When a scenario defines more than one stack (e.g.
+[`guides/multi-model-wva`](../config/scenarios/guides/multi-model-wva.yaml)),
+every per-stack step in the `run` phase executes once per rendered stack —
+endpoint detection, model verification, profile rendering, configmap creation,
+harness deploy, wait, and collect. Each stack's results are collected into
+its own experiment-ID-keyed subdirectory under the workspace.
+
+**Per-stack endpoints.** For shared-HTTPRoute scenarios (`httpRoute.mode: shared`
+in the scenario file), step 03 `detect_endpoint` bakes the stack's path prefix
+into the detected URL — e.g. `http://gw:80/qwen3-06b` for stack `qwen3-06b`.
+Every downstream step treats the endpoint as an opaque base URL, so:
+
+- `test_model_serving` hits `http://gw:80/qwen3-06b/v1/models`.
+- The harness pod env var `LLMDBENCH_HARNESS_STACK_ENDPOINT_URL` becomes
+  `http://gw:80/qwen3-06b`; the harness script then calls
+  `${endpoint_url}/v1/completions` which resolves to
+  `http://gw:80/qwen3-06b/v1/completions`.
+- The shared HTTPRoute rewrites `/qwen3-06b/*` → `/*` so the upstream vLLM
+  still sees `/v1/completions` and its friends.
+
+Nothing in the harness scripts changes — the routing prefix is invisible to them.
+
+**Parallelism knobs.** `--parallel N` (default 4) caps how many stacks the
+executor runs per-stack steps for at once. Set `--parallel 1` to serialize
+for easier debugging, especially when multi-stack harness pods compete for
+the same accelerator nodes. (Note: the `smoketest` phase always runs stacks
+sequentially regardless of `--parallel`, since interleaved `/health` and
+`/v1/models` probes across stacks make failures harder to read.)
+
+### Discovering deployed endpoints
+
+After standup, `--list-endpoints` prints a table of per-stack routing URLs
+and a copy-paste block of ready-to-run invocations — no harness pods
+launched:
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p <namespace> --list-endpoints
+```
+
+Useful when you've forgotten the stack names, the gateway IP, or just want
+a quick sanity-check that both pools resolved correctly. The flag runs
+the full render pipeline (so the printed endpoints match exactly what a
+real `standup` would produce) and then short-circuits before launching
+any harness pods.
+
+### Targeting a single pool (`--stack`)
+
+`--stack NAME` (or comma-separated list) restricts run execution to one
+stack. Endpoint URL auto-resolves for the selected stack — no need to
+pass `--endpoint-url` manually:
+
+```bash
+# Benchmark qwen3-06b only with guidellm, two parallel harness pods
+llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
+  --stack qwen3-06b \
+  -l guidellm -w sanity_random.yaml -j 2
+```
+
+`--stack` also works on `standup`, `smoketest`, and `teardown`. Unknown
+names fail loudly with a list of valid ones. Available via
+`LLMDBENCH_STACK` env var too.
+
+### CLI overrides in multi-stack scenarios
+
+| Flag | Multi-stack behavior |
+|------|----------------------|
+| `-p / --namespace` | Applies to every stack (namespaces are scenario-wide). |
+| `-t / --methods` | Applies to every stack. |
+| `-f / --monitoring` | Applies to every stack. |
+| `-u / --wva` | Applies to every stack. |
+| `-l / --harness`, `-w / --workload`, `-o / --overrides` | Applies to every stack's harness pod — all stacks run the same workload. |
+| `-j / --parallelism` | Applies to every stack — each stack launches N parallel harness pods. |
+| `--endpoint-url` | Single endpoint for run-only mode; bypasses auto-detect. In multi-stack, only meaningful when combined with `--stack` (otherwise every stack targets the same endpoint, which is rarely desired). |
+| `--stack NAME[,NAME…]` | Scopes every per-stack step to the named subset. |
+| **`-m / --models`** | **Scopes to the filter when `--stack NAME` names exactly one stack** — only that stack's model is overridden; siblings keep their scenario-defined models. Without `--stack` (or with a broader filter), `-m` applies to every stack and emits a warning — that collapses a multi-model scenario into N copies of one model, which is almost never desired. |
+
+So the clean pattern for "rerun pool A against a different model":
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p <ns> \
+  --stack qwen3-06b \
+  --model meta-llama/Llama-3.2-3B \
+  -l inference-perf -w sanity_random.yaml
+```
+
+The filter scopes `-m` to one stack; sibling stacks are left alone.
+
+The rule: anything that's inherently per-stack configuration (model name,
+path, shortName) is best edited in the scenario YAML, not overridden via
+CLI. CLI flags are designed to override *scenario-wide* knobs (namespace,
+harness, workload) uniformly across every stack — or, when combined with
+`--stack`, to target a single stack without disturbing the others.
+
+### Benchmarking a single stack from a multi-stack scenario
+
+Preferred — use `--stack`, endpoint auto-resolves:
+
+```bash
+# After standup of guides/multi-model-wva
+llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
+  --stack qwen3-06b \
+  -l inference-perf -w sanity_random.yaml
+```
+
+Equivalent — pin `--endpoint-url` yourself (useful if the scenario file
+isn't available locally):
+
+```bash
+llmdbenchmark run \
+  --endpoint-url http://<gateway>:80/qwen3-06b \
+  --model Qwen/Qwen3-0.6B \
+  --namespace <namespace> \
+  -l inference-perf -w sanity_random.yaml
+```
+
+Include the path prefix in the URL exactly as shown — the HTTPRoute
+rewrites it away before the request reaches vLLM.
 
 ## Harnesses
 

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -23,7 +23,7 @@ top-level `shared:` block that's merged into every stack before per-stack
 overrides.
 
 Cluster-scoped infrastructure that would race with itself across N parallel
-standup executions is deduplicated at render time — only the first stack
+standup executions is deduplicated at render time - only the first stack
 emits the istio control-plane helmfile and the `infra-llmdbench` Helm
 release; subsequent stacks render empty files for those templates. WVA
 controller installation is deduplicated at the step level (one per
@@ -31,11 +31,11 @@ controller installation is deduplicated at the step level (one per
 
 Currently shipped multi-stack guide:
 
-- [`guides/multi-model-wva`](../config/scenarios/guides/multi-model-wva.yaml) —
+- [`guides/multi-model-wva`](../config/scenarios/guides/multi-model-wva.yaml) -
   two models (Qwen3-0.6B + Meta-Llama-3.1-8B), each with its own EPP +
   InferencePool + VariantAutoscaling + HPA, one shared WVA controller,
   one HTTPRoute with two backendRefs routing by path prefix
-  (`/qwen3-06b/*` → Qwen pool, `/llama-31-8b/*` → Llama pool).
+  (`/qwen3-06b/*` -> Qwen pool, `/llama-31-8b/*` -> Llama pool).
 
 See [`config/README.md`](../config/README.md#method-1-scenario-file-recommended-for-deployment-specific-config)
 for the `shared:` merge semantics and the developer guide's
@@ -43,7 +43,7 @@ for the `shared:` merge semantics and the developer guide's
 section for the render-engine details.
 
 `--stack NAME[,NAME...]` (also `LLMDBENCH_STACK=NAME`) restricts standup to
-a subset of rendered stacks — handy for re-deploying a single pool after a
+a subset of rendered stacks - handy for re-deploying a single pool after a
 scenario edit without tearing down siblings. Global steps (cluster admin
 prereqs, shared-infra helmfile, WVA controller install, scenario-wide
 PVCs) still run as usual; only per-stack steps (06+ for standup) are

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -12,6 +12,53 @@ b) "llm-d", which leverages a combination of [llm-d-infra](https://github.com/ll
 ## Scenarios
 All the information required for the standup of a stack is contained on a "scenario file". This information is encoded in the form of environment variables, with default values defined in `config/defaults.yaml` which can be then overriden inside a [scenario file](../config/scenarios) (YAML-based) or via [specification templates](../config/specification) (Jinja2 `.yaml.j2` files).
 
+### Multi-Stack Scenarios
+
+A scenario may define more than one stack in its `scenario:` list. Standup
+iterates every per-stack step across all stacks (in parallel, bounded by
+`--parallel`), so you can stand up N models behind one gateway in a single
+`llmdbenchmark standup` invocation. Scenario-wide config (gateway class,
+WVA controller, shared HTTPRoute, chart versions) lives in an optional
+top-level `shared:` block that's merged into every stack before per-stack
+overrides.
+
+Cluster-scoped infrastructure that would race with itself across N parallel
+standup executions is deduplicated at render time — only the first stack
+emits the istio control-plane helmfile and the `infra-llmdbench` Helm
+release; subsequent stacks render empty files for those templates. WVA
+controller installation is deduplicated at the step level (one per
+`wva.namespace`).
+
+Currently shipped multi-stack guide:
+
+- [`guides/multi-model-wva`](../config/scenarios/guides/multi-model-wva.yaml) —
+  two models (Qwen3-0.6B + Meta-Llama-3.1-8B), each with its own EPP +
+  InferencePool + VariantAutoscaling + HPA, one shared WVA controller,
+  one HTTPRoute with two backendRefs routing by path prefix
+  (`/qwen3-06b/*` → Qwen pool, `/llama-31-8b/*` → Llama pool).
+
+See [`config/README.md`](../config/README.md#method-1-scenario-file-recommended-for-deployment-specific-config)
+for the `shared:` merge semantics and the developer guide's
+[Multi-Stack Scenarios](developer-guide.md#multi-stack-scenarios-and-the-shared-block)
+section for the render-engine details.
+
+`--stack NAME[,NAME...]` (also `LLMDBENCH_STACK=NAME`) restricts standup to
+a subset of rendered stacks — handy for re-deploying a single pool after a
+scenario edit without tearing down siblings. Global steps (cluster admin
+prereqs, shared-infra helmfile, WVA controller install, scenario-wide
+PVCs) still run as usual; only per-stack steps (06+ for standup) are
+filtered. Unknown names fail loudly with a list of valid ones.
+
+```bash
+# One stack:
+llmdbenchmark --spec guides/multi-model-wva standup -p my-namespace --stack qwen3-06b
+
+# Multiple named stacks (comma-separated):
+llmdbenchmark --spec guides/multi-model-wva standup -p my-namespace --stack qwen3-06b,llama-31-8b
+```
+
+The same flag works on `smoketest`, `run`, and `teardown` with identical
+semantics, so you can scope every lifecycle phase to the same subset.
 
 ## Multiple steps
 The full standup of a stack is a multi-step process. The [lifecycle](lifecycle.md) document go into more details explaning the meaning of each different individual step.

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-04-23 20:05:13` (UTC)
-- Generated against git ref: `69f6f693a410bf378dd8064765aa362d19783e7d`
+- Generated at: `2026-04-24 20:03:55` (UTC)
+- Generated against git ref: `49e7a252c70b8f32beb299b83a5fff3cae726e67`
 
 ## System Tool Dependencies
 
@@ -60,10 +60,10 @@ generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **benchmark** | `v0.6.0rc5` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 330 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
-| **inferenceScheduler** | `v0.7.1` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 349 (`images.inferenceScheduler`) | [llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`ghcr.io/llm-d/llm-d-inference-scheduler`) |
+| **benchmark** | `v0.6.0rc6` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 330 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
+| **inferenceScheduler** | `v0.8.0-rc.1` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 349 (`images.inferenceScheduler`) | [llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`ghcr.io/llm-d/llm-d-inference-scheduler`) |
 | **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 368 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
-| **routingSidecar** | `v0.7.1` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 355 (`images.routingSidecar`) | [llm-d/llm-d-routing-sidecar](https://github.com/llm-d/llm-d-routing-sidecar) (`ghcr.io/llm-d/llm-d-routing-sidecar`) |
+| **routingSidecar** | `v0.8.0-rc.1` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 355 (`images.routingSidecar`) | [llm-d/llm-d-routing-sidecar](https://github.com/llm-d/llm-d-routing-sidecar) (`ghcr.io/llm-d/llm-d-routing-sidecar`) |
 | **udsTokenizer** | `v0.7.1` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 361 (`images.udsTokenizer`) | [llm-d/llm-d-kv-cache (services/uds_tokenizer)](https://github.com/llm-d/llm-d-kv-cache) (`ghcr.io/llm-d/llm-d-uds-tokenizer`) |
 | **vllm** | `v0.6.0` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 336 (`images.vllm`) | [llm-d/llm-d (docker/Dockerfile.cuda)](https://github.com/llm-d/llm-d) (`ghcr.io/llm-d/llm-d-cuda`) |
 | **vllmOpenai** | `v0.9.2` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 343 (`images.vllmOpenai`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
@@ -132,7 +132,7 @@ annotated with their `pyproject.toml` line.
 | **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
 | **httptools** | `0.7.1` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
 | **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
-| **huggingface_hub** | `1.11.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
+| **huggingface_hub** | `1.12.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
 | **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
 | **idna** | `3.13` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
 | **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |

--- a/docs/workload-variant-autoscaler.md
+++ b/docs/workload-variant-autoscaler.md
@@ -8,12 +8,12 @@ safely on a shared cluster, and how to debug the most common failure modes.
 
 For background on the autoscaler itself, see:
 
-- [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) — the controller source
-- [llm-d well-lit-path WVA guide](https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md) — the upstream install reference our integration mirrors
+- [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) - the controller source
+- [llm-d well-lit-path WVA guide](https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md) - the upstream install reference our integration mirrors
 
 > **Platform support:** WVA install is currently only verified on **OpenShift**.
 > On other platforms, every WVA-related step (install, smoketest, teardown) is
-> deliberately skipped — the scenario YAML can still render the WVA blocks, but
+> deliberately skipped - the scenario YAML can still render the WVA blocks, but
 > nothing is applied to the cluster.
 
 ---
@@ -62,7 +62,7 @@ llmdbenchmark --spec guides/inference-scheduling-wva standup  -p <namespace>
 ```
 
 The shared cluster-wide infrastructure (`prometheus-adapter`, ClusterRole,
-prometheus-ca ConfigMap) survives teardown automatically — see
+prometheus-ca ConfigMap) survives teardown automatically - see
 [Section 4](#4-cluster-wide-vs-per-tenant-resources--teardown-semantics)
 for the full preservation policy.
 
@@ -77,7 +77,7 @@ provisions the following resources, in this order:
 cluster-wide / shared
     prometheus-adapter      v5.2.0, in openshift-user-workload-monitoring
                             serves wva_desired_replicas via external-metrics API
-    prometheus-ca           ConfigMap, same ns — CA cert for thanos-querier auth
+    prometheus-ca           ConfigMap, same ns - CA cert for thanos-querier auth
     allow-thanos-querier-api-access
                             ClusterRole granting prometheus-adapter access
                             to OCP's monitoring stack
@@ -115,7 +115,7 @@ cluster-wide / shared
 
 Our integration ensures **every join along that chain is byte-aligned**
 (`controllerInstance` value, VA label, HPA selector). Misalignment in any
-one of them surfaces as `TARGETS: <unknown>` on the HPA — see the
+one of them surfaces as `TARGETS: <unknown>` on the HPA - see the
 [smoketest validations](#5-smoketest-checks) for what catches each case.
 
 ---
@@ -135,7 +135,7 @@ llmdbenchmark --spec guides/inference-scheduling standup -p <namespace> --wva
 ```
 
 That sets `wva.enabled: true` at render time. All other WVA settings come from
-defaults — fine for a quick test, but you can't tweak per-experiment HPA
+defaults - fine for a quick test, but you can't tweak per-experiment HPA
 behavior without editing the defaults file.
 
 ### 2b. Via the dedicated `inference-scheduling-wva` scenario
@@ -165,7 +165,7 @@ Deploys N models behind a single gateway, each with its own EPP +
 InferencePool + VariantAutoscaling + HPA. One WVA controller in the
 namespace watches every VA (deduplicated by `wva.namespace`), so the
 Prometheus/adapter/controller wiring is identical to the single-model
-case — only the number of autoscaling targets scales.
+case - only the number of autoscaling targets scales.
 
 The scenario uses the top-level `shared:` block to hold scenario-wide
 settings (controller image, chart versions, EPP plugin config, shared
@@ -178,36 +178,36 @@ Topology:
 
 ```
          Gateway (shared infra-llmdbench-inference-gateway)
-           │
-   ┌───────┴─────────── HTTPRoute multi-model-route ─────────────┐
-   │ /qwen3-06b/*                                 /llama-31-8b/* │
-   ▼                                                             ▼
+           |
+   +-------+----------- HTTPRoute multi-model-route -------------+
+   | /qwen3-06b/*                                 /llama-31-8b/* |
+   v                                                             v
 EPP+InferencePool (qwen3-06b)           EPP+InferencePool (llama-31-8b)
-   │                                                             │
+   |                                                             |
 vLLM decode + VA + HPA                   vLLM decode + VA + HPA
-             ▲                               ▲
-             └─────── WVA controller (1) ────┘
+             ^                               ^
+             +------- WVA controller (1) ----+
 ```
 
 What the scenario layout buys you:
 
-- **Shared control plane** — one `infra-llmdbench` gateway release, one
+- **Shared control plane** - one `infra-llmdbench` gateway release, one
   istio control plane, one WVA controller, one prometheus-adapter, one
   shared model PVC (sized for the sum of all models; each stack's weights
   live in its own `model.path` subdirectory). Rendered once in the
   scenario's "shared-infra-owner" stack (first non-standalone stack) and
   skipped on siblings to avoid parallel-helmfile races.
-- **Per-stack scaling intent** — each stack's VA caps what the controller
+- **Per-stack scaling intent** - each stack's VA caps what the controller
   is willing to compute (`variantAutoscaling.{min,max}Replicas`,
   `variantCost`) and each stack's HPA caps what actually gets applied to
   the Deployment. They're independent per pool, so pool A scaling up to
   its max doesn't push pool B past its own cap.
-- **One routing URL per pool** — the shared HTTPRoute uses
+- **One routing URL per pool** - the shared HTTPRoute uses
   `httpRoute.pathPrefix: /{stack.name}` so every pool is reachable at
   `http://<gateway>/{stack-name}/v1/...`. Gateway rewrites the prefix
   away before the request reaches upstream vLLM, so pods continue to see
   plain `/v1/*` paths.
-- **`flowControl` feature gate on every pool** — enabled in the
+- **`flowControl` feature gate on every pool** - enabled in the
   `shared.inferenceExtension.pluginsCustomConfig` block and inherited by
   every stack. This is non-optional for WVA: the controller reads EPP
   queue depth to compute scale signals, and flow-control is what
@@ -253,7 +253,7 @@ wva:
 **Image tag note:** the *helm chart* version is bare semver (`chartVersions.wva: 0.6.0`),
 the *container image* tag uses a leading `v` (`v0.6.0`). They're set independently.
 
-### 3.2 VariantAutoscaling spec — per-model scaling intent
+### 3.2 VariantAutoscaling spec - per-model scaling intent
 
 ```yaml
 wva:
@@ -271,13 +271,13 @@ wva:
 scale when several share GPU capacity. Lower `slo.tpot`/`slo.ttft` = more
 aggressive scale-up under load.
 
-### 3.3 HorizontalPodAutoscaler spec — what actually changes the replica count
+### 3.3 HorizontalPodAutoscaler spec - what actually changes the replica count
 
 ```yaml
 wva:
   hpa:
     enabled: true
-    minReplicas: 1               # never scale below this; must be ≥ 1
+    minReplicas: 1               # never scale below this; must be >= 1
     maxReplicas: 10              # safety ceiling regardless of controller computation
     targetAvgValue: 1            # 1 = "match controller's desiredReplicas exactly"
 
@@ -297,7 +297,7 @@ wva:
 ```
 
 Keep `wva.hpa.{min,max}Replicas` aligned with `wva.variantAutoscaling.{min,max}Replicas`
-— the VA caps what the controller is willing to compute, the HPA caps what
+- the VA caps what the controller is willing to compute, the HPA caps what
 actually gets applied to the Deployment.
 
 For more `behavior` tuning options:
@@ -329,7 +329,7 @@ multi-tenant clusters healthy, our standup and teardown follow this policy:
 
 **The principle:** `--deep` only removes resources that live in the target namespace.
 Cluster-shared infrastructure (`prometheus-adapter` + its supporting CRBs/CMs)
-is **never** removed by us — it's used by every WVA tenant in the cluster, so
+is **never** removed by us - it's used by every WVA tenant in the cluster, so
 its lifecycle belongs to the platform admin, not to a per-tenant teardown.
 
 If you need to fully remove the shared adapter, do it explicitly:
@@ -352,14 +352,14 @@ verifying so a failure points at the broken link rather than a vague
 | Check | What it verifies | Failure means |
 |---|---|---|
 | `wva_platform_gate` | Cluster is OpenShift (or stack is correctly skipped on other platforms) | informational only |
-| `wva_controller_deployment` | Polls `Deployment/workload-variant-autoscaler-controller-manager` until `Available` with all replicas Ready (≤180s). **Fails fast** if the manager container's `restartCount` grows mid-wait | controller pod is crash-looping; check `oc logs -n <ns> deploy/workload-variant-autoscaler-controller-manager --previous` |
+| `wva_controller_deployment` | Polls `Deployment/workload-variant-autoscaler-controller-manager` until `Available` with all replicas Ready (<=180s). **Fails fast** if the manager container's `restartCount` grows mid-wait | controller pod is crash-looping; check `oc logs -n <ns> deploy/workload-variant-autoscaler-controller-manager --previous` |
 | `wva_prometheus_adapter` | `Deployment/prometheus-adapter` in the user-workload monitoring ns is `Available` | adapter wasn't installed, or another tenant's broken install is squatting the cluster role |
 | `wva_variantautoscaling` | The per-stack `VariantAutoscaling/{model_id_label}-decode` exists | step_09 didn't apply the rendered VA |
-| `wva_va_controller_instance_label` | The VA carries `wva.llmd.ai/controller-instance=<value>` matching the controller's `CONTROLLER_INSTANCE` | the controller's predicate filters out the VA → "No active VariantAutoscalings found" loop, no metric ever emitted. **The most subtle WVA gate.** |
+| `wva_va_controller_instance_label` | The VA carries `wva.llmd.ai/controller-instance=<value>` matching the controller's `CONTROLLER_INSTANCE` | the controller's predicate filters out the VA -> "No active VariantAutoscalings found" loop, no metric ever emitted. **The most subtle WVA gate.** |
 | `wva_hpa_target` | The HPA's `scaleTargetRef.name` equals `{model_id_label}-decode` | template drift between VA and HPA |
-| `wva_hpa_selector_alignment` | The HPA's `metric.selector.matchLabels` has all three of `variant_name`, `exported_namespace`, `controller_instance` matching what the controller emits | HPA selector misalignment — controller's metric is in Prometheus but the HPA's selector matches zero rows |
+| `wva_hpa_selector_alignment` | The HPA's `metric.selector.matchLabels` has all three of `variant_name`, `exported_namespace`, `controller_instance` matching what the controller emits | HPA selector misalignment - controller's metric is in Prometheus but the HPA's selector matches zero rows |
 | `wva_hpa_able_to_scale` (best-effort) | HPA's `AbleToScale` condition is `True` | HPA hasn't initialized yet, or scale subresource lookup failed |
-| `wva_hpa_targets_resolved` | Polls the HPA's `.status.currentMetrics[*].external.current` until the value resolves from `<unknown>` to a number (≤180s). Includes the most recent `ScalingActive=False` reason in the failure message if it times out | full pipeline isn't producing a metric value — could be controller not reconciling, Prometheus not scraping, adapter rule missing, or selector mismatch |
+| `wva_hpa_targets_resolved` | Polls the HPA's `.status.currentMetrics[*].external.current` until the value resolves from `<unknown>` to a number (<=180s). Includes the most recent `ScalingActive=False` reason in the failure message if it times out | full pipeline isn't producing a metric value - could be controller not reconciling, Prometheus not scraping, adapter rule missing, or selector mismatch |
 
 All polling timeouts are constants at the top of
 [`llmdbenchmark/smoketests/validators/wva.py`](../llmdbenchmark/smoketests/validators/wva.py)
@@ -376,7 +376,7 @@ idle stack at `minReplicas: 1` would falsely fail when `decode.replicas: 2`.
 
 The role allow-list lives at module top in
 [`llmdbenchmark/smoketests/base.py`](../llmdbenchmark/smoketests/base.py)
-as `_WVA_HPA_MANAGED_ROLES = frozenset({"decode"})` — extend it if upstream
+as `_WVA_HPA_MANAGED_ROLES = frozenset({"decode"})` - extend it if upstream
 WVA grows native prefill autoscaling.
 
 ---
@@ -408,14 +408,14 @@ oc get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<ns>/wva_desired_
 oc get hpa -n <ns>
 ```
 
-If 1–3 are green but 4 is empty → controller isn't reconciling (most likely
-`wva.llmd.ai/controller-instance` label mismatch — check #3 against the
+If 1-3 are green but 4 is empty -> controller isn't reconciling (most likely
+`wva.llmd.ai/controller-instance` label mismatch - check #3 against the
 controller's `CONTROLLER_INSTANCE` env var).
 
-If 4 has a value but 5 is empty → prometheus-adapter doesn't have the rule
+If 4 has a value but 5 is empty -> prometheus-adapter doesn't have the rule
 (install was wrong namespace, or rule values file wasn't applied).
 
-If 5 has a value but 6 is `<unknown>` → HPA selector doesn't match the
+If 5 has a value but 6 is `<unknown>` -> HPA selector doesn't match the
 metric's labels.
 
 ---
@@ -438,7 +438,7 @@ oc label va -n <ns> <model-id>-decode \
   wva.llmd.ai/controller-instance=<controller-instance> --overwrite
 ```
 
-…or re-run standup so the rendered template (which already includes the
+...or re-run standup so the rendered template (which already includes the
 label) is applied.
 
 ### HPA shows `TARGETS: <unknown>` indefinitely
@@ -548,7 +548,7 @@ llmdbenchmark --spec guides/multi-model-wva standup -p <namespace>
 Renders both stacks, installs shared infra (istio, Gateway,
 `infra-llmdbench`, WVA controller, prometheus-adapter, model PVC) once,
 then deploys each pool's `-ms` + `-gaie` + VA + HPA. Downloads run in
-parallel — wall time ≈ slowest model, not the sum. Standup
+parallel - wall time ~ slowest model, not the sum. Standup
 auto-chains into the smoketest phase unless you pass
 `--skip-smoketest`.
 
@@ -565,7 +565,7 @@ have produced) and exits before launching any harness pods.
 
 ### 10.3 Benchmark a single pool
 
-**Preferred — let `--stack` auto-resolve the endpoint:**
+**Preferred - let `--stack` auto-resolve the endpoint:**
 
 ```bash
 llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
@@ -576,9 +576,9 @@ llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
 With `--stack qwen3-06b`, step 03 auto-detects the gateway endpoint,
 bakes in the `/qwen3-06b` path prefix, and the harness pod hits
 `http://<gateway>/qwen3-06b/v1/completions`. The gateway rewrites
-`/qwen3-06b/*` → `/*` so vLLM sees plain `/v1/completions`.
+`/qwen3-06b/*` -> `/*` so vLLM sees plain `/v1/completions`.
 
-**Alternative — pin `--endpoint-url` yourself** (useful for run-only
+**Alternative - pin `--endpoint-url` yourself** (useful for run-only
 mode without the scenario file locally):
 
 ```bash
@@ -607,7 +607,7 @@ both pods; result collection pulls both directories back.
 ### 10.5 Compare two pools side-by-side (two shells)
 
 ```bash
-# Shell 1 — --workspace is a global option, placed before the subcommand
+# Shell 1 - --workspace is a global option, placed before the subcommand
 llmdbenchmark --spec guides/multi-model-wva --workspace /tmp/run-qwen run -p <namespace> \
   --stack qwen3-06b \
   -l guidellm -w sanity_random.yaml -j 2
@@ -622,7 +622,7 @@ Distinct `--workspace` dirs keep the two invocations' render plans,
 logs, and collected results fully isolated. The WVA controller will
 see load on both pools' VAs simultaneously and scale them
 independently. `--workspace` (and `--spec`, `--base-dir`, `--dry-run`,
-`--verbose`, `--non-admin`) are **global options** — they must appear
+`--verbose`, `--non-admin`) are **global options** - they must appear
 before the subcommand name (`run`, `standup`, etc.), not after.
 
 ### 10.6 Rerun one pool against a different model
@@ -637,7 +637,7 @@ llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
   -l inference-perf -w sanity_random.yaml
 ```
 
-Without `--stack`, `-m` applies to every stack and emits a warning —
+Without `--stack`, `-m` applies to every stack and emits a warning -
 it would collapse the multi-model scenario into N copies of one model,
 which is rarely desired.
 
@@ -653,7 +653,7 @@ llmdbenchmark --spec guides/multi-model-wva standup -p <namespace> \
 
 Global steps (admin prereqs, shared-infra helmfile, WVA controller,
 model PVC) still run (they're scenario-wide and idempotent). Per-stack
-steps only fire for `llama-31-8b` — qwen3-06b's running pods and VA
+steps only fire for `llama-31-8b` - qwen3-06b's running pods and VA
 are left completely alone.
 
 ### 10.8 Tear down one pool, keep siblings running
@@ -666,7 +666,7 @@ llmdbenchmark --spec guides/multi-model-wva teardown -p <namespace> \
 Uninstalls the `llama-31-8b-ms` and `llama-31-8b-gaie` Helm releases
 (plus their VA + HPA), leaves `qwen3-06b` and the shared
 `infra-llmdbench` + WVA controller + prometheus-adapter in place.
-Useful for cost management — shrink to one pool over a weekend
+Useful for cost management - shrink to one pool over a weekend
 without disturbing the other.
 
 ### 10.9 Observe scaling events

--- a/docs/workload-variant-autoscaler.md
+++ b/docs/workload-variant-autoscaler.md
@@ -120,12 +120,13 @@ one of them surfaces as `TARGETS: <unknown>` on the HPA — see the
 
 ---
 
-## 2. Two ways to enable WVA on a scenario
+## 2. Three ways to enable WVA on a scenario
 
 | Method | When to use |
 |---|---|
 | `-u / --wva` CLI flag on any existing scenario | Quick toggle without editing files; uses defaults from `config/templates/values/defaults.yaml` |
 | `--spec guides/inference-scheduling-wva` | Dedicated scenario where every WVA knob is spelled out inline so you can tweak them per-experiment |
+| `--spec guides/multi-model-wva` | Multi-model scenario: two or more pools under one gateway, each with its own VA + HPA, one shared WVA controller |
 
 ### 2a. Via the CLI flag
 
@@ -153,6 +154,64 @@ You'd choose this scenario when you want to:
 - Override the controller image tag, prometheus-adapter version, etc.
 - Author a DoE experiment that sweeps over `wva.hpa.maxReplicas` or
   `wva.variantAutoscaling.variantCost`
+
+### 2c. Via the `multi-model-wva` scenario (multiple pools, one WVA controller)
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva standup -p <namespace>
+```
+
+Deploys N models behind a single gateway, each with its own EPP +
+InferencePool + VariantAutoscaling + HPA. One WVA controller in the
+namespace watches every VA (deduplicated by `wva.namespace`), so the
+Prometheus/adapter/controller wiring is identical to the single-model
+case — only the number of autoscaling targets scales.
+
+The scenario uses the top-level `shared:` block to hold scenario-wide
+settings (controller image, chart versions, EPP plugin config, shared
+HTTPRoute); per-stack blocks hold only model-specific knobs (model name,
+decode resources, VA + HPA min/max). To add a third model, copy one of
+the stack entries and change `name` + `model`. See
+[`guides/multi-model-wva.yaml`](../config/scenarios/guides/multi-model-wva.yaml).
+
+Topology:
+
+```
+         Gateway (shared infra-llmdbench-inference-gateway)
+           │
+   ┌───────┴─────────── HTTPRoute multi-model-route ─────────────┐
+   │ /qwen3-06b/*                                 /llama-31-8b/* │
+   ▼                                                             ▼
+EPP+InferencePool (qwen3-06b)           EPP+InferencePool (llama-31-8b)
+   │                                                             │
+vLLM decode + VA + HPA                   vLLM decode + VA + HPA
+             ▲                               ▲
+             └─────── WVA controller (1) ────┘
+```
+
+What the scenario layout buys you:
+
+- **Shared control plane** — one `infra-llmdbench` gateway release, one
+  istio control plane, one WVA controller, one prometheus-adapter, one
+  shared model PVC (sized for the sum of all models; each stack's weights
+  live in its own `model.path` subdirectory). Rendered once in the
+  scenario's "shared-infra-owner" stack (first non-standalone stack) and
+  skipped on siblings to avoid parallel-helmfile races.
+- **Per-stack scaling intent** — each stack's VA caps what the controller
+  is willing to compute (`variantAutoscaling.{min,max}Replicas`,
+  `variantCost`) and each stack's HPA caps what actually gets applied to
+  the Deployment. They're independent per pool, so pool A scaling up to
+  its max doesn't push pool B past its own cap.
+- **One routing URL per pool** — the shared HTTPRoute uses
+  `httpRoute.pathPrefix: /{stack.name}` so every pool is reachable at
+  `http://<gateway>/{stack-name}/v1/...`. Gateway rewrites the prefix
+  away before the request reaches upstream vLLM, so pods continue to see
+  plain `/v1/*` paths.
+- **`flowControl` feature gate on every pool** — enabled in the
+  `shared.inferenceExtension.pluginsCustomConfig` block and inherited by
+  every stack. This is non-optional for WVA: the controller reads EPP
+  queue depth to compute scale signals, and flow-control is what
+  exposes queue depth in the metrics.
 
 ---
 
@@ -467,3 +526,182 @@ HPA, but it's still considered cluster-hygiene rude to run cluster-scoped.
 | Teardown logic | [`llmdbenchmark/teardown/steps/step_01_uninstall_helm.py`](../llmdbenchmark/teardown/steps/step_01_uninstall_helm.py) |
 | Smoketest WVA mixin | [`llmdbenchmark/smoketests/validators/wva.py`](../llmdbenchmark/smoketests/validators/wva.py) |
 | WVA-enabled scenario (the one to copy/edit for new experiments) | [`config/scenarios/guides/inference-scheduling-wva.yaml`](../config/scenarios/guides/inference-scheduling-wva.yaml) |
+| Multi-model WVA scenario (N pools, 1 gateway, 1 controller) | [`config/scenarios/guides/multi-model-wva.yaml`](../config/scenarios/guides/multi-model-wva.yaml) |
+
+---
+
+## 10. Multi-model operations cookbook
+
+Recipes for the day-to-day lifecycle + benchmarking against the
+`multi-model-wva` scenario. All commands assume you've installed
+`llmdbenchmark` and pointed `KUBECONFIG` at a cluster where you have
+(or will have) namespace admin in `<namespace>`. Stack names
+(`qwen3-06b`, `llama-31-8b`) mirror the shipped scenario; substitute
+your own if you've customized.
+
+### 10.1 First-time standup
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva standup -p <namespace>
+```
+
+Renders both stacks, installs shared infra (istio, Gateway,
+`infra-llmdbench`, WVA controller, prometheus-adapter, model PVC) once,
+then deploys each pool's `-ms` + `-gaie` + VA + HPA. Downloads run in
+parallel — wall time ≈ slowest model, not the sum. Standup
+auto-chains into the smoketest phase unless you pass
+`--skip-smoketest`.
+
+### 10.2 Discover what's deployed (`--list-endpoints`)
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p <namespace> --list-endpoints
+```
+
+Prints a table of per-stack endpoint URLs + a copy-paste block of
+ready-to-run `llmdbenchmark run` invocations. Runs the full render
+pipeline (so the detected endpoints match exactly what standup would
+have produced) and exits before launching any harness pods.
+
+### 10.3 Benchmark a single pool
+
+**Preferred — let `--stack` auto-resolve the endpoint:**
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
+  --stack qwen3-06b \
+  -l inference-perf -w sanity_random.yaml -j 1
+```
+
+With `--stack qwen3-06b`, step 03 auto-detects the gateway endpoint,
+bakes in the `/qwen3-06b` path prefix, and the harness pod hits
+`http://<gateway>/qwen3-06b/v1/completions`. The gateway rewrites
+`/qwen3-06b/*` → `/*` so vLLM sees plain `/v1/completions`.
+
+**Alternative — pin `--endpoint-url` yourself** (useful for run-only
+mode without the scenario file locally):
+
+```bash
+llmdbenchmark run \
+  --endpoint-url http://<gateway>/qwen3-06b \
+  --model Qwen/Qwen3-0.6B \
+  --namespace <namespace> \
+  -l guidellm -w sanity_random.yaml -j 2
+```
+
+### 10.4 Two parallel guidellm jobs against one pool
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
+  --stack qwen3-06b \
+  -l guidellm -w sanity_random.yaml \
+  -j 2
+```
+
+`-j 2` launches two guidellm pods hitting the same endpoint
+simultaneously. Both run the same workload, but each writes to its own
+`{experiment_id}_1` / `{experiment_id}_2` results subdirectory on the
+workload PVC, so metrics don't collide. The harness `wait` step polls
+both pods; result collection pulls both directories back.
+
+### 10.5 Compare two pools side-by-side (two shells)
+
+```bash
+# Shell 1 — --workspace is a global option, placed before the subcommand
+llmdbenchmark --spec guides/multi-model-wva --workspace /tmp/run-qwen run -p <namespace> \
+  --stack qwen3-06b \
+  -l guidellm -w sanity_random.yaml -j 2
+
+# Shell 2 (in parallel)
+llmdbenchmark --spec guides/multi-model-wva --workspace /tmp/run-llama run -p <namespace> \
+  --stack llama-31-8b \
+  -l guidellm -w sanity_random.yaml -j 2
+```
+
+Distinct `--workspace` dirs keep the two invocations' render plans,
+logs, and collected results fully isolated. The WVA controller will
+see load on both pools' VAs simultaneously and scale them
+independently. `--workspace` (and `--spec`, `--base-dir`, `--dry-run`,
+`--verbose`, `--non-admin`) are **global options** — they must appear
+before the subcommand name (`run`, `standup`, etc.), not after.
+
+### 10.6 Rerun one pool against a different model
+
+`--stack NAME` scopes `-m/--models` to that one stack; siblings keep
+their scenario-defined models untouched:
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva run -p <namespace> \
+  --stack qwen3-06b \
+  --model meta-llama/Llama-3.2-3B \
+  -l inference-perf -w sanity_random.yaml
+```
+
+Without `--stack`, `-m` applies to every stack and emits a warning —
+it would collapse the multi-model scenario into N copies of one model,
+which is rarely desired.
+
+### 10.7 Re-deploy one pool after a scenario edit
+
+Edit the scenario YAML's stack for `llama-31-8b` (e.g. bump
+`decode.replicas`, swap the model, tweak `wva.hpa.maxReplicas`), then:
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva standup -p <namespace> \
+  --stack llama-31-8b
+```
+
+Global steps (admin prereqs, shared-infra helmfile, WVA controller,
+model PVC) still run (they're scenario-wide and idempotent). Per-stack
+steps only fire for `llama-31-8b` — qwen3-06b's running pods and VA
+are left completely alone.
+
+### 10.8 Tear down one pool, keep siblings running
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva teardown -p <namespace> \
+  --stack llama-31-8b
+```
+
+Uninstalls the `llama-31-8b-ms` and `llama-31-8b-gaie` Helm releases
+(plus their VA + HPA), leaves `qwen3-06b` and the shared
+`infra-llmdbench` + WVA controller + prometheus-adapter in place.
+Useful for cost management — shrink to one pool over a weekend
+without disturbing the other.
+
+### 10.9 Observe scaling events
+
+With both pools running, watch the VA + HPA state in real time:
+
+```bash
+# Per-pool VariantAutoscaling
+kubectl get variantautoscaling -n <namespace> -w
+
+# Per-pool HPA with current/target metric
+kubectl get hpa -n <namespace> -w
+
+# Controller logs (look for "Reconciling" per VA)
+kubectl logs -n <namespace> -l control-plane=controller-manager -f
+
+# Raw wva_desired_replicas metric for a pool
+kubectl exec -n <namespace> \
+  $(kubectl get pod -n <namespace> -l app.kubernetes.io/name=workload-variant-autoscaler -o name | head -1) \
+  -- curl -sk https://localhost:8443/metrics \
+  | grep wva_desired_replicas
+```
+
+Every query that takes a label selector can be filtered to one pool:
+`-l wva.llmd.ai/controller-instance=<namespace>,llm-d.ai/model=qwen-qwen3-0-6b`
+for VAs / HPAs; pods don't carry the routing-prefix label but do carry
+`llm-d.ai/model` keyed on each stack's `model.shortName`.
+
+### 10.10 Full teardown
+
+```bash
+llmdbenchmark --spec guides/multi-model-wva teardown -p <namespace>
+```
+
+Removes every Helm release in both stacks plus shared infra and the
+WVA controller. Prometheus-adapter and istio control-plane persist by
+design (shared across tenants); add `--deep` to remove all cluster
+resources in the deploy + harness namespaces.

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -116,6 +116,7 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
             cli_methods=getattr(args, "methods", None),
             cli_monitoring=getattr(args, "monitoring", False),
             cli_wva=getattr(args, "wva", False),
+            cli_stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
         ).eval()
 
         try:
@@ -431,6 +432,7 @@ def _do_standup(args, logger, render_plan_errors):
         gateway_deploy_timeout=int(getattr(args, "gateway_deploy_timeout", 120) or 120),
         modelservice_deploy_timeout=int(getattr(args, "modelservice_deploy_timeout", 1500) or 1500),
         pvc_bind_timeout=int(getattr(args, "pvc_bind_timeout", 240) or 240),
+        stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
     _check_model_access(context, all_stacks_info, logger)
@@ -508,13 +510,19 @@ def _do_smoketest(args, logger, render_plan_errors):
         harness_namespace=harness_ns,
         model_name=plan_info.get("model_name"),
         logger=logger,
+        stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
+    # Smoketest runs per-stack checks sequentially (max_parallel_stacks=1):
+    # parallel runs would interleave /health + /v1/models probe logs across
+    # stacks, hammer the shared gateway with concurrent curls, and make
+    # multi-stack failures harder to debug. Standup/run stay at the
+    # user-configured default via --parallel; smoketest overrides.
     executor = StepExecutor(
         steps=get_smoketest_steps(),
         context=context,
         logger=logger,
-        max_parallel_stacks=getattr(args, "parallel", 4),
+        max_parallel_stacks=1,
     )
 
     step_spec = getattr(args, "step", None)
@@ -594,13 +602,17 @@ def _print_standup_summary(context, result, logger):
     harness_ns = context.harness_namespace or ns
     username = context.username or "unknown"
     platform = context.platform_type
-    model = context.model_name or "unknown"
     methods = (
         ", ".join(context.deployed_methods) if context.deployed_methods else "default"
     )
     stacks = len(context.rendered_stacks)
     mode = "dry-run" if context.dry_run else "live"
     endpoints = context.deployed_endpoints or {}
+
+    # Aggregate per-stack models for the multi-stack case. context.model_name
+    # holds only a single value (first stack / CLI override) and would
+    # misrepresent the deployment otherwise. Honors --stack filter.
+    stack_models = _collect_stack_models(context)
 
     W = 62
     logger.log_info("═" * W)
@@ -609,7 +621,15 @@ def _print_standup_summary(context, result, logger):
     logger.log_info(f"  User:       {username}")
     logger.log_info(f"  Platform:   {platform}")
     logger.log_info(f"  Mode:       {mode}")
-    logger.log_info(f"  Model:      {model}")
+    if len(stack_models) > 1:
+        logger.log_info(f"  Models:     {len(stack_models)} (one per stack)")
+        for stack_name, model in stack_models:
+            logger.log_info(f"    - {stack_name.ljust(20)} {model}")
+    else:
+        single_model = (
+            stack_models[0][1] if stack_models else (context.model_name or "unknown")
+        )
+        logger.log_info(f"  Model:      {single_model}")
     logger.log_info(f"  Namespace:  {ns}")
     if harness_ns != ns:
         logger.log_info(f"  Harness NS: {harness_ns}")
@@ -678,6 +698,7 @@ def _do_teardown(args, logger, render_plan_errors):
         harness_namespace=harness_ns,
         model_name=plan_info.get("model_name"),
         logger=logger,
+        stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
     executor = StepExecutor(
@@ -777,7 +798,23 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         generate_config_only=getattr(args, "generate_config", False),
         dataset_url=getattr(args, "dataset", None),
         harness_data_access_timeout=int(getattr(args, "data_access_timeout", 120) or 120),
+        stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
+
+    # --list-endpoints: detect endpoints (step 03 only), print a copy-paste
+    # table with per-stack routing URLs, and exit without deploying any
+    # harness pods. Useful for discovering what's live in a multi-stack
+    # scenario before picking an endpoint for a targeted `run`.
+    if getattr(args, "list_endpoints", False):
+        executor = StepExecutor(
+            steps=get_run_steps(),
+            context=context,
+            logger=logger,
+            max_parallel_stacks=1,
+        )
+        result = executor.execute(step_spec="3")
+        _print_endpoints_table(context, logger, args)
+        return context, result
 
     executor = StepExecutor(
         steps=get_run_steps(),
@@ -795,6 +832,131 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
     return context, result
 
 
+def _collect_stack_models(context) -> list[tuple[str, str]]:
+    """Return ``[(stack_name, model_name), …]`` from rendered configs.
+
+    Honors the ``--stack`` filter so the benchmark summary reflects only
+    the stacks that actually ran. Returns an empty list when there are
+    no rendered stacks (run-only / endpoint-url mode), in which case the
+    summary falls back to ``context.model_name``.
+    """
+    import yaml as _yaml
+    rendered = getattr(context, "rendered_stacks", []) or []
+    if not rendered:
+        return []
+    stack_filter = getattr(context, "stack_filter", None) or []
+    rows: list[tuple[str, str]] = []
+    for stack_path in rendered:
+        stack_name = stack_path.name
+        if stack_filter and stack_name not in stack_filter:
+            continue
+        cfg_file = stack_path / "config.yaml"
+        model_name = "?"
+        if cfg_file.exists():
+            try:
+                with open(cfg_file, encoding="utf-8") as fh:
+                    cfg = _yaml.safe_load(fh) or {}
+                model_name = (cfg.get("model") or {}).get("name", "?") or "?"
+            except (OSError, _yaml.YAMLError):
+                pass
+        rows.append((stack_name, model_name))
+    return rows
+
+
+def _parse_stack_filter(raw: str | None) -> list[str] | None:
+    """Parse --stack / LLMDBENCH_STACK into a list of stack names, or None."""
+    if not raw:
+        return None
+    names = [n.strip() for n in str(raw).split(",") if n.strip()]
+    return names or None
+
+
+def _print_endpoints_table(context, logger, args) -> None:
+    """Print a table of per-stack endpoints + copy-paste `run` commands.
+
+    Called by --list-endpoints after step 03 has populated
+    context.deployed_endpoints. Output is human-readable AND machine-
+    friendly: the copy-paste block can be pasted as-is to benchmark a
+    specific pool.
+    """
+    from pathlib import Path as _P
+    import yaml as _yaml
+
+    endpoints = context.deployed_endpoints or {}
+    if not endpoints:
+        logger.log_warning(
+            "No endpoints detected. Have you run standup first? "
+            "(`llmdbenchmark standup -p <namespace>` on this spec)"
+        )
+        return
+
+    rows: list[tuple[str, str, str]] = []
+    for stack_path in context.rendered_stacks or []:
+        stack_name = stack_path.name
+        cfg_file = stack_path / "config.yaml"
+        model_name = "?"
+        if cfg_file.exists():
+            try:
+                with open(cfg_file, encoding="utf-8") as fh:
+                    cfg = _yaml.safe_load(fh) or {}
+                model_name = (cfg.get("model") or {}).get("name", "?") or "?"
+            except (OSError, _yaml.YAMLError):
+                pass
+        url = endpoints.get(stack_name, "<not detected>")
+        rows.append((stack_name, model_name, url))
+
+    # Pretty table
+    col_stack = max(len("STACK"), max(len(r[0]) for r in rows))
+    col_model = max(len("MODEL"), max(len(r[1]) for r in rows))
+    col_url = max(len("ENDPOINT URL"), max(len(r[2]) for r in rows))
+
+    logger.line_break()
+    logger.log_info("📋 Detected endpoints:")
+    logger.log_info(
+        f"  {'STACK'.ljust(col_stack)}  "
+        f"{'MODEL'.ljust(col_model)}  {'ENDPOINT URL'.ljust(col_url)}"
+    )
+    logger.log_info(
+        f"  {'-' * col_stack}  {'-' * col_model}  {'-' * col_url}"
+    )
+    for stack_name, model_name, url in rows:
+        logger.log_info(
+            f"  {stack_name.ljust(col_stack)}  "
+            f"{model_name.ljust(col_model)}  {url.ljust(col_url)}"
+        )
+    logger.line_break()
+
+    # Copy-paste block — one ready-to-run invocation per stack, with the
+    # flags the user most likely wants to customize (harness, workload,
+    # parallelism) left as placeholders.
+    spec_raw = getattr(args, "specification_file", None)
+    spec = str(spec_raw) if spec_raw else "<spec>"
+    if "/" in spec or spec.endswith(".yaml.j2"):
+        # Full path (e.g. /abs/path/config/specification/guides/multi-model-wva.yaml.j2)
+        # → trim to the friendly `category/name` form the CLI understands.
+        import os
+        parent = os.path.basename(os.path.dirname(spec)) if "/" in spec else ""
+        stem = os.path.basename(spec)
+        if stem.endswith(".yaml.j2"):
+            stem = stem[:-len(".yaml.j2")]
+        spec = f"{parent}/{stem}" if parent else stem
+    namespace = context.namespace or "<namespace>"
+    logger.log_info("💡 Copy-paste to benchmark one pool:")
+    logger.line_break()
+    # log_plain writes to every logger handler (terminal + attached log
+    # files) without the timestamp / level prefix, so the block both
+    # copy-pastes cleanly from the terminal AND lands verbatim in the
+    # log file for later auditing.
+    for stack_name, model_name, url in rows:
+        logger.log_plain(f"  # {stack_name} — {model_name}")
+        logger.log_plain(f"  llmdbenchmark --spec {spec} run \\")
+        logger.log_plain(f"    --namespace {namespace} \\")
+        logger.log_plain(f"    --endpoint-url {url} \\")
+        logger.log_plain(f"    --model {model_name} \\")
+        logger.log_plain("    -l <harness> -w <workload.yaml> -j <parallel-pods>")
+        logger.log_plain("")
+
+
 def _execute_run(args, logger, render_plan_errors):
     """Build execution context and run experiment steps."""
     try:
@@ -802,6 +964,12 @@ def _execute_run(args, logger, render_plan_errors):
     except PhaseError as e:
         logger.log_error(str(e))
         sys.exit(1)
+
+    # --list-endpoints short-circuits the run — no harness pods launched,
+    # no results collected, no ConfigMap stored. Skip the benchmark
+    # summary banner entirely; the endpoints table was the whole output.
+    if getattr(args, "list_endpoints", False):
+        return
 
     endpoint_url = getattr(args, "endpoint_url", None)
     run_config_file = getattr(args, "run_config", None)
@@ -814,10 +982,15 @@ def _execute_run(args, logger, render_plan_errors):
     # --- Summary banner ---
     results_dir = context.run_results_dir()
     namespace = context.harness_namespace or context.namespace or "unknown"
-    model_name = context.model_name or "unknown"
     workload = context.harness_profile or "unknown"
     experiment_ids = getattr(context, "experiment_ids", [])
     parallelism = context.harness_parallelism or 1
+
+    # Multi-stack scenarios benchmark more than one model simultaneously;
+    # context.model_name holds only a single value (from the first stack
+    # or a CLI override). Aggregate per-stack model names from the
+    # rendered configs so the banner reflects reality.
+    stack_models = _collect_stack_models(context)
 
     logger.line_break()
     logger.log_info("=" * 60)
@@ -825,7 +998,15 @@ def _execute_run(args, logger, render_plan_errors):
     logger.log_info("=" * 60)
     logger.log_info(f"  Harness:       {harness}")
     logger.log_info(f"  Workload:      {workload}")
-    logger.log_info(f"  Model:         {model_name}")
+    if len(stack_models) > 1:
+        logger.log_info(f"  Models:        {len(stack_models)} (one per stack)")
+        for stack_name, model in stack_models:
+            logger.log_info(f"    - {stack_name.ljust(20)} {model}")
+    else:
+        single_model = (
+            stack_models[0][1] if stack_models else (context.model_name or "unknown")
+        )
+        logger.log_info(f"  Model:         {single_model}")
     logger.log_info(f"  Namespace:     {namespace}")
     logger.log_info(f"  Mode:          {mode}")
     logger.log_info(f"  Parallelism:   {parallelism}")

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -133,7 +133,7 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
         # Pre-render Helm chart manifests so the plan directory contains
         # all K8s resources (both Jinja2-rendered and Helm-rendered).
         # This enables kustomize overlays and full manifest inspection.
-        # Runs even in dry-run mode — helmfile template is purely local
+        # Runs even in dry-run mode - helmfile template is purely local
         # and does not touch the cluster.
         _render_helm_manifests(config.plan_dir, logger)
 
@@ -159,7 +159,7 @@ def _render_helm_manifests(plan_dir: Path, logger) -> None:
     ``helm-modelservice.yaml`` in the stack directory alongside the
     Jinja2-rendered templates.
 
-    Stacks that deploy via ``standalone`` are skipped entirely — they
+    Stacks that deploy via ``standalone`` are skipped entirely - they
     do not use the modelservice Helm chart, so pre-rendering it would
     produce an empty helmfile and fail with "no top-level config keys".
 
@@ -181,7 +181,7 @@ def _render_helm_manifests(plan_dir: Path, logger) -> None:
         if not helmfile_src.exists() or not ms_values.exists():
             continue
 
-        # Read config once per stack — we need it both to decide
+        # Read config once per stack - we need it both to decide
         # whether modelservice rendering applies and to extract the
         # model_id_label used by the helmfile selector.
         config_file = stack_dir / "config.yaml"
@@ -221,7 +221,7 @@ def _render_helm_manifests(plan_dir: Path, logger) -> None:
         # directory and copy the values files with expected names.
         shutil.copy2(helmfile_src, helm_dir / "helmfile.yaml")
 
-        # Only the modelservice values file is needed — the selector
+        # Only the modelservice values file is needed - the selector
         # targets only the -ms release so infra/gaie values are not read.
         shutil.copy2(ms_values, helm_dir / "ms-values.yaml")
 
@@ -615,9 +615,9 @@ def _print_standup_summary(context, result, logger):
     stack_models = _collect_stack_models(context)
 
     W = 62
-    logger.log_info("═" * W)
+    logger.log_info("=" * W)
     logger.log_info(f"  STANDUP COMPLETE")
-    logger.log_info("═" * W)
+    logger.log_info("=" * W)
     logger.log_info(f"  User:       {username}")
     logger.log_info(f"  Platform:   {platform}")
     logger.log_info(f"  Mode:       {mode}")
@@ -652,12 +652,12 @@ def _print_standup_summary(context, result, logger):
     logger.log_info(f"  Steps:      {steps_summary}")
 
     if endpoints:
-        logger.log_info("─" * W)
+        logger.log_info("-" * W)
         logger.log_info(f"  Deployed Endpoints:")
         for name, url in endpoints.items():
             logger.log_info(f"    {name}: {url}")
 
-    logger.log_info("═" * W)
+    logger.log_info("=" * W)
     logger.line_break()
     logger.log_info(f"Workspace: {context.workspace}")
     logger.log_info("All standup steps complete.", emoji="✅")
@@ -833,14 +833,13 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
 
 
 def _collect_stack_models(context) -> list[tuple[str, str]]:
-    """Return ``[(stack_name, model_name), …]`` from rendered configs.
+    """Return ``[(stack_name, model_name), ...]`` from rendered configs.
 
     Honors the ``--stack`` filter so the benchmark summary reflects only
     the stacks that actually ran. Returns an empty list when there are
     no rendered stacks (run-only / endpoint-url mode), in which case the
     summary falls back to ``context.model_name``.
     """
-    import yaml as _yaml
     rendered = getattr(context, "rendered_stacks", []) or []
     if not rendered:
         return []
@@ -879,9 +878,6 @@ def _print_endpoints_table(context, logger, args) -> None:
     friendly: the copy-paste block can be pasted as-is to benchmark a
     specific pool.
     """
-    from pathlib import Path as _P
-    import yaml as _yaml
-
     endpoints = context.deployed_endpoints or {}
     if not endpoints:
         logger.log_warning(
@@ -926,15 +922,14 @@ def _print_endpoints_table(context, logger, args) -> None:
         )
     logger.line_break()
 
-    # Copy-paste block — one ready-to-run invocation per stack, with the
+    # Copy-paste block - one ready-to-run invocation per stack, with the
     # flags the user most likely wants to customize (harness, workload,
     # parallelism) left as placeholders.
     spec_raw = getattr(args, "specification_file", None)
     spec = str(spec_raw) if spec_raw else "<spec>"
     if "/" in spec or spec.endswith(".yaml.j2"):
         # Full path (e.g. /abs/path/config/specification/guides/multi-model-wva.yaml.j2)
-        # → trim to the friendly `category/name` form the CLI understands.
-        import os
+        # - trim to the friendly `category/name` form the CLI understands.
         parent = os.path.basename(os.path.dirname(spec)) if "/" in spec else ""
         stem = os.path.basename(spec)
         if stem.endswith(".yaml.j2"):
@@ -948,7 +943,7 @@ def _print_endpoints_table(context, logger, args) -> None:
     # copy-pastes cleanly from the terminal AND lands verbatim in the
     # log file for later auditing.
     for stack_name, model_name, url in rows:
-        logger.log_plain(f"  # {stack_name} — {model_name}")
+        logger.log_plain(f"  # {stack_name} - {model_name}")
         logger.log_plain(f"  llmdbenchmark --spec {spec} run \\")
         logger.log_plain(f"    --namespace {namespace} \\")
         logger.log_plain(f"    --endpoint-url {url} \\")
@@ -965,7 +960,7 @@ def _execute_run(args, logger, render_plan_errors):
         logger.log_error(str(e))
         sys.exit(1)
 
-    # --list-endpoints short-circuits the run — no harness pods launched,
+    # --list-endpoints short-circuits the run - no harness pods launched,
     # no results collected, no ConfigMap stored. Skip the benchmark
     # summary banner entirely; the endpoints table was the whole output.
     if getattr(args, "list_endpoints", False):
@@ -1168,7 +1163,7 @@ def _render_plans_for_experiment(args, logger, setup_overrides=None):
 
 
 def _execute_experiment(args, logger):
-    """Orchestrate a full DoE experiment: setup × run treatment matrix."""
+    """Orchestrate a full DoE experiment: setup x run treatment matrix."""
     from llmdbenchmark.experiment.parser import parse_experiment, SetupTreatment
     from llmdbenchmark.experiment.summary import ExperimentSummary
 

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -25,7 +25,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     rendered_stacks: list[Path] = field(default_factory=list)
     # Optional CLI filter: if set, per-stack steps only execute for stacks
     # whose name appears here. Useful in multi-stack scenarios to run
-    # (or re-run) just one pool — e.g. `--stack pool-a` when benchmarking
+    # (or re-run) just one pool - e.g. `--stack pool-a` when benchmarking
     # a single model in the multi-model-wva scenario. Global steps are
     # unaffected. Empty / None means "all stacks" (existing behavior).
     stack_filter: list[str] | None = None

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -23,6 +23,12 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     base_dir: Path | None = None  # project root (for templates, scenarios, etc.)
     specification_file: str | None = None  # resolved --spec path
     rendered_stacks: list[Path] = field(default_factory=list)
+    # Optional CLI filter: if set, per-stack steps only execute for stacks
+    # whose name appears here. Useful in multi-stack scenarios to run
+    # (or re-run) just one pool — e.g. `--stack pool-a` when benchmarking
+    # a single model in the multi-model-wva scenario. Global steps are
+    # unaffected. Empty / None means "all stacks" (existing behavior).
+    stack_filter: list[str] | None = None
 
     # Execution flags
     dry_run: bool = False

--- a/llmdbenchmark/executor/step.py
+++ b/llmdbenchmark/executor/step.py
@@ -309,9 +309,14 @@ class Step(ABC):
             return True
 
         if existing_gi > requested_gi:
-            context.logger.log_warning(
-                f"PVC '{pvc_name}' exists with size {existing_size_str} "
-                f"(requested {requested_size}) -- larger than needed, continuing"
+            # Benign: a shared PVC sized for ALL models in a multi-model
+            # scenario will appear "larger than needed" on stacks past the
+            # first one (their per-stack size covers only their own model).
+            # Also covers operators who pre-provisioned a PVC with headroom.
+            # Log info, not warning — nothing is wrong.
+            context.logger.log_info(
+                f"PVC '{pvc_name}' already exists ({existing_size_str}) with "
+                f"enough capacity for requested {requested_size} — reusing"
             )
             return True
 

--- a/llmdbenchmark/executor/step_executor.py
+++ b/llmdbenchmark/executor/step_executor.py
@@ -161,6 +161,29 @@ class StepExecutor:
             )
             return
 
+        # CLI `--stack NAME[,NAME...]` restricts execution to a subset of
+        # rendered stacks. Unknown names (typos) fail loudly rather than
+        # silently running zero stacks. Lets operators run a single pool
+        # in a multi-model scenario without editing the scenario YAML.
+        stack_filter = self.context.stack_filter or []
+        if stack_filter:
+            all_names = {s.name for s in stacks}
+            unknown = [n for n in stack_filter if n not in all_names]
+            if unknown:
+                self.logger.log_error(
+                    f"--stack filter references unknown stack(s): "
+                    f"{', '.join(unknown)}. Known stacks: "
+                    f"{', '.join(sorted(all_names))}"
+                )
+                return
+            filtered = [s for s in stacks if s.name in stack_filter]
+            self.logger.line_break()
+            self.logger.log_info(
+                f"🎯 --stack filter active: running {len(filtered)}/{len(stacks)} "
+                f"stack(s): {', '.join(s.name for s in filtered)}"
+            )
+            stacks = filtered
+
         self.logger.line_break()
         self.logger.log_info(
             f"📋 Executing {len(per_stack_steps)} per-stack step(s) across "

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -94,7 +94,7 @@ def add_subcommands(parser: argparse._SubParsersAction):
             "Comma-separated list of stack names to restrict execution to. "
             "Useful in multi-stack scenarios (e.g. guides/multi-model-wva) "
             "to benchmark a single pool without re-deploying. "
-            "Endpoint URL auto-resolves for the selected stack — no need to "
+            "Endpoint URL auto-resolves for the selected stack - no need to "
             "pass --endpoint-url. Unknown names fail loudly. "
             "Example: --stack qwen3-06b."
         ),

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -88,6 +88,30 @@ def add_subcommands(parser: argparse._SubParsersAction):
         help="Number of parallel harness pods to create.",
     )
     run_parser.add_argument(
+        "--stack",
+        default=env("LLMDBENCH_STACK"),
+        help=(
+            "Comma-separated list of stack names to restrict execution to. "
+            "Useful in multi-stack scenarios (e.g. guides/multi-model-wva) "
+            "to benchmark a single pool without re-deploying. "
+            "Endpoint URL auto-resolves for the selected stack — no need to "
+            "pass --endpoint-url. Unknown names fail loudly. "
+            "Example: --stack qwen3-06b."
+        ),
+    )
+    run_parser.add_argument(
+        "--list-endpoints",
+        action="store_true",
+        default=False,
+        help=(
+            "Detect and print per-stack endpoint URLs for a deployed "
+            "scenario, then exit (no harness pods launched). The output "
+            "includes a copy-paste block with ready-to-run `llmdbenchmark` "
+            "invocations pre-populated with each stack's --endpoint-url "
+            "and --model."
+        ),
+    )
+    run_parser.add_argument(
         "--wait-timeout",
         type=int,
         default=env_int("LLMDBENCH_WAIT_TIMEOUT"),

--- a/llmdbenchmark/interface/smoketest.py
+++ b/llmdbenchmark/interface/smoketest.py
@@ -39,6 +39,14 @@ def add_subcommands(parser: argparse._SubParsersAction):
         help="Max number of stacks to test in parallel (default: 4).",
     )
     smoketest_parser.add_argument(
+        "--stack",
+        default=env("LLMDBENCH_STACK"),
+        help=(
+            "Comma-separated list of stack names to restrict execution to. "
+            "Useful for re-running the smoketest against a single pool."
+        ),
+    )
+    smoketest_parser.add_argument(
         "--kubeconfig",
         "-k",
         default=env("LLMDBENCH_KUBECONFIG") or env("KUBECONFIG"),

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -83,6 +83,15 @@ def add_subcommands(parser: argparse._SubParsersAction):
         help="Max number of stacks to deploy in parallel (default: 4).",
     )
     standup_parser.add_argument(
+        "--stack",
+        default=env("LLMDBENCH_STACK"),
+        help=(
+            "Comma-separated list of stack names to restrict execution to. "
+            "Useful for re-deploying a single pool in a multi-stack scenario "
+            "without tearing down siblings."
+        ),
+    )
+    standup_parser.add_argument(
         "--kubeconfig",
         "-k",
         default=env("LLMDBENCH_KUBECONFIG") or env("KUBECONFIG"),

--- a/llmdbenchmark/interface/teardown.py
+++ b/llmdbenchmark/interface/teardown.py
@@ -54,3 +54,12 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env("LLMDBENCH_KUBECONFIG") or env("KUBECONFIG"),
         help="Path to kubeconfig file for kubectl/helm/helmfile commands.",
     )
+    teardown_parser.add_argument(
+        "--stack",
+        default=env("LLMDBENCH_STACK"),
+        help=(
+            "Comma-separated list of stack names to restrict execution to. "
+            "Useful for removing one pool from a multi-stack scenario while "
+            "leaving siblings in place."
+        ),
+    )

--- a/llmdbenchmark/logging/logger.py
+++ b/llmdbenchmark/logging/logger.py
@@ -58,7 +58,7 @@ class LLMDBenchmarkLogger:
     _shared_stderr_handler: FileHandler | None = None
     _shared_log_dir: Path | None = None
 
-    INDENT_PREFIX = "    │ "
+    INDENT_PREFIX = "    | "
 
     def __init__(self, log_dir: Path, log_name: str, verbose: bool = False):
         self._indent_level = 0
@@ -179,12 +179,12 @@ class LLMDBenchmarkLogger:
             handler.flush()
 
     def log_plain(self, msg: str) -> None:
-        """Write *msg* verbatim to every handler — no timestamp or level prefix.
+        """Write *msg* verbatim to every handler - no timestamp or level prefix.
 
         For human-facing payloads where the log formatting would be more
         noise than signal: copy-paste blocks, banners, ASCII art. Still
         routed through every logger handler, so the text lands in both
-        the terminal and any attached FileHandler(s) — unlike print(),
+        the terminal and any attached FileHandler(s) - unlike print(),
         which only reaches stdout.
         """
         for handler in self.logger.handlers:

--- a/llmdbenchmark/logging/logger.py
+++ b/llmdbenchmark/logging/logger.py
@@ -178,6 +178,19 @@ class LLMDBenchmarkLogger:
             handler.stream.write("\n")
             handler.flush()
 
+    def log_plain(self, msg: str) -> None:
+        """Write *msg* verbatim to every handler — no timestamp or level prefix.
+
+        For human-facing payloads where the log formatting would be more
+        noise than signal: copy-paste blocks, banners, ASCII art. Still
+        routed through every logger handler, so the text lands in both
+        the terminal and any attached FileHandler(s) — unlike print(),
+        which only reaches stdout.
+        """
+        for handler in self.logger.handlers:
+            handler.stream.write(str(msg) + "\n")
+            handler.flush()
+
 
 def get_logger(
     log_dir: Union[str, Path],

--- a/llmdbenchmark/parser/README.md
+++ b/llmdbenchmark/parser/README.md
@@ -56,7 +56,7 @@ For each stack in the scenario:
 
 1. Merge defaults with the optional top-level `shared:` block (scenario-wide
    settings applied to every stack), then with stack-specific overrides:
-   `defaults → shared → stack`.
+   `defaults -> shared -> stack`.
 2. Apply setup overrides (from DoE experiment treatments) if present.
 3. Apply resource preset (if `resourcePreset` is set in the config).
 4. Run the resolver chain (see below).
@@ -100,7 +100,7 @@ During plan rendering, the following resolvers execute in order on the merged va
 5. **Namespace resolution** -- Apply CLI `--namespace` override or resolve `"auto"` to default `"llmdbench"`. Supports comma-separated `deploy,harness,wva` format.
 6. **Model resolution** -- Apply CLI `--models` override.
 7. **Model ID label resolution** (`_resolve_model_id_label`) -- Compute `model_id_label` from the model name using the hashed format `{first8}-{sha256_8}-{last8}`. This label is used in all templates for Kubernetes resource naming.
-8. **Per-stack identity resolution** (`_resolve_per_stack_identity`) -- Multi-stack scenarios (N ≥ 2) only. Auto-suffix shipped-default resource names (`storage.modelPvc.name`, `downloadJob.name`, `inferenceExtension.monitoring.secretName`) with `-{model_id_label}` so each stack gets unique names and Helm releases / PVCs don't collide in a shared namespace. Explicit overrides are preserved. See `_STACK_SCOPED_DEFAULTS` for the full list.
+8. **Per-stack identity resolution** (`_resolve_per_stack_identity`) -- Multi-stack scenarios (N >= 2) only. Auto-suffix shipped-default resource names (`storage.modelPvc.name`, `downloadJob.name`, `inferenceExtension.monitoring.secretName`) with `-{model_id_label}` so each stack gets unique names and Helm releases / PVCs don't collide in a shared namespace. Explicit overrides are preserved. See `_STACK_SCOPED_DEFAULTS` for the full list.
 9. **Custom command conflict warning** -- Warns when CLI `--models` won't propagate into hardcoded `customCommand` values.
 10. **Deploy method resolution** -- Apply CLI `--methods` override (`standalone` or `modelservice`). Only one may be active.
 11. **Monitoring resolution** -- Apply CLI `--monitoring` flag. Enables PodMonitor and metrics scraping.
@@ -172,11 +172,11 @@ class RenderResult:
 
 ```
 parser/
-├── __init__.py                    -- Empty package marker
-├── render_specification.py        -- RenderSpecification
-├── render_plans.py                -- RenderPlans (full pipeline)
-├── render_result.py               -- RenderResult, StackErrors
-├── config_schema.py               -- Pydantic v2 config schema
-├── version_resolver.py            -- VersionResolver
-└── cluster_resource_resolver.py   -- ClusterResourceResolver
++-- __init__.py                    -- Empty package marker
++-- render_specification.py        -- RenderSpecification
++-- render_plans.py                -- RenderPlans (full pipeline)
++-- render_result.py               -- RenderResult, StackErrors
++-- config_schema.py               -- Pydantic v2 config schema
++-- version_resolver.py            -- VersionResolver
++-- cluster_resource_resolver.py   -- ClusterResourceResolver
 ```

--- a/llmdbenchmark/parser/README.md
+++ b/llmdbenchmark/parser/README.md
@@ -54,14 +54,20 @@ Templates are loaded from `.j2` files in the template directory. Files prefixed 
 
 For each stack in the scenario:
 
-1. Merge defaults with stack-specific config overrides.
+1. Merge defaults with the optional top-level `shared:` block (scenario-wide
+   settings applied to every stack), then with stack-specific overrides:
+   `defaults → shared → stack`.
 2. Apply setup overrides (from DoE experiment treatments) if present.
 3. Apply resource preset (if `resourcePreset` is set in the config).
 4. Run the resolver chain (see below).
 5. Validate against the Pydantic config schema.
-6. Render all templates with the merged values.
-7. Write `config.yaml` with the fully-resolved config (JSON round-trip strips YAML anchors).
-8. Validate all generated YAML files for syntax.
+6. Inject the scenario-wide sibling summary (`siblingStacks`) and this
+   stack's 1-indexed `stackIndex` into the Jinja values so templates can
+   emit cross-stack constructs (e.g. a shared HTTPRoute with N backendRefs)
+   or gate cluster-scoped resources on `stackIndex == 1` to avoid races.
+7. Render all templates with the merged values.
+8. Write `config.yaml` with the fully-resolved config (JSON round-trip strips YAML anchors).
+9. Validate all generated YAML files for syntax.
 
 ### 3. Config Schema Validation (`config_schema.py`)
 
@@ -94,11 +100,12 @@ During plan rendering, the following resolvers execute in order on the merged va
 5. **Namespace resolution** -- Apply CLI `--namespace` override or resolve `"auto"` to default `"llmdbench"`. Supports comma-separated `deploy,harness,wva` format.
 6. **Model resolution** -- Apply CLI `--models` override.
 7. **Model ID label resolution** (`_resolve_model_id_label`) -- Compute `model_id_label` from the model name using the hashed format `{first8}-{sha256_8}-{last8}`. This label is used in all templates for Kubernetes resource naming.
-8. **Custom command conflict warning** -- Warns when CLI `--models` won't propagate into hardcoded `customCommand` values.
-9. **Deploy method resolution** -- Apply CLI `--methods` override (`standalone` or `modelservice`). Only one may be active.
-10. **Monitoring resolution** -- Apply CLI `--monitoring` flag. Enables PodMonitor and metrics scraping.
-11. **HuggingFace token auto-detection** -- Detect HF token from `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` env vars when the configured token is a sentinel value (`REPLACE_TOKEN` or empty).
-12. **Config schema validation** -- Non-blocking Pydantic validation.
+8. **Per-stack identity resolution** (`_resolve_per_stack_identity`) -- Multi-stack scenarios (N ≥ 2) only. Auto-suffix shipped-default resource names (`storage.modelPvc.name`, `downloadJob.name`, `inferenceExtension.monitoring.secretName`) with `-{model_id_label}` so each stack gets unique names and Helm releases / PVCs don't collide in a shared namespace. Explicit overrides are preserved. See `_STACK_SCOPED_DEFAULTS` for the full list.
+9. **Custom command conflict warning** -- Warns when CLI `--models` won't propagate into hardcoded `customCommand` values.
+10. **Deploy method resolution** -- Apply CLI `--methods` override (`standalone` or `modelservice`). Only one may be active.
+11. **Monitoring resolution** -- Apply CLI `--monitoring` flag. Enables PodMonitor and metrics scraping.
+12. **HuggingFace token auto-detection** -- Detect HF token from `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` env vars when the configured token is a sentinel value (`REPLACE_TOKEN` or empty).
+13. **Config schema validation** -- Non-blocking Pydantic validation.
 
 ## Version Resolver (`version_resolver.py`)
 

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -18,6 +18,7 @@ from jinja2 import Environment, TemplateSyntaxError, UndefinedError
 
 from llmdbenchmark.config import config
 from llmdbenchmark.logging.logger import get_logger
+from llmdbenchmark.parser.config_schema import validate_config
 from llmdbenchmark.parser.render_result import StackErrors, RenderResult
 
 
@@ -369,11 +370,11 @@ class RenderPlans:
 
         Multi-stack scoping rules:
 
-        1. Single-stack scenario → apply unconditionally (normal override).
-        2. Multi-stack + ``--stack NAME`` selecting exactly one stack →
+        1. Single-stack scenario -> apply unconditionally (normal override).
+        2. Multi-stack + ``--stack NAME`` selecting exactly one stack ->
            apply to that stack only; sibling stacks keep their
            scenario-defined models.
-        3. Multi-stack with no filter (or filter selecting >1 stack) →
+        3. Multi-stack with no filter (or filter selecting >1 stack) ->
            apply to every stack and emit a warning, because the same
            model across N stacks collapses the scenario into N copies.
 
@@ -383,7 +384,7 @@ class RenderPlans:
         if not self.cli_model:
             return values
 
-        # Rule 2: filter narrows to exactly one stack — skip non-matching
+        # Rule 2: filter narrows to exactly one stack - skip non-matching
         # stacks entirely so their scenario-defined models survive.
         filter_len = len(self.cli_stack_filter)
         if total_stacks > 1 and filter_len == 1:
@@ -391,7 +392,7 @@ class RenderPlans:
                 return values
             # Matching stack: apply silently (operator explicitly scoped).
 
-        # Rule 3: multi-stack with a broad (or missing) filter → warn once.
+        # Rule 3: multi-stack with a broad (or missing) filter -> warn once.
         elif total_stacks > 1 and not self._cli_model_multi_stack_warned:
             self.logger.log_warning(
                 f"-m/--models={self.cli_model!r} is applied identically "
@@ -589,7 +590,7 @@ class RenderPlans:
 
         return values
 
-    # Defaults whose "bare" form collides across multi-stack scenarios —
+    # Defaults whose "bare" form collides across multi-stack scenarios -
     # rewrite to {default}-{model_id_label} so each stack gets a uniquely
     # named resource. The rewrite only fires when the config is still at
     # the shipped default, so an explicit override (in ``defaults.yaml``,
@@ -597,7 +598,7 @@ class RenderPlans:
     # preserved as-is.
     #
     # Intentionally NOT included:
-    #   - storage.modelPvc.name — model weights share one PVC keyed by
+    #   - storage.modelPvc.name - model weights share one PVC keyed by
     #     the per-stack `model.path`, not by the PVC name. NVMe-backed
     #     RWX PVCs in particular want one volume with per-model subdirs,
     #     not N independent volumes. The download Job name still gets
@@ -605,7 +606,7 @@ class RenderPlans:
     _STACK_SCOPED_DEFAULTS: tuple[tuple[tuple[str, ...], str], ...] = (
         # config path, default value that triggers the rewrite
         (("downloadJob", "name"), "download-model"),
-        # EPP metrics-reader Secret — the gaie chart uses this to give its
+        # EPP metrics-reader Secret - the gaie chart uses this to give its
         # SA access to the user-workload-monitoring Prometheus. Two gaie
         # Helm releases sharing this Secret name in one namespace fail
         # with "owned by another helm release".
@@ -626,7 +627,7 @@ class RenderPlans:
         config is still at the default.
 
         Skipped for single-stack scenarios to keep their resource names
-        stable across releases — with only one stack, the collision this
+        stable across releases - with only one stack, the collision this
         resolver guards against can't happen.
 
         See ``_STACK_SCOPED_DEFAULTS`` for the list of rewritten paths.
@@ -808,7 +809,7 @@ class RenderPlans:
 
         self.logger.log_info(
             "HuggingFace token detected from environment "
-            f"(hf_{'*' * 4}…{env_token[-4:]})",
+            f"(hf_{'*' * 4}...{env_token[-4:]})",
             emoji="🔑",
         )
 
@@ -886,13 +887,13 @@ class RenderPlans:
         iterate over to emit one backendRef per sibling stack.
 
         Each entry contains:
-          * ``name``        — the stack's ``name`` (for logs / diagnostics)
-          * ``modelName``   — the raw ``model.name`` (HuggingFace ID); the
+          * ``name``        - the stack's ``name`` (for logs / diagnostics)
+          * ``modelName``   - the raw ``model.name`` (HuggingFace ID); the
                               template runs this through the ``model_id_label``
                               Jinja filter with the resolved namespace to
                               produce the same hashed label the rest of the
                               pipeline uses.
-          * ``standalone``  — True if this stack deploys via standalone mode
+          * ``standalone``  - True if this stack deploys via standalone mode
                               (no InferencePool, no gateway routing).
                               Templates iterating siblings for backendRefs
                               must skip these.
@@ -909,7 +910,7 @@ class RenderPlans:
                 continue
             model_name = (stack.get("model") or {}).get("name", "")
             # Stack-level standalone.enabled wins; otherwise shared-level;
-            # otherwise None (undetermined → treat as non-standalone).
+            # otherwise None (undetermined -> treat as non-standalone).
             stack_standalone = (stack.get("standalone") or {}).get("enabled")
             is_standalone = bool(
                 stack_standalone
@@ -935,13 +936,12 @@ class RenderPlans:
 
         Non-fatal: warnings only. Per-stack validation still runs later.
         """
-        from llmdbenchmark.parser.config_schema import validate_config
         shared_view = self.deep_merge(defaults, shared)
         warnings = validate_config(shared_view, self.logger)
         if warnings:
             self.logger.log_warning(
                 f"`shared:` block has {len(warnings)} potential issue(s) "
-                "— these will propagate to every stack. See above."
+                "- these will propagate to every stack. See above."
             )
 
     @staticmethod
@@ -950,11 +950,11 @@ class RenderPlans:
 
         This stack "owns" scenario-shared infra (`infra-llmdbench` release,
         istio helmfile, shared HTTPRoute). Standalone stacks cannot own
-        shared modelservice infra — they don't install the Helm charts
+        shared modelservice infra - they don't install the Helm charts
         those templates need. So a scenario with stack 1 standalone and
         stack 2 modelservice correctly promotes stack 2 to owner.
 
-        If every stack is standalone (edge case), returns 1 — the
+        If every stack is standalone (edge case), returns 1 - the
         rendered templates are empty for standalone anyway, so the
         choice is moot.
         """
@@ -992,7 +992,7 @@ class RenderPlans:
         result.stacks[stack_name] = stack_errors
 
         stack_config = {k: v for k, v in stack.items() if k != "name"}
-        # Merge order: defaults → shared (scenario-wide) → stack → CLI/setup
+        # Merge order: defaults -> shared (scenario-wide) -> stack -> CLI/setup
         # overrides. Per-stack always wins so a stack can opt out of any
         # shared value by setting it explicitly.
         merged_values = self.deep_merge(defaults, shared or {})
@@ -1040,8 +1040,6 @@ class RenderPlans:
         merged_values["siblingStacks"] = sibling_stacks or []
         merged_values["stackIndex"] = stack_index
         merged_values["sharedInfraStackIndex"] = shared_infra_stack_index
-
-        from llmdbenchmark.parser.config_schema import validate_config
 
         validation_warnings = validate_config(merged_values, self.logger)
         if validation_warnings:
@@ -1145,7 +1143,7 @@ class RenderPlans:
         # pipeline rather than silently passing through render and dying
         # when the executor iterates stacks. A stale defense-in-depth
         # check still lives in step_executor, but this is the primary
-        # catch now — fails fast with a list of known names.
+        # catch now - fails fast with a list of known names.
         if self.cli_stack_filter:
             known_stack_names = {
                 s.get("name") for s in stacks
@@ -1163,7 +1161,7 @@ class RenderPlans:
                 return result
 
         # Scenario-wide settings. Merged into every stack between `defaults`
-        # and the per-stack overrides — so per-stack always wins. See
+        # and the per-stack overrides - so per-stack always wins. See
         # docs/developer-guide.md for the merge semantics.
         shared = scenario.get("shared") or {}
         if not isinstance(shared, dict):

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -49,6 +49,7 @@ class RenderPlans:
         cli_monitoring: bool = False,
         cli_wva: bool = False,
         setup_overrides: dict | None = None,
+        cli_stack_filter: list[str] | None = None,
     ):
         self.template_dir = Path(template_dir)
         self.defaults_file = Path(defaults_file)
@@ -62,6 +63,16 @@ class RenderPlans:
         self.cli_monitoring = cli_monitoring
         self.cli_wva = cli_wva
         self.setup_overrides = setup_overrides
+        # When --stack selects exactly one stack, -m/--models scopes to
+        # that stack only (sibling stacks keep their scenario-defined
+        # models). When --stack isn't set or selects multiple stacks and
+        # the scenario is multi-stack, -m applies to every stack with a
+        # warning. See _resolve_model.
+        self.cli_stack_filter: list[str] = list(cli_stack_filter or [])
+        # Latched flag so the "-m applies to every stack" warning in
+        # _resolve_model fires once per RenderPlans instance, not N times
+        # in a multi-stack scenario.
+        self._cli_model_multi_stack_warned: bool = False
 
         self.logger = logger or get_logger(
             config.log_dir, verbose=config.verbose, log_name=__name__
@@ -340,7 +351,9 @@ class RenderPlans:
         hash8 = digest[:8]
         return f"{first8}-{hash8}-{last8}".lower()
 
-    def _resolve_model(self, values: dict) -> dict:
+    def _resolve_model(
+        self, values: dict, total_stacks: int = 1, stack_name: str = "",
+    ) -> dict:
         """Resolve model configuration from CLI ``--models`` override.
 
         When the user passes ``-m <model>`` on the command line the model
@@ -353,9 +366,43 @@ class RenderPlans:
 
         The ``shortName`` is derived from the model ID and the already-
         resolved namespace (``_resolve_namespace`` must run first).
+
+        Multi-stack scoping rules:
+
+        1. Single-stack scenario → apply unconditionally (normal override).
+        2. Multi-stack + ``--stack NAME`` selecting exactly one stack →
+           apply to that stack only; sibling stacks keep their
+           scenario-defined models.
+        3. Multi-stack with no filter (or filter selecting >1 stack) →
+           apply to every stack and emit a warning, because the same
+           model across N stacks collapses the scenario into N copies.
+
+        Rule 2 is the common case operators want: "rerun pool-a against
+        a different model," without touching pool-b.
         """
         if not self.cli_model:
             return values
+
+        # Rule 2: filter narrows to exactly one stack — skip non-matching
+        # stacks entirely so their scenario-defined models survive.
+        filter_len = len(self.cli_stack_filter)
+        if total_stacks > 1 and filter_len == 1:
+            if stack_name != self.cli_stack_filter[0]:
+                return values
+            # Matching stack: apply silently (operator explicitly scoped).
+
+        # Rule 3: multi-stack with a broad (or missing) filter → warn once.
+        elif total_stacks > 1 and not self._cli_model_multi_stack_warned:
+            self.logger.log_warning(
+                f"-m/--models={self.cli_model!r} is applied identically "
+                f"to all {total_stacks} stack(s). In a multi-model scenario "
+                "this replaces every stack's model with the same value, "
+                "which collapses the scenario into N copies of one model. "
+                "To scope -m to a single stack, combine with --stack <name>; "
+                "to benchmark a pre-existing pool, drop -m entirely and "
+                "let --stack <name> auto-resolve the endpoint."
+            )
+            self._cli_model_multi_stack_warned = True
 
         result = deepcopy(values)
         model_config = result.get("model", {})
@@ -371,8 +418,10 @@ class RenderPlans:
 
         result["model"] = model_config
 
+        suffix = f" [stack={stack_name}]" if stack_name else ""
         self.logger.log_info(
-            f"Model from CLI: {model_id} " f"(shortName={model_config['shortName']})"
+            f"Model from CLI: {model_id} "
+            f"(shortName={model_config['shortName']}){suffix}"
         )
 
         return result
@@ -539,6 +588,82 @@ class RenderPlans:
             values["model_id_label"] = model.get("shortName", "")
 
         return values
+
+    # Defaults whose "bare" form collides across multi-stack scenarios —
+    # rewrite to {default}-{model_id_label} so each stack gets a uniquely
+    # named resource. The rewrite only fires when the config is still at
+    # the shipped default, so an explicit override (in ``defaults.yaml``,
+    # the scenario's ``shared:`` block, or a per-stack block) is
+    # preserved as-is.
+    #
+    # Intentionally NOT included:
+    #   - storage.modelPvc.name — model weights share one PVC keyed by
+    #     the per-stack `model.path`, not by the PVC name. NVMe-backed
+    #     RWX PVCs in particular want one volume with per-model subdirs,
+    #     not N independent volumes. The download Job name still gets
+    #     per-stacked (below) so parallel downloads don't race.
+    _STACK_SCOPED_DEFAULTS: tuple[tuple[tuple[str, ...], str], ...] = (
+        # config path, default value that triggers the rewrite
+        (("downloadJob", "name"), "download-model"),
+        # EPP metrics-reader Secret — the gaie chart uses this to give its
+        # SA access to the user-workload-monitoring Prometheus. Two gaie
+        # Helm releases sharing this Secret name in one namespace fail
+        # with "owned by another helm release".
+        (("inferenceExtension", "monitoring", "secretName"),
+         "inference-gateway-sa-metrics-reader-secret"),
+    )
+
+    def _resolve_per_stack_identity(
+        self, values: dict, total_stacks: int = 1
+    ) -> dict:
+        """Auto-suffix stack-scoped resource names with ``model_id_label``.
+
+        Multi-stack scenarios need per-model PVCs, Download Jobs, and EPP
+        Secrets so releases / Jobs from different stacks don't collide or
+        race on the same Kubernetes resource. Rather than make scenario
+        authors remember to override every such name, we rewrite the
+        shipped defaults to ``{default}-{model_id_label}`` whenever the
+        config is still at the default.
+
+        Skipped for single-stack scenarios to keep their resource names
+        stable across releases — with only one stack, the collision this
+        resolver guards against can't happen.
+
+        See ``_STACK_SCOPED_DEFAULTS`` for the list of rewritten paths.
+        """
+        if total_stacks < 2:
+            return values
+
+        label = values.get("model_id_label") or ""
+        if not label:
+            return values
+
+        for path, default in self._STACK_SCOPED_DEFAULTS:
+            current = self._get_nested(values, path)
+            if current == default:
+                self._set_nested(values, path, f"{default}-{label}")
+
+        return values
+
+    @staticmethod
+    def _get_nested(root: dict, path: tuple[str, ...]) -> Any:
+        """Walk ``root`` along ``path``; return the leaf value or ``None``."""
+        cur: Any = root
+        for part in path:
+            if not isinstance(cur, dict) or part not in cur:
+                return None
+            cur = cur[part]
+        return cur
+
+    @staticmethod
+    def _set_nested(root: dict, path: tuple[str, ...], value: Any) -> None:
+        """Walk ``root`` along ``path``, creating dicts as needed, then set."""
+        cur = root
+        for part in path[:-1]:
+            if part not in cur or not isinstance(cur[part], dict):
+                cur[part] = {}
+            cur = cur[part]
+        cur[path[-1]] = value
 
     def _resolve_inference_pool_host(self, values: dict) -> dict:
         """Auto-populate destinationRule.host from model_id_label when not set.
@@ -754,6 +879,90 @@ class RenderPlans:
                 errors.append(f"{yaml_file.name}: {str(e)[:100]}")
         return errors
 
+    def _build_sibling_stacks(
+        self, stacks: list[dict], shared: dict | None = None,
+    ) -> list[dict]:
+        """Build a minimal per-stack summary list the HTTPRoute template can
+        iterate over to emit one backendRef per sibling stack.
+
+        Each entry contains:
+          * ``name``        — the stack's ``name`` (for logs / diagnostics)
+          * ``modelName``   — the raw ``model.name`` (HuggingFace ID); the
+                              template runs this through the ``model_id_label``
+                              Jinja filter with the resolved namespace to
+                              produce the same hashed label the rest of the
+                              pipeline uses.
+          * ``standalone``  — True if this stack deploys via standalone mode
+                              (no InferencePool, no gateway routing).
+                              Templates iterating siblings for backendRefs
+                              must skip these.
+
+        We do NOT pre-hash here because the namespace isn't resolved yet at
+        this point (CLI overrides are applied during ``_process_stack``);
+        deferring to template time keeps the label computation in exactly
+        one place.
+        """
+        shared_standalone = (shared or {}).get("standalone", {}).get("enabled")
+        siblings: list[dict] = []
+        for stack in stacks:
+            if not isinstance(stack, dict):
+                continue
+            model_name = (stack.get("model") or {}).get("name", "")
+            # Stack-level standalone.enabled wins; otherwise shared-level;
+            # otherwise None (undetermined → treat as non-standalone).
+            stack_standalone = (stack.get("standalone") or {}).get("enabled")
+            is_standalone = bool(
+                stack_standalone
+                if stack_standalone is not None
+                else shared_standalone
+            )
+            siblings.append({
+                "name": stack.get("name", ""),
+                "modelName": model_name,
+                "standalone": is_standalone,
+            })
+        return siblings
+
+    def _validate_shared_block(self, defaults: dict, shared: dict) -> None:
+        """Pre-validate defaults+shared against the config schema.
+
+        A typo at the root of `shared:` (e.g. ``modle:`` instead of
+        ``model:``) silently merges into every stack's root where
+        ``extra="allow"`` accepts it, so the typo propagates without a
+        visible error and the misspelled value never takes effect. By
+        running the same Pydantic validator over defaults+shared first
+        we surface the typo once, at its source.
+
+        Non-fatal: warnings only. Per-stack validation still runs later.
+        """
+        from llmdbenchmark.parser.config_schema import validate_config
+        shared_view = self.deep_merge(defaults, shared)
+        warnings = validate_config(shared_view, self.logger)
+        if warnings:
+            self.logger.log_warning(
+                f"`shared:` block has {len(warnings)} potential issue(s) "
+                "— these will propagate to every stack. See above."
+            )
+
+    @staticmethod
+    def _resolve_shared_infra_stack_index(siblings: list[dict]) -> int:
+        """Return the 1-indexed position of the first modelservice stack.
+
+        This stack "owns" scenario-shared infra (`infra-llmdbench` release,
+        istio helmfile, shared HTTPRoute). Standalone stacks cannot own
+        shared modelservice infra — they don't install the Helm charts
+        those templates need. So a scenario with stack 1 standalone and
+        stack 2 modelservice correctly promotes stack 2 to owner.
+
+        If every stack is standalone (edge case), returns 1 — the
+        rendered templates are empty for standalone anyway, so the
+        choice is moot.
+        """
+        for i, sibling in enumerate(siblings, 1):
+            if not sibling.get("standalone"):
+                return i
+        return 1
+
     def _process_stack(
         self,
         stack: dict,
@@ -763,6 +972,9 @@ class RenderPlans:
         templates: list[dict],
         base_path: Path,
         result: RenderResult,
+        sibling_stacks: list[dict] | None = None,
+        shared: dict | None = None,
+        shared_infra_stack_index: int = 1,
     ) -> None:
         """Merge values, resolve overrides, render templates, and validate output for one stack."""
         if "name" not in stack:
@@ -780,7 +992,11 @@ class RenderPlans:
         result.stacks[stack_name] = stack_errors
 
         stack_config = {k: v for k, v in stack.items() if k != "name"}
-        merged_values = self.deep_merge(defaults, stack_config)
+        # Merge order: defaults → shared (scenario-wide) → stack → CLI/setup
+        # overrides. Per-stack always wins so a stack can opt out of any
+        # shared value by setting it explicitly.
+        merged_values = self.deep_merge(defaults, shared or {})
+        merged_values = self.deep_merge(merged_values, stack_config)
 
         if self.setup_overrides:
             merged_values = self.deep_merge(merged_values, self.setup_overrides)
@@ -804,15 +1020,26 @@ class RenderPlans:
             )
 
         merged_values = self._resolve_namespace(merged_values)
-        merged_values = self._resolve_model(merged_values)
+        merged_values = self._resolve_model(
+            merged_values,
+            total_stacks=total_stacks,
+            stack_name=stack.get("name", ""),
+        )
         self._warn_custom_command_conflicts(merged_values)
         merged_values = self._resolve_deploy_method(merged_values)
         merged_values = self._resolve_monitoring(merged_values)
         merged_values = self._resolve_wva(merged_values)
         merged_values = self._resolve_hf_token(merged_values)
         merged_values = self._resolve_model_id_label(merged_values)
+        merged_values = self._resolve_per_stack_identity(
+            merged_values, total_stacks=total_stacks
+        )
         merged_values = self._resolve_inference_pool_host(merged_values)
         merged_values = self._substitute_config_variables(merged_values)
+
+        merged_values["siblingStacks"] = sibling_stacks or []
+        merged_values["stackIndex"] = stack_index
+        merged_values["sharedInfraStackIndex"] = shared_infra_stack_index
 
         from llmdbenchmark.parser.config_schema import validate_config
 
@@ -913,7 +1140,50 @@ class RenderPlans:
             result.global_errors.append(msg)
             return result
 
+        # Validate --stack filter against known stack names BEFORE rendering
+        # anything, so typos fail with a clear error at the start of the
+        # pipeline rather than silently passing through render and dying
+        # when the executor iterates stacks. A stale defense-in-depth
+        # check still lives in step_executor, but this is the primary
+        # catch now — fails fast with a list of known names.
+        if self.cli_stack_filter:
+            known_stack_names = {
+                s.get("name") for s in stacks
+                if isinstance(s, dict) and s.get("name")
+            }
+            unknown = [n for n in self.cli_stack_filter if n not in known_stack_names]
+            if unknown:
+                msg = (
+                    f"--stack filter references unknown stack(s): "
+                    f"{', '.join(unknown)}. Known stacks in this scenario: "
+                    f"{', '.join(sorted(known_stack_names)) or '<none>'}."
+                )
+                self.logger.log_error(msg)
+                result.global_errors.append(msg)
+                return result
+
+        # Scenario-wide settings. Merged into every stack between `defaults`
+        # and the per-stack overrides — so per-stack always wins. See
+        # docs/developer-guide.md for the merge semantics.
+        shared = scenario.get("shared") or {}
+        if not isinstance(shared, dict):
+            msg = "'shared' must be a mapping when present"
+            self.logger.log_error(msg)
+            result.global_errors.append(msg)
+            return result
+
         self.logger.log_info(f"Processing scenario with {len(stacks)} stack(s)...")
+        if shared:
+            self.logger.log_info(
+                f"  (scenario-wide `shared` block merged into each stack: "
+                f"{len(shared)} top-level key(s))"
+            )
+            # Validate the shared block against the config schema BEFORE
+            # per-stack processing. Catches typos at their source rather
+            # than having the same "extra='forbid'" failure emitted once
+            # per stack during rendering. Warn-only: the per-stack render
+            # still runs and still validates, so we never block here.
+            self._validate_shared_block(defaults, shared)
         self.logger.line_break()
 
         try:
@@ -930,6 +1200,11 @@ class RenderPlans:
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
+        sibling_stacks = self._build_sibling_stacks(stacks, shared=shared)
+        shared_infra_stack_index = self._resolve_shared_infra_stack_index(
+            sibling_stacks
+        )
+
         for i, stack in enumerate(stacks, 1):
             self._process_stack(
                 stack=stack,
@@ -939,6 +1214,9 @@ class RenderPlans:
                 templates=templates,
                 base_path=self.output_dir,
                 result=result,
+                sibling_stacks=sibling_stacks,
+                shared=shared,
+                shared_infra_stack_index=shared_infra_stack_index,
             )
 
         self.logger.log_info(

--- a/llmdbenchmark/run/steps/step_03_detect_endpoint.py
+++ b/llmdbenchmark/run/steps/step_03_detect_endpoint.py
@@ -11,6 +11,7 @@ from llmdbenchmark.utilities.endpoint import (
     find_custom_endpoint,
     discover_hf_token_secret,
     extract_hf_token_from_secret,
+    compute_gateway_path_prefix,
 )
 
 
@@ -141,14 +142,25 @@ class DetectEndpointStep(Step):
                     stack_name=stack_name,
                 )
 
-        # Build full URL
+        # Build full URL. For shared-HTTPRoute multi-model scenarios,
+        # append the per-stack path prefix (e.g. /pool-a) so that every
+        # downstream `{endpoint_url}/v1/completions` becomes
+        # `{gateway}/pool-a/v1/completions` — the gateway rewrites
+        # /pool-a/* → /* and the request reaches THIS stack's
+        # InferencePool. Returns "" (no-op) for every other scenario.
         protocol = "https" if gateway_port == "443" else "http"
         endpoint_url = f"{protocol}://{service_ip}:{gateway_port}"
+        path_prefix = compute_gateway_path_prefix(
+            plan_config, stack_name, is_standalone=is_standalone,
+        )
+        if path_prefix:
+            endpoint_url = f"{endpoint_url}{path_prefix}"
         context.deployed_endpoints[stack_name] = endpoint_url
 
         context.logger.log_info(
             f"Detected endpoint: {endpoint_url} "
-            f"(service={service_name}, stack_type={stack_type})"
+            f"(service={service_name}, stack_type={stack_type}"
+            f"{', path_prefix=' + path_prefix if path_prefix else ''})"
         )
 
         # --- HF token auto-discovery for custom deployments ---

--- a/llmdbenchmark/run/steps/step_03_detect_endpoint.py
+++ b/llmdbenchmark/run/steps/step_03_detect_endpoint.py
@@ -145,8 +145,8 @@ class DetectEndpointStep(Step):
         # Build full URL. For shared-HTTPRoute multi-model scenarios,
         # append the per-stack path prefix (e.g. /pool-a) so that every
         # downstream `{endpoint_url}/v1/completions` becomes
-        # `{gateway}/pool-a/v1/completions` — the gateway rewrites
-        # /pool-a/* → /* and the request reaches THIS stack's
+        # `{gateway}/pool-a/v1/completions` - the gateway rewrites
+        # /pool-a/* -> /* and the request reaches THIS stack's
         # InferencePool. Returns "" (no-op) for every other scenario.
         protocol = "https" if gateway_port == "443" else "http"
         endpoint_url = f"{protocol}://{service_ip}:{gateway_port}"

--- a/llmdbenchmark/run/steps/step_04_verify_model.py
+++ b/llmdbenchmark/run/steps/step_04_verify_model.py
@@ -69,8 +69,12 @@ class VerifyModelStep(Step):
                 stack_name=stack_name,
             )
 
-        # Parse host and port from endpoint URL
-        host, port = self._parse_endpoint(endpoint_url)
+        # Parse host, port, and optional path prefix from endpoint URL.
+        # Shared-HTTPRoute scenarios bake the per-stack prefix into the
+        # detected endpoint (e.g. http://gw:80/pool-a) so {endpoint_url}/v1/*
+        # works end-to-end in the harness. We peel it back off here to
+        # pass to test_model_serving, which reassembles it internally.
+        host, port, url_path_prefix = self._parse_endpoint(endpoint_url)
         namespace = context.harness_namespace or context.namespace or ""
 
         context.logger.log_info(
@@ -87,6 +91,7 @@ class VerifyModelStep(Step):
             max_retries=3,
             retry_interval=10,
             service_account=context.harness_service_account,
+            url_path_prefix=url_path_prefix,
         )
 
         # Clean up ephemeral smoketest/curl pods
@@ -115,24 +120,36 @@ class VerifyModelStep(Step):
         )
 
     @staticmethod
-    def _parse_endpoint(url: str) -> tuple[str, str]:
-        """Extract host and port from an endpoint URL.
+    def _parse_endpoint(url: str) -> tuple[str, str, str]:
+        """Extract host, port, and path prefix from an endpoint URL.
 
         Examples:
-            http://10.0.0.1:80 to ('10.0.0.1', '80')
-            https://gateway.example.com:443 to ('gateway.example.com', '443')
+            http://10.0.0.1:80           -> ('10.0.0.1', '80', '')
+            https://gw.example.com:443   -> ('gw.example.com', '443', '')
+            http://10.0.0.1:80/pool-a    -> ('10.0.0.1', '80', '/pool-a')
+            http://10.0.0.1/pool-a/v1    -> ('10.0.0.1', '80', '/pool-a/v1')
+
+        The path prefix is whatever remains after ``host:port`` — empty
+        string for plain endpoints, and the full routing prefix for
+        shared-HTTPRoute multi-model scenarios where step_03 baked it in.
         """
         # Strip protocol
         stripped = url
+        is_https = url.startswith("https")
         if "://" in stripped:
             stripped = stripped.split("://", 1)[1]
-        # Strip trailing path
-        stripped = stripped.split("/", 1)[0]
+        # Split authority from path
+        if "/" in stripped:
+            authority, rest = stripped.split("/", 1)
+            path_prefix = "/" + rest.rstrip("/")
+            if path_prefix == "/":
+                path_prefix = ""
+        else:
+            authority, path_prefix = stripped, ""
         # Split host:port
-        if ":" in stripped:
-            host, port = stripped.rsplit(":", 1)
-            return host, port
-        # Default port based on protocol
-        if url.startswith("https"):
-            return stripped, "443"
-        return stripped, "80"
+        if ":" in authority:
+            host, port = authority.rsplit(":", 1)
+        else:
+            host = authority
+            port = "443" if is_https else "80"
+        return host, port, path_prefix

--- a/llmdbenchmark/run/steps/step_04_verify_model.py
+++ b/llmdbenchmark/run/steps/step_04_verify_model.py
@@ -129,7 +129,7 @@ class VerifyModelStep(Step):
             http://10.0.0.1:80/pool-a    -> ('10.0.0.1', '80', '/pool-a')
             http://10.0.0.1/pool-a/v1    -> ('10.0.0.1', '80', '/pool-a/v1')
 
-        The path prefix is whatever remains after ``host:port`` — empty
+        The path prefix is whatever remains after ``host:port`` - empty
         string for plain endpoints, and the full routing prefix for
         shared-HTTPRoute multi-model scenarios where step_03 baked it in.
         """

--- a/llmdbenchmark/smoketests/README.md
+++ b/llmdbenchmark/smoketests/README.md
@@ -35,8 +35,8 @@ Scenarios without a dedicated validator (cicd paths, sim, etc.) run steps 00 and
 
 ## Multi-Stack Smoketests
 
-Smoketest steps are per-stack — each rendered stack (e.g. `qwen3-06b`,
-`llama-31-8b`) runs through steps 00–02 independently. Two behaviors differ
+Smoketest steps are per-stack - each rendered stack (e.g. `qwen3-06b`,
+`llama-31-8b`) runs through steps 00-02 independently. Two behaviors differ
 from the standup and run phases:
 
 - **Sequential execution.** Smoketest pins `max_parallel_stacks=1` regardless
@@ -45,8 +45,8 @@ from the standup and run phases:
   real failures hard to spot. Configured in `cli.py`'s `_do_smoketest`.
 - **Per-stack gateway path prefix.** When a scenario uses a shared HTTPRoute
   (`httpRoute.mode: shared` in the scenario YAML), the smoketest inserts the
-  stack's routing prefix into every gateway URL — e.g. `/qwen3-06b/health`
-  and `/qwen3-06b/v1/models` — so requests actually reach this stack's
+  stack's routing prefix into every gateway URL - e.g. `/qwen3-06b/health`
+  and `/qwen3-06b/v1/models` - so requests actually reach this stack's
   InferencePool. Pod-direct-IP probes (which bypass the gateway) continue to
   hit `/health` and `/v1/models` without a prefix. The prefix is computed
   from `httpRoute.pathPrefix` by `compute_gateway_path_prefix` in
@@ -56,7 +56,7 @@ from the standup and run phases:
   `httpRoute.rewriteTo` to something other than `"/"` (e.g. `/v1`), the
   gateway intentionally doesn't route `/health` (which lives at vLLM's
   root, not under `/v1`). The smoketest detects this case via
-  `_gateway_routes_health` and logs an INFO skip instead of failing —
+  `_gateway_routes_health` and logs an INFO skip instead of failing -
   `/v1/models` + direct-pod-IP probes still run and still validate health.
 
 ## Step 00: Health check
@@ -158,23 +158,23 @@ The stack name is the `-name` field from the scenario YAML (e.g., `pd-disaggrega
 
 ```
 smoketests/
-├── __init__.py            -- get_validator() registry lookup
-├── base.py                -- BaseSmoketest: health checks, inference test, validate_role_pods
-├── report.py              -- SmoketestReport / CheckResult tracking
-├── steps/
-│   ├── __init__.py        -- get_smoketest_steps() registry
-│   ├── step_00_health_check.py
-│   ├── step_01_inference_test.py
-│   └── step_02_validate_config.py
-└── validators/
-    ├── __init__.py         -- VALIDATORS dict (stack name to validator class)
-    ├── cpu.py
-    ├── gpu.py
-    ├── spyre.py
-    ├── inference_scheduling.py
-    ├── pd_disaggregation.py
-    ├── precise_prefix_cache_aware.py
-    ├── simulated_accelerators.py
-    ├── tiered_prefix_cache.py
-    └── wide_ep_lws.py
++-- __init__.py            -- get_validator() registry lookup
++-- base.py                -- BaseSmoketest: health checks, inference test, validate_role_pods
++-- report.py              -- SmoketestReport / CheckResult tracking
++-- steps/
+|   +-- __init__.py        -- get_smoketest_steps() registry
+|   +-- step_00_health_check.py
+|   +-- step_01_inference_test.py
+|   +-- step_02_validate_config.py
++-- validators/
+    +-- __init__.py         -- VALIDATORS dict (stack name to validator class)
+    +-- cpu.py
+    +-- gpu.py
+    +-- spyre.py
+    +-- inference_scheduling.py
+    +-- pd_disaggregation.py
+    +-- precise_prefix_cache_aware.py
+    +-- simulated_accelerators.py
+    +-- tiered_prefix_cache.py
+    +-- wide_ep_lws.py
 ```

--- a/llmdbenchmark/smoketests/README.md
+++ b/llmdbenchmark/smoketests/README.md
@@ -33,6 +33,32 @@ Smoketests also run automatically at the end of `llmdbenchmark standup`. Use `--
 
 Scenarios without a dedicated validator (cicd paths, sim, etc.) run steps 00 and 01 only. Step 02 logs a skip message and passes.
 
+## Multi-Stack Smoketests
+
+Smoketest steps are per-stack — each rendered stack (e.g. `qwen3-06b`,
+`llama-31-8b`) runs through steps 00–02 independently. Two behaviors differ
+from the standup and run phases:
+
+- **Sequential execution.** Smoketest pins `max_parallel_stacks=1` regardless
+  of `--parallel`. Parallel `/health` + `/v1/models` probes across stacks
+  hammer a shared gateway unnecessarily and interleave logs in ways that make
+  real failures hard to spot. Configured in `cli.py`'s `_do_smoketest`.
+- **Per-stack gateway path prefix.** When a scenario uses a shared HTTPRoute
+  (`httpRoute.mode: shared` in the scenario YAML), the smoketest inserts the
+  stack's routing prefix into every gateway URL — e.g. `/qwen3-06b/health`
+  and `/qwen3-06b/v1/models` — so requests actually reach this stack's
+  InferencePool. Pod-direct-IP probes (which bypass the gateway) continue to
+  hit `/health` and `/v1/models` without a prefix. The prefix is computed
+  from `httpRoute.pathPrefix` by `compute_gateway_path_prefix` in
+  `llmdbenchmark.utilities.endpoint`; scenarios that don't opt into shared
+  HTTPRoute get `""` and the existing single-model behavior is unchanged.
+- **Health-probe skip for narrowed routing.** If an operator sets
+  `httpRoute.rewriteTo` to something other than `"/"` (e.g. `/v1`), the
+  gateway intentionally doesn't route `/health` (which lives at vLLM's
+  root, not under `/v1`). The smoketest detects this case via
+  `_gateway_routes_health` and logs an INFO skip instead of failing —
+  `/v1/models` + direct-pod-IP probes still run and still validate health.
+
 ## Step 00: Health check
 
 The health check validates every layer of the serving stack:

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -9,11 +9,13 @@ from llmdbenchmark.executor.command import CommandExecutor
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.smoketests.report import CheckResult, SmoketestReport
 from llmdbenchmark.utilities.endpoint import (
-    _rand_suffix,
     _build_overrides,
     _ephemeral_label_args,
-    find_standalone_endpoint,
+    _normalize_url_prefix,
+    _rand_suffix,
+    compute_gateway_path_prefix,
     find_gateway_endpoint,
+    find_standalone_endpoint,
     test_model_serving,
 )
 
@@ -61,7 +63,6 @@ class BaseSmoketest:
         Kept as a method so subclasses can still override if some future
         validator needs scenario-specific routing logic.
         """
-        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
         return compute_gateway_path_prefix(
             plan_config, stack_name, is_standalone=is_standalone,
         )
@@ -73,7 +74,7 @@ class BaseSmoketest:
         A shared HTTPRoute with ``rewriteTo: /`` routes everything, so
         `/{stack-prefix}/health` reaches vLLM's /health at the root. But
         ``rewriteTo: /v1`` (or any non-root path) narrows routing to the
-        /v1/* namespace — /health isn't under /v1, so the gateway would
+        /v1/* namespace - /health isn't under /v1, so the gateway would
         have no rule matching it and a smoketest probe would 404.
 
         The smoketest uses this to decide whether to skip the /health
@@ -82,9 +83,9 @@ class BaseSmoketest:
         """
         http_route = plan_config.get("httpRoute") or {}
         if http_route.get("mode") != "shared":
-            return True  # not a shared route — direct /health works
+            return True  # not a shared route - direct /health works
         rewrite_to = (http_route.get("rewriteTo") or "/").strip()
-        # "/" or "" means "rewrite to root" → /health routes cleanly.
+        # "/" or "" means "rewrite to root" -> /health routes cleanly.
         return rewrite_to in ("", "/")
 
     @staticmethod
@@ -200,7 +201,7 @@ class BaseSmoketest:
                         ))
                     else:
                         context.logger.log_info(
-                            f"All {len(phases)} {pod_type} pod(s) running ✓"
+                            f"All {len(phases)} {pod_type} pod(s) running (ok)"
                         )
                         report.add(CheckResult(
                             f"{pod_type}_pods_running", True,
@@ -236,7 +237,7 @@ class BaseSmoketest:
                                 ))
                             else:
                                 context.logger.log_info(
-                                    f"All {pod_type} containers ready ✓"
+                                    f"All {pod_type} containers ready (ok)"
                                 )
                 else:
                     report.add(CheckResult(
@@ -252,15 +253,15 @@ class BaseSmoketest:
             return report
 
         # When the scenario uses a shared HTTPRoute with path-based routing
-        # (e.g. /pool-a/v1 → pool A, /pool-b/v1 → pool B), prepend this
+        # (e.g. /pool-a/v1 -> pool A, /pool-b/v1 -> pool B), prepend this
         # stack's path prefix to the gateway URLs so requests actually hit
         # the InferencePool for THIS stack. Returns "" for the usual case
-        # (single-model scenarios, standalone) — unchanged behavior.
+        # (single-model scenarios, standalone) - unchanged behavior.
         url_path_prefix = self._gateway_path_prefix_for_stack(
             plan_config, is_standalone, stack_name=stack_path.name,
         )
 
-        # 2. Health check (/health) — skip gracefully when a shared
+        # 2. Health check (/health) - skip gracefully when a shared
         # HTTPRoute deliberately narrows routing to /v1/* (i.e.
         # rewriteTo != "/"). vLLM's /health endpoint lives at the root,
         # so a request to {prefix}/health wouldn't match any route rule
@@ -315,7 +316,7 @@ class BaseSmoketest:
         else:
             service_test_passed = True
             context.logger.log_info(
-                f"Service {service_ip}:{gateway_port} responding ✓"
+                f"Service {service_ip}:{gateway_port} responding (ok)"
             )
             report.add(CheckResult("service_endpoint", True, message="Service responding"))
 
@@ -357,7 +358,7 @@ class BaseSmoketest:
                             message=f"Curl to {pod_ip}:{inference_port} failed: {test_result}",
                         ))
                 else:
-                    context.logger.log_info(f"Pod {pod_ip} responding ✓")
+                    context.logger.log_info(f"Pod {pod_ip} responding (ok)")
 
         # 6. OpenShift route (only for modelservice -- standalone has no gateway route)
         if context.is_openshift and not is_standalone:
@@ -399,10 +400,10 @@ class BaseSmoketest:
 
         protocol = "https" if str(gateway_port) == "443" else "http"
         # Shared-HTTPRoute scenarios route by path prefix (e.g. /pool-a/*
-        # → this stack's InferencePool). Bake the prefix into base_url so
+        # -> this stack's InferencePool). Bake the prefix into base_url so
         # every downstream {base_url}/v1/completions becomes
-        # {base_url}/pool-a/v1/completions — the gateway then rewrites
-        # /pool-a/* → /* before the request reaches vLLM. Empty string for
+        # {base_url}/pool-a/v1/completions - the gateway then rewrites
+        # /pool-a/* -> /* before the request reaches vLLM. Empty string for
         # every other scenario, preserving existing behavior.
         prefix = self._gateway_path_prefix_for_stack(
             plan_config, _is_standalone, stack_name=stack_path.name,
@@ -780,7 +781,7 @@ class BaseSmoketest:
             # so a reader can still tell what's happening.
             #
             # Multinode (LWS) deployments scale via LeaderWorkerSet, not
-            # HPA, so the relaxation must not apply to them — keep strict
+            # HPA, so the relaxation must not apply to them - keep strict
             # equality there.
             hpa_managed = (
                 _nested_get(config, "wva", "enabled")
@@ -1141,7 +1142,6 @@ class BaseSmoketest:
         poll_interval: int = 10,
         url_path_prefix: str = "",
     ) -> str | None:
-        from llmdbenchmark.utilities.endpoint import _normalize_url_prefix
         protocol = "https" if str(port) == "443" else "http"
         prefix = _normalize_url_prefix(url_path_prefix)
         url = f"{protocol}://{host}:{port}{prefix}/health"
@@ -1188,7 +1188,7 @@ class BaseSmoketest:
 
             if status_code == "200":
                 context.logger.log_info(
-                    f"vLLM health check passed ✓ ({int(elapsed)}s elapsed)"
+                    f"vLLM health check passed (ok) ({int(elapsed)}s elapsed)"
                 )
                 return None
 
@@ -1240,7 +1240,7 @@ class BaseSmoketest:
 
             if result is None:
                 context.logger.log_info(
-                    f"Model ready at {host}:{port} ✓ ({int(elapsed)}s elapsed)"
+                    f"Model ready at {host}:{port} (ok) ({int(elapsed)}s elapsed)"
                 )
                 return
 
@@ -1294,7 +1294,7 @@ class BaseSmoketest:
                         message=f"Route test failed: {test_result}",
                     ))
             else:
-                context.logger.log_info(f"Route {route_host} responding ✓")
+                context.logger.log_info(f"Route {route_host} responding (ok)")
                 report.add(CheckResult(
                     "openshift_route", True,
                     message="Route responding",

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -51,6 +51,43 @@ class BaseSmoketest:
     """
 
     @staticmethod
+    def _gateway_path_prefix_for_stack(
+        plan_config: dict,
+        is_standalone: bool,
+        stack_name: str = "",
+    ) -> str:
+        """Thin wrapper over ``utilities.endpoint.compute_gateway_path_prefix``.
+
+        Kept as a method so subclasses can still override if some future
+        validator needs scenario-specific routing logic.
+        """
+        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
+        return compute_gateway_path_prefix(
+            plan_config, stack_name, is_standalone=is_standalone,
+        )
+
+    @staticmethod
+    def _gateway_routes_health(plan_config: dict) -> bool:
+        """Return True when the gateway routes /health to upstream pods.
+
+        A shared HTTPRoute with ``rewriteTo: /`` routes everything, so
+        `/{stack-prefix}/health` reaches vLLM's /health at the root. But
+        ``rewriteTo: /v1`` (or any non-root path) narrows routing to the
+        /v1/* namespace — /health isn't under /v1, so the gateway would
+        have no rule matching it and a smoketest probe would 404.
+
+        The smoketest uses this to decide whether to skip the /health
+        probe gracefully in shared-HTTPRoute scenarios where the operator
+        deliberately chose narrower routing.
+        """
+        http_route = plan_config.get("httpRoute") or {}
+        if http_route.get("mode") != "shared":
+            return True  # not a shared route — direct /health works
+        rewrite_to = (http_route.get("rewriteTo") or "/").strip()
+        # "/" or "" means "rewrite to root" → /health routes cleanly.
+        return rewrite_to in ("", "/")
+
+    @staticmethod
     def discover_endpoint(
         cmd: CommandExecutor,
         context: ExecutionContext,
@@ -214,30 +251,62 @@ class BaseSmoketest:
             ))
             return report
 
-        # 2. Health check (/health)
-        health_err = self._check_health(
-            cmd, context, namespace, service_ip, gateway_port, plan_config,
+        # When the scenario uses a shared HTTPRoute with path-based routing
+        # (e.g. /pool-a/v1 → pool A, /pool-b/v1 → pool B), prepend this
+        # stack's path prefix to the gateway URLs so requests actually hit
+        # the InferencePool for THIS stack. Returns "" for the usual case
+        # (single-model scenarios, standalone) — unchanged behavior.
+        url_path_prefix = self._gateway_path_prefix_for_stack(
+            plan_config, is_standalone, stack_name=stack_path.name,
         )
-        if health_err:
-            report.add(CheckResult("health_endpoint", False, message=health_err))
+
+        # 2. Health check (/health) — skip gracefully when a shared
+        # HTTPRoute deliberately narrows routing to /v1/* (i.e.
+        # rewriteTo != "/"). vLLM's /health endpoint lives at the root,
+        # so a request to {prefix}/health wouldn't match any route rule
+        # and would return 404 regardless of pod health.
+        if url_path_prefix and not self._gateway_routes_health(plan_config):
+            context.logger.log_info(
+                f"Skipping /health probe: gateway rewriteTo="
+                f"{(plan_config.get('httpRoute') or {}).get('rewriteTo', '/')!r} "
+                "deliberately narrows routing to /v1/* paths. /v1/models "
+                "probe + direct-pod-IP health check still run."
+            )
+            report.add(CheckResult(
+                "health_endpoint_skipped", True,
+                message=(
+                    "/health not routable via gateway (by design); "
+                    "relying on /v1/models + direct-pod-IP probe"
+                ),
+            ))
         else:
-            report.add(CheckResult("health_endpoint", True, message="/health responding"))
+            health_err = self._check_health(
+                cmd, context, namespace, service_ip, gateway_port, plan_config,
+                url_path_prefix=url_path_prefix,
+            )
+            if health_err:
+                report.add(CheckResult("health_endpoint", False, message=health_err))
+            else:
+                report.add(CheckResult("health_endpoint", True, message="/health responding"))
 
         # 3. Wait for model ready (/v1/models)
         if report.passed:
             self._wait_for_model_ready(
                 cmd, context, namespace, service_ip, gateway_port,
                 model_name, plan_config,
+                url_path_prefix=url_path_prefix,
             )
 
         # 4. Test service/gateway
         service_test_passed = False
         context.logger.log_info(
-            f'Testing service/gateway "{service_ip}" (port {gateway_port})...'
+            f'Testing service/gateway "{service_ip}" (port {gateway_port})'
+            f'{" [prefix=" + url_path_prefix + "]" if url_path_prefix else ""}...'
         )
         test_result = test_model_serving(
             cmd, namespace, service_ip, gateway_port,
             model_name, plan_config, max_retries=1,
+            url_path_prefix=url_path_prefix,
         )
         if test_result:
             report.add(CheckResult(
@@ -329,7 +398,16 @@ class BaseSmoketest:
             return report
 
         protocol = "https" if str(gateway_port) == "443" else "http"
-        base_url = f"{protocol}://{service_ip}:{gateway_port}"
+        # Shared-HTTPRoute scenarios route by path prefix (e.g. /pool-a/*
+        # → this stack's InferencePool). Bake the prefix into base_url so
+        # every downstream {base_url}/v1/completions becomes
+        # {base_url}/pool-a/v1/completions — the gateway then rewrites
+        # /pool-a/* → /* before the request reaches vLLM. Empty string for
+        # every other scenario, preserving existing behavior.
+        prefix = self._gateway_path_prefix_for_stack(
+            plan_config, _is_standalone, stack_name=stack_path.name,
+        )
+        base_url = f"{protocol}://{service_ip}:{gateway_port}{prefix}"
 
         context.logger.log_info(f"Running sample inference against {base_url}...")
 
@@ -1061,9 +1139,12 @@ class BaseSmoketest:
         plan_config: dict | None = None,
         timeout: int = 120,
         poll_interval: int = 10,
+        url_path_prefix: str = "",
     ) -> str | None:
+        from llmdbenchmark.utilities.endpoint import _normalize_url_prefix
         protocol = "https" if str(port) == "443" else "http"
-        url = f"{protocol}://{host}:{port}/health"
+        prefix = _normalize_url_prefix(url_path_prefix)
+        url = f"{protocol}://{host}:{port}{prefix}/health"
         curl_image = "quay.io/curl/curl"
         override_args = _build_overrides(plan_config)
 
@@ -1129,6 +1210,7 @@ class BaseSmoketest:
         plan_config: dict | None = None,
         timeout: int = 300,
         poll_interval: int = 15,
+        url_path_prefix: str = "",
     ):
         context.logger.log_info(
             f"Waiting for model to be ready at {host}:{port} "
@@ -1150,6 +1232,7 @@ class BaseSmoketest:
             result = test_model_serving(
                 cmd, namespace, host, port, expected_model, plan_config,
                 max_retries=1,
+                url_path_prefix=url_path_prefix,
             )
 
             if cmd.dry_run:

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -11,7 +11,7 @@ Steps are registered in `steps/__init__.py` via `get_standup_steps()` and execut
 | 00 | `EnsureInfraStep` | global | Validate system dependencies (kubectl, helm, etc.) and print cluster summary banner |
 | 02 | `AdminPrerequisitesStep` | global | Install cluster-level admin prerequisites (CRDs, gateways, LeaderWorkerSet, SCCs) |
 | 03 | `WorkloadMonitoringStep` | global | Validate cluster resources and configure workload monitoring (PodMonitors). Installs WVA controller once per `wva.namespace` across all rendered stacks. |
-| 04 | `ModelNamespaceStep` | global | Prepare the model namespace. Creates one shared model PVC (idempotent across stacks) and one download Job per stack with `modelservice.uriProtocol: pvc` (or standalone). Jobs are launched in parallel (phase 1) and waited on in turn (phase 2), so total wall time ≈ slowest model. Every stack's weights live in a distinct `model.path` subdirectory on the shared PVC. |
+| 04 | `ModelNamespaceStep` | global | Prepare the model namespace. Creates one shared model PVC (idempotent across stacks) and one download Job per stack with `modelservice.uriProtocol: pvc` (or standalone). Jobs are launched in parallel (phase 1) and waited on in turn (phase 2), so total wall time ~ slowest model. Every stack's weights live in a distinct `model.path` subdirectory on the shared PVC. |
 | 05 | `HarnessNamespaceStep` | global | Prepare the harness namespace (scenario-wide workload PVC, data access pod, secrets) |
 | 06 | `FMADeployStep` | global | Deploy FMA controllers |
 | 06 | `StandaloneDeployStep` | global | Deploy vLLM as standalone Kubernetes Deployments and Services |
@@ -70,20 +70,20 @@ Contains scripts executed during standalone deployment setup:
 
 ```
 standup/
-├── __init__.py              -- Package marker
-├── preprocess/
-│   ├── set_llmdbench_environment.py
-│   └── standalone-preprocess.py
-└── steps/
-    ├── __init__.py           -- Step registry (get_standup_steps)
-    ├── step_00_ensure_infra.py
-    ├── step_02_admin_prerequisites.py
-    ├── step_03_workload_monitoring.py
-    ├── step_04_model_namespace.py
-    ├── step_05_harness_namespace.py
-    ├── step_06_fma_deploy.py
-    ├── step_06_standalone_deploy.py
-    ├── step_07_deploy_setup.py
-    ├── step_08_deploy_gaie.py
-    └── step_09_deploy_modelservice.py
++-- __init__.py              -- Package marker
++-- preprocess/
+|   +-- set_llmdbench_environment.py
+|   +-- standalone-preprocess.py
++-- steps/
+    +-- __init__.py           -- Step registry (get_standup_steps)
+    +-- step_00_ensure_infra.py
+    +-- step_02_admin_prerequisites.py
+    +-- step_03_workload_monitoring.py
+    +-- step_04_model_namespace.py
+    +-- step_05_harness_namespace.py
+    +-- step_06_fma_deploy.py
+    +-- step_06_standalone_deploy.py
+    +-- step_07_deploy_setup.py
+    +-- step_08_deploy_gaie.py
+    +-- step_09_deploy_modelservice.py
 ```

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -10,9 +10,9 @@ Steps are registered in `steps/__init__.py` via `get_standup_steps()` and execut
 |------|------|-------|-------------|
 | 00 | `EnsureInfraStep` | global | Validate system dependencies (kubectl, helm, etc.) and print cluster summary banner |
 | 02 | `AdminPrerequisitesStep` | global | Install cluster-level admin prerequisites (CRDs, gateways, LeaderWorkerSet, SCCs) |
-| 03 | `WorkloadMonitoringStep` | global | Validate cluster resources and configure workload monitoring (PodMonitors) |
-| 04 | `ModelNamespaceStep` | global | Prepare the model namespace (PVC, secrets, model download job) |
-| 05 | `HarnessNamespaceStep` | global | Prepare the harness namespace (PVC, data access pod, secrets) |
+| 03 | `WorkloadMonitoringStep` | global | Validate cluster resources and configure workload monitoring (PodMonitors). Installs WVA controller once per `wva.namespace` across all rendered stacks. |
+| 04 | `ModelNamespaceStep` | global | Prepare the model namespace. Creates one shared model PVC (idempotent across stacks) and one download Job per stack with `modelservice.uriProtocol: pvc` (or standalone). Jobs are launched in parallel (phase 1) and waited on in turn (phase 2), so total wall time ≈ slowest model. Every stack's weights live in a distinct `model.path` subdirectory on the shared PVC. |
+| 05 | `HarnessNamespaceStep` | global | Prepare the harness namespace (scenario-wide workload PVC, data access pod, secrets) |
 | 06 | `FMADeployStep` | global | Deploy FMA controllers |
 | 06 | `StandaloneDeployStep` | global | Deploy vLLM as standalone Kubernetes Deployments and Services |
 | 08 | `DeploySetupStep` | global | Set up Helm repos and deploy gateway infrastructure for modelservice mode |

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -47,19 +47,71 @@ class ModelNamespaceStep(Step):
                     errors=errors,
                 )
 
-        # PVC and download only needed for "pvc" protocol or standalone mode;
-        # S3/OCI/hf protocols fetch at runtime
-        plan_config = self._load_plan_config(context)
-        needs_pvc = self._requires_pvc_download(plan_config)
+        # PVC and download are per-stack: only needed for "pvc" protocol or
+        # standalone mode — S3/OCI/hf protocols fetch at runtime and skip
+        # PVC creation entirely, deferring to the modelservice chart (hf
+        # downloads happen in the decode Pod's init container).
+        # In multi-model scenarios different stacks can pick different
+        # uriProtocols; the scenario's first stack no longer dictates the
+        # choice for everyone.
+        stacks = list(context.rendered_stacks or [])
+        pvc_stacks: list[Path] = []
+        for stack_path in stacks:
+            stack_cfg = self._load_stack_config(stack_path)
+            if self._requires_pvc_download(stack_cfg):
+                pvc_stacks.append(stack_path)
 
-        if needs_pvc:
-            self._create_model_pvc(cmd, context, errors)
-            self._create_extra_pvc(cmd, context, errors)
+        # Context secret (kubeconfig for harness pods) is scenario-wide —
+        # one per namespace regardless of per-stack uriProtocol — so it
+        # still keys off the first stack's config.
+        plan_config = self._load_plan_config(context)
+
+        # Multi-stack preflight: check the shared PVC is sized for the sum
+        # of every pvc-protocol stack's model weights. Warn-only so single-
+        # stack scenarios and operators with intentional headroom are
+        # unaffected. See _warn_on_undersized_model_pvc for the rules.
+        if len(pvc_stacks) >= 2:
+            self._warn_on_undersized_model_pvc(context, pvc_stacks)
+
+        for stack_path in pvc_stacks:
+            self._create_model_pvc(cmd, context, errors, stack_path)
+            self._create_extra_pvc(cmd, context, errors, stack_path)
 
         self._add_context_secret(cmd, context, errors, plan_config)
 
-        if needs_pvc:
-            self._launch_download_job(cmd, context, errors, plan_config)
+        if pvc_stacks:
+            # Two-phase parallel download (only for stacks that need it):
+            #   Phase 1 — apply every download Job back-to-back; they all
+            #             start running concurrently in the cluster.
+            #   Phase 2 — wait on each in turn. Subsequent waits return
+            #             nearly instantly once their Job is already done,
+            #             so total wall time ≈ max(individual), not sum.
+            launched = []
+            for stack_path in pvc_stacks:
+                applied = self._apply_download_job(
+                    cmd, context, errors, stack_path
+                )
+                if applied is not None:
+                    job_name, download_yaml = applied
+                    launched.append((stack_path, job_name, download_yaml))
+
+            if len(launched) > 1:
+                context.logger.log_info(
+                    f"📦 Launched {len(launched)} model downloads in parallel; "
+                    "waiting for completion..."
+                )
+
+            for stack_path, job_name, download_yaml in launched:
+                self._wait_for_download_job(
+                    cmd, context, errors, stack_path, job_name, download_yaml
+                )
+
+        skipped = len(stacks) - len(pvc_stacks)
+        if skipped:
+            context.logger.log_info(
+                f"ℹ️  Skipped PVC + download job for {skipped} stack(s) using "
+                "hf / s3 / oci protocol (modelservice handles fetch at runtime)"
+            )
 
         if errors:
             for err in errors:
@@ -78,6 +130,77 @@ class ModelNamespaceStep(Step):
             success=True,
             message=f"Model namespace prepared (ns={context.namespace})",
         )
+
+    @staticmethod
+    def _parse_size_to_gib(raw: str | None) -> float:
+        """Parse a k8s resource-size string to GiB as a float.
+
+        Returns 0.0 when input is empty or unparseable — caller treats
+        that as "unknown, skip comparison", which is the right fallback
+        for a warn-only pre-flight.
+        """
+        import re
+        if not raw:
+            return 0.0
+        s = str(raw).strip()
+        m = re.match(r"^([0-9]*\.?[0-9]+)\s*([KMGTPE]i?)?$", s)
+        if not m:
+            return 0.0
+        n = float(m.group(1))
+        unit = (m.group(2) or "Gi").strip()
+        table = {
+            # Binary (IEC) units
+            "Ki": n / (1024 ** 2), "Mi": n / 1024,
+            "Gi": n, "Ti": n * 1024, "Pi": n * 1024 ** 2, "Ei": n * 1024 ** 3,
+            # Decimal (SI) units — approximate to GiB
+            "K": n / (1024 ** 2), "M": n / 1024, "G": n,
+            "T": n * 1024, "P": n * 1024 ** 2, "E": n * 1024 ** 3,
+        }
+        return table.get(unit, n)
+
+    def _warn_on_undersized_model_pvc(
+        self, context: ExecutionContext, pvc_stacks: list[Path],
+    ) -> None:
+        """Warn if the shared model PVC looks too small to hold all models.
+
+        Sums ``model.size`` across every pvc-protocol stack and compares
+        against ``storage.modelPvc.size``. If the sum exceeds 90% of
+        capacity, log a warning — the first download to run out of space
+        would otherwise fail opaquely mid-standup. Warn-only: cluster
+        storage classes with thin provisioning or aggressive compression
+        may legitimately oversubscribe, so we don't block.
+
+        Called only when ``len(pvc_stacks) >= 2``; single-stack scenarios
+        don't have a summing problem.
+        """
+        first_cfg = self._load_stack_config(pvc_stacks[0])
+        pvc_capacity_str = (
+            first_cfg.get("storage", {}).get("modelPvc", {}).get("size")
+        )
+        capacity_gib = self._parse_size_to_gib(pvc_capacity_str)
+        if capacity_gib == 0:
+            return
+
+        total_gib = 0.0
+        per_stack_sizes: list[tuple[str, str]] = []
+        for stack_path in pvc_stacks:
+            cfg = self._load_stack_config(stack_path)
+            model_size = cfg.get("model", {}).get("size")
+            per_stack_sizes.append((stack_path.name, str(model_size or "?")))
+            total_gib += self._parse_size_to_gib(model_size)
+
+        if total_gib == 0:
+            return  # all model.size unset/unparseable — skip quietly
+
+        if total_gib > capacity_gib * 0.9:
+            breakdown = ", ".join(f"{n}={s}" for n, s in per_stack_sizes)
+            context.logger.log_warning(
+                f"Shared model PVC size ({pvc_capacity_str}) may be "
+                f"under-sized for this scenario: sum of model.size across "
+                f"{len(pvc_stacks)} pvc-protocol stack(s) is ~{total_gib:.0f}GiB "
+                f"(>= 90% of capacity). Stacks: {breakdown}. Downloads that "
+                f"exceed capacity will fail mid-standup with an opaque PVC error."
+            )
 
     def _requires_pvc_download(self, plan_config: dict | None) -> bool:
         """Return True when models need a PVC and pre-download job."""
@@ -117,14 +240,24 @@ class ModelNamespaceStep(Step):
             pass
 
     def _create_model_pvc(
-        self, cmd: CommandExecutor, context: ExecutionContext, errors: list
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        errors: list,
+        stack_path: Path,
     ):
-        """Create the model PVC from rendered YAML."""
-        pvc_yaml = self._find_rendered_yaml(context, "02_pvc_model-pvc")
+        """Create a single stack's model PVC from its rendered YAML.
+
+        Reads PVC manifest + name/size from *this stack's* plan directory,
+        not "the first stack across the scenario", so each model gets its
+        own PVC named after its model ID label (see
+        ``render_plans._resolve_per_stack_identity``).
+        """
+        pvc_yaml = self._find_yaml(stack_path, "02_pvc_model-pvc")
         if not pvc_yaml:
             return
 
-        plan_config = self._load_plan_config(context)
+        plan_config = self._load_stack_config(stack_path)
         pvc_name = self._require_config(plan_config, "storage", "modelPvc", "name")
         pvc_size = self._require_config(plan_config, "storage", "modelPvc", "size")
 
@@ -162,10 +295,14 @@ class ModelNamespaceStep(Step):
             )
 
     def _create_extra_pvc(
-        self, cmd: CommandExecutor, context: ExecutionContext, errors: list
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        errors: list,
+        stack_path: Path,
     ):
-        """Create the extra PVC from rendered YAML, if present."""
-        extra_pvc_yaml = self._find_rendered_yaml(context, "16_pvc_extra-pvc")
+        """Create a single stack's extra PVC from its rendered YAML, if present."""
+        extra_pvc_yaml = self._find_yaml(stack_path, "16_pvc_extra-pvc")
         if not extra_pvc_yaml:
             return
 
@@ -176,7 +313,7 @@ class ModelNamespaceStep(Step):
         except OSError:
             return
 
-        plan_config = self._load_plan_config(context)
+        plan_config = self._load_stack_config(stack_path)
         extra_pvc = plan_config.get("storage", {}).get("extraPvc", {}) if plan_config else {}
         pvc_name = extra_pvc.get("name", "")
         pvc_size = extra_pvc.get("size", "10Gi")
@@ -268,65 +405,110 @@ class ModelNamespaceStep(Step):
                 f"Could not generate context secret: {result.stderr}"
             )
 
-    def _launch_download_job(
+    def _apply_download_job(
         self, cmd: CommandExecutor, context: ExecutionContext,
-        errors: list, plan_config: dict | None = None,
-    ):
-        """Launch the model download job and wait for completion."""
-        download_yaml = self._find_rendered_yaml(context, "04_download_job")
+        errors: list, stack_path: Path,
+    ) -> tuple[str, Path] | None:
+        """Apply a single stack's download Job without waiting.
+
+        Phase 1 of the two-phase parallel-download flow: every stack's
+        Job is applied back-to-back in ``execute()`` so all N downloads
+        run concurrently in the cluster. Phase 2 (``_wait_for_download_job``)
+        then waits on each in turn — since ``kubectl wait`` is a watch,
+        not a poll, subsequent waits return nearly instantly once their
+        Job has already completed. Total wall time is bounded by the
+        slowest model, not the sum.
+
+        Returns ``(job_name, download_yaml_path)`` for the waiter, or
+        ``None`` if nothing was applied (missing rendered manifest, or
+        apply failed — the error is appended to ``errors`` in that case).
+        """
+        download_yaml = self._find_yaml(stack_path, "04_download_job")
         if not download_yaml:
-            return
+            return None
 
-        self._cleanup_download_pods(cmd, context)
+        plan_config = self._load_stack_config(stack_path)
+        job_name = plan_config.get("downloadJob", {}).get("name") or "download-model"
 
+        self._cleanup_download_pods(cmd, context, job_name)
         self._delete_existing_job(cmd, context, download_yaml)
 
         result = cmd.kube("apply", "-f", str(download_yaml))
         if not result.success:
-            errors.append(f"Failed to launch model download job: {result.stderr}")
-            return
+            errors.append(
+                f"Failed to launch model download job {job_name}: {result.stderr}"
+            )
+            return None
 
+        return job_name, download_yaml
+
+    def _wait_for_download_job(
+        self, cmd: CommandExecutor, context: ExecutionContext,
+        errors: list, stack_path: Path, job_name: str, download_yaml: Path,
+    ) -> None:
+        """Wait for a single stack's download Job to complete, with retries.
+
+        Phase 2 of the parallel-download flow. By the time this runs the
+        Job is already executing in the cluster (applied in phase 1), so
+        the wait itself isn't on a cold start. Retries re-apply just
+        *this* Job while other stacks' downloads continue or complete
+        independently.
+        """
+        plan_config = self._load_stack_config(stack_path)
         timeout = int(self._require_config(plan_config, "storage", "downloadTimeout"))
         max_retries = int(self._require_config(plan_config, "storage", "downloadMaxRetries"))
+
         for attempt in range(1, max_retries + 1):
             wait_result = cmd.wait_for_job(
-                job_name="download-model",
+                job_name=job_name,
                 namespace=context.require_namespace(),
                 timeout=timeout,
                 poll_interval=15,
-                description=f"model download (attempt {attempt}/{max_retries})",
+                description=f"model download {job_name} (attempt {attempt}/{max_retries})",
             )
             if wait_result.success:
                 context.logger.log_info(
-                    f"✅ Model download completed (attempt {attempt})"
+                    f"✅ Model download {job_name} completed (attempt {attempt})"
                 )
                 return
 
             if attempt < max_retries:
                 context.logger.log_warning(
-                    f"⚠️  Model download failed (attempt {attempt}), retrying..."
+                    f"⚠️  Model download {job_name} failed "
+                    f"(attempt {attempt}), retrying..."
                 )
-                self._cleanup_download_pods(cmd, context)
+                self._cleanup_download_pods(cmd, context, job_name)
                 self._delete_existing_job(cmd, context, download_yaml)
                 re_result = cmd.kube("apply", "-f", str(download_yaml))
                 if not re_result.success:
                     errors.append(
-                        f"Failed to re-launch download job: {re_result.stderr}"
+                        f"Failed to re-launch download job {job_name}: {re_result.stderr}"
                     )
                     return
             else:
                 errors.append(
-                    f"Model download job did not complete after "
+                    f"Model download job {job_name} did not complete after "
                     f"{max_retries} attempts: {wait_result.stderr}"
                 )
 
-    def _cleanup_download_pods(self, cmd: CommandExecutor, context: ExecutionContext):
-        """Delete completed/failed download job pods before re-launching."""
+    def _cleanup_download_pods(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        job_name: str = "download-model",
+    ):
+        """Delete completed/failed download job pods before re-launching.
+
+        Scoped to a specific ``job_name`` so multi-stack scenarios (each
+        with its own ``download-{model_id_label}`` Job) only clean up
+        their own Pods instead of clobbering a sibling stack's
+        in-flight download.
+        """
         namespace = context.require_namespace()
         cmd.kube(
             "delete",
             "pods",
-            "--selector=job-name=download-model",
+            f"--selector=job-name={job_name}",
             "--namespace",
             namespace,
             "--field-selector=status.phase!=Running",

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -1,6 +1,7 @@
 """Step 04 -- Prepare the model namespace (PVC, secrets, download job)."""
 
 import json
+import re
 import tempfile
 from pathlib import Path
 
@@ -48,7 +49,7 @@ class ModelNamespaceStep(Step):
                 )
 
         # PVC and download are per-stack: only needed for "pvc" protocol or
-        # standalone mode — S3/OCI/hf protocols fetch at runtime and skip
+        # standalone mode - S3/OCI/hf protocols fetch at runtime and skip
         # PVC creation entirely, deferring to the modelservice chart (hf
         # downloads happen in the decode Pod's init container).
         # In multi-model scenarios different stacks can pick different
@@ -61,8 +62,8 @@ class ModelNamespaceStep(Step):
             if self._requires_pvc_download(stack_cfg):
                 pvc_stacks.append(stack_path)
 
-        # Context secret (kubeconfig for harness pods) is scenario-wide —
-        # one per namespace regardless of per-stack uriProtocol — so it
+        # Context secret (kubeconfig for harness pods) is scenario-wide -
+        # one per namespace regardless of per-stack uriProtocol - so it
         # still keys off the first stack's config.
         plan_config = self._load_plan_config(context)
 
@@ -81,11 +82,11 @@ class ModelNamespaceStep(Step):
 
         if pvc_stacks:
             # Two-phase parallel download (only for stacks that need it):
-            #   Phase 1 — apply every download Job back-to-back; they all
+            #   Phase 1 - apply every download Job back-to-back; they all
             #             start running concurrently in the cluster.
-            #   Phase 2 — wait on each in turn. Subsequent waits return
+            #   Phase 2 - wait on each in turn. Subsequent waits return
             #             nearly instantly once their Job is already done,
-            #             so total wall time ≈ max(individual), not sum.
+            #             so total wall time ~ max(individual), not sum.
             launched = []
             for stack_path in pvc_stacks:
                 applied = self._apply_download_job(
@@ -135,11 +136,10 @@ class ModelNamespaceStep(Step):
     def _parse_size_to_gib(raw: str | None) -> float:
         """Parse a k8s resource-size string to GiB as a float.
 
-        Returns 0.0 when input is empty or unparseable — caller treats
+        Returns 0.0 when input is empty or unparseable - caller treats
         that as "unknown, skip comparison", which is the right fallback
         for a warn-only pre-flight.
         """
-        import re
         if not raw:
             return 0.0
         s = str(raw).strip()
@@ -152,7 +152,7 @@ class ModelNamespaceStep(Step):
             # Binary (IEC) units
             "Ki": n / (1024 ** 2), "Mi": n / 1024,
             "Gi": n, "Ti": n * 1024, "Pi": n * 1024 ** 2, "Ei": n * 1024 ** 3,
-            # Decimal (SI) units — approximate to GiB
+            # Decimal (SI) units - approximate to GiB
             "K": n / (1024 ** 2), "M": n / 1024, "G": n,
             "T": n * 1024, "P": n * 1024 ** 2, "E": n * 1024 ** 3,
         }
@@ -165,7 +165,7 @@ class ModelNamespaceStep(Step):
 
         Sums ``model.size`` across every pvc-protocol stack and compares
         against ``storage.modelPvc.size``. If the sum exceeds 90% of
-        capacity, log a warning — the first download to run out of space
+        capacity, log a warning - the first download to run out of space
         would otherwise fail opaquely mid-standup. Warn-only: cluster
         storage classes with thin provisioning or aggressive compression
         may legitimately oversubscribe, so we don't block.
@@ -190,7 +190,7 @@ class ModelNamespaceStep(Step):
             total_gib += self._parse_size_to_gib(model_size)
 
         if total_gib == 0:
-            return  # all model.size unset/unparseable — skip quietly
+            return  # all model.size unset/unparseable - skip quietly
 
         if total_gib > capacity_gib * 0.9:
             breakdown = ", ".join(f"{n}={s}" for n, s in per_stack_sizes)
@@ -414,14 +414,14 @@ class ModelNamespaceStep(Step):
         Phase 1 of the two-phase parallel-download flow: every stack's
         Job is applied back-to-back in ``execute()`` so all N downloads
         run concurrently in the cluster. Phase 2 (``_wait_for_download_job``)
-        then waits on each in turn — since ``kubectl wait`` is a watch,
+        then waits on each in turn - since ``kubectl wait`` is a watch,
         not a poll, subsequent waits return nearly instantly once their
         Job has already completed. Total wall time is bounded by the
         slowest model, not the sum.
 
         Returns ``(job_name, download_yaml_path)`` for the waiter, or
         ``None`` if nothing was applied (missing rendered manifest, or
-        apply failed — the error is appended to ``errors`` in that case).
+        apply failed - the error is appended to ``errors`` in that case).
         """
         download_yaml = self._find_yaml(stack_path, "04_download_job")
         if not download_yaml:

--- a/llmdbenchmark/standup/steps/step_07_deploy_setup.py
+++ b/llmdbenchmark/standup/steps/step_07_deploy_setup.py
@@ -86,19 +86,32 @@ class DeploySetupStep(Step):
             if context.non_admin:
                 self._patch_helmfile_for_non_admin(helmfile_work)
 
-            result = cmd.helmfile(
-                "--namespace",
-                namespace,
-                "--selector",
-                f"name=infra-{release}",
-                "apply",
-                "-f",
-                str(helmfile_work),
-                "--skip-diff-on-install",
-                "--skip-schema-validation",
-            )
-            if not result.success:
-                errors.append(f"Failed to apply infra helmfile: {result.stderr}")
+            # Multi-stack scenarios dedupe the `infra-{release}` helm
+            # release into one stack (see 10_helmfile-main.yaml.j2 —
+            # stacks 2..N omit it). Pre-check whether THIS stack's
+            # helmfile declares the release before invoking helmfile;
+            # otherwise the apply exits non-zero with "no releases found
+            # that matches specified selector" which is harmless but
+            # noisy in the standup log.
+            if self._helmfile_declares_release(helmfile_work, f"infra-{release}"):
+                result = cmd.helmfile(
+                    "--namespace",
+                    namespace,
+                    "--selector",
+                    f"name=infra-{release}",
+                    "apply",
+                    "-f",
+                    str(helmfile_work),
+                    "--skip-diff-on-install",
+                    "--skip-schema-validation",
+                )
+                if not result.success:
+                    errors.append(f"Failed to apply infra helmfile: {result.stderr}")
+            else:
+                context.logger.log_info(
+                    f"    │ infra-{release} not in this stack's helmfile "
+                    f"(shared infra is owned by another stack) — skipping"
+                )
 
         if errors:
             for err in errors:
@@ -122,6 +135,32 @@ class DeploySetupStep(Step):
             ),
             stack_name=stack_path.name,
         )
+
+    @staticmethod
+    def _helmfile_declares_release(helmfile_path: Path, release_name: str) -> bool:
+        """Return True if *helmfile_path* declares a release named *release_name*.
+
+        Used to skip a ``helmfile apply --selector`` invocation that would
+        otherwise "fail" noisily on stacks that intentionally dropped a
+        shared release (e.g. ``infra-llmdbench`` in multi-stack scenarios).
+
+        Parses the helmfile YAML and walks ``releases[*].name`` — a
+        substring check was too permissive: a label value, annotation,
+        or values-block key with the text ``name: X`` would falsely
+        match without actually declaring a release.
+        """
+        try:
+            content = helmfile_path.read_text(encoding="utf-8")
+            docs = list(yaml.safe_load_all(content))
+        except (OSError, yaml.YAMLError):
+            return False
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            for release in doc.get("releases") or []:
+                if isinstance(release, dict) and release.get("name") == release_name:
+                    return True
+        return False
 
     def _prepare_helm_dir(
         self, context: ExecutionContext, stack_path: Path, errors: list

--- a/llmdbenchmark/standup/steps/step_07_deploy_setup.py
+++ b/llmdbenchmark/standup/steps/step_07_deploy_setup.py
@@ -87,7 +87,7 @@ class DeploySetupStep(Step):
                 self._patch_helmfile_for_non_admin(helmfile_work)
 
             # Multi-stack scenarios dedupe the `infra-{release}` helm
-            # release into one stack (see 10_helmfile-main.yaml.j2 —
+            # release into one stack (see 10_helmfile-main.yaml.j2 -
             # stacks 2..N omit it). Pre-check whether THIS stack's
             # helmfile declares the release before invoking helmfile;
             # otherwise the apply exits non-zero with "no releases found
@@ -109,8 +109,8 @@ class DeploySetupStep(Step):
                     errors.append(f"Failed to apply infra helmfile: {result.stderr}")
             else:
                 context.logger.log_info(
-                    f"    │ infra-{release} not in this stack's helmfile "
-                    f"(shared infra is owned by another stack) — skipping"
+                    f"    | infra-{release} not in this stack's helmfile "
+                    f"(shared infra is owned by another stack) - skipping"
                 )
 
         if errors:
@@ -144,7 +144,7 @@ class DeploySetupStep(Step):
         otherwise "fail" noisily on stacks that intentionally dropped a
         shared release (e.g. ``infra-llmdbench`` in multi-stack scenarios).
 
-        Parses the helmfile YAML and walks ``releases[*].name`` — a
+        Parses the helmfile YAML and walks ``releases[*].name`` - a
         substring check was too permissive: a label value, annotation,
         or values-block key with the text ``name: X`` would falsely
         match without actually declaring a release.

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -1,5 +1,7 @@
 """Step 09 -- Deploy the model via the llm-d modelservice Helm chart."""
 
+import hashlib
+import time
 from pathlib import Path
 
 from llmdbenchmark.executor.step import Step, StepResult, Phase
@@ -326,7 +328,7 @@ class DeployModelserviceStep(Step):
         """Wait for each sibling stack's InferencePool CR to exist.
 
         Closes the race window between HTTPRoute apply and sibling gaie
-        helm releases finishing install — without this, the shared route
+        helm releases finishing install - without this, the shared route
         lingers in ResolvedRefs=False for the few seconds it takes other
         stacks' step 09 to finish their modelservice Helm release.
 
@@ -344,7 +346,6 @@ class DeployModelserviceStep(Step):
         # Template uses {model_id_label}-gaie for the InferencePool CR
         # name. Compute each sibling's label the same way render_plans
         # does (via its Jinja filter).
-        import hashlib
         def _label_for(model_name: str) -> str:
             if not model_name:
                 return ""
@@ -365,13 +366,12 @@ class DeployModelserviceStep(Step):
             return
 
         context.logger.log_info(
-            f"    │ Waiting for {len(pool_names)} sibling InferencePool(s) "
+            f"    | Waiting for {len(pool_names)} sibling InferencePool(s) "
             f"to exist so the shared HTTPRoute resolves cleanly..."
         )
 
         # Poll up to 2 minutes. Each gaie Helm release typically finishes
         # within seconds of being applied; 2 minutes is generous.
-        import time
         deadline = time.time() + 120
         missing = list(pool_names)
         while missing and time.time() < deadline:
@@ -393,14 +393,14 @@ class DeployModelserviceStep(Step):
             # Non-fatal: the route self-heals when pools eventually appear.
             # Log a warning so operators know the window is wider than expected.
             context.logger.log_warning(
-                f"    │ Shared HTTPRoute applied but {len(missing)} "
+                f"    | Shared HTTPRoute applied but {len(missing)} "
                 f"InferencePool(s) still not found after 120s: "
                 f"{', '.join(missing)}. Route will self-heal when they appear."
             )
         else:
             context.logger.log_info(
-                f"    │ All {len(pool_names)} referenced InferencePool(s) "
-                f"present — shared HTTPRoute fully resolved"
+                f"    | All {len(pool_names)} referenced InferencePool(s) "
+                f"present - shared HTTPRoute fully resolved"
             )
 
     def _check_priority_class(
@@ -582,7 +582,7 @@ class DeployModelserviceStep(Step):
 
         Lets the standup output show what got created (VA OPTIMIZED, HPA
         TARGETS / REPLICAS, etc.) without the operator needing a follow-up
-        ``oc get``. Best-effort — failures here don't fail step_09.
+        ``oc get``. Best-effort - failures here don't fail step_09.
         """
         wva_cfg = plan_config.get("wva", {}) or {}
         wva_ns = (

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -111,6 +111,15 @@ class DeployModelserviceStep(Step):
             result = cmd.kube("apply", "-f", str(httproute_yaml))
             if not result.success:
                 errors.append(f"Failed to apply HTTPRoute: {result.stderr}")
+            elif plan_config.get("httpRoute", {}).get("mode") == "shared":
+                # Shared-mode HTTPRoute references sibling InferencePools
+                # that may still be installing (other stacks' `-gaie`
+                # helm releases run in parallel with this one). Wait for
+                # each referenced pool to exist so the route doesn't
+                # linger in ResolvedRefs=False after step 09 returns.
+                self._wait_for_sibling_inference_pools(
+                    cmd, context, errors, plan_config, namespace,
+                )
 
         if not errors:
             decode_wait = cmd.wait_for_pods(
@@ -305,6 +314,94 @@ class DeployModelserviceStep(Step):
             message=f"Modelservice deployed for {stack_name}",
             stack_name=stack_name,
         )
+
+    def _wait_for_sibling_inference_pools(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        errors: list[str],
+        plan_config: dict,
+        namespace: str,
+    ) -> None:
+        """Wait for each sibling stack's InferencePool CR to exist.
+
+        Closes the race window between HTTPRoute apply and sibling gaie
+        helm releases finishing install — without this, the shared route
+        lingers in ResolvedRefs=False for the few seconds it takes other
+        stacks' step 09 to finish their modelservice Helm release.
+
+        Only runs on the shared-infra-owner stack (the one that rendered
+        a non-empty HTTPRoute). Standalone siblings have no InferencePool
+        and are skipped.
+        """
+        if context.dry_run:
+            return
+
+        siblings = plan_config.get("siblingStacks") or []
+        if not siblings:
+            return
+
+        # Template uses {model_id_label}-gaie for the InferencePool CR
+        # name. Compute each sibling's label the same way render_plans
+        # does (via its Jinja filter).
+        import hashlib
+        def _label_for(model_name: str) -> str:
+            if not model_name:
+                return ""
+            model_id = model_name.replace("/", "-").replace(".", "-")
+            hash_input = f"{namespace}/{model_id}" if namespace else model_id
+            digest = hashlib.sha256(hash_input.encode("utf-8")).hexdigest()
+            return f"{model_id[:8]}-{digest[:8]}-{model_id[-8:]}".lower()
+
+        pool_names: list[str] = []
+        for sibling in siblings:
+            if not isinstance(sibling, dict) or sibling.get("standalone"):
+                continue
+            label = _label_for(sibling.get("modelName", ""))
+            if label:
+                pool_names.append(f"{label}-gaie")
+
+        if not pool_names:
+            return
+
+        context.logger.log_info(
+            f"    │ Waiting for {len(pool_names)} sibling InferencePool(s) "
+            f"to exist so the shared HTTPRoute resolves cleanly..."
+        )
+
+        # Poll up to 2 minutes. Each gaie Helm release typically finishes
+        # within seconds of being applied; 2 minutes is generous.
+        import time
+        deadline = time.time() + 120
+        missing = list(pool_names)
+        while missing and time.time() < deadline:
+            still_missing = []
+            for name in missing:
+                check = cmd.kube(
+                    "get", "inferencepool", name,
+                    "--namespace", namespace,
+                    "-o", "name",
+                    check=False,
+                )
+                if not check.success:
+                    still_missing.append(name)
+            missing = still_missing
+            if missing:
+                time.sleep(3)
+
+        if missing:
+            # Non-fatal: the route self-heals when pools eventually appear.
+            # Log a warning so operators know the window is wider than expected.
+            context.logger.log_warning(
+                f"    │ Shared HTTPRoute applied but {len(missing)} "
+                f"InferencePool(s) still not found after 120s: "
+                f"{', '.join(missing)}. Route will self-heal when they appear."
+            )
+        else:
+            context.logger.log_info(
+                f"    │ All {len(pool_names)} referenced InferencePool(s) "
+                f"present — shared HTTPRoute fully resolved"
+            )
 
     def _check_priority_class(
         self,

--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -45,7 +45,7 @@ def compute_gateway_path_prefix(
     Used by smoketest + run-phase steps to route traffic at a specific
     stack in a shared-HTTPRoute scenario. Returns ``""`` for any scenario
     that doesn't use the shared-HTTPRoute pattern (standalone, FMA,
-    single-model modelservice) — preserves existing behavior.
+    single-model modelservice) - preserves existing behavior.
 
     For ``httpRoute.mode: shared``, substitutes the stack name into
     ``httpRoute.pathPrefix`` (e.g. ``/pool-a``). The shared HTTPRoute
@@ -492,7 +492,7 @@ def test_model_serving(
     the multi-model shared-HTTPRoute setup, each stack's prefix is its
     routing path (e.g. ``/pool-a/v1``); the HTTPRoute URLRewrite strips
     it and the upstream vLLM sees ``/v1/models`` as usual. Default is
-    empty — preserves existing behavior for every other scenario.
+    empty - preserves existing behavior for every other scenario.
 
     Retries up to *max_retries* times (default 12 x 15 s = 3 min) when
     the response indicates the model is still loading or the decode

--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -21,6 +21,49 @@ EPHEMERAL_POD_LABEL = "llm-d-benchmark/ephemeral=true"
 """Label applied to all ephemeral curl/smoketest pods for cleanup."""
 
 
+def _normalize_url_prefix(prefix: str | None) -> str:
+    """Normalize a URL path prefix for safe concatenation with ``/v1/models``.
+
+    Returns an empty string for None or empty input; otherwise returns
+    the prefix with a leading slash and no trailing slash. Lets callers
+    write ``f"http://{host}:{port}{prefix}/v1/models"`` without worrying
+    about double-slashes or missing leading slashes.
+    """
+    if not prefix:
+        return ""
+    p = prefix if prefix.startswith("/") else "/" + prefix
+    return p.rstrip("/")
+
+
+def compute_gateway_path_prefix(
+    plan_config: dict,
+    stack_name: str,
+    is_standalone: bool = False,
+) -> str:
+    """Return the URL path prefix a caller should prepend to the gateway host.
+
+    Used by smoketest + run-phase steps to route traffic at a specific
+    stack in a shared-HTTPRoute scenario. Returns ``""`` for any scenario
+    that doesn't use the shared-HTTPRoute pattern (standalone, FMA,
+    single-model modelservice) — preserves existing behavior.
+
+    For ``httpRoute.mode: shared``, substitutes the stack name into
+    ``httpRoute.pathPrefix`` (e.g. ``/pool-a``). The shared HTTPRoute
+    then rewrites that prefix to ``httpRoute.rewriteTo`` before the
+    request reaches the upstream InferencePool, so the pod still sees
+    the usual ``/v1/*`` paths.
+    """
+    if is_standalone:
+        return ""
+    http_route = (plan_config or {}).get("httpRoute") or {}
+    if http_route.get("mode") != "shared":
+        return ""
+    tmpl = http_route.get("pathPrefix") or ""
+    if not (stack_name and tmpl):
+        return ""
+    return _normalize_url_prefix(tmpl.replace("{stack.name}", stack_name))
+
+
 def _build_overrides(plan_config: dict | None, service_account: str | None = None) -> list[str]:
     """Build --overrides args for ephemeral curl pods (imagePullSecrets, serviceAccount)."""
     overrides: dict = {}
@@ -440,8 +483,16 @@ def test_model_serving(
     max_retries: int = 12,
     retry_interval: int = 15,
     service_account: str | None = None,
+    url_path_prefix: str = "",
 ) -> str | None:
     """Test an endpoint by querying /v1/models via an ephemeral curl pod.
+
+    ``url_path_prefix`` is inserted before ``/v1/models`` (without a
+    trailing slash) to support gateways with path-based routing. For
+    the multi-model shared-HTTPRoute setup, each stack's prefix is its
+    routing path (e.g. ``/pool-a/v1``); the HTTPRoute URLRewrite strips
+    it and the upstream vLLM sees ``/v1/models`` as usual. Default is
+    empty — preserves existing behavior for every other scenario.
 
     Retries up to *max_retries* times (default 12 x 15 s = 3 min) when
     the response indicates the model is still loading or the decode
@@ -450,7 +501,8 @@ def test_model_serving(
     Returns None on success, or an error string describing the failure.
     """
     protocol = "https" if str(port) == "443" else "http"
-    url = f"{protocol}://{host}:{port}/v1/models"
+    prefix = _normalize_url_prefix(url_path_prefix)
+    url = f"{protocol}://{host}:{port}{prefix}/v1/models"
     
     # Auto-ensure service account and RBAC
     sa_name = service_account or (plan_config.get("serviceAccount", {}).get("name") if plan_config else "default")

--- a/tests/test_shared_block_and_identity.py
+++ b/tests/test_shared_block_and_identity.py
@@ -2,9 +2,9 @@
 
 Covers two related pieces of render_plans.py:
 
-1. `shared:` merge — scenario-wide config applied to every stack before the
+1. `shared:` merge - scenario-wide config applied to every stack before the
    per-stack overrides. Per-stack always wins.
-2. `_resolve_per_stack_identity` — auto-suffixes shipped-default resource
+2. `_resolve_per_stack_identity` - auto-suffixes shipped-default resource
    names (model PVC, download Job, EPP Secret) with the model_id_label so
    multi-stack scenarios don't race on the same Kubernetes resource.
    Skipped for single-stack scenarios to keep their names stable.
@@ -21,7 +21,7 @@ from llmdbenchmark.parser.render_plans import RenderPlans
 
 @pytest.fixture
 def renderer():
-    """Bypass __init__ — we only need the pure logic under test."""
+    """Bypass __init__ - we only need the pure logic under test."""
     logger = MagicMock()
     logger.log_warning = MagicMock()
     logger.log_info = MagicMock()
@@ -31,7 +31,7 @@ def renderer():
 
 
 class TestPerStackIdentity:
-    """_resolve_per_stack_identity — auto-derived unique names."""
+    """_resolve_per_stack_identity - auto-derived unique names."""
 
     def _base_values(self, label: str = "my-model") -> dict:
         # Mirrors defaults.yaml shape for the keys we care about.
@@ -83,7 +83,7 @@ class TestPerStackIdentity:
         assert out["downloadJob"]["name"] == "download-model-qwen-07df-6b"
 
     def test_missing_model_id_label_is_a_noop(self, renderer):
-        """No label → nothing to suffix with; must not crash."""
+        """No label -> nothing to suffix with; must not crash."""
         values = self._base_values(label="")
         out = renderer._resolve_per_stack_identity(values, total_stacks=5)
         # Names stay at their shipped defaults.
@@ -92,7 +92,7 @@ class TestPerStackIdentity:
 
 
 class TestDeepMergeSharedBlock:
-    """Merge order for the scenario `shared:` block — defaults < shared < stack."""
+    """Merge order for the scenario `shared:` block - defaults < shared < stack."""
 
     def test_shared_overrides_defaults(self, renderer):
         defaults = {"gateway": {"className": "istio"}}
@@ -129,11 +129,11 @@ class TestDeepMergeSharedBlock:
         )
         # From shared
         assert merged["wva"]["enabled"] is True
-        # From defaults — preserved because shared didn't touch image.tag
+        # From defaults - preserved because shared didn't touch image.tag
         assert merged["wva"]["image"]["tag"] == "v0.5.0"
 
     def test_treatment_overrides_shared_and_stack(self, renderer):
-        """Full precedence chain: defaults → shared → stack → setup_overrides.
+        """Full precedence chain: defaults -> shared -> stack -> setup_overrides.
 
         Ensures DoE experiment treatments (applied as ``setup_overrides``)
         win over every earlier layer, so a sweep over a shared-block
@@ -160,7 +160,7 @@ class TestDeepMergeSharedBlock:
 
 
 class TestSharedInfraStackIndex:
-    """_resolve_shared_infra_stack_index — promote owner past standalone stacks."""
+    """_resolve_shared_infra_stack_index - promote owner past standalone stacks."""
 
     @pytest.fixture
     def resolve(self):
@@ -175,7 +175,7 @@ class TestSharedInfraStackIndex:
         assert resolve(siblings) == 1
 
     def test_standalone_first_skips_to_modelservice(self, resolve):
-        """Leading standalone stacks can't own shared infra — skip them."""
+        """Leading standalone stacks can't own shared infra - skip them."""
         siblings = [
             {"name": "pool-a", "standalone": True},
             {"name": "pool-b", "standalone": False},
@@ -191,7 +191,7 @@ class TestSharedInfraStackIndex:
         assert resolve(siblings) == 3
 
     def test_all_standalone_falls_back_to_one(self, resolve):
-        """Edge case: every stack is standalone → no modelservice infra
+        """Edge case: every stack is standalone -> no modelservice infra
         installs, so the index is moot but still deterministic."""
         siblings = [
             {"name": "a", "standalone": True},
@@ -201,7 +201,7 @@ class TestSharedInfraStackIndex:
 
 
 class TestHelmfileDeclaresRelease:
-    """step_07_deploy_setup._helmfile_declares_release — YAML walk not substring."""
+    """step_07_deploy_setup._helmfile_declares_release - YAML walk not substring."""
 
     @pytest.fixture
     def check(self):
@@ -251,7 +251,7 @@ releases:
 
 
 class TestGatewayRoutesHealth:
-    """BaseSmoketest._gateway_routes_health — skip /health when routing narrows."""
+    """BaseSmoketest._gateway_routes_health - skip /health when routing narrows."""
 
     @pytest.fixture
     def check(self):
@@ -259,7 +259,7 @@ class TestGatewayRoutesHealth:
         return BaseSmoketest._gateway_routes_health
 
     def test_non_shared_always_routes(self, check):
-        """Per-stack HTTPRoute is a single-backend catch-all — always routes /health."""
+        """Per-stack HTTPRoute is a single-backend catch-all - always routes /health."""
         assert check({}) is True
         assert check({"httpRoute": {"mode": "per-stack"}}) is True
 
@@ -268,18 +268,18 @@ class TestGatewayRoutesHealth:
         assert check(cfg) is True
 
     def test_shared_default_rewrite_routes(self, check):
-        """rewriteTo absent → falls back to '/' → /health routes."""
+        """rewriteTo absent -> falls back to '/' -> /health routes."""
         cfg = {"httpRoute": {"mode": "shared"}}
         assert check(cfg) is True
 
     def test_shared_with_v1_rewrite_does_not_route(self, check):
-        """rewriteTo: /v1 narrows routing to /v1/* — /health won't match."""
+        """rewriteTo: /v1 narrows routing to /v1/* - /health won't match."""
         cfg = {"httpRoute": {"mode": "shared", "rewriteTo": "/v1"}}
         assert check(cfg) is False
 
 
 class TestCliModelOverrideMultiStack:
-    """_resolve_model — warn (once) when -m/--models is used in multi-stack."""
+    """_resolve_model - warn (once) when -m/--models is used in multi-stack."""
 
     @pytest.fixture
     def renderer(self):
@@ -296,7 +296,7 @@ class TestCliModelOverrideMultiStack:
         return r
 
     def test_single_stack_no_warning(self, renderer):
-        """-m on a single-stack scenario is a normal override — no warning."""
+        """-m on a single-stack scenario is a normal override - no warning."""
         values = {
             "model": {"name": "Qwen/Qwen3-32B"},
             "namespace": {"name": "ns"},
@@ -312,14 +312,14 @@ class TestCliModelOverrideMultiStack:
         }
         renderer._resolve_model(values, total_stacks=2, stack_name="qwen3-06b")
         renderer._resolve_model(values, total_stacks=2, stack_name="llama-31-8b")
-        # Warn exactly once — not once per stack.
+        # Warn exactly once - not once per stack.
         assert renderer.logger.log_warning.call_count == 1
         msg = renderer.logger.log_warning.call_args[0][0]
         assert "--stack" in msg
         assert "N copies of one model" in msg
 
     def test_multi_stack_still_overrides(self, renderer):
-        """Warning doesn't block the override — current behavior preserved."""
+        """Warning doesn't block the override - current behavior preserved."""
         values = {
             "model": {"name": "Qwen/Qwen3-0.6B"},
             "namespace": {"name": "ns"},
@@ -339,7 +339,7 @@ class TestCliModelOverrideMultiStack:
         renderer.logger.log_warning.assert_not_called()
 
     def test_stack_filter_scopes_override_to_matching_stack(self, renderer):
-        """--stack NAME + -m MODEL → override only the named stack."""
+        """--stack NAME + -m MODEL -> override only the named stack."""
         renderer.cli_stack_filter = ["qwen3-06b"]
         target_values = {"model": {"name": "orig"}, "namespace": {"name": "ns"}}
         out = renderer._resolve_model(
@@ -349,7 +349,7 @@ class TestCliModelOverrideMultiStack:
         renderer.logger.log_warning.assert_not_called()
 
     def test_stack_filter_leaves_non_matching_stack_alone(self, renderer):
-        """--stack NAME + -m MODEL → sibling stacks preserve their model."""
+        """--stack NAME + -m MODEL -> sibling stacks preserve their model."""
         renderer.cli_stack_filter = ["qwen3-06b"]
         sibling_values = {"model": {"name": "orig-sibling"}, "namespace": {"name": "ns"}}
         out = renderer._resolve_model(
@@ -359,7 +359,7 @@ class TestCliModelOverrideMultiStack:
         renderer.logger.log_warning.assert_not_called()
 
     def test_broad_filter_still_warns(self, renderer):
-        """--stack X,Y + -m MODEL (>1 in filter) → warn as if unscoped."""
+        """--stack X,Y + -m MODEL (>1 in filter) -> warn as if unscoped."""
         renderer.cli_stack_filter = ["qwen3-06b", "llama-31-8b"]
         values = {"model": {"name": "orig"}, "namespace": {"name": "ns"}}
         renderer._resolve_model(values, total_stacks=2, stack_name="qwen3-06b")
@@ -367,7 +367,7 @@ class TestCliModelOverrideMultiStack:
 
 
 class TestPrintEndpointsTable:
-    """cli._print_endpoints_table — tolerates Path-typed specification_file."""
+    """cli._print_endpoints_table - tolerates Path-typed specification_file."""
 
     def _mock_ctx(self, tmp_path, stacks_with_models):
         from unittest.mock import MagicMock
@@ -406,7 +406,7 @@ class TestPrintEndpointsTable:
         ])
         logger, lines = self._capturing_logger()
 
-        # This is the real shape coming from RenderSpecification — a Path.
+        # This is the real shape coming from RenderSpecification - a Path.
         args = type("A", (), {"specification_file": Path(
             "/abs/path/config/specification/guides/multi-model-wva.yaml.j2"
         )})()
@@ -434,7 +434,7 @@ class TestPrintEndpointsTable:
         assert "guides/multi-model-wva" in combined
 
     def test_no_endpoints_warns(self, tmp_path):
-        """Empty endpoints dict → warn the user to stand up first."""
+        """Empty endpoints dict -> warn the user to stand up first."""
         from llmdbenchmark.cli import _print_endpoints_table
 
         from unittest.mock import MagicMock
@@ -453,7 +453,7 @@ class TestPrintEndpointsTable:
         )
 
     def test_copy_paste_block_goes_through_logger(self, tmp_path):
-        """log_plain lines end up in every handler — including log files."""
+        """log_plain lines end up in every handler - including log files."""
         from llmdbenchmark.cli import _print_endpoints_table
 
         ctx = self._mock_ctx(tmp_path, [
@@ -477,7 +477,7 @@ class TestPrintEndpointsTable:
 
 
 class TestRenderStackFilterValidation:
-    """RenderPlans.eval() — --stack typos fail at render time, not later."""
+    """RenderPlans.eval() - --stack typos fail at render time, not later."""
 
     def _write_scenario(self, tmp_path, names):
         import yaml as _yaml
@@ -517,7 +517,7 @@ class TestRenderStackFilterValidation:
     def test_valid_stack_passes_validation(self, tmp_path):
         scenario = self._write_scenario(tmp_path, ["qwen3-06b", "llama-31-8b"])
         r = self._renderer(tmp_path, scenario, ["qwen3-06b"])
-        # Can't fully render without templates — but the unknown-stack
+        # Can't fully render without templates - but the unknown-stack
         # gate must NOT fire. Validate by checking global_errors absence
         # BEFORE template loading starts. We short-circuit by returning
         # early in the first stages; the filter validation is among the
@@ -539,7 +539,7 @@ class TestRenderStackFilterValidation:
 
 
 class TestParseSizeToGib:
-    """step_04_model_namespace._parse_size_to_gib — warn-friendly parser."""
+    """step_04_model_namespace._parse_size_to_gib - warn-friendly parser."""
 
     @pytest.fixture
     def parse(self):
@@ -576,7 +576,7 @@ class TestRequiresPvcDownload:
 
     @pytest.fixture
     def step(self):
-        """A ModelNamespaceStep instance — the method under test is pure."""
+        """A ModelNamespaceStep instance - the method under test is pure."""
         from llmdbenchmark.standup.steps.step_04_model_namespace import (
             ModelNamespaceStep,
         )
@@ -592,7 +592,7 @@ class TestRequiresPvcDownload:
         assert step._requires_pvc_download(cfg) is True
 
     def test_hf_protocol_skips_pvc(self, step):
-        """hf uriProtocol means modelservice fetches at runtime — no PVC."""
+        """hf uriProtocol means modelservice fetches at runtime - no PVC."""
         cfg = {"modelservice": {"uriProtocol": "hf"}, "standalone": {"enabled": False}}
         assert step._requires_pvc_download(cfg) is False
 
@@ -619,7 +619,7 @@ class TestComputeGatewayPathPrefix:
         assert compute_gateway_path_prefix(cfg, "pool-a", is_standalone=True) == ""
 
     def test_per_stack_mode_returns_empty(self):
-        """httpRoute.mode: per-stack (or unset) → no prefix injection."""
+        """httpRoute.mode: per-stack (or unset) -> no prefix injection."""
         from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
         cfg = {"httpRoute": {"mode": "per-stack", "pathPrefix": "/ignored"}}
         assert compute_gateway_path_prefix(cfg, "pool-a") == ""
@@ -641,7 +641,7 @@ class TestComputeGatewayPathPrefix:
 
 
 class TestParseEndpoint:
-    """step_04_verify_model._parse_endpoint — host/port/prefix extraction."""
+    """step_04_verify_model._parse_endpoint - host/port/prefix extraction."""
 
     @pytest.fixture
     def parse(self):

--- a/tests/test_shared_block_and_identity.py
+++ b/tests/test_shared_block_and_identity.py
@@ -1,0 +1,670 @@
+"""Tests for the scenario-wide `shared:` block and per-stack identity rewrites.
+
+Covers two related pieces of render_plans.py:
+
+1. `shared:` merge — scenario-wide config applied to every stack before the
+   per-stack overrides. Per-stack always wins.
+2. `_resolve_per_stack_identity` — auto-suffixes shipped-default resource
+   names (model PVC, download Job, EPP Secret) with the model_id_label so
+   multi-stack scenarios don't race on the same Kubernetes resource.
+   Skipped for single-stack scenarios to keep their names stable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+
+@pytest.fixture
+def renderer():
+    """Bypass __init__ — we only need the pure logic under test."""
+    logger = MagicMock()
+    logger.log_warning = MagicMock()
+    logger.log_info = MagicMock()
+    r = RenderPlans.__new__(RenderPlans)
+    r.logger = logger
+    return r
+
+
+class TestPerStackIdentity:
+    """_resolve_per_stack_identity — auto-derived unique names."""
+
+    def _base_values(self, label: str = "my-model") -> dict:
+        # Mirrors defaults.yaml shape for the keys we care about.
+        return {
+            "model_id_label": label,
+            "storage": {"modelPvc": {"name": "model-pvc", "size": "50Gi"}},
+            "downloadJob": {"name": "download-model"},
+            "inferenceExtension": {
+                "monitoring": {
+                    "secretName": "inference-gateway-sa-metrics-reader-secret",
+                    "interval": "10s",
+                },
+            },
+        }
+
+    def test_single_stack_leaves_names_unchanged(self, renderer):
+        """Single-stack: no collision risk, so don't churn resource names."""
+        values = self._base_values()
+        out = renderer._resolve_per_stack_identity(values, total_stacks=1)
+        assert out["storage"]["modelPvc"]["name"] == "model-pvc"
+        assert out["downloadJob"]["name"] == "download-model"
+        assert (
+            out["inferenceExtension"]["monitoring"]["secretName"]
+            == "inference-gateway-sa-metrics-reader-secret"
+        )
+
+    def test_multi_stack_suffixes_default_names(self, renderer):
+        """Multi-stack: download-Job + EPP secret get suffixed (PVC does not)."""
+        values = self._base_values(label="qwen-07df-6b")
+        out = renderer._resolve_per_stack_identity(values, total_stacks=2)
+        assert out["downloadJob"]["name"] == "download-model-qwen-07df-6b"
+        assert out["inferenceExtension"]["monitoring"]["secretName"] == (
+            "inference-gateway-sa-metrics-reader-secret-qwen-07df-6b"
+        )
+
+    def test_multi_stack_model_pvc_is_always_shared(self, renderer):
+        """Model PVC stays at its default so N stacks share one volume."""
+        values = self._base_values(label="qwen-07df-6b")
+        out = renderer._resolve_per_stack_identity(values, total_stacks=3)
+        assert out["storage"]["modelPvc"]["name"] == "model-pvc"
+
+    def test_multi_stack_preserves_explicit_override(self, renderer):
+        """Explicit scenario overrides must not be rewritten."""
+        values = self._base_values(label="qwen-07df-6b")
+        values["inferenceExtension"]["monitoring"]["secretName"] = "custom-secret"
+        out = renderer._resolve_per_stack_identity(values, total_stacks=2)
+        assert out["inferenceExtension"]["monitoring"]["secretName"] == "custom-secret"
+        # Unchanged paths still get the default rewrite
+        assert out["downloadJob"]["name"] == "download-model-qwen-07df-6b"
+
+    def test_missing_model_id_label_is_a_noop(self, renderer):
+        """No label → nothing to suffix with; must not crash."""
+        values = self._base_values(label="")
+        out = renderer._resolve_per_stack_identity(values, total_stacks=5)
+        # Names stay at their shipped defaults.
+        assert out["storage"]["modelPvc"]["name"] == "model-pvc"
+        assert out["downloadJob"]["name"] == "download-model"
+
+
+class TestDeepMergeSharedBlock:
+    """Merge order for the scenario `shared:` block — defaults < shared < stack."""
+
+    def test_shared_overrides_defaults(self, renderer):
+        defaults = {"gateway": {"className": "istio"}}
+        shared = {"gateway": {"className": "agentgateway"}}
+        stack = {"name": "pool-a"}
+
+        # Simulate the merge chain in RenderPlans.eval / _process_stack
+        merged = renderer.deep_merge(defaults, shared)
+        merged = renderer.deep_merge(
+            merged, {k: v for k, v in stack.items() if k != "name"}
+        )
+        assert merged["gateway"]["className"] == "agentgateway"
+
+    def test_stack_overrides_shared(self, renderer):
+        defaults = {"decode": {"replicas": 1}}
+        shared = {"decode": {"replicas": 2}}
+        stack = {"name": "pool-a", "decode": {"replicas": 5}}
+
+        merged = renderer.deep_merge(defaults, shared)
+        merged = renderer.deep_merge(
+            merged, {k: v for k, v in stack.items() if k != "name"}
+        )
+        assert merged["decode"]["replicas"] == 5
+
+    def test_shared_deep_merges_with_defaults(self, renderer):
+        """Nested keys only present in one side must both survive the merge."""
+        defaults = {"wva": {"enabled": False, "image": {"tag": "v0.5.0"}}}
+        shared = {"wva": {"enabled": True}}
+        stack = {"name": "pool-a"}
+
+        merged = renderer.deep_merge(defaults, shared)
+        merged = renderer.deep_merge(
+            merged, {k: v for k, v in stack.items() if k != "name"}
+        )
+        # From shared
+        assert merged["wva"]["enabled"] is True
+        # From defaults — preserved because shared didn't touch image.tag
+        assert merged["wva"]["image"]["tag"] == "v0.5.0"
+
+    def test_treatment_overrides_shared_and_stack(self, renderer):
+        """Full precedence chain: defaults → shared → stack → setup_overrides.
+
+        Ensures DoE experiment treatments (applied as ``setup_overrides``)
+        win over every earlier layer, so a sweep over a shared-block
+        field actually takes effect on every stack.
+        """
+        defaults = {"decode": {"replicas": 1}}
+        shared = {"decode": {"replicas": 2}}
+        stack_a = {"name": "pool-a", "decode": {"replicas": 3}}
+        stack_b = {"name": "pool-b"}  # inherits from shared
+        treatment = {"decode": {"replicas": 5}}
+
+        # Simulate per-stack merge chain for each stack with treatment applied
+        # last (same order as RenderPlans._process_stack).
+        for stack_cfg in (stack_a, stack_b):
+            merged = renderer.deep_merge(defaults, shared)
+            merged = renderer.deep_merge(
+                merged, {k: v for k, v in stack_cfg.items() if k != "name"}
+            )
+            merged = renderer.deep_merge(merged, treatment)
+            # Treatment always wins, no matter what shared/stack set.
+            assert merged["decode"]["replicas"] == 5, (
+                f"Stack {stack_cfg['name']}: treatment didn't win over layers"
+            )
+
+
+class TestSharedInfraStackIndex:
+    """_resolve_shared_infra_stack_index — promote owner past standalone stacks."""
+
+    @pytest.fixture
+    def resolve(self):
+        from llmdbenchmark.parser.render_plans import RenderPlans
+        return RenderPlans._resolve_shared_infra_stack_index
+
+    def test_all_modelservice_first_is_owner(self, resolve):
+        siblings = [
+            {"name": "pool-a", "standalone": False},
+            {"name": "pool-b", "standalone": False},
+        ]
+        assert resolve(siblings) == 1
+
+    def test_standalone_first_skips_to_modelservice(self, resolve):
+        """Leading standalone stacks can't own shared infra — skip them."""
+        siblings = [
+            {"name": "pool-a", "standalone": True},
+            {"name": "pool-b", "standalone": False},
+        ]
+        assert resolve(siblings) == 2
+
+    def test_multiple_standalone_then_modelservice(self, resolve):
+        siblings = [
+            {"name": "a", "standalone": True},
+            {"name": "b", "standalone": True},
+            {"name": "c", "standalone": False},
+        ]
+        assert resolve(siblings) == 3
+
+    def test_all_standalone_falls_back_to_one(self, resolve):
+        """Edge case: every stack is standalone → no modelservice infra
+        installs, so the index is moot but still deterministic."""
+        siblings = [
+            {"name": "a", "standalone": True},
+            {"name": "b", "standalone": True},
+        ]
+        assert resolve(siblings) == 1
+
+
+class TestHelmfileDeclaresRelease:
+    """step_07_deploy_setup._helmfile_declares_release — YAML walk not substring."""
+
+    @pytest.fixture
+    def check(self):
+        from llmdbenchmark.standup.steps.step_07_deploy_setup import DeploySetupStep
+        return DeploySetupStep._helmfile_declares_release
+
+    def _write(self, tmp_path, content):
+        p = tmp_path / "helmfile.yaml"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_release_declared(self, check, tmp_path):
+        p = self._write(tmp_path, """
+releases:
+  - name: infra-llmdbench
+    chart: foo/bar
+""")
+        assert check(p, "infra-llmdbench") is True
+
+    def test_release_absent(self, check, tmp_path):
+        p = self._write(tmp_path, """
+releases:
+  - name: model-a-ms
+    chart: foo/bar
+""")
+        assert check(p, "infra-llmdbench") is False
+
+    def test_label_value_does_not_match(self, check, tmp_path):
+        """Guards against the old substring-match false positive: a label
+        value or similar 'name: X' occurrence must NOT be mistaken for a
+        release declaration."""
+        p = self._write(tmp_path, """
+releases:
+  - name: model-a-ms
+    chart: foo/bar
+    labels:
+      name: infra-llmdbench
+""")
+        assert check(p, "infra-llmdbench") is False
+
+    def test_empty_file(self, check, tmp_path):
+        p = self._write(tmp_path, "")
+        assert check(p, "infra-llmdbench") is False
+
+    def test_missing_file(self, check, tmp_path):
+        assert check(tmp_path / "nope.yaml", "infra-llmdbench") is False
+
+
+class TestGatewayRoutesHealth:
+    """BaseSmoketest._gateway_routes_health — skip /health when routing narrows."""
+
+    @pytest.fixture
+    def check(self):
+        from llmdbenchmark.smoketests.base import BaseSmoketest
+        return BaseSmoketest._gateway_routes_health
+
+    def test_non_shared_always_routes(self, check):
+        """Per-stack HTTPRoute is a single-backend catch-all — always routes /health."""
+        assert check({}) is True
+        assert check({"httpRoute": {"mode": "per-stack"}}) is True
+
+    def test_shared_with_root_rewrite_routes(self, check):
+        cfg = {"httpRoute": {"mode": "shared", "rewriteTo": "/"}}
+        assert check(cfg) is True
+
+    def test_shared_default_rewrite_routes(self, check):
+        """rewriteTo absent → falls back to '/' → /health routes."""
+        cfg = {"httpRoute": {"mode": "shared"}}
+        assert check(cfg) is True
+
+    def test_shared_with_v1_rewrite_does_not_route(self, check):
+        """rewriteTo: /v1 narrows routing to /v1/* — /health won't match."""
+        cfg = {"httpRoute": {"mode": "shared", "rewriteTo": "/v1"}}
+        assert check(cfg) is False
+
+
+class TestCliModelOverrideMultiStack:
+    """_resolve_model — warn (once) when -m/--models is used in multi-stack."""
+
+    @pytest.fixture
+    def renderer(self):
+        from llmdbenchmark.parser.render_plans import RenderPlans
+        logger = MagicMock()
+        logger.log_warning = MagicMock()
+        logger.log_info = MagicMock()
+        r = RenderPlans.__new__(RenderPlans)
+        r.logger = logger
+        r.cli_model = "meta-llama/Llama-3.2-3B"
+        r.cli_stack_filter = []
+        r.DEFAULT_NAMESPACE = "llmdbench"
+        r._cli_model_multi_stack_warned = False
+        return r
+
+    def test_single_stack_no_warning(self, renderer):
+        """-m on a single-stack scenario is a normal override — no warning."""
+        values = {
+            "model": {"name": "Qwen/Qwen3-32B"},
+            "namespace": {"name": "ns"},
+        }
+        renderer._resolve_model(values, total_stacks=1)
+        renderer.logger.log_warning.assert_not_called()
+
+    def test_multi_stack_warns_once(self, renderer):
+        """First stack emits the warning; subsequent stacks stay silent."""
+        values = {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "namespace": {"name": "ns"},
+        }
+        renderer._resolve_model(values, total_stacks=2, stack_name="qwen3-06b")
+        renderer._resolve_model(values, total_stacks=2, stack_name="llama-31-8b")
+        # Warn exactly once — not once per stack.
+        assert renderer.logger.log_warning.call_count == 1
+        msg = renderer.logger.log_warning.call_args[0][0]
+        assert "--stack" in msg
+        assert "N copies of one model" in msg
+
+    def test_multi_stack_still_overrides(self, renderer):
+        """Warning doesn't block the override — current behavior preserved."""
+        values = {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "namespace": {"name": "ns"},
+        }
+        out = renderer._resolve_model(values, total_stacks=2, stack_name="qwen3-06b")
+        assert out["model"]["name"] == "meta-llama/Llama-3.2-3B"
+
+    def test_no_cli_model_is_noop(self, renderer):
+        """When -m is not set, _resolve_model must be a pure no-op."""
+        renderer.cli_model = None
+        values = {
+            "model": {"name": "Qwen/Qwen3-0.6B"},
+            "namespace": {"name": "ns"},
+        }
+        out = renderer._resolve_model(values, total_stacks=5)
+        assert out["model"]["name"] == "Qwen/Qwen3-0.6B"
+        renderer.logger.log_warning.assert_not_called()
+
+    def test_stack_filter_scopes_override_to_matching_stack(self, renderer):
+        """--stack NAME + -m MODEL → override only the named stack."""
+        renderer.cli_stack_filter = ["qwen3-06b"]
+        target_values = {"model": {"name": "orig"}, "namespace": {"name": "ns"}}
+        out = renderer._resolve_model(
+            target_values, total_stacks=2, stack_name="qwen3-06b"
+        )
+        assert out["model"]["name"] == "meta-llama/Llama-3.2-3B"
+        renderer.logger.log_warning.assert_not_called()
+
+    def test_stack_filter_leaves_non_matching_stack_alone(self, renderer):
+        """--stack NAME + -m MODEL → sibling stacks preserve their model."""
+        renderer.cli_stack_filter = ["qwen3-06b"]
+        sibling_values = {"model": {"name": "orig-sibling"}, "namespace": {"name": "ns"}}
+        out = renderer._resolve_model(
+            sibling_values, total_stacks=2, stack_name="llama-31-8b"
+        )
+        assert out["model"]["name"] == "orig-sibling"
+        renderer.logger.log_warning.assert_not_called()
+
+    def test_broad_filter_still_warns(self, renderer):
+        """--stack X,Y + -m MODEL (>1 in filter) → warn as if unscoped."""
+        renderer.cli_stack_filter = ["qwen3-06b", "llama-31-8b"]
+        values = {"model": {"name": "orig"}, "namespace": {"name": "ns"}}
+        renderer._resolve_model(values, total_stacks=2, stack_name="qwen3-06b")
+        renderer.logger.log_warning.assert_called_once()
+
+
+class TestPrintEndpointsTable:
+    """cli._print_endpoints_table — tolerates Path-typed specification_file."""
+
+    def _mock_ctx(self, tmp_path, stacks_with_models):
+        from unittest.mock import MagicMock
+        ctx = MagicMock()
+        ctx.namespace = "test-ns"
+        rendered = []
+        endpoints = {}
+        for name, model, url in stacks_with_models:
+            stack_dir = tmp_path / name
+            stack_dir.mkdir(parents=True, exist_ok=True)
+            (stack_dir / "config.yaml").write_text(
+                f"model:\n  name: {model}\n", encoding="utf-8"
+            )
+            rendered.append(stack_dir)
+            endpoints[name] = url
+        ctx.rendered_stacks = rendered
+        ctx.deployed_endpoints = endpoints
+        return ctx
+
+    def _capturing_logger(self):
+        lines: list[str] = []
+        logger = MagicMock = type("L", (), {})()
+        logger.log_info = lambda msg: lines.append(str(msg))
+        logger.log_warning = lambda msg: lines.append("WARN:" + str(msg))
+        logger.log_plain = lambda msg: lines.append(str(msg))
+        logger.line_break = lambda: lines.append("")
+        return logger, lines
+
+    def test_specification_file_as_posixpath(self, tmp_path, capsys):
+        """Regression: PosixPath spec must not crash the table printer."""
+        from pathlib import Path
+        from llmdbenchmark.cli import _print_endpoints_table
+
+        ctx = self._mock_ctx(tmp_path, [
+            ("pool-a", "Qwen/Qwen3-0.6B", "http://gw:80/pool-a"),
+        ])
+        logger, lines = self._capturing_logger()
+
+        # This is the real shape coming from RenderSpecification — a Path.
+        args = type("A", (), {"specification_file": Path(
+            "/abs/path/config/specification/guides/multi-model-wva.yaml.j2"
+        )})()
+
+        _print_endpoints_table(ctx, logger, args)  # must not raise
+
+        # Table (logger) + copy-paste block (stdout) combined.
+        combined = "\n".join(lines) + "\n" + capsys.readouterr().out
+        assert "guides/multi-model-wva" in combined
+        assert "http://gw:80/pool-a" in combined
+        assert "Qwen/Qwen3-0.6B" in combined
+
+    def test_specification_file_as_short_name(self, tmp_path, capsys):
+        """Bare spec name (e.g. 'gpu') should flow through unchanged."""
+        from llmdbenchmark.cli import _print_endpoints_table
+
+        ctx = self._mock_ctx(tmp_path, [
+            ("pool-a", "Qwen/Qwen3-0.6B", "http://gw:80/pool-a"),
+        ])
+        logger, lines = self._capturing_logger()
+        args = type("A", (), {"specification_file": "guides/multi-model-wva"})()
+
+        _print_endpoints_table(ctx, logger, args)
+        combined = "\n".join(lines) + "\n" + capsys.readouterr().out
+        assert "guides/multi-model-wva" in combined
+
+    def test_no_endpoints_warns(self, tmp_path):
+        """Empty endpoints dict → warn the user to stand up first."""
+        from llmdbenchmark.cli import _print_endpoints_table
+
+        from unittest.mock import MagicMock
+        ctx = MagicMock()
+        ctx.rendered_stacks = []
+        ctx.deployed_endpoints = {}
+        ctx.namespace = "test-ns"
+
+        logger, lines = self._capturing_logger()
+        args = type("A", (), {"specification_file": "guides/x"})()
+
+        _print_endpoints_table(ctx, logger, args)
+        assert any(
+            "no endpoints" in line.lower() or "standup first" in line.lower()
+            for line in lines
+        )
+
+    def test_copy_paste_block_goes_through_logger(self, tmp_path):
+        """log_plain lines end up in every handler — including log files."""
+        from llmdbenchmark.cli import _print_endpoints_table
+
+        ctx = self._mock_ctx(tmp_path, [
+            ("pool-a", "Qwen/Qwen3-0.6B", "http://gw:80/pool-a"),
+        ])
+        # Capturing logger records log_plain calls too so the assertion
+        # below holds regardless of whether a real FileHandler is attached.
+        plain_lines: list[str] = []
+        logger, lines = self._capturing_logger()
+        logger.log_plain = lambda msg: plain_lines.append(str(msg))
+
+        args = type("A", (), {"specification_file": "guides/x"})()
+        _print_endpoints_table(ctx, logger, args)
+
+        # The command lines must flow through log_plain (not print),
+        # so piped-to-file log output captures them.
+        joined = "\n".join(plain_lines)
+        assert "llmdbenchmark --spec" in joined
+        assert "http://gw:80/pool-a" in joined
+        assert "Qwen/Qwen3-0.6B" in joined
+
+
+class TestRenderStackFilterValidation:
+    """RenderPlans.eval() — --stack typos fail at render time, not later."""
+
+    def _write_scenario(self, tmp_path, names):
+        import yaml as _yaml
+        stacks = [{"name": n, "model": {"name": f"m/{n}"}} for n in names]
+        p = tmp_path / "scenario.yaml"
+        p.write_text(_yaml.safe_dump({"scenario": stacks}), encoding="utf-8")
+        return p
+
+    def _renderer(self, tmp_path, scenario_path, cli_stack_filter):
+        from llmdbenchmark.parser.render_plans import RenderPlans
+        # Minimal instance; bypass __init__ and set only what eval() needs
+        r = RenderPlans.__new__(RenderPlans)
+        logger = MagicMock()
+        logger.log_info = MagicMock()
+        logger.log_warning = MagicMock()
+        logger.log_error = MagicMock()
+        logger.line_break = MagicMock()
+        r.logger = logger
+        r.defaults_file = tmp_path / "defaults.yaml"
+        r.defaults_file.write_text("", encoding="utf-8")
+        r.scenarios_file = scenario_path
+        r.output_dir = tmp_path / "out"
+        r.cli_stack_filter = cli_stack_filter
+        return r
+
+    def test_unknown_stack_fails_at_render(self, tmp_path):
+        scenario = self._write_scenario(tmp_path, ["qwen3-06b", "llama-31-8b"])
+        r = self._renderer(tmp_path, scenario, ["typo"])
+        result = r.eval()
+        assert result.has_errors
+        err_msg = "\n".join(result.global_errors)
+        assert "unknown stack" in err_msg.lower()
+        assert "typo" in err_msg
+        assert "qwen3-06b" in err_msg
+        assert "llama-31-8b" in err_msg
+
+    def test_valid_stack_passes_validation(self, tmp_path):
+        scenario = self._write_scenario(tmp_path, ["qwen3-06b", "llama-31-8b"])
+        r = self._renderer(tmp_path, scenario, ["qwen3-06b"])
+        # Can't fully render without templates — but the unknown-stack
+        # gate must NOT fire. Validate by checking global_errors absence
+        # BEFORE template loading starts. We short-circuit by returning
+        # early in the first stages; the filter validation is among the
+        # first checks. If it DID fire, result would contain the "unknown"
+        # error. Any later error (missing templates, etc.) is unrelated
+        # to the filter and fine for this test's purpose.
+        result = r.eval()
+        for err in result.global_errors or []:
+            assert "unknown stack" not in err.lower(), (
+                f"Valid filter rejected: {err}"
+            )
+
+    def test_no_filter_is_noop(self, tmp_path):
+        scenario = self._write_scenario(tmp_path, ["a", "b"])
+        r = self._renderer(tmp_path, scenario, [])
+        result = r.eval()
+        for err in result.global_errors or []:
+            assert "unknown stack" not in err.lower()
+
+
+class TestParseSizeToGib:
+    """step_04_model_namespace._parse_size_to_gib — warn-friendly parser."""
+
+    @pytest.fixture
+    def parse(self):
+        from llmdbenchmark.standup.steps.step_04_model_namespace import (
+            ModelNamespaceStep,
+        )
+        return ModelNamespaceStep._parse_size_to_gib
+
+    def test_gibibytes(self, parse):
+        assert parse("50Gi") == 50.0
+
+    def test_mebibytes(self, parse):
+        assert abs(parse("1024Mi") - 1.0) < 1e-9
+
+    def test_tebibytes(self, parse):
+        assert parse("1Ti") == 1024.0
+
+    def test_si_gigabytes(self, parse):
+        assert parse("1G") == 1.0
+
+    def test_decimal(self, parse):
+        assert parse("0.5Gi") == 0.5
+
+    def test_empty_returns_zero(self, parse):
+        assert parse("") == 0.0
+        assert parse(None) == 0.0
+
+    def test_unparseable_returns_zero(self, parse):
+        assert parse("not-a-size") == 0.0
+
+
+class TestRequiresPvcDownload:
+    """Step 4 gating: PVC + download Job only for pvc/standalone stacks."""
+
+    @pytest.fixture
+    def step(self):
+        """A ModelNamespaceStep instance — the method under test is pure."""
+        from llmdbenchmark.standup.steps.step_04_model_namespace import (
+            ModelNamespaceStep,
+        )
+        return ModelNamespaceStep()
+
+    def test_pvc_protocol_needs_pvc(self, step):
+        cfg = {"modelservice": {"uriProtocol": "pvc"}, "standalone": {"enabled": False}}
+        assert step._requires_pvc_download(cfg) is True
+
+    def test_standalone_mode_needs_pvc(self, step):
+        """Standalone mode uses a PVC even when uriProtocol is non-pvc."""
+        cfg = {"modelservice": {"uriProtocol": "hf"}, "standalone": {"enabled": True}}
+        assert step._requires_pvc_download(cfg) is True
+
+    def test_hf_protocol_skips_pvc(self, step):
+        """hf uriProtocol means modelservice fetches at runtime — no PVC."""
+        cfg = {"modelservice": {"uriProtocol": "hf"}, "standalone": {"enabled": False}}
+        assert step._requires_pvc_download(cfg) is False
+
+    def test_s3_protocol_skips_pvc(self, step):
+        cfg = {"modelservice": {"uriProtocol": "s3"}, "standalone": {"enabled": False}}
+        assert step._requires_pvc_download(cfg) is False
+
+    def test_oci_protocol_skips_pvc(self, step):
+        cfg = {"modelservice": {"uriProtocol": "oci"}, "standalone": {"enabled": False}}
+        assert step._requires_pvc_download(cfg) is False
+
+
+class TestComputeGatewayPathPrefix:
+    """utilities.endpoint.compute_gateway_path_prefix."""
+
+    def test_default_returns_empty(self):
+        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
+        cfg = {}
+        assert compute_gateway_path_prefix(cfg, "pool-a") == ""
+
+    def test_standalone_returns_empty(self):
+        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
+        cfg = {"httpRoute": {"mode": "shared", "pathPrefix": "/{stack.name}"}}
+        assert compute_gateway_path_prefix(cfg, "pool-a", is_standalone=True) == ""
+
+    def test_per_stack_mode_returns_empty(self):
+        """httpRoute.mode: per-stack (or unset) → no prefix injection."""
+        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
+        cfg = {"httpRoute": {"mode": "per-stack", "pathPrefix": "/ignored"}}
+        assert compute_gateway_path_prefix(cfg, "pool-a") == ""
+
+    def test_shared_mode_substitutes_stack_name(self):
+        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
+        cfg = {"httpRoute": {"mode": "shared", "pathPrefix": "/{stack.name}"}}
+        assert compute_gateway_path_prefix(cfg, "pool-a") == "/pool-a"
+
+    def test_shared_mode_preserves_nested_prefix(self):
+        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
+        cfg = {"httpRoute": {"mode": "shared", "pathPrefix": "/{stack.name}/v1"}}
+        assert compute_gateway_path_prefix(cfg, "pool-a") == "/pool-a/v1"
+
+    def test_missing_stack_name_returns_empty(self):
+        from llmdbenchmark.utilities.endpoint import compute_gateway_path_prefix
+        cfg = {"httpRoute": {"mode": "shared", "pathPrefix": "/{stack.name}"}}
+        assert compute_gateway_path_prefix(cfg, "") == ""
+
+
+class TestParseEndpoint:
+    """step_04_verify_model._parse_endpoint — host/port/prefix extraction."""
+
+    @pytest.fixture
+    def parse(self):
+        from llmdbenchmark.run.steps.step_04_verify_model import VerifyModelStep
+        return VerifyModelStep._parse_endpoint
+
+    def test_plain_endpoint(self, parse):
+        assert parse("http://10.0.0.1:80") == ("10.0.0.1", "80", "")
+
+    def test_https_default_port(self, parse):
+        assert parse("https://gw.example.com") == ("gw.example.com", "443", "")
+
+    def test_http_default_port(self, parse):
+        assert parse("http://gw.example.com") == ("gw.example.com", "80", "")
+
+    def test_endpoint_with_prefix(self, parse):
+        assert parse("http://10.0.0.1:80/pool-a") == ("10.0.0.1", "80", "/pool-a")
+
+    def test_endpoint_with_multi_segment_prefix(self, parse):
+        assert parse("http://10.0.0.1:80/pool-a/v1") == ("10.0.0.1", "80", "/pool-a/v1")
+
+    def test_trailing_slash_stripped(self, parse):
+        assert parse("http://10.0.0.1:80/pool-a/") == ("10.0.0.1", "80", "/pool-a")
+
+    def test_root_only_is_empty_prefix(self, parse):
+        assert parse("http://10.0.0.1:80/") == ("10.0.0.1", "80", "")


### PR DESCRIPTION
# Summary

Adds capability to fully deploy N models with autoscaling utilizing llm-d.

Adds a new well-lit path (`guides/multi-model-wva`) that deploys N models behind a single gateway, each with its own EPP + InferencePool + VariantAutoscaling + HPA, sharing one WVA controller and one HTTPRoute with N backend refs. Every lifecycle phase (standup / smoketest / run / teardown) is now multi-stack-aware.

### Scenario authoring

- **`shared:` block** - scenario-wide config merged into every stack before per-stack overrides (`defaults -> shared -> stack -> CLI`).
- **`httpRoute.mode: shared`** - single HTTPRoute, one backend ref per stack, path-based routing (`/{stack.name}/v1/...`).
- **Auto-derived per-stack identity** (N >= 2) - `downloadJob.name`, `inferenceExtension.monitoring.secretName` auto-suffixed with `model_id_label` so Helm releases and Jobs never collide. Model PVC stays shared (one volume, per-model subdirs).

### Render engine

- `siblingStacks`, `stackIndex`, `sharedInfraStackIndex` injected into Jinja. Shared-infra owner promoted to first non-standalone stack, so mixed standalone + modelservice scenarios install infra correctly.
- `--stack` typos fail at render time with a list of valid names.
- `shared:` typos surface via Pydantic validation at render start.

### Lifecycle

- **Standup:** parallel per-stack downloads; size preflight warns on under-sized shared PVC; `helmfile declares release` pre-check suppresses noisy "no releases matched" errors.
- **Run step 09:** waits for sibling InferencePool CRs after applying the shared HTTPRoute.
- **Smoketest:** sequential per-stack; per-stack URL prefix inserted into `/health` and `/v1/models` probes; skips `/health` gracefully when `rewriteTo` narrows routing.
- **Summary banners:** show per-stack Models table when N >= 2.

### New CLI flags

| Flag | Phases | Effect |
|------|--------|--------|
| `--stack NAME[,NAME...]` | standup, smoketest, run, teardown | Restrict per-stack execution to the named subset. Endpoint URL auto-resolves. Also via `LLMDBENCH_STACK`. |
| `--list-endpoints` | run | Detect per-stack endpoint URLs, print a copy-paste table of `llmdbenchmark run` invocations, exit. |
| `-m / --models` scoped by `--stack` | run | When `--stack` names exactly one stack, `-m` scopes to it only; siblings keep their scenario-defined models. Broad use warns. |

### Bug fixes

- EPP metrics-reader Secret now writes to `inferenceExtension.monitoring.prometheus.auth.secretName` (the chart's real knob) instead of the silently-ignored `monitoring.secret.name`.
- `extraObjects` list-style `indent(2)` -> `indent(2, first=True)`.
- `_helmfile_declares_release` walks YAML instead of substring-matching.
- `_check_existing_pvc` "larger than needed" demoted to INFO.
- `_print_endpoints_table` tolerates `PosixPath` for `specification_file`.

### Backward compatibility

Fully additive. Every existing scenario renders and runs identically; single-stack resource names unchanged. `shared:`, `httpRoute.mode`, `--stack`, and `--list-endpoints` are all opt-in.


### Documentation

- `README.md` multi-model section, CLI reference updated for `--stack` + `--list-endpoints`.
- `docs/workload-variant-autoscaler.md` section 2c + new section 10 "Multi-model operations cookbook" (10 recipes).
- `docs/developer-guide.md` "Multi-Stack Scenarios and the `shared:` Block".
- `docs/run.md`, `docs/standup.md`, `docs/lifecycle.md`, `docs/quickstart.md`, `config/README.md`, `llmdbenchmark/{parser,standup,smoketests}/README.md` updated throughout.