### PR TITLE
style: fix linting part 1

### DIFF
--- a/docs/analysis/aggregate_runs.py
+++ b/docs/analysis/aggregate_runs.py
@@ -35,7 +35,6 @@ import json
 import math
 import os
 import sys
-from pathlib import Path
 
 try:
     import yaml

--- a/docs/analysis/analysis.ipynb
+++ b/docs/analysis/analysis.ipynb
@@ -62,7 +62,6 @@
     "    plot_scenario,\n",
     "    plot_scenario_tradeoff,\n",
     "    plot_pareto_tradeoff,\n",
-    "    plot_col_histogram,\n",
     "    plot_scenario_histogram,\n",
     ")\n",
     "\n",

--- a/experimental/multi-turn/production-trace-replay-qwen.py
+++ b/experimental/multi-turn/production-trace-replay-qwen.py
@@ -1,33 +1,27 @@
 import asyncio
 import json
 import logging
-import sys
 import os
 import argparse
 import functools
 import numpy as np
 
 from dataclasses import dataclass
-from typing import Generator, List, Optional, Tuple, Dict, Any
+from typing import Generator, List, Optional, Dict, Any
 from pydantic import ConfigDict, Field
 
 from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData
 from inference_perf.apis.completion import CompletionAPIData
-from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
-from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData, InferenceInfo
+from inference_perf.apis.base import InferenceInfo
 from inference_perf.client.modelserver.vllm_client import vLLMModelServerClient
 from inference_perf.client.requestdatacollector.multiprocess import MultiprocessRequestDataCollector
 from aiohttp import ClientResponse
-import random
-import time
 from inference_perf.config import (
     APIConfig,
     APIType,
     DataConfig,
     LoadConfig,
     StandardLoadStage,
-    ModelServerClientConfig,
-    ModelServerType,
     CustomTokenizerConfig,
     LoadType,
     ReportConfig,
@@ -43,7 +37,6 @@ from inference_perf.loadgen.load_generator import LoadGenerator
 from inference_perf.loadgen.load_timer import LoadTimer
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.reportgen.base import ReportGenerator
-from inference_perf.client.metricsclient.base import StageRuntimeInfo
 from inference_perf.client.metricsclient import PerfRuntimeParameters
 
 # Configure logging
@@ -377,7 +370,7 @@ async def main():
     limit = args.limit
     trace_file = args.trace_file
     
-    logger.info(f"Starting Multi-turn Benchmark")
+    logger.info("Starting Multi-turn Benchmark")
     logger.info(f"Model: {model_name}")
     logger.info(f"Base URL: {base_url}")
     logger.info(f"Limit: {limit}")

--- a/llmdbenchmark/analysis/visualize_metrics.py
+++ b/llmdbenchmark/analysis/visualize_metrics.py
@@ -12,7 +12,6 @@ import sys
 import glob
 import re
 from datetime import datetime
-from pathlib import Path
 
 try:
     import matplotlib

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -618,7 +618,7 @@ def _print_standup_summary(context, result, logger):
 
     W = 62
     logger.log_info("=" * W)
-    logger.log_info(f"  STANDUP COMPLETE")
+    logger.log_info("  STANDUP COMPLETE")
     logger.log_info("=" * W)
     logger.log_info(f"  User:       {username}")
     logger.log_info(f"  Platform:   {platform}")
@@ -655,7 +655,7 @@ def _print_standup_summary(context, result, logger):
 
     if endpoints:
         logger.log_info("-" * W)
-        logger.log_info(f"  Deployed Endpoints:")
+        logger.log_info("  Deployed Endpoints:")
         for name, url in endpoints.items():
             logger.log_info(f"    {name}: {url}")
 


### PR DESCRIPTION
Part 1 of fixing lint errors with ruff. Related to #938.

The following errors have been fixed:

```bash
F401 [*] `pathlib.Path` imported but unused
  --> docs/analysis/aggregate_runs.py:38:21
   |
36 | import os
37 | import sys
38 | from pathlib import Path
   |                     ^^^^
39 |
40 | try:
   |
help: Remove unused import: `pathlib.Path`

F401 [*] `plotting.plot_col_histogram` imported but unused
  --> docs/analysis/analysis.ipynb:cell 4:21:5
   |
19 |     plot_scenario_tradeoff,
20 |     plot_pareto_tradeoff,
21 |     plot_col_histogram,
   |     ^^^^^^^^^^^^^^^^^^
22 |     plot_scenario_histogram,
23 | )
   |
help: Remove unused import: `plotting.plot_col_histogram`

F401 [*] `sys` imported but unused
 --> experimental/multi-turn/production-trace-replay-qwen.py:4:8
  |
2 | import json
3 | import logging
4 | import sys
  |        ^^^
5 | import os
6 | import argparse
  |
help: Remove unused import: `sys`

F401 [*] `typing.Tuple` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:11:47
   |
10 | from dataclasses import dataclass
11 | from typing import Generator, List, Optional, Tuple, Dict, Any
   |                                               ^^^^^
12 | from pydantic import ConfigDict, Field
   |
help: Remove unused import: `typing.Tuple`

F401 [*] `inference_perf.apis.user_session.LocalUserSession` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:16:46
   |
14 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData 15 | from inference_perf.apis.completion import CompletionAPIData 16 | from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
   |                                              ^^^^^^^^^^^^^^^^
17 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData, InferenceInfo
18 | from inference_perf.client.modelserver.vllm_client import vLLMModelServerClient
   |
help: Remove unused import

F401 [*] `inference_perf.apis.user_session.UserSessionCompletionAPIData` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:16:64
   |
14 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData 15 | from inference_perf.apis.completion import CompletionAPIData 16 | from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
   |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData, InferenceInfo
18 | from inference_perf.client.modelserver.vllm_client import vLLMModelServerClient
   |
help: Remove unused import

F811 [*] Redefinition of unused `InferenceAPIData` from line 14
  --> experimental/multi-turn/production-trace-replay-qwen.py:14:38
   |
12 | from pydantic import ConfigDict, Field
13 |
14 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData
   |                                      ---------------- previous definition of `InferenceAPIData` here
15 | from inference_perf.apis.completion import CompletionAPIData
16 | from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
17 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData, InferenceInfo
   |                                      ^^^^^^^^^^^^^^^^ `InferenceAPIData` redefined here
18 | from inference_perf.client.modelserver.vllm_client import vLLMModelServerClient
19 | from inference_perf.client.requestdatacollector.multiprocess import MultiprocessRequestDataCollector
   |
help: Remove definition: `InferenceAPIData`

F811 [*] Redefinition of unused `LazyLoadInferenceAPIData` from line 14
  --> experimental/multi-turn/production-trace-replay-qwen.py:14:56
   |
12 | from pydantic import ConfigDict, Field
13 |
14 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData
   |                                                        ------------------------ previous definition of `LazyLoadInferenceAPIData` here
15 | from inference_perf.apis.completion import CompletionAPIData
16 | from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
17 | from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData, InferenceInfo
   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^ `LazyLoadInferenceAPIData` redefined here
18 | from inference_perf.client.modelserver.vllm_client import vLLMModelServerClient
19 | from inference_perf.client.requestdatacollector.multiprocess import MultiprocessRequestDataCollector
   |
help: Remove definition: `LazyLoadInferenceAPIData`

F401 [*] `random` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:21:8
   |
19 | from inference_perf.client.requestdatacollector.multiprocess import MultiprocessRequestDataCollector 20 | from aiohttp import ClientResponse
21 | import random
   |        ^^^^^^
22 | import time
23 | from inference_perf.config import (
   |
help: Remove unused import: `random`

F401 [*] `time` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:22:8
   |
20 | from aiohttp import ClientResponse
21 | import random
22 | import time
   |        ^^^^
23 | from inference_perf.config import (
24 |     APIConfig,
   |
help: Remove unused import: `time`

F401 [*] `inference_perf.config.ModelServerClientConfig` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:29:5
   |
27 |     LoadConfig,
28 |     StandardLoadStage,
29 |     ModelServerClientConfig,
   |     ^^^^^^^^^^^^^^^^^^^^^^^
30 |     ModelServerType,
31 |     CustomTokenizerConfig,
   |
help: Remove unused import

F401 [*] `inference_perf.config.ModelServerType` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:30:5
   |
28 |     StandardLoadStage,
29 |     ModelServerClientConfig,
30 |     ModelServerType,
   |     ^^^^^^^^^^^^^^^
31 |     CustomTokenizerConfig,
32 |     LoadType,
   |
help: Remove unused import

F401 [*] `inference_perf.client.metricsclient.base.StageRuntimeInfo` imported but unused
  --> experimental/multi-turn/production-trace-replay-qwen.py:46:54
   |
44 | from inference_perf.utils.custom_tokenizer import CustomTokenizer 45 | from inference_perf.reportgen.base import ReportGenerator 46 | from inference_perf.client.metricsclient.base import StageRuntimeInfo
   |                                                      ^^^^^^^^^^^^^^^^
47 | from inference_perf.client.metricsclient import PerfRuntimeParameters
   |
help: Remove unused import: `inference_perf.client.metricsclient.base.StageRuntimeInfo`

F541 [*] f-string without any placeholders
   --> experimental/multi-turn/production-trace-replay-qwen.py:380:17
    |
378 |     trace_file = args.trace_file
379 |
380 |     logger.info(f"Starting Multi-turn Benchmark")
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
381 |     logger.info(f"Model: {model_name}")
382 |     logger.info(f"Base URL: {base_url}")
    |
help: Remove extraneous `f` prefix

F401 [*] `pathlib.Path` imported but unused
  --> llmdbenchmark/analysis/visualize_metrics.py:15:21
   |
13 | import re
14 | from datetime import datetime
15 | from pathlib import Path
   |                     ^^^^
16 |
17 | try:
   |
help: Remove unused import: `pathlib.Path`

F541 [*] f-string without any placeholders
   --> llmdbenchmark/cli.py:621:21
    |
619 |     W = 62
620 |     logger.log_info("=" * W)
621 |     logger.log_info(f"  STANDUP COMPLETE")
    |                     ^^^^^^^^^^^^^^^^^^^^^
622 |     logger.log_info("=" * W)
623 |     logger.log_info(f"  User:       {username}")
    |
help: Remove extraneous `f` prefix

F541 [*] f-string without any placeholders
   --> llmdbenchmark/cli.py:658:25
    |
656 |     if endpoints:
657 |         logger.log_info("-" * W)
658 |         logger.log_info(f"  Deployed Endpoints:")
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^
659 |         for name, url in endpoints.items():
660 |             logger.log_info(f"    {name}: {url}")
    |
help: Remove extraneous `f` prefix
```