### PR TITLE
Remove -f in llmdbenchmark run

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ llmdbenchmark --version
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
 | `--stack NAME[,NAME...]` | `LLMDBENCH_STACK` | Restrict per-stack execution to the named subset. Useful in multi-stack scenarios (e.g. `guides/multi-model-wva`) to re-deploy a single pool without touching siblings. Unknown names fail loudly. |
-| `-f` / `--monitoring` | `LLMDBENCH_MONITORING` | Enable PodMonitor creation and EPP verbosity during standup |
+| `--monitoring` | `LLMDBENCH_MONITORING` | Enable PodMonitor creation and EPP verbosity during standup |
 | `--skip-smoketest` | | Skip automatic smoketest after standup completes |
 | `--affinity` | `LLMDBENCH_AFFINITY` | Node affinity / tolerations label |
 | `--annotations` | `LLMDBENCH_ANNOTATIONS` | Extra annotations for deployed resources |
@@ -473,7 +473,7 @@ llmdbenchmark --version
 | `--generate-config` | | Generate config and exit |
 | `-x DATASET` | `LLMDBENCH_DATASET` | Dataset URL for harness replay |
 | `--wait-timeout N` | `LLMDBENCH_WAIT_TIMEOUT` | Seconds to wait for harness completion |
-| `-f` / `--monitoring` | | Enable metrics scraping and EPP log capture during benchmark |
+| `--monitoring` | | Enable metrics scraping and EPP log capture during benchmark |
 | `-q` / `--serviceaccount` | `LLMDBENCH_SERVICE_ACCOUNT` | Service account name for harness pods |
 | `-g` / `--envvarspod` | `LLMDBENCH_HARNESS_ENVVARS_TO_YAML` | Comma-separated env var names to propagate into harness pod |
 | `--analyze` | | Run local analysis on results after collection |

--- a/config/README.md
+++ b/config/README.md
@@ -1269,7 +1269,7 @@ The `--monitoring` and `--no-monitoring` flags control monitoring across both st
 - Ensures PodMonitor resources are created for Prometheus scraping of vLLM pods
 - Sets EPP verbosity to 4 (richer logs for post-run analysis)
 
-**`--monitoring` (run / `-f`):**
+**`--monitoring` (run):**
 - Sets `metricsScrapeEnabled: true` — harness pods run `collect_metrics.sh` to scrape `/metrics` from all vLLM pods during the benchmark
 - After each treatment, captures model-serving, EPP, and IGW pod logs
 - Runs `process_epp_logs.py` on captured EPP logs to extract scheduling metrics
@@ -1283,7 +1283,7 @@ The `--monitoring` and `--no-monitoring` flags control monitoring across both st
 - Scenario defaults from `defaults.yaml` apply as-is
 - By default, `monitoring.podmonitor.enabled: true` (PodMonitors are created at standup)
 - By default, `monitoring.metricsScrapeEnabled: false` (harness does not scrape metrics during run)
-- To enable metrics scraping during run, pass `-f` / `--monitoring` explicitly
+- To enable metrics scraping during run, pass `--monitoring` explicitly
 
 **Environment variable:** `LLMDBENCH_MONITORING=true` or `LLMDBENCH_MONITORING=false` can be used as an alternative to the CLI flags. The CLI flag takes precedence when both are set.
 

--- a/docs/metrics_collection.md
+++ b/docs/metrics_collection.md
@@ -38,11 +38,11 @@ Harness Pod (in-cluster)
 
 ## Configuration
 
-Metrics collection can be enabled via CLI (`llmdbenchmark run -f` / `--monitoring`) or via scenario config. The CLI flag sets `metricsScrapeEnabled: true` at runtime, overriding the scenario default.
+Metrics collection can be enabled via CLI (`llmdbenchmark run --monitoring`) or via scenario config. The CLI flag sets `metricsScrapeEnabled: true` at runtime, overriding the scenario default.
 
 | Environment Variable | Default | Description |
 |---|---|---|
-| `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED` | `false` | Enable/disable metrics collection. Set automatically when `--monitoring` / `-f` is passed. |
+| `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED` | `false` | Enable/disable metrics collection. Set automatically when `--monitoring` is passed. |
 | `METRICS_COLLECTION_INTERVAL` | `15` | Seconds between collection snapshots |
 | `LLMDBENCH_VLLM_COMMON_METRICS_PORT` | `8200` | Prometheus metrics port (modelservice) |
 | `LLMDBENCH_VLLM_COMMON_INFERENCE_PORT` | `8000` | Fallback port (standalone vLLM) |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -7,7 +7,7 @@ The `--monitoring` and `--no-monitoring` flags provide CLI control over monitori
 ```bash
 # Enable monitoring: creates PodMonitors at standup, enables metrics scraping during run
 llmdbenchmark standup -s <scenario> --monitoring
-llmdbenchmark run -f   # -f is shorthand for --monitoring
+llmdbenchmark run --monitoring
 
 # Disable monitoring: skips PodMonitor and GAIE ServiceMonitor creation
 # Use when the cluster lacks Prometheus CRDs (e.g. GKE without GMP enabled)
@@ -22,7 +22,7 @@ See [config/README.md — Monitoring and Metrics](../config/README.md#monitoring
 
 ### Benchmark-Built-In Metrics
 
-The benchmark collects metrics automatically during runs when `metricsScrapeEnabled: true` is set in the scenario config (or when `--monitoring` / `-f` is passed on the CLI). This includes:
+The benchmark collects metrics automatically during runs when `metricsScrapeEnabled: true` is set in the scenario config (or when `--monitoring` is passed on the CLI). This includes:
 
 - **vLLM Prometheus metrics** — KV cache usage, GPU/CPU cache and memory, request queues, prefix cache hit rates, NIXL KV transfers, preemptions (scraped every 15s)
 - **EPP Prometheus metrics** — Pool-level gauges (KV cache utilization, queue size, ready pods), scheduler/plugin/request duration histograms, token distributions, P/D decision counters

--- a/docs/run.md
+++ b/docs/run.md
@@ -212,7 +212,7 @@ names fail loudly with a list of valid ones. Available via
 |------|----------------------|
 | `-p / --namespace` | Applies to every stack (namespaces are scenario-wide). |
 | `-t / --methods` | Applies to every stack. |
-| `-f / --monitoring` | Applies to every stack. |
+| `--monitoring` | Applies to every stack. |
 | `-u / --wva` | Applies to every stack. |
 | `-l / --harness`, `-w / --workload`, `-o / --overrides` | Applies to every stack's harness pod - all stacks run the same workload. |
 | `-j / --parallelism` | Applies to every stack - each stack launches N parallel harness pods. |

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -73,7 +73,7 @@ Provisions model infrastructure from a specification. Implicitly generates a pla
 | `-b` / `--annotations` | `LLMDBENCH_ANNOTATIONS` | Pod annotations |
 | `-r` / `--release` | `LLMDBENCH_RELEASE` | Helm chart release name |
 | `-u` / `--wva` | `LLMDBENCH_WVA` | Enable Workload Variant Autoscaler |
-| `-f` / `--monitoring` | -- | Enable PodMonitor and metrics scraping |
+| `--monitoring` | -- | Enable PodMonitor and metrics scraping |
 | `--parallel` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
 | `-k` / `--kubeconfig` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--skip-smoketest` | -- | Skip automatic post-standup smoketests |
@@ -113,7 +113,7 @@ Executes benchmark experiments against deployed infrastructure.
 | `-j` / `--parallelism` | `LLMDBENCH_PARALLELISM` | Parallel harness pods |
 | `--wait-timeout` | `LLMDBENCH_WAIT_TIMEOUT` | Wait timeout in seconds (0 = don't wait) |
 | `-x` / `--dataset` | `LLMDBENCH_DATASET` | Dataset URL for replay |
-| `-f` / `--monitoring` | -- | Enable metrics scraping and log capture |
+| `--monitoring` | -- | Enable metrics scraping and log capture |
 | `-q` / `--serviceaccount` | `LLMDBENCH_SERVICE_ACCOUNT` | Service account for harness pods |
 | `-g` / `--envvarspod` | `LLMDBENCH_HARNESS_ENVVARS_TO_YAML` | Env vars to propagate to harness pods |
 | `-z` / `--skip` | -- | Skip execution, collect existing results only |

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -133,7 +133,6 @@ def add_subcommands(parser: argparse._SubParsersAction):
 
     # Monitoring
     run_parser.add_argument(
-        "-f",
         "--monitoring",
         action="store_true",
         default=None,

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -455,7 +455,7 @@ class RenderPlans:
     def _resolve_monitoring(self, values: dict) -> dict:
         """Override monitoring based on ``--monitoring`` / ``--no-monitoring``.
 
-        When enabled (``--monitoring`` on standup, ``-f`` on run):
+        When enabled (``--monitoring``):
         - ``podmonitor.enabled`` → PodMonitor CRDs created for Prometheus
         - ``metricsScrapeEnabled`` → harness scrapes vLLM /metrics during run
 

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -17,7 +17,7 @@ llmdbenchmark --spec guides/pd-disaggregation run -p <NS> \
 
 # Run with monitoring (metrics scraping + pod log capture)
 llmdbenchmark --spec guides/pd-disaggregation run -p <NS> \
-  -l inference-perf -w sanity_random.yaml -f
+  -l inference-perf -w sanity_random.yaml --monitoring
 
 # Run with a different harness
 llmdbenchmark --spec guides/pd-disaggregation run -p <NS> \
@@ -110,7 +110,7 @@ llmdbenchmark --spec guides/inference-scheduling run -p <NS> -z
 | `-U URL` | `LLMDBENCH_ENDPOINT_URL` | Explicit endpoint URL -- enables run-only mode, skips auto-detection |
 | `-c FILE` | | Run config YAML file -- enables run-only mode |
 | `--generate-config` | | Generate a run config YAML from current settings and exit |
-| `-f` | `LLMDBENCH_MONITORING` | Enable vLLM metrics scraping and pod log capture |
+| `--monitoring` | `LLMDBENCH_MONITORING` | Enable vLLM metrics scraping and pod log capture |
 | `-q SA` | `LLMDBENCH_SERVICE_ACCOUNT` | Service account for harness pods |
 | `-g VARS` | `LLMDBENCH_HARNESS_ENVVARS_TO_YAML` | Comma-separated env var names to propagate into harness pod |
 | `-e FILE` | `LLMDBENCH_EXPERIMENTS` | Experiment treatments YAML for parameter sweeping |
@@ -219,10 +219,10 @@ results to a separate subdirectory on the PVC.
 
 ```bash
 llmdbenchmark --spec guides/pd-disaggregation run -p <NS> \
-  -l inference-perf -w sanity_random.yaml -f
+  -l inference-perf -w sanity_random.yaml --monitoring
 ```
 
-With `-f`, the run:
+With `--monitoring`, the run:
 
 1. Sets `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED=true` on the harness pod --
    the harness entrypoint scrapes vLLM `/metrics` before and after each benchmark

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -41,14 +41,14 @@ After standup completes, smoketests run automatically as a separate phase. The s
 
 Use `--skip-smoketest` to skip the automatic post-standup smoketests. They can also be run independently via `llmdbenchmark smoketest`. See [smoketests/README.md](../smoketests/README.md) for details.
 
-## `-f` / `--monitoring` Flag
+## `--monitoring` Flag
 
-When passed, `-f` enables monitoring infrastructure during standup:
+When passed, `--monitoring` enables monitoring infrastructure during standup:
 
 - Creates PodMonitor resources for Prometheus to scrape vLLM pods
 - Sets EPP (inference scheduler) log verbosity to level 4 for detailed scheduling diagnostics
 
-This is separate from the run-phase `-f` flag, which controls metrics scraping and log capture during benchmark execution.
+This is separate from the run-phase `--monitoring` flag, which controls metrics scraping and log capture during benchmark execution.
 
 ## Dry-Run Behavior
 


### PR DESCRIPTION
Remove `-f` in `llmdbenchmark run` for the consistency with `llmdbenchmark standup` 