### PR TITLE
feat: expose model_id_label as ${model.idLabel} for use in extraObjec…

### DIFF
--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -605,6 +605,8 @@ class RenderPlans:
         else:
             values["model_id_label"] = model.get("shortName", "")
 
+        model["idLabel"] = values["model_id_label"]
+
         return values
 
     # Defaults whose "bare" form collides across multi-stack scenarios -

--- a/tests/test_config_variable_substitution.py
+++ b/tests/test_config_variable_substitution.py
@@ -128,3 +128,30 @@ class TestSubstituteConfigVariables:
         }
         result = renderer._substitute_config_variables(values)
         assert result["field"] == "max len is 32768"
+
+
+class TestModelIdLabelAlias:
+    """Tests that _resolve_model_id_label exposes model_id_label as model.idLabel."""
+
+    def test_model_id_label_available_as_dotted_path(self, renderer):
+        """${model.idLabel} resolves to the computed model_id_label value."""
+        values = {
+            "model": {"name": "meta-llama/Llama-3.2-1B-Instruct"},
+            "namespace": {"name": "benchmark"},
+            "extraObjects": [
+                {
+                    "apiVersion": "inference.networking.x-k8s.io/v1alpha2",
+                    "kind": "InferenceObjective",
+                    "spec": {"poolRef": {"name": "${model.idLabel}-gaie"}},
+                }
+            ],
+        }
+        resolved = renderer._resolve_model_id_label(values)
+        result = renderer._substitute_config_variables(resolved)
+
+        expected_label = resolved["model_id_label"]
+        assert expected_label, "model_id_label should be computed"
+        assert (
+            result["extraObjects"][0]["spec"]["poolRef"]["name"]
+            == f"{expected_label}-gaie"
+        )


### PR DESCRIPTION
Fixes https://github.com/llm-d/llm-d-benchmark/issues/1102

Aliases the computed model_id_label into the model dict so the existing ${dotted.path} substitution mechanism can resolve it. This lets scenarios reference it, using `${model.idLabel}`. 