### PR TITLE
Feature: Added lint and format check to the CI/CD Pipeline

### DIFF
--- a/.github/workflows/ci-pr-lint-and-format.yaml
+++ b/.github/workflows/ci-pr-lint-and-format.yaml
@@ -1,0 +1,25 @@
+name: CI - PR Lint and Format Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ruff-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6.0.2
+
+      # 1. Run Linting (Checks only, does not modify any files)
+      - name: Run Ruff Lint Check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check --diff"
+
+      # 2. Run Formatting Check (Fails if code isn't formatted, but won't modify any files)
+      - name: Run Ruff Format Check
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"


### PR DESCRIPTION
Part of #938, this change introduces a new workflow step where ruff is used to check whether the files within a PR pass the lint and format rules. As we are in the process of formatting the codebase, we can merge this change once all the files are brought up to date and we are ready to enforce the lint/format rules going forward on new PRs.