### PR TITLE
FMA teardown hangs due to finalizer not being deleted properly plus CKS and GKE do not need capacity checks for FMA

### DIFF
--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -279,6 +279,12 @@ class WorkloadMonitoringStep(Step):
             for key, value in affinity["nodeSelector"].items():
                 selectors.append(("affinity.nodeSelector", key, str(value)))
 
+        # FMA deploys launcher pods, not standalone/decode/prefill vLLM pods.
+        # Skip their acceleratorType validation.
+        is_fma = plan_config.get("fma", {}).get("enabled", False)
+        if is_fma:
+            return
+
         for method in ("standalone", "decode", "prefill"):
             method_config = plan_config.get(method, {})
             if not method_config:

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -59,6 +59,12 @@ class UninstallHelmStep(Step):
 
         is_fma_enabled = "fma" in context.deployed_methods
 
+        # Delete FMA CRs before uninstalling the Helm chart so the
+        # controller is still running and can remove pod finalizers.
+        if is_fma_enabled:
+            for ns in namespaces:
+                self._delete_fma_crs(cmd, context, ns)
+
         for ns in namespaces:
             self._uninstall_releases(cmd, context, ns, release, model_labels, errors)
             if not is_fma_enabled:
@@ -86,6 +92,40 @@ class UninstallHelmStep(Step):
             success=True,
             message="Helm releases uninstalled",
         )
+
+    def _delete_fma_crs(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        namespace: str,
+    ) -> None:
+        """Deletes LauncherPopulationPolicy, InferenceServerConfig, and
+        LauncherConfig so the dual-pods controller can remove pod
+        finalizers before the Helm chart uninstall takes the controller down.
+        """
+        fma_cr_kinds = [
+            "launcherpopulationpolicy",
+            "inferenceserverconfig",
+            "launcherconfig",
+        ]
+        for kind in fma_cr_kinds:
+            result = cmd.kube(
+                "get", kind, "--namespace", namespace,
+                "-o", "name", "--ignore-not-found",
+                check=False,
+            )
+            if not result.success or not result.stdout.strip():
+                continue
+            for cr in result.stdout.strip().splitlines():
+                context.logger.log_info(
+                    f"  Deleting FMA CR {cr} (before Helm uninstall)",
+                    emoji="🗑️",
+                )
+                cmd.kube(
+                    "delete", "--namespace", namespace,
+                    "--ignore-not-found=true",
+                    cr, check=False,
+                )
 
     def _collect_model_labels(self, context: ExecutionContext) -> list[str]:
         """Collect model ID labels used to match helm releases."""

--- a/llmdbenchmark/utilities/capacity_validator.py
+++ b/llmdbenchmark/utilities/capacity_validator.py
@@ -417,6 +417,11 @@ def run_capacity_planner(
             "(deployment will halt if validation fails)"
         )
 
+    is_fma = plan_config.get("fma", {}).get("enabled", False)
+    if is_fma:
+        log.log_info("Deployment method is fma -- skipping vLLM capacity validation")
+        return all_messages
+
     standalone = plan_config.get("standalone", {})
     is_standalone = (
         standalone.get("enabled", False) and int(standalone.get("replicas", 0)) > 0


### PR DESCRIPTION
Issues seen in nightly CI runs:

1. CKS and GKE: 
```2026-04-30 08:58:15,450 - INFO    -     | Validating vLLM configuration against Capacity Planner (deployment will continue even if validation fails)
2026-04-30 08:58:15,451 - INFO    -     | Deployment method is modelservice -- checking decode and prefill configurations
2026-04-30 08:58:15,451 - INFO    -     | Validating decode vLLM arguments for ['facebook/opt-125m'] ...
2026-04-30 08:58:15,517 - WARNING - ⚠️     | [decode] WARNING: maxModelLen=16384 exceeds model limit of 2048 for facebook/opt-125m
2026-04-30 08:58:15,517 - INFO    -     | [decode] 80 GB per GPU, 80 x 0.95 (gpu_memory_utilization) = 76.0 GB available
2026-04-30 08:58:15,517 - INFO    -     | [decode] Each replica requires 1 GPUs, total available GPU memory = 76.0 GB
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
2026-04-30 08:58:15,598 - WARNING - ⚠️     | [decode] WARNING: Cannot estimate model memory or KV cache for facebook/opt-125m: 'facebook/opt-125m' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files.
2026-04-30 08:58:15,599 - ERROR   - ❌     | Validation error: Node selector label 'nvidia.com/gpu.product=NVIDIA-H100-80GB-HBM3' (from decode.acceleratorType) not found on any cluster node. Pods using this selector will be stuck in Pending.
2026-04-30 08:58:15,599 - ERROR   - ❌ [03] FAILED: [03] workload_monitoring: FAILED - Resource validation / monitoring had errors
2026-04-30 08:58:15,598 - INFO    -     | prefill is disabled or has 0 replicas -- skipping
2026-04-30 08:58:15,599 - ERROR   - ❌ Standup failed:
Phase: standup
Global errors: 1
  - Global step 03 (workload_monitoring) failed
Failed global steps: 1
  - [03] workload_monitoring: FAILED - Resource validation / monitoring had errors
Error: Process completed with exit code 1.
```

2. OCP:
FMA teardown hangs sometimes: FMA launcher and requester pods have finalizers set by the dual-pods controller. Previously, the Helm chart (which includes the controller) was uninstalled first (`llm-d-benchmark/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py`), leaving the controller dead before the FMA CRs were deleted (`llmdbenchmark/teardown/steps/step_03_delete_resources.py`). With no controller running to process CR deletions and remove finalizers, pod deletion would hang indefinitely. The fix deletes the FMA CR (LauncherPopulationPolicy, InferenceServerConfig, LauncherConfig) before the Helm uninstall, while the controller is still running and able to remove finalizers and terminate pods gracefully. Maybe there's another way to order these deletions??