### PR TITLE
fix: replace eval() with safe integer parsing in pod index computation

### DIFF
--- a/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
+++ b/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
@@ -476,12 +476,21 @@ if disable_acs == "1" :
 
 env_file_contents.append("echo")
 
+def _parse_pod_index(suffix):
+    """Safely compute pod index by summing dash-separated integers from a pod name suffix."""
+    parts = suffix.split('-')
+    total = 0
+    for p in parts:
+        if p.isdigit():
+            total += int(p)
+    return total
+
 pod_index = None
 if lws_leader_address :
     if pod_name.count("decode") :
-        pod_index=eval(pod_name.split('decode-')[-1].replace('-','+'))
+        pod_index = _parse_pod_index(pod_name.split('decode-')[-1])
     if pod_name.count("prefill") :
-        pod_index=eval(pod_name.split('prefill-')[-1].replace('-','+'))
+        pod_index = _parse_pod_index(pod_name.split('prefill-')[-1])
 
 print(f"DEBUG: Pod index is \"{pod_index}\"")
 


### PR DESCRIPTION
## Description

The `set_llmdbench_environment.py` script uses `eval()` on pod name suffixes to compute pod indices for decode/prefill workers. For example, a pod named `model-decode-0-1` would have its suffix `0-1` transformed to `0+1` and passed to `eval()`, yielding `1`.

While Kubernetes pod naming constraints limit the practical attack surface, `eval()` on externally derived data is a well-known code injection risk and is flagged by all major static analysis tools (Bandit, Semgrep, CodeQL). If the script is ever reused in a context with less constrained input, arbitrary code execution becomes possible.

This PR replaces both `eval()` calls (lines 482, 484) with a safe `_parse_pod_index()` helper function that:
1. Splits the suffix on `-`
2. Filters for digit-only parts
3. Sums them as integers

This produces **identical results** to the original `eval(suffix.replace('-','+'))` for all valid Kubernetes pod names, while being safe against code injection.

### Before
```python
pod_index=eval(pod_name.split('decode-')[-1].replace('-','+'))
```

### After
```python
def _parse_pod_index(suffix):
    """Safely compute pod index by summing dash-separated integers from a pod name suffix."""
    parts = suffix.split('-')
    total = 0
    for p in parts:
        if p.isdigit():
            total += int(p)
    return total

pod_index = _parse_pod_index(pod_name.split('decode-')[-1])
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Unit-level validation
Tested the replacement function against 7 pod name patterns to verify output parity with `eval()`:

| Pod suffix | `eval()` result | `_parse_pod_index()` result | Match |
|------------|----------------|-----------------------------|-------|
| `0` | 0 | 0 | ✅ |
| `1` | 1 | 1 | ✅ |
| `0-1` | 1 | 1 | ✅ |
| `1-2` | 3 | 3 | ✅ |
| `0-0` | 0 | 0 | ✅ |
| `3-4-5` | 12 | 12 | ✅ |
| `10` | 10 | 10 | ✅ |

### Security validation
- Malicious input (e.g. `__import__("os").system("echo pwned")`) safely returns `0` with no code execution.

### Integration validation
- Deployed full llm-d stack on a Kind cluster (EPP v0.7.1, Simulator v0.8.2, Istio 1.28.1) and verified inference requests work end-to-end.
- Python syntax validation passed (`ast.parse`).

### Test Configuration
- Python 3.12
- Kubernetes v1.32.0 (Kind)
- Podman backend

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [ ] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly