### PR TITLE
feat: Persist WVA Resources on per-stack Teardown

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-cks.yaml
+++ b/.github/workflows/ci-nightly-benchmark-cks.yaml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Standup
         run: |
-          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
+          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup --no-monitoring -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
         shell: bash
 
       - name: Debug info (on failure)
@@ -215,7 +215,7 @@ jobs:
 
       - name: Standup
         run: |
-          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
+          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup --no-monitoring -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
         shell: bash
 
       - name: Debug info (on failure)

--- a/.github/workflows/ci-nightly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Standup
         run: |
-          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
+          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup --no-monitoring -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
         shell: bash
 
       - name: Debug info (on failure)
@@ -243,7 +243,7 @@ jobs:
 
       - name: Standup
         run: |
-          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
+          llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" standup --no-monitoring -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
         shell: bash
 
       - name: Debug info (on failure)

--- a/config/README.md
+++ b/config/README.md
@@ -1205,13 +1205,19 @@ decode:
 
 When `podmonitor.enabled: true`, the templates `17_standalone-podmonitor.yaml.j2` (standalone) or `18_podmonitor.yaml.j2` (modelservice) render PodMonitor CRDs that tell Prometheus to scrape vLLM pods.
 
-**Metrics exposed by vLLM pods** (scraped via PodMonitor):
-- `vllm:kv_cache_usage_perc` --KV cache utilization
-- `vllm:num_requests_running` --active requests in batch
-- `vllm:num_requests_waiting` --queued requests
-- `vllm:prompt_tokens_total` --prefill token count
-- `vllm:generation_tokens_total` --decode token count
-- `vllm:prefix_cache_hits_total` / `vllm:prefix_cache_queries_total` --cache hit rate
+**Key metrics exposed by vLLM pods** (scraped via PodMonitor):
+- `vllm:kv_cache_usage_perc` -- KV cache utilization (%)
+- `vllm:gpu_cache_usage_perc` / `vllm:cpu_cache_usage_perc` -- GPU/CPU cache utilization (%)
+- `vllm:gpu_memory_usage_bytes` / `vllm:cpu_memory_usage_bytes` -- memory usage
+- `vllm:num_requests_running` -- active requests in batch
+- `vllm:num_requests_waiting` -- queued requests
+- `vllm:num_requests_swapped` -- requests swapped to CPU
+- `vllm:num_preemptions_total` -- cumulative preemptions
+- `vllm:prefix_cache_hits_total` / `vllm:prefix_cache_queries_total` -- prefix cache hit rate
+- `vllm:external_prefix_cache_hits_total` / `vllm:external_prefix_cache_queries_total` -- cross-instance cache
+- `vllm:nixl_xfer_time_seconds` / `vllm:nixl_bytes_transferred` -- NIXL KV transfer metrics
+
+See [metrics_collection.md](../docs/metrics_collection.md) for the full list of collected metrics.
 
 #### EPP (Inference Scheduler) monitoring
 
@@ -1229,30 +1235,57 @@ inferenceExtension:
 ```
 
 This creates a ServiceMonitor for the EPP pod, enabling Prometheus to scrape inference scheduler metrics:
-- `inference_extension_scheduler_e2e_duration_seconds` --scheduling latency
-- `inference_pool_average_kv_cache_utilization` --pool-wide cache utilization
-- `inference_pool_average_queue_size` --average request queue depth
-- `inference_pool_ready_pods` --ready pod count
+
+**Pool-level gauges:**
+- `inference_pool_average_kv_cache_utilization` -- pool-wide KV cache utilization (%)
+- `inference_pool_average_queue_size` -- average request queue depth
+- `inference_pool_average_running_requests` -- average running requests
+- `inference_pool_ready_pods` -- ready pod count
+
+**Scheduler and request histograms:**
+- `inference_extension_scheduler_e2e_duration_seconds` -- end-to-end scheduling latency
+- `inference_extension_plugin_duration_seconds` -- per-plugin processing time
+- `inference_extension_request_duration_seconds` -- total request duration
+- `inference_extension_request_ttft_duration_seconds` -- time to first token
+
+**Token and routing metrics:**
+- `inference_extension_input_tokens` / `inference_extension_output_tokens` -- token distributions
+- `inference_extension_normalized_time_per_output_token` -- NTPOT distribution
+- `inference_extension_prefix_indexer_hit_ratio` / `inference_extension_prefix_indexer_size` -- prefix indexer
+
+**P/D decision metrics:**
+- `llm_d_inference_scheduler_pd_decision_total` -- P/D routing decisions
+- `llm_d_inference_scheduler_disagg_decision_total` -- disaggregation decisions
 
 When flow control is enabled (see [KV Transfer Configuration](#kv-transfer-configuration) for EPP config), additional metrics are emitted:
-- `inference_extension_flow_control_queue_size` --flow control queue depth
-- `inference_extension_flow_control_pool_saturation` --pool saturation level
+- `inference_extension_flow_control_queue_size` -- flow control queue depth
+- `inference_extension_flow_control_pool_saturation` -- pool saturation level
 
-#### CLI monitoring flag (`-f`)
+#### CLI monitoring flags (`--monitoring` / `--no-monitoring`)
 
-The `-f` / `--monitoring` flag enables monitoring across both standup and run phases:
+The `--monitoring` and `--no-monitoring` flags control monitoring across both standup and run phases. These are tri-state: when neither is passed, the scenario defaults apply unchanged.
 
-**During standup (`-f`):**
-- Creates PodMonitor resources for Prometheus scraping of vLLM pods
+**`--monitoring` (standup):**
+- Ensures PodMonitor resources are created for Prometheus scraping of vLLM pods
 - Sets EPP verbosity to 4 (richer logs for post-run analysis)
 
-**During run (`-f`):**
-- Sets `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED=true` on harness pods
-- The harness runs `collect_metrics.sh` to scrape `/metrics` from all vLLM pods during the benchmark
+**`--monitoring` (run / `-f`):**
+- Sets `metricsScrapeEnabled: true` — harness pods run `collect_metrics.sh` to scrape `/metrics` from all vLLM pods during the benchmark
 - After each treatment, captures model-serving, EPP, and IGW pod logs
 - Runs `process_epp_logs.py` on captured EPP logs to extract scheduling metrics
 
-Without `-f`, metrics scraping is disabled and pod logs are not captured.
+**`--no-monitoring` (standup):**
+- Disables PodMonitor creation (`monitoring.podmonitor.enabled: false`)
+- Disables GAIE ServiceMonitor creation (`inferenceExtension.monitoring.prometheus.enabled: false`)
+- Use this when the cluster lacks Prometheus CRDs (PodMonitor, ServiceMonitor) and you want to avoid CRD-not-found errors during Helm install
+
+**No flag passed:**
+- Scenario defaults from `defaults.yaml` apply as-is
+- By default, `monitoring.podmonitor.enabled: true` (PodMonitors are created at standup)
+- By default, `monitoring.metricsScrapeEnabled: false` (harness does not scrape metrics during run)
+- To enable metrics scraping during run, pass `-f` / `--monitoring` explicitly
+
+**Environment variable:** `LLMDBENCH_MONITORING=true` or `LLMDBENCH_MONITORING=false` can be used as an alternative to the CLI flags. The CLI flag takes precedence when both are set.
 
 #### Enabling monitoring in a scenario
 

--- a/docs/metrics_collection.md
+++ b/docs/metrics_collection.md
@@ -38,9 +38,11 @@ Harness Pod (in-cluster)
 
 ## Configuration
 
+Metrics collection can be enabled via CLI (`llmdbenchmark run -f` / `--monitoring`) or via scenario config. The CLI flag sets `metricsScrapeEnabled: true` at runtime, overriding the scenario default.
+
 | Environment Variable | Default | Description |
 |---|---|---|
-| `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED` | `false` | Enable/disable metrics collection |
+| `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED` | `false` | Enable/disable metrics collection. Set automatically when `--monitoring` / `-f` is passed. |
 | `METRICS_COLLECTION_INTERVAL` | `15` | Seconds between collection snapshots |
 | `LLMDBENCH_VLLM_COMMON_METRICS_PORT` | `8200` | Prometheus metrics port (modelservice) |
 | `LLMDBENCH_VLLM_COMMON_INFERENCE_PORT` | `8000` | Fallback port (standalone vLLM) |
@@ -62,81 +64,104 @@ Only pods with `status.phase=Running` are scraped.
 
 ### Currently Implemented and Working
 
-1. **Pod-Level Prometheus Metrics** - Collecting 117+ metrics from vLLM pods via `/metrics` endpoint
-2. **Metrics Processing** - Aggregating and calculating statistics (mean, stddev, min, max, percentiles)
-3. **Replica Status** - Desired vs ready vs available replica counts per Deployment/StatefulSet, grouped by model and role
-4. **Pod Startup Times** - Creation-to-Ready duration per pod, per node, grouped by model and role
-5. **EPP Metrics** - Endpoint Picker metrics (dispatch latency, endpoint scores, request distribution, plugin latencies)
-6. **Time-Series Visualization** - Static PNG graphs generated after benchmark completion
-7. **Benchmark Report Integration** - All metrics surfaced in `results.observability` section
-8. **RBAC Setup** - Automatic ServiceAccount creation with required permissions
-9. **Metrics Storage** - Raw and processed metrics saved to results directory
+1. **vLLM Pod Prometheus Metrics** - Cache, queue, memory, preemption, and NIXL KV transfer metrics scraped from vLLM pods
+2. **EPP Prometheus Metrics** - Pool-level gauges, scheduler histograms, token distributions, P/D decision counters scraped from EPP pods
+3. **DCGM GPU Metrics** - GPU utilization, framebuffer usage, and power consumption (requires DCGM exporter deployed on the cluster)
+4. **Container Metrics (cAdvisor)** - Memory, CPU, and network usage from kubelet
+5. **Metrics Processing** - Per-pod and cluster-wide aggregation with statistics (mean, stddev, min, max, p25/p50/p75/p90/p95/p99)
+6. **Replica Status** - Desired vs ready vs available replica counts per Deployment/StatefulSet, grouped by model and role
+7. **Pod Startup Times** - Creation-to-Ready duration per pod, per node, grouped by model and role
+8. **EPP Log-Derived Metrics** - Dispatch latency, endpoint scores, request distribution, plugin latencies, saturation config from EPP pod logs
+9. **Time-Series Visualization** - Static PNG graphs generated after benchmark completion
+10. **Benchmark Report Integration** - All metrics surfaced in `results.observability` section
+11. **RBAC Setup** - Automatic ServiceAccount creation with required permissions
+12. **Metrics Storage** - Raw and processed metrics saved to results directory
 
 ### Not Yet Implemented
 
-1. **DCGM GPU Metrics** - Direct GPU monitoring metrics (DCGM_FI_DEV_GPU_UTIL, DCGM_FI_DEV_POWER_USAGE, etc.)
-   - These metrics require DCGM exporter to be deployed in the cluster
-   - Currently relying on vLLM's built-in Prometheus metrics instead
-
-2. **Real-time Visualization** - Live metric streaming during benchmark execution
+1. **Real-time Visualization** - Live metric streaming during benchmark execution
    - Currently generates static graphs after benchmark completion
 
-3. **Custom Metric Queries** - User-defined Prometheus queries
+2. **Custom Metric Queries** - User-defined Prometheus queries
    - Currently collects predefined set of metrics
 
 ## Collected Metrics
 
-The metrics collection system gathers metrics from vLLM pod Prometheus endpoints.
+The metrics collection system scrapes Prometheus endpoints from vLLM pods and EPP pods, collects Kubernetes infrastructure snapshots, and extracts scheduling metrics from EPP logs. All metrics are aggregated into per-pod statistics (mean, stddev, min, max, p25/p50/p75/p90/p95/p99).
 
-### Pod-Level Metrics (vLLM Prometheus Endpoint)
+### vLLM Pod Metrics (Prometheus `/metrics` endpoint)
 
-Collected from each vLLM pod's `/metrics` endpoint (default port 8200 for modelservice, 8000 for standalone):
+Scraped from each vLLM pod (default port 8200 for modelservice, 8000 for standalone):
 
 #### Cache Metrics
-- **`vllm:kv_cache_usage_perc`** - KV cache utilization percentage (0-100)
-- **`vllm:prefix_cache_hits_total`** - Total number of prefix cache hits (tokens)
-- **`vllm:prefix_cache_queries_total`** - Total number of prefix cache queries (tokens)
-- **`vllm:external_prefix_cache_hits_total`** - External cache hits from KV connector cross-instance sharing
-- **`vllm:external_prefix_cache_queries_total`** - External cache queries from KV connector
-- **`vllm:mm_cache_hits_total`** - Multi-modal cache hits (items)
-- **`vllm:mm_cache_queries_total`** - Multi-modal cache queries (items)
-- **Prefix cache hit rate** - Computed from `prefix_cache_hits_total / prefix_cache_queries_total`
-- **External prefix cache hit rate** - Computed from `external_prefix_cache_hits_total / external_prefix_cache_queries_total`
+- **`vllm:kv_cache_usage_perc`** - KV cache utilization (%)
+- **`vllm:gpu_cache_usage_perc`** - GPU cache utilization (%)
+- **`vllm:cpu_cache_usage_perc`** - CPU cache utilization (%)
+- **`vllm:prefix_cache_hits_total`** - Prefix cache hits (tokens)
+- **`vllm:prefix_cache_queries_total`** - Prefix cache queries (tokens)
+- **`vllm:external_prefix_cache_hits_total`** - Cross-instance external cache hits (tokens)
+- **`vllm:external_prefix_cache_queries_total`** - Cross-instance external cache queries (tokens)
+- **`vllm:prefix_cache_hit_rate`** - Computed: `hits / queries` (%)
+- **`vllm:external_prefix_cache_hit_rate`** - Computed: `external_hits / external_queries` (%)
 
-#### Request & Token Metrics
-- **`vllm:num_requests_running`** - Number of requests currently in execution batches
-- **`vllm:num_requests_waiting`** - Number of requests waiting to be processed
-- **`vllm:prompt_tokens_total`** - Total number of prefill tokens processed
-- **`vllm:generation_tokens_total`** - Total number of generation tokens produced
-- **`vllm:iteration_tokens_total`** - Total tokens processed per iteration
-- **`vllm:request_prompt_tokens`** - Prompt tokens per request (histogram)
-- **`vllm:request_generation_tokens`** - Generation tokens per request (histogram)
-- **`vllm:request_max_num_generation_tokens`** - Maximum generation tokens per request
-- **`vllm:request_success_total`** - Total number of successful requests
+#### Request Queue Metrics
+- **`vllm:num_requests_running`** - Requests currently in execution batches (count)
+- **`vllm:num_requests_waiting`** - Requests waiting to be processed (count)
+- **`vllm:num_requests_swapped`** - Requests swapped to CPU (count)
+- **`vllm:num_preemptions_total`** - Cumulative request preemptions (count)
+
+#### Memory Metrics
+- **`vllm:gpu_memory_usage_bytes`** - GPU memory usage (bytes)
+- **`vllm:cpu_memory_usage_bytes`** - CPU memory usage (bytes)
 
 #### NIXL KV Transfer Metrics
-- **`vllm:nixl_xfer_time_seconds`** - Transfer duration for NIXL KV cache transfers (histogram)
-- **`vllm:nixl_bytes_transferred`** - Bytes transferred via NIXL (histogram)
-- **`vllm:nixl_num_descriptors`** - Number of NIXL descriptors (histogram)
-- **`vllm:nixl_num_failed_transfers_total`** - Failed NIXL transfers
-- **`vllm:nixl_num_failed_notifications_total`** - Failed NIXL notifications
-- **`vllm:nixl_num_kv_expired_reqs_total`** - Expired KV transfer requests
-- **`vllm:nixl_post_time_seconds`** - NIXL post time (histogram)
+- **`vllm:nixl_xfer_time_seconds_sum`** - Cumulative NIXL transfer time (seconds)
+- **`vllm:nixl_xfer_time_seconds_count`** - Number of NIXL transfers (count)
+- **`vllm:nixl_bytes_transferred_sum`** - Cumulative bytes transferred via NIXL (bytes)
+- **`vllm:nixl_bytes_transferred_count`** - Number of NIXL byte transfers (count)
 
-#### System Metrics
-- **`vllm:num_preemptions_total`** - Cumulative number of request preemptions
-- **`vllm:engine_sleep_state`** - Engine sleep state (awake/weights_offloaded/discard_all)
-- **`process_cpu_seconds_total`** - Total CPU time consumed by the process
-- **`process_resident_memory_bytes`** - Resident memory size (RSS)
-- **`process_virtual_memory_bytes`** - Virtual memory size
-- **`process_open_fds`** - Number of open file descriptors
-- **`process_max_fds`** - Maximum number of file descriptors
+### GPU/System Metrics (DCGM and cAdvisor)
 
-#### Python Runtime Metrics
-- **`python_gc_collections_total`** - Number of garbage collection cycles
-- **`python_gc_objects_collected_total`** - Objects collected during GC
-- **`python_gc_objects_uncollectable_total`** - Uncollectable objects found during GC
-- **`python_info`** - Python version information
+Scraped from cluster monitoring infrastructure when available (requires DCGM exporter or kubelet cAdvisor):
+
+#### DCGM GPU Metrics
+- **`DCGM_FI_DEV_FB_USED`** - GPU framebuffer memory used (bytes)
+- **`DCGM_FI_DEV_GPU_UTIL`** - GPU utilization (%)
+- **`DCGM_FI_DEV_POWER_USAGE`** - GPU power consumption (watts)
+
+#### Container Metrics (cAdvisor)
+- **`container_memory_usage_bytes`** - Container memory usage (converted to GB in output)
+- **`container_memory_working_set_bytes`** - Container working set memory (converted to GB)
+- **`container_network_receive_bytes_total`** - Network bytes received (converted to MB)
+- **`container_network_transmit_bytes_total`** - Network bytes transmitted (converted to MB)
+- **`container_cpu_usage_seconds_total`** - Container CPU time (seconds)
+
+### EPP Prometheus Metrics (Inference Extension)
+
+Scraped from EPP pods (default port 9090, bearer token auth):
+
+#### Pool-Level Gauges
+- **`inference_pool_average_kv_cache_utilization`** - Pool-wide KV cache utilization (%)
+- **`inference_pool_average_queue_size`** - Average request queue depth (count)
+- **`inference_pool_average_running_requests`** - Average running requests (count)
+- **`inference_pool_ready_pods`** - Ready pod count (count)
+
+#### Scheduler Histograms
+- **`inference_extension_scheduler_e2e_duration_seconds`** - End-to-end scheduling latency (bucket/sum/count)
+- **`inference_extension_plugin_duration_seconds`** - Per-plugin processing time (bucket/sum/count)
+- **`inference_extension_request_duration_seconds`** - Total request duration (bucket/sum/count)
+- **`inference_extension_request_ttft_duration_seconds`** - Time to first token (bucket/sum/count)
+
+#### Token and Routing Metrics
+- **`inference_extension_input_tokens`** - Input token count distribution (bucket)
+- **`inference_extension_output_tokens`** - Output token count distribution (bucket)
+- **`inference_extension_normalized_time_per_output_token`** - NTPOT distribution (bucket)
+- **`inference_extension_prefix_indexer_hit_ratio`** - Prefix indexer hit ratio (bucket)
+- **`inference_extension_prefix_indexer_size`** - Prefix indexer size (count)
+
+#### P/D Decision Metrics
+- **`llm_d_inference_scheduler_pd_decision_total`** - P/D routing decisions (count)
+- **`llm_d_inference_scheduler_disagg_decision_total`** - Disaggregation decisions (count)
 
 ### Infrastructure Metrics (Kubernetes API)
 
@@ -158,13 +183,15 @@ Per Running vLLM pod:
 - **`model`** - From `llm-d.ai/model` label
 - **`role`** - From `llm-d.ai/role` label
 
-### EPP Metrics (`epp_metrics_summary.json`)
+### EPP Log-Derived Metrics (`epp_metrics_summary.json`)
 
-Collected from EPP (Endpoint Picker) pod logs by `process_epp_logs.py`:
-- **Dispatch latency** - End-to-end request routing latency
-- **Endpoint scores** - Per-endpoint scoring metrics
-- **Request distribution** - Request count per endpoint
-- **Plugin latencies** - Per-plugin processing times (filter, scorer, picker)
+Extracted from EPP pod structured JSON logs by `process_epp_logs.py`:
+- **Dispatch latency** - End-to-end request routing latency (`assembled_time` to `picker_complete_time`), with mean/stddev/min/max/p50/p95/p99
+- **Endpoint scores** - Per-endpoint scoring statistics
+- **Request distribution** - Request count per picked endpoint
+- **Plugin latencies** - Per filter and scorer plugin processing times (seconds)
+- **Saturation config** - `queueDepthThreshold`, `kvCacheUtilThreshold`, `metricsStalenessThreshold` from EPP startup logs
+- **Error tracking** - Error message counts by type
 
 ## Key Files
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,13 +1,35 @@
 ## Observability
 
+### CLI Monitoring Flags
+
+The `--monitoring` and `--no-monitoring` flags provide CLI control over monitoring behavior:
+
+```bash
+# Enable monitoring: creates PodMonitors at standup, enables metrics scraping during run
+llmdbenchmark standup -s <scenario> --monitoring
+llmdbenchmark run -f   # -f is shorthand for --monitoring
+
+# Disable monitoring: skips PodMonitor and GAIE ServiceMonitor creation
+# Use when the cluster lacks Prometheus CRDs (e.g. GKE without GMP enabled)
+llmdbenchmark standup -s <scenario> --no-monitoring
+
+# No flag: scenario defaults apply (PodMonitors created, but no metrics scraping during run)
+llmdbenchmark standup -s <scenario>
+llmdbenchmark run     # no metrics scraping
+```
+
+See [config/README.md — Monitoring and Metrics](../config/README.md#monitoring-and-metrics) for full configuration reference.
+
 ### Benchmark-Built-In Metrics
 
-The benchmark collects metrics automatically during runs when `metricsScrapeEnabled: true` is set in the scenario config. This includes:
+The benchmark collects metrics automatically during runs when `metricsScrapeEnabled: true` is set in the scenario config (or when `--monitoring` / `-f` is passed on the CLI). This includes:
 
-- **vLLM Prometheus metrics** — KV cache, request queues, prefix cache, NIXL transfers, preemptions (117+ metrics scraped every 15s)
+- **vLLM Prometheus metrics** — KV cache usage, GPU/CPU cache and memory, request queues, prefix cache hit rates, NIXL KV transfers, preemptions (scraped every 15s)
+- **EPP Prometheus metrics** — Pool-level gauges (KV cache utilization, queue size, ready pods), scheduler/plugin/request duration histograms, token distributions, P/D decision counters
+- **GPU/System metrics** — DCGM GPU utilization/power/memory (requires DCGM exporter), container memory/CPU/network via cAdvisor
 - **Replica status** — Desired vs ready vs available replica counts per model per role
 - **Pod startup times** — Creation-to-Ready duration per pod per node
-- **EPP metrics** — Endpoint Picker dispatch latency, routing scores, request distribution
+- **EPP log-derived metrics** — Dispatch latency, endpoint scores, request distribution, per-plugin filter/scorer latencies
 
 Results are written to the `metrics/` directory within each experiment's results and integrated into the benchmark report under `results.observability`.
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -114,7 +114,7 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
             cli_namespace=getattr(args, "namespace", None),
             cli_model=getattr(args, "models", None),
             cli_methods=getattr(args, "methods", None),
-            cli_monitoring=getattr(args, "monitoring", False),
+            cli_monitoring=getattr(args, "monitoring", None),
             cli_wva=getattr(args, "wva", False),
             cli_stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
         ).eval()
@@ -1150,7 +1150,7 @@ def _render_plans_for_experiment(args, logger, setup_overrides=None):
         cli_namespace=getattr(args, "namespace", None),
         cli_model=getattr(args, "models", None),
         cli_methods=getattr(args, "methods", None),
-        cli_monitoring=getattr(args, "monitoring", False),
+        cli_monitoring=getattr(args, "monitoring", None),
         cli_wva=getattr(args, "wva", False),
         setup_overrides=setup_overrides,
     ).eval()
@@ -1646,8 +1646,8 @@ def cli() -> None:
         args.verbose = env_bool("LLMDBENCH_VERBOSE")
     if not args.non_admin:
         args.non_admin = env_bool("LLMDBENCH_NON_ADMIN")
-    if hasattr(args, "monitoring") and not args.monitoring:
-        args.monitoring = env_bool("LLMDBENCH_MONITORING")
+    if hasattr(args, "monitoring") and args.monitoring is None:
+        args.monitoring = env_bool("LLMDBENCH_MONITORING") or None
     if hasattr(args, "deep") and not args.deep:
         args.deep = env_bool("LLMDBENCH_DEEP_CLEAN")
     if hasattr(args, "skip") and not args.skip:

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -45,6 +45,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
 
     # Platform detection flags (set by step 00)
     is_openshift: bool = False
+    is_gke: bool = False
     is_kind: bool = False
     is_minikube: bool = False
     # Resolved cluster metadata
@@ -170,6 +171,8 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
         """Human-readable platform label (e.g. 'OpenShift', 'Kind')."""
         if self.is_openshift:
             return "OpenShift"
+        if self.is_gke:
+            return "GKE"
         if self.is_kind:
             return "Kind"
         if self.is_minikube:

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -92,6 +92,7 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env("LLMDBENCH_STACK"),
         help=(
             "Comma-separated list of stack names to restrict execution to. "
+            "Default: unset, meaning 'run against every stack of the scenario'. "
             "Useful in multi-stack scenarios (e.g. guides/multi-model-wva) "
             "to benchmark a single pool without re-deploying. "
             "Endpoint URL auto-resolves for the selected stack - no need to "

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -136,8 +136,8 @@ def add_subcommands(parser: argparse._SubParsersAction):
         "-f",
         "--monitoring",
         action="store_true",
-        default=False,
-        help="Enable vLLM /metrics scraping and pod log capture during the run.",
+        default=None,
+        help="Enable vLLM /metrics scraping and pod log capture during the run. Without this flag, metrics are not collected.",
     )
 
     # Pod configuration

--- a/llmdbenchmark/interface/smoketest.py
+++ b/llmdbenchmark/interface/smoketest.py
@@ -43,6 +43,7 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env("LLMDBENCH_STACK"),
         help=(
             "Comma-separated list of stack names to restrict execution to. "
+            "Default: unset, meaning 'smoketest every stack of the scenario'. "
             "Useful for re-running the smoketest against a single pool."
         ),
     )

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -70,11 +70,10 @@ def add_subcommands(parser: argparse._SubParsersAction):
         help="Enable Workload Variant Autoscaler (WVA) for this standup.",
     )
     standup_parser.add_argument(
-        "-f",
         "--monitoring",
-        action="store_true",
-        default=False,
-        help="Enable PodMonitor for Prometheus and vLLM /metrics scraping.",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable monitoring. --monitoring creates PodMonitors and enables metrics scraping. --no-monitoring disables PodMonitor and GAIE ServiceMonitor creation (use when cluster lacks Prometheus CRDs). Omit to use scenario defaults.",
     )
     standup_parser.add_argument(
         "--parallel",

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -87,6 +87,7 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env("LLMDBENCH_STACK"),
         help=(
             "Comma-separated list of stack names to restrict execution to. "
+            "Default: unset, meaning 'deploy every stack of the scenario'. "
             "Useful for re-deploying a single pool in a multi-stack scenario "
             "without tearing down siblings."
         ),

--- a/llmdbenchmark/interface/teardown.py
+++ b/llmdbenchmark/interface/teardown.py
@@ -12,7 +12,14 @@ def add_subcommands(parser: argparse._SubParsersAction):
         description=(
             "The `teardown` command removes resources deployed by a previous standup. "
             "It uninstalls Helm releases, deletes namespaced resources, and optionally "
-            "removes cluster-scoped roles. Use --deep for a full namespace wipe."
+            "removes cluster-scoped roles. Use --deep for a full namespace wipe.\n"
+            "\n"
+            "By default --stack is unset, which means 'tear down every stack of the "
+            "scenario'. In that mode the per-namespace WVA controller is also "
+            "uninstalled (no remaining stacks of this scenario depend on it). "
+            "Pass --stack to scope teardown to specific stacks; the WVA controller "
+            "is then preserved so the sibling stacks keep autoscaling. --deep "
+            "uninstalls the controller regardless of --stack."
         ),
         help="Tear down a previously deployed llm-d stack.",
     )
@@ -39,7 +46,12 @@ def add_subcommands(parser: argparse._SubParsersAction):
     teardown_parser.add_argument(
         "-d", "--deep",
         action="store_true",
-        help="Deep cleaning: delete ALL resources in both namespaces.",
+        help=(
+            "Deep cleaning: delete ALL resources in both namespaces. "
+            "Forces the WVA controller to be uninstalled even when --stack "
+            "is set. prometheus-adapter and shared cluster-wide RBAC are "
+            "still preserved (other tenants depend on them)."
+        ),
     )
     teardown_parser.add_argument(
         "-p", "--namespace",
@@ -59,7 +71,11 @@ def add_subcommands(parser: argparse._SubParsersAction):
         default=env("LLMDBENCH_STACK"),
         help=(
             "Comma-separated list of stack names to restrict execution to. "
+            "Default: unset, meaning 'tear down every stack of the scenario'. "
             "Useful for removing one pool from a multi-stack scenario while "
-            "leaving siblings in place."
+            "leaving siblings in place. When set, the per-namespace WVA "
+            "controller is preserved (sibling stacks still need it); when "
+            "unset, the controller is also uninstalled. --deep overrides "
+            "this and always uninstalls the controller."
         ),
     )

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -47,7 +47,7 @@ class RenderPlans:
         cli_namespace: str | None = None,
         cli_model: str | None = None,
         cli_methods: str | None = None,
-        cli_monitoring: bool = False,
+        cli_monitoring: bool | None = None,
         cli_wva: bool = False,
         setup_overrides: dict | None = None,
         cli_stack_filter: list[str] | None = None,
@@ -453,25 +453,42 @@ class RenderPlans:
                 )
 
     def _resolve_monitoring(self, values: dict) -> dict:
-        """Enable PodMonitor and metrics scraping when ``--monitoring`` is set.
+        """Override monitoring based on ``--monitoring`` / ``--no-monitoring``.
 
-        Matches the bash ``-f/--monitoring`` flag which sets:
-        - ``LLMDBENCH_VLLM_MONITORING_PODMONITOR_ENABLED=true``
-        - ``LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED=true``
+        When enabled (``--monitoring`` on standup, ``-f`` on run):
+        - ``podmonitor.enabled`` → PodMonitor CRDs created for Prometheus
+        - ``metricsScrapeEnabled`` → harness scrapes vLLM /metrics during run
+
+        When disabled (``--no-monitoring``):
+        - ``podmonitor.enabled`` → False (no PodMonitor created)
+
+        When neither flag is given, scenario/defaults values are used
+        (podmonitor enabled by default, metricsScrapeEnabled disabled).
         """
-        if not self.cli_monitoring:
+        if self.cli_monitoring is None:
             return values
 
         result = deepcopy(values)
-
         monitoring_config = result.setdefault("monitoring", {})
         podmonitor_config = monitoring_config.setdefault("podmonitor", {})
-        podmonitor_config["enabled"] = True
-        monitoring_config["metricsScrapeEnabled"] = True
 
-        self.logger.log_info(
-            "Monitoring enabled from CLI: PodMonitor + metrics scraping"
-        )
+        if self.cli_monitoring:
+            podmonitor_config["enabled"] = True
+            monitoring_config["metricsScrapeEnabled"] = True
+            self.logger.log_info(
+                "Monitoring enabled from CLI: PodMonitor + metrics scraping"
+            )
+        else:
+            podmonitor_config["enabled"] = False
+            ie = result.setdefault("inferenceExtension", {})
+            ie_mon = ie.setdefault("monitoring", {})
+            ie_prom = ie_mon.setdefault("prometheus", {})
+            ie_prom["enabled"] = False
+            self.logger.log_info(
+                "Monitoring disabled from CLI (--no-monitoring): "
+                "PodMonitor and GAIE ServiceMonitor will not be created"
+            )
+
         return result
 
     def _resolve_wva(self, values: dict) -> dict:

--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -147,6 +147,12 @@ class AdminPrerequisitesStep(Step):
                 cmd, plan_config, existing_crds,
             )
 
+        # After any auto-install attempt, validate that monitoring CRDs are
+        # present when monitoring is enabled.  Re-fetch CRDs so we pick up
+        # anything that was just installed above.
+        refreshed_crds = self._get_existing_crds(cmd, context)
+        self._validate_monitoring_crds(cmd, context, plan_config, refreshed_crds, errors)
+
         self._apply_namespace_yaml(cmd, context, errors)
         self._apply_openshift_sccs(cmd, context, plan_config)
 
@@ -398,6 +404,102 @@ class AdminPrerequisitesStep(Step):
 
         cmd.logger.log_info(
             "✅ Prometheus Operator CRDs installed (PodMonitor, ServiceMonitor)"
+        )
+
+    def _validate_monitoring_crds(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        plan_config: dict,
+        existing_crds: list[str],
+        errors: list,
+    ):
+        """Fail early when monitoring is enabled but required CRDs are missing.
+
+        Checks for ``podmonitors.monitoring.coreos.com`` and
+        ``servicemonitors.monitoring.coreos.com``.  If either is absent the
+        step records an error with platform-aware remediation guidance.
+        """
+        monitoring = plan_config.get("monitoring", {})
+        podmonitor_enabled = monitoring.get("podmonitor", {}).get("enabled", False)
+        scrape_enabled = monitoring.get("metricsScrapeEnabled", False)
+
+        if not podmonitor_enabled and not scrape_enabled:
+            return
+
+        required_crds = [
+            "podmonitors.monitoring.coreos.com",
+            "servicemonitors.monitoring.coreos.com",
+        ]
+        missing = [c for c in required_crds if c not in existing_crds]
+        if not missing:
+            cmd.logger.log_info(
+                "✅ Monitoring CRDs present on cluster"
+            )
+            return
+
+        missing_str = ", ".join(missing)
+        guidance = self._monitoring_guidance(context)
+        msg = (
+            f"Monitoring is enabled but the following required CRDs are missing "
+            f"from the cluster: {missing_str}.\n{guidance}"
+        )
+        cmd.logger.log_error(msg)
+        errors.append(msg)
+
+    @staticmethod
+    def _monitoring_guidance(context: ExecutionContext) -> str:
+        """Return platform-specific remediation guidance for missing monitoring CRDs."""
+        common_tail = (
+            "Alternatively, pass '--no-monitoring' to disable monitoring."
+        )
+
+        if context.is_gke:
+            return (
+                "On GKE, enable Google Managed Prometheus with managed collection:\n"
+                "  gcloud container clusters update <CLUSTER> \\\n"
+                "    --enable-managed-prometheus \\\n"
+                "    --location=<LOCATION>\n"
+                "This lets GKE natively scrape PodMonitor resources.\n"
+                "See: https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed\n"
+                f"{common_tail}"
+            )
+
+        if context.is_kind or context.is_minikube:
+            return (
+                f"On {context.platform_type}, install the kube-prometheus-stack Helm chart:\n"
+                "  helm repo add prometheus-community "
+                "https://prometheus-community.github.io/helm-charts\n"
+                "  helm install prometheus prometheus-community/kube-prometheus-stack \\\n"
+                "    --namespace monitoring --create-namespace\n"
+                f"{common_tail}"
+            )
+
+        if context.is_openshift:
+            return (
+                "On OpenShift, ensure user workload monitoring is enabled:\n"
+                "  oc apply -f - <<EOF\n"
+                "  apiVersion: v1\n"
+                "  kind: ConfigMap\n"
+                "  metadata:\n"
+                "    name: cluster-monitoring-config\n"
+                "    namespace: openshift-monitoring\n"
+                "  data:\n"
+                "    config.yaml: |\n"
+                "      enableUserWorkload: true\n"
+                "  EOF\n"
+                f"{common_tail}"
+            )
+
+        # Generic Kubernetes
+        return (
+            "Install the Prometheus Operator (or its CRDs) on the cluster.\n"
+            "For example, using the kube-prometheus-stack Helm chart:\n"
+            "  helm repo add prometheus-community "
+            "https://prometheus-community.github.io/helm-charts\n"
+            "  helm install prometheus prometheus-community/kube-prometheus-stack \\\n"
+            "    --namespace monitoring --create-namespace\n"
+            f"{common_tail}"
         )
 
     def _apply_namespace_yaml(

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -206,14 +206,26 @@ class DeployModelserviceStep(Step):
             if not podmonitor_yaml:
                 podmonitor_yaml = self._find_yaml(stack_path, "18_podmonitor")
             if podmonitor_yaml and self._has_yaml_content(podmonitor_yaml):
-                result = cmd.kube("apply", "-f", str(podmonitor_yaml))
-                if not result.success:
-                    context.logger.log_warning(
-                        f"PodMonitor apply failed (non-fatal): {result.stderr}"
-                    )
+                # Check if PodMonitor CRD exists before attempting to apply
+                crd_check = cmd.kube(
+                    "get", "crd", "podmonitors.monitoring.coreos.com",
+                    check=False,
+                )
+                if crd_check.success:
+                    result = cmd.kube("apply", "-f", str(podmonitor_yaml))
+                    if not result.success:
+                        context.logger.log_warning(
+                            f"PodMonitor apply failed (non-fatal): {result.stderr}"
+                        )
+                    else:
+                        context.logger.log_info(
+                            "PodMonitor created for Prometheus scraping"
+                        )
                 else:
-                    context.logger.log_info(
-                        "PodMonitor created for Prometheus scraping"
+                    context.logger.log_warning(
+                        "PodMonitor CRD (monitoring.coreos.com/v1) not found on cluster -- "
+                        "skipping PodMonitor creation. Install Prometheus Operator CRDs "
+                        "or pass '--no-monitoring' to disable monitoring."
                     )
             else:
                 context.logger.log_info(

--- a/llmdbenchmark/teardown/README.md
+++ b/llmdbenchmark/teardown/README.md
@@ -22,12 +22,24 @@ Loads the rendered plan config (`config.yaml`) from the first rendered stack. Po
 
 ### Step 01 -- Uninstall Helm Releases
 
-Skipped when `modelservice` is not in `context.deployed_methods`.
+Skipped when `modelservice` is not in `context.deployed_methods` and no rendered stack has `wva.enabled: true`.
 
 For each target namespace:
 - Uninstalls Helm releases matching the release prefix and model labels.
 - Deletes OpenShift routes (if on OpenShift) matching the release prefix.
 - Deletes model download jobs.
+
+#### WVA controller teardown policy
+
+When any rendered stack has `wva.enabled: true`, the step also tears down WVA resources:
+
+- **Per-stack `VariantAutoscaling` + `HPA`**: always deleted, so the model stops auto-scaling after teardown.
+- **Per-namespace WVA controller (`workload-variant-autoscaler` helm release)**:
+  - Default (no `--stack` filter, i.e. tearing down the entire scenario): **uninstalled**. No remaining stacks of this scenario depend on it.
+  - With `--stack X` (partial-stack teardown): **preserved**. Sibling stacks of this scenario in the same namespace still need it to autoscale.
+  - With `--deep`: **uninstalled** regardless of `--stack` (deep wins).
+- **Shared cluster-wide infrastructure** (`prometheus-adapter`, the `prometheus-ca` ConfigMap, the `allow-thanos-querier-api-access` ClusterRole): **never** removed by teardown -- not even with `--deep`. They are managed once at the cluster level (e.g. by a platform admin) and removing them on a per-tenant teardown would break every other namespace's autoscaling.
+- **Non-OpenShift platforms**: WVA teardown is a no-op (standup never installs WVA off-OpenShift).
 
 ### Step 02 -- Clean Harness
 

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -65,9 +65,10 @@ class UninstallHelmStep(Step):
                 self._delete_openshift_routes(cmd, context, ns, release)
                 self._delete_download_job(cmd, context, ns)
 
-        # WVA teardown: always remove per-stack VA+HPA. Only uninstall the
-        # shared controller + prometheus-adapter when the user passed -d
-        # (context.deep_clean) -- other stacks may still be using them.
+        # WVA teardown: always remove per-stack VA+HPA. The shared controller
+        # is uninstalled on full-scenario teardowns (no --stack filter); a
+        # partial-stack teardown preserves it because the remaining stacks
+        # still depend on it. --deep forces uninstall regardless.
         self._teardown_wva(cmd, context, errors)
 
         if errors:
@@ -167,9 +168,14 @@ class UninstallHelmStep(Step):
         """Tear down WVA resources.
 
         Always deletes the per-stack VariantAutoscaling + HPA so the model
-        no longer auto-scales after teardown. The (per-namespace) WVA
-        controller is preserved unless ``--deep`` (``deep_clean``) is set,
-        because other stacks in the same namespace may still depend on it.
+        no longer auto-scales after teardown.
+
+        The (per-namespace) WVA controller is uninstalled on full-scenario
+        teardowns (no ``--stack`` filter), because there are no remaining
+        stacks of this scenario to depend on it. A partial-stack teardown
+        (``--stack X``) preserves the controller -- the sibling stacks of
+        this scenario in the same namespace still need it. ``--deep``
+        forces uninstall regardless of the filter.
 
         prometheus-adapter and its supporting cluster-wide resources
         (``allow-thanos-querier-api-access`` ClusterRole, ``prometheus-ca``
@@ -236,11 +242,11 @@ class UninstallHelmStep(Step):
                         f"  Deleted {kind}/{resource_name}", emoji="🗑️"
                     )
 
-        # 2. WVA controller(s): only on --deep. The controller is per-namespace
-        # (one per unique wva.namespace, all of which are target namespaces
-        # for this teardown), so removing it on --deep is in-scope.
+        # 2. WVA controller(s): uninstalled on full-scenario teardowns and
+        # forced on --deep; preserved on partial-stack teardowns so sibling
+        # stacks of this scenario keep autoscaling.
         #
-        # PRINCIPLE: --deep only removes resources that live in the target
+        # PRINCIPLE: teardown only removes resources that live in the target
         # namespace(s). It MUST NOT touch cross-namespace or cluster-scoped
         # resources -- doing so would silently break other tenants. That's
         # why we explicitly do NOT remove on any teardown:
@@ -252,17 +258,22 @@ class UninstallHelmStep(Step):
         # (e.g. by a platform admin). Our standup install is idempotent
         # and skips when a cluster-wide install already exists, so leaving
         # them in place across teardowns is always correct.
-        if not context.deep_clean:
+        is_partial_stack_teardown = bool(context.stack_filter)
+        if is_partial_stack_teardown and not context.deep_clean:
             context.logger.log_info(
-                "Preserving WVA controller (pass -d/--deep to uninstall). "
-                "prometheus-adapter and shared cluster-wide RBAC are always "
-                "preserved regardless of --deep -- other tenants depend on them."
+                "Preserving WVA controller: --stack filter is active, "
+                "sibling stacks in this scenario still depend on it. "
+                "Pass -d/--deep to force uninstall."
             )
             return
 
+        if context.deep_clean:
+            mode_msg = "Deep clean: uninstalling WVA controller(s)."
+        else:
+            mode_msg = "Full-scenario teardown: uninstalling WVA controller(s)."
         context.logger.log_info(
-            "Deep clean: uninstalling WVA controller(s). "
-            "prometheus-adapter and shared cluster RBAC are kept intact."
+            f"{mode_msg} prometheus-adapter and shared cluster RBAC are "
+            "kept intact."
         )
         for wva_ns in sorted(seen_ns):
             context.logger.log_info(

--- a/llmdbenchmark/utilities/cluster.py
+++ b/llmdbenchmark/utilities/cluster.py
@@ -338,7 +338,7 @@ def _kube_api_connect(context: ExecutionContext) -> None:
 
 
 def _detect_local_platform(cmd: CommandExecutor, context: ExecutionContext) -> None:
-    """Detect Kind or Minikube by inspecting kube-system pods."""
+    """Detect Kind, Minikube, or GKE by inspecting cluster resources."""
     if context.is_openshift:
         return
 
@@ -356,6 +356,17 @@ def _detect_local_platform(cmd: CommandExecutor, context: ExecutionContext) -> N
         context.is_kind = True
     elif "etcd-minikube" in pod_names or "minikube" in pod_names:
         context.is_minikube = True
+    else:
+        # Detect GKE by checking for GKE-specific node labels
+        node_result = cmd.kube(
+            "get",
+            "nodes",
+            "-o",
+            "jsonpath={.items[0].metadata.labels}",
+            check=False,
+        )
+        if node_result.success and "cloud.google.com/gke-" in node_result.stdout:
+            context.is_gke = True
 
 
 def _store_kubeconfig(cmd: CommandExecutor, context: ExecutionContext) -> None:

--- a/tests/test_teardown_wva.py
+++ b/tests/test_teardown_wva.py
@@ -1,0 +1,256 @@
+"""Tests for WVA controller teardown policy in ``UninstallHelmStep._teardown_wva``.
+
+Behavior under test:
+- Full-scenario teardown (no ``--stack`` filter): controller is uninstalled.
+- Partial-stack teardown (``--stack X`` filter set): controller is preserved.
+- ``--deep``: controller is uninstalled regardless of filter.
+- Per-stack VariantAutoscaling + HPA are always deleted, regardless of mode.
+- Non-OpenShift platforms: WVA teardown is skipped entirely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from llmdbenchmark.teardown.steps.step_01_uninstall_helm import UninstallHelmStep
+
+
+# ---------------------------------------------------------------------------
+# Stubs / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _StubLogger:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def log_info(self, msg: str, **_: Any) -> None:
+        self.messages.append(msg)
+
+    def log_warning(self, msg: str, **_: Any) -> None:
+        self.messages.append(f"WARN: {msg}")
+
+    def log_error(self, msg: str, **_: Any) -> None:
+        self.messages.append(f"ERR: {msg}")
+
+
+@dataclass
+class _StubResult:
+    success: bool = True
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _StubCmd:
+    """Records every kube/helm invocation."""
+
+    kube_calls: list[tuple] = field(default_factory=list)
+    helm_calls: list[tuple] = field(default_factory=list)
+
+    def kube(self, *args: str, **_: Any) -> _StubResult:
+        self.kube_calls.append(args)
+        return _StubResult(success=True)
+
+    def helm(self, *args: str, **_: Any) -> _StubResult:
+        self.helm_calls.append(args)
+        return _StubResult(success=True)
+
+
+@dataclass
+class _StubContext:
+    """Minimal stand-in for ExecutionContext sufficient for _teardown_wva."""
+
+    rendered_stacks: list[Path] = field(default_factory=list)
+    stack_filter: list[str] | None = None
+    deep_clean: bool = False
+    is_openshift: bool = True
+    platform_type: str = "openshift"
+    logger: _StubLogger = field(default_factory=_StubLogger)
+
+
+def _write_stack(tmp_path: Path, name: str, *, wva_ns: str, model_id: str) -> Path:
+    """Create a rendered-stack directory with a wva-enabled config.yaml."""
+    stack_dir = tmp_path / name
+    stack_dir.mkdir(parents=True)
+    cfg = {
+        "wva": {"enabled": True, "namespace": wva_ns},
+        "namespace": {"name": wva_ns},
+        "model_id_label": model_id,
+    }
+    (stack_dir / "config.yaml").write_text(yaml.safe_dump(cfg))
+    return stack_dir
+
+
+# ---------------------------------------------------------------------------
+# Helpers for assertions
+# ---------------------------------------------------------------------------
+
+
+def _controller_was_uninstalled(cmd: _StubCmd) -> bool:
+    return any(
+        "uninstall" in args and "workload-variant-autoscaler" in args
+        for args in cmd.helm_calls
+    )
+
+
+def _va_hpa_deleted_for(cmd: _StubCmd, model_id: str) -> bool:
+    expected = f"{model_id}-decode"
+    return any(
+        "delete" in args and expected in args
+        for args in cmd.kube_calls
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWvaTeardownPolicy:
+    def test_full_scenario_uninstalls_controller(self, tmp_path: Path) -> None:
+        """No --stack filter => controller is uninstalled."""
+        step = UninstallHelmStep()
+        ctx = _StubContext(
+            rendered_stacks=[
+                _write_stack(tmp_path, "stack-a", wva_ns="ns1", model_id="modelA"),
+                _write_stack(tmp_path, "stack-b", wva_ns="ns1", model_id="modelB"),
+            ],
+            stack_filter=None,
+            deep_clean=False,
+        )
+        cmd = _StubCmd()
+
+        step._teardown_wva(cmd, ctx, errors=[])
+
+        assert _controller_was_uninstalled(cmd), (
+            f"Expected controller uninstall on full-scenario teardown; "
+            f"helm calls={cmd.helm_calls}"
+        )
+        assert _va_hpa_deleted_for(cmd, "modelA")
+        assert _va_hpa_deleted_for(cmd, "modelB")
+
+    def test_partial_stack_preserves_controller(self, tmp_path: Path) -> None:
+        """--stack filter present => controller is preserved."""
+        step = UninstallHelmStep()
+        ctx = _StubContext(
+            rendered_stacks=[
+                _write_stack(tmp_path, "stack-a", wva_ns="ns1", model_id="modelA"),
+                _write_stack(tmp_path, "stack-b", wva_ns="ns1", model_id="modelB"),
+            ],
+            stack_filter=["stack-a"],
+            deep_clean=False,
+        )
+        cmd = _StubCmd()
+
+        step._teardown_wva(cmd, ctx, errors=[])
+
+        assert not _controller_was_uninstalled(cmd), (
+            f"Expected controller preservation under --stack filter; "
+            f"helm calls={cmd.helm_calls}"
+        )
+        assert any(
+            "Preserving WVA controller" in m for m in ctx.logger.messages
+        ), f"Expected preservation log message; got: {ctx.logger.messages}"
+
+    def test_deep_clean_uninstalls_controller_even_with_stack_filter(
+        self, tmp_path: Path
+    ) -> None:
+        """--deep + --stack => controller is uninstalled (deep wins)."""
+        step = UninstallHelmStep()
+        ctx = _StubContext(
+            rendered_stacks=[
+                _write_stack(tmp_path, "stack-a", wva_ns="ns1", model_id="modelA"),
+            ],
+            stack_filter=["stack-a"],
+            deep_clean=True,
+        )
+        cmd = _StubCmd()
+
+        step._teardown_wva(cmd, ctx, errors=[])
+
+        assert _controller_was_uninstalled(cmd), (
+            f"Expected --deep to force controller uninstall; "
+            f"helm calls={cmd.helm_calls}"
+        )
+
+    def test_non_openshift_skips_entirely(self, tmp_path: Path) -> None:
+        """WVA teardown is a no-op on non-OpenShift platforms."""
+        step = UninstallHelmStep()
+        ctx = _StubContext(
+            rendered_stacks=[
+                _write_stack(tmp_path, "stack-a", wva_ns="ns1", model_id="modelA"),
+            ],
+            is_openshift=False,
+            platform_type="kind",
+        )
+        cmd = _StubCmd()
+
+        step._teardown_wva(cmd, ctx, errors=[])
+
+        assert cmd.helm_calls == []
+        assert cmd.kube_calls == []
+
+    def test_full_scenario_multiple_namespaces(self, tmp_path: Path) -> None:
+        """Full teardown uninstalls the controller in every wva-enabled namespace."""
+        step = UninstallHelmStep()
+        ctx = _StubContext(
+            rendered_stacks=[
+                _write_stack(tmp_path, "stack-a", wva_ns="ns1", model_id="modelA"),
+                _write_stack(tmp_path, "stack-b", wva_ns="ns2", model_id="modelB"),
+            ],
+            stack_filter=None,
+        )
+        cmd = _StubCmd()
+
+        step._teardown_wva(cmd, ctx, errors=[])
+
+        # Controller uninstalled once per unique namespace
+        ns_uninstalls = [
+            args for args in cmd.helm_calls
+            if "uninstall" in args and "workload-variant-autoscaler" in args
+        ]
+        namespaces = {args[args.index("--namespace") + 1] for args in ns_uninstalls}
+        assert namespaces == {"ns1", "ns2"}, (
+            f"Expected controller uninstall in both ns1 and ns2; "
+            f"got {namespaces}"
+        )
+
+    @pytest.mark.parametrize(
+        "stack_filter,deep,expected_uninstall",
+        [
+            (None, False, True),       # full scenario: uninstall
+            (None, True, True),        # full scenario + deep: uninstall
+            (["stack-a"], False, False),  # partial: preserve
+            (["stack-a"], True, True),    # partial + deep: uninstall
+        ],
+    )
+    def test_policy_matrix(
+        self,
+        tmp_path: Path,
+        stack_filter: list[str] | None,
+        deep: bool,
+        expected_uninstall: bool,
+    ) -> None:
+        step = UninstallHelmStep()
+        ctx = _StubContext(
+            rendered_stacks=[
+                _write_stack(tmp_path, "stack-a", wva_ns="ns1", model_id="modelA"),
+            ],
+            stack_filter=stack_filter,
+            deep_clean=deep,
+        )
+        cmd = _StubCmd()
+
+        step._teardown_wva(cmd, ctx, errors=[])
+
+        assert _controller_was_uninstalled(cmd) == expected_uninstall, (
+            f"stack_filter={stack_filter}, deep={deep}: "
+            f"expected uninstall={expected_uninstall}, "
+            f"helm calls={cmd.helm_calls}"
+        )


### PR DESCRIPTION
# Fix WVA controller teardown for partial-stack scenarios

## Summary

Make the per-namespace WVA controller (`workload-variant-autoscaler` helm release) follow the user's intent based on the `--stack` filter:

- **Full-scenario teardown** (no `--stack` filter) — controller is **uninstalled**. No remaining stacks of this scenario depend on it.
- **Partial-stack teardown** (`--stack X`) — controller is **preserved**. Sibling stacks of this scenario in the same namespace still need it to autoscale.
- **`--deep`** — controller is uninstalled regardless of the filter (deep wins).

Previously, the controller was preserved unless `--deep` was passed, which meant a normal full-scenario teardown left the WVA helm release sitting in the namespace.

The actual `helm uninstall workload-variant-autoscaler` loop below is unchanged — it just runs in one more case now.

## Invariants preserved

- Per-stack `VariantAutoscaling` + `HPA` are still always deleted (model stops auto-scaling on every teardown).
- `prometheus-adapter`, the `prometheus-ca` ConfigMap, and the `allow-thanos-querier-api-access` ClusterRole are still **never** removed by teardown — not even with `--deep`. They're shared cluster-wide infrastructure managed once at the cluster level; removing them on a per-tenant teardown would silently break every other namespace's autoscaling.
- Non-OpenShift platforms still skip WVA teardown entirely (standup never installs WVA off-OpenShift).