### PR TITLE
Otel trace replay workload

### DIFF
--- a/workload/profiles/inference-perf/otel_traces.yaml.in
+++ b/workload/profiles/inference-perf/otel_traces.yaml.in
@@ -1,0 +1,32 @@
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+      num_sessions: 2
+      session_rate: 1.0
+    - concurrent_sessions: 5
+      num_sessions: 5
+      session_rate: 1.0
+  worker_max_concurrency: 200
+api:
+  type: chat
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: otel_trace_replay
+  otel_trace_replay:
+    trace_directory: REPLACE_ENV_LLMDBENCH_RUN_DATASET_DIR/REPLACE_ENV_LLMDBENCH_RUN_DATASET_FILE
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace


### PR DESCRIPTION
inference-perf 0.5.0 now supports Open telemetry trace replay. This PR adds a sample benchmark using that functionality

*N.B.* For this to work, the `ghcr.io/llm-d/llm-d-benchmark` needs to be rebuild to include the inference-perf at version >= 0.5.0 