### PR TITLE
Fixes problem running llmdbenchmark from within the cluster

### DIFF
--- a/llmdbenchmark/utilities/cluster.py
+++ b/llmdbenchmark/utilities/cluster.py
@@ -532,10 +532,10 @@ def _server_from_kubeconfig_data(data: dict) -> str | None:
     current_ctx = data.get("current-context", "")
     if not current_ctx:
         return None
-    for ctx in data.get("contexts", []):
+    for ctx in data.get("contexts") or []:
         if ctx.get("name") == current_ctx:
             cluster_ref = ctx.get("context", {}).get("cluster", "")
-            for cluster_entry in data.get("clusters", []):
+            for cluster_entry in data.get("contexts") or []:
                 if cluster_entry.get("name") == cluster_ref:
                     return cluster_entry.get("cluster", {}).get("server")
     return None
@@ -551,10 +551,10 @@ def _resolve_cluster_metadata(cmd: CommandExecutor, context: ExecutionContext) -
 
     context.context_name = data.get("current-context", "")
 
-    for ctx in data.get("contexts", []):
+    for ctx in data.get("contexts") or []:
         if ctx.get("name") == context.context_name:
             cluster_ref = ctx.get("context", {}).get("cluster", "")
-            for cluster_entry in data.get("clusters", []):
+            for cluster_entry in data.get("clusters") or []:
                 if cluster_entry.get("name") == cluster_ref:
                     server = cluster_entry.get("cluster", {}).get("server", "")
                     context.cluster_server = server


### PR DESCRIPTION
This PR fixes enables llmdbenchmark to be run successfully from within the cluster.

I ran:

```
llmdbenchmark --spec /tmp/llmdbench-config/spec.yaml.j2 --non-admin standup -p kalantar
```

From a tekton task running in the cluster. It failed with this error:

```
[install-and-standup] 2026-05-01 13:32:29,966 - WARNING - ⚠️ Could not create context.ctx -- subsequent steps will use default kubeconfig
[install-and-standup] Traceback (most recent call last):
[install-and-standup]   File "/workspace/source/llm-d-benchmark/.venv/bin/llmdbenchmark", line 8, in <module>
[install-and-standup]     sys.exit(cli())
[install-and-standup]              ^^^^^
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/cli.py", line 1736, in cli
[install-and-standup]     dispatch_cli(args, logger)
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/cli.py", line 141, in dispatch_cli
[install-and-standup]     _execute_standup(args, logger, render_plan_errors)
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/cli.py", line 459, in _execute_standup
[install-and-standup]     context, result = _do_standup(args, logger, render_plan_errors)
[install-and-standup]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/cli.py", line 448, in _do_standup
[install-and-standup]     result = executor.execute(step_spec=step_spec)
[install-and-standup]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/executor/step_executor.py", line 51, in execute
[install-and-standup]     self.context.resolve_cluster()
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/executor/context.py", line 148, in resolve_cluster
[install-and-standup]     _resolve(self)
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/utilities/cluster.py", line 47, in resolve_cluster
[install-and-standup]     _resolve_cluster_metadata(cmd, context)
[install-and-standup]   File "/workspace/source/llm-d-benchmark/llmdbenchmark/utilities/cluster.py", line 554, in _resolve_cluster_metadata
[install-and-standup]     for ctx in data.get("contexts", []):
[install-and-standup]                ^^^^^^^^^^^^^^^^^^^^^^^^
[install-and-standup] TypeError: 'NoneType' object is not iterable
```