### PR TITLE
[Standup] Fixes for spyre accelerator in multiple architectures

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -56,8 +56,8 @@ WORKDIR /workspace
 # Install harnesses
 
 ARG INFERENCE_PERF_REPO=https://github.com/kubernetes-sigs/inference-perf.git
-ARG INFERENCE_PERF_BRANCH=main
-ARG INFERENCE_PERF_COMMIT=v0.4.0
+ARG INFERENCE_PERF_BRANCH=release-v0.5.0
+ARG INFERENCE_PERF_COMMIT=v0.5.0
 RUN git clone --branch ${INFERENCE_PERF_BRANCH} ${INFERENCE_PERF_REPO}
 RUN cd inference-perf; \
     git checkout ${INFERENCE_PERF_COMMIT}; \
@@ -91,8 +91,8 @@ RUN cd vllm; VLLM_TARGET_DEVICE=empty pip install -e . --no-build-isolation
 
 # GuideLLM also requires torch, installed above
 ARG GUIDELLM_REPO=https://github.com/vllm-project/guidellm.git
-ARG GUIDELLM_BRANCH=v0.5.4
-ARG GUIDELLM_COMMIT=v0.5.4
+ARG GUIDELLM_BRANCH=v0.6.0
+ARG GUIDELLM_COMMIT=v0.6.0
 RUN git clone --branch ${GUIDELLM_BRANCH} ${GUIDELLM_REPO}
 RUN cd guidellm; \
     git checkout ${GUIDELLM_COMMIT}; \

--- a/config/scenarios/cicd/gke.yaml
+++ b/config/scenarios/cicd/gke.yaml
@@ -79,7 +79,7 @@ scenario:
         customCommand: |
           export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
           export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-          vllm serve /model-storage/$MODEL_PATH \
+          vllm serve /model-cache/$MODEL_PATH \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_INFERENCE_PORT \

--- a/config/scenarios/examples/spyre-s390x.yaml
+++ b/config/scenarios/examples/spyre-s390x.yaml
@@ -211,7 +211,7 @@ scenario:
 
       # -----------------------------------------------------------------------
       # Model is not pre-compiled , so vllm is taking around to 17 min for coming up completely
-      # Added Startup probe for 1200 sec 
+      # Added Startup probe for 1200 sec
       # Then validating liveness on /health & readiness o n /v1/models
       # -----------------------------------------------------------------------
 
@@ -237,10 +237,10 @@ scenario:
       resources:
         limits:
           memory: 200Gi
-          cpu: "8"
+          cpu: "4"
         requests:
           memory: 200Gi
-          cpu: "8"
+          cpu: "4"
 
       vllm:
         customCommand: |
@@ -331,7 +331,7 @@ scenario:
       #     maxNumSeq: 32
       #
       # Model is not pre-compiled , so vllm is taking around to 17 min for coming up completely
-      # Added Startup probe for 1200 sec 
+      # Added Startup probe for 1200 sec
       # Then validating liveness on /health & readiness o n /v1/models
 
       probes:

--- a/config/scenarios/examples/spyre.yaml
+++ b/config/scenarios/examples/spyre.yaml
@@ -201,7 +201,7 @@ scenario:
 
       vllm:
         customCommand: |
-          /home/senuser/container-scripts/simple_vllm_serve.sh /model-storage/$MODEL_PATH \
+          /home/senuser/container-scripts/simple_vllm_serve.sh /model-cache/$MODEL_PATH \
           --served-model-name $MODEL_NAME \
           --port $VLLM_INFERENCE_PORT \
           --max-model-len $VLLM_MAX_MODEL_LEN \

--- a/config/templates/jinja/14_standalone-deployment_yaml.j2
+++ b/config/templates/jinja/14_standalone-deployment_yaml.j2
@@ -8,7 +8,7 @@
 
    Volume handling:
      Uses vllmCommon.volumes/volumeMounts as the dynamic base (shared with
-     modelservice), plus a conditional model-storage PVC and any additional
+     modelservice), plus a conditional model-cache PVC and any additional
      volumes defined in standalone.additionalVolumes/additionalVolumeMounts.
      This matches the original bash behavior where ALL volumes are injected
      dynamically — no hard-coded volumes.
@@ -411,7 +411,7 @@ spec:
 {% endfor %}
 {# Conditional model storage volume mount #}
 {% if standalone.mountModelVolume %}
-        - name: model-storage
+        - name: model-cache
           mountPath: {{ standalone.modelMountPath }}
           readOnly: true
 {% endif %}
@@ -611,7 +611,7 @@ spec:
 {% endif %}
 {% endfor %}
 {% if standalone.mountModelVolume %}
-        - name: model-storage
+        - name: model-cache
           mountPath: {{ standalone.modelMountPath }}
           readOnly: true
 {% endif %}
@@ -666,7 +666,7 @@ spec:
 {% endfor %}
 {# Conditional model storage PVC volume #}
 {% if standalone.mountModelVolume %}
-      - name: model-storage
+      - name: model-cache
         persistentVolumeClaim:
           claimName: {{ standalone.modelPvcName }}
 {% endif %}

--- a/config/templates/jinja/24_fma-deployment.yaml.j2
+++ b/config/templates/jinja/24_fma-deployment.yaml.j2
@@ -110,13 +110,13 @@ spec:
               nvidia.com/gpu: "1"
           volumeMounts:
 {% if fma.mountModelVolume %}
-          - name: model-storage
+          - name: model-cache
             mountPath: {{ fma.modelMountPath }}
             readOnly: False
 {% endif %}
       volumes:
 {% if fma.mountModelVolume %}
-      - name: model-storage
+      - name: model-cache
         persistentVolumeClaim:
           claimName: {{ fma.modelPvcName }}
 {% endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1111,7 +1111,7 @@ standalone:
   # NOTE: The model PVC is standalone-specific (not in vllmCommon.volumes)
   # because modelservice handles its own model volume via the Helm chart.
   mountModelVolume: true
-  modelMountPath: /model-storage
+  modelMountPath: /model-cache
   modelPvcName: model-pvc
 
   # Launcher container (optional second container in the same pod)

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-05-06 13:38:37` (UTC)
-- Generated against git ref: `ce85e9272f48542ff6435062b3dd6ac0127b666e`
+- Generated at: `2026-05-06 17:39:38` (UTC)
+- Generated against git ref: `3da85b8644d889ad48f823da422a1825fea86c37`
 
 ## System Tool Dependencies
 
@@ -23,11 +23,11 @@ whatever the host's package manager provides.
 | **curl** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [curl/curl](https://github.com/curl/curl) |
 | **git** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [git/git](https://github.com/git/git) |
 | **helm** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [helm/helm](https://github.com/helm/helm) |
-| **helm-diff** | `latest` | plugin (latest) | `install.sh` line 580 (`helm_diff_url`) | [databus23/helm-diff](https://github.com/databus23/helm-diff) |
-| **helmfile** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [helmfile/helmfile](https://github.com/helmfile/helmfile) |
+| **helm-diff** | `latest` | plugin (latest) | `install.sh` line 677 (`helm_diff_url`) | [databus23/helm-diff](https://github.com/databus23/helm-diff) |
+| **helmfile** | `1.1.3` | version | `install.sh` line 499 (`install_helmfile_linux`) | [helmfile/helmfile](https://github.com/helmfile/helmfile) |
 | **jq** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [jqlang/jq](https://github.com/jqlang/jq) |
 | **kustomize** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) |
-| **llm-d-planner (git)** | `e50305af90f0812e77e1827f3bc740fe75b76370` | commit SHA | `install.sh` line 677 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
+| **llm-d-planner (git)** | `e50305af90f0812e77e1827f3bc740fe75b76370` | commit SHA | `install.sh` line 769 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
 | **oc** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [openshift/oc](https://github.com/openshift/oc) |
 | **skopeo** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [containers/skopeo](https://github.com/containers/skopeo) |
 | **yq** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | [mikefarah/yq](https://github.com/mikefarah/yq) |
@@ -89,121 +89,3 @@ captured in the snapshot table below.
 | **PyYAML** | `(unpinned)` | (unpinned) | `pyproject.toml` line 7 | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
 | **requests** | `(unpinned)` | (unpinned) | `pyproject.toml` line 9 | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **transformers** | `(unpinned)` | (unpinned) | `pyproject.toml` line 16 | [transformers (PyPI)](https://pypi.org/project/transformers/) |
-
-
-## Python Package Dependencies (installed snapshot)
-
-Output of `pip freeze` against the project venv (`.venv`). Includes
-every transitive dependency actually installed; direct deps are
-annotated with their `pyproject.toml` line.
-
-<details>
-<summary>Click to expand the full pip-freeze snapshot</summary>
-
-| Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
-|---|---|---|---|---|
-| **aiohappyeyeballs** | `2.6.1` | version | (transitive in `.venv`) | [aiohappyeyeballs (PyPI)](https://pypi.org/project/aiohappyeyeballs/) |
-| **aiohttp** | `3.13.5` | version | (transitive in `.venv`) | [aiohttp (PyPI)](https://pypi.org/project/aiohttp/) |
-| **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
-| **annotated-doc** | `0.0.4` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
-| **annotated-types** | `0.7.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
-| **anyio** | `4.13.0` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
-| **attrs** | `26.1.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
-| **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
-| **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
-| **certifi** | `2026.4.22` | version | (transitive in `.venv`) | [certifi (PyPI)](https://pypi.org/project/certifi/) |
-| **cffi** | `2.0.0` | version | (transitive in `.venv`) | [cffi (PyPI)](https://pypi.org/project/cffi/) |
-| **cfgv** | `3.5.0` | version | (transitive in `.venv`) | [cfgv (PyPI)](https://pypi.org/project/cfgv/) |
-| **chardet** | `6.0.0.post1` | version | (transitive in `.venv`) | [chardet (PyPI)](https://pypi.org/project/chardet/) |
-| **charset-normalizer** | `3.4.7` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
-| **click** | `8.3.3` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
-| **cryptography** | `48.0.0` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
-| **detect_secrets** | `38ba7e335083e0a4db8c53e9be414795b27891e9` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
-| **distlib** | `0.4.0` | version | (transitive in `.venv`) | [distlib (PyPI)](https://pypi.org/project/distlib/) |
-| **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
-| **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
-| **fastapi** | `0.136.1` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
-| **filelock** | `3.29.0` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
-| **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
-| **fsspec** | `2026.4.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
-| **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
-| **GitPython** | `3.1.50` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
-| **google-auth** | `2.50.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
-| **h11** | `0.16.0` | version | (transitive in `.venv`) | [h11 (PyPI)](https://pypi.org/project/h11/) |
-| **hf-xet** | `1.5.0` | version | (transitive in `.venv`) | [hf-xet (PyPI)](https://pypi.org/project/hf-xet/) |
-| **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
-| **httptools** | `0.7.1` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
-| **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
-| **huggingface_hub** | `1.13.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
-| **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
-| **idna** | `3.13` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
-| **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
-| **Jinja2** | `3.1.6` | version | `pyproject.toml` line 8 (direct) | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
-| **jiter** | `0.14.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |
-| **kubernetes** | `35.0.0` | version | `pyproject.toml` line 11 (direct) | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
-| **kubernetes_asyncio** | `35.0.1` | version | (transitive in `.venv`) | [kubernetes_asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
-| **llm-optimizer** | `bb82d22e8863b762e856be66e831d551d27576b1` | commit SHA | (transitive in `.venv`) | [llm-optimizer (PyPI)](https://pypi.org/project/llm-optimizer/) |
-| **llmdbenchmark** | `editable` | editable | (transitive in `.venv`) | [llmdbenchmark (PyPI)](https://pypi.org/project/llmdbenchmark/) |
-| **markdown-it-py** | `4.0.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
-| **MarkupSafe** | `3.0.3` | version | (transitive in `.venv`) | [MarkupSafe (PyPI)](https://pypi.org/project/markupsafe/) |
-| **mdurl** | `0.1.2` | version | (transitive in `.venv`) | [mdurl (PyPI)](https://pypi.org/project/mdurl/) |
-| **multidict** | `6.7.1` | version | (transitive in `.venv`) | [multidict (PyPI)](https://pypi.org/project/multidict/) |
-| **nodeenv** | `1.10.0` | version | (transitive in `.venv`) | [nodeenv (PyPI)](https://pypi.org/project/nodeenv/) |
-| **numpy** | `2.4.4` | version | (transitive in `.venv`) | [numpy (PyPI)](https://pypi.org/project/numpy/) |
-| **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
-| **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
-| **ollama** | `0.6.1` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
-| **openai** | `2.34.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
-| **packaging** | `26.2` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
-| **pandas** | `3.0.2` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
-| **planner** | `e50305af90f0812e77e1827f3bc740fe75b76370` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
-| **platformdirs** | `4.9.6` | version | (transitive in `.venv`) | [platformdirs (PyPI)](https://pypi.org/project/platformdirs/) |
-| **pluggy** | `1.6.0` | version | (transitive in `.venv`) | [pluggy (PyPI)](https://pypi.org/project/pluggy/) |
-| **pre_commit** | `4.6.0` | version | (transitive in `.venv`) | [pre_commit (PyPI)](https://pypi.org/project/pre-commit/) |
-| **propcache** | `0.4.1` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
-| **psutil** | `7.2.2` | version | (transitive in `.venv`) | [psutil (PyPI)](https://pypi.org/project/psutil/) |
-| **psycopg2-binary** | `2.9.12` | version | (transitive in `.venv`) | [psycopg2-binary (PyPI)](https://pypi.org/project/psycopg2-binary/) |
-| **pyasn1** | `0.6.3` | version | (transitive in `.venv`) | [pyasn1 (PyPI)](https://pypi.org/project/pyasn1/) |
-| **pyasn1_modules** | `0.4.2` | version | (transitive in `.venv`) | [pyasn1_modules (PyPI)](https://pypi.org/project/pyasn1-modules/) |
-| **pycparser** | `3.0` | version | (transitive in `.venv`) | [pycparser (PyPI)](https://pypi.org/project/pycparser/) |
-| **pydantic** | `2.13.3` | version | `pyproject.toml` line 17 (direct) | [pydantic (PyPI)](https://pypi.org/project/pydantic/) |
-| **pydantic-settings** | `2.14.0` | version | (transitive in `.venv`) | [pydantic-settings (PyPI)](https://pypi.org/project/pydantic-settings/) |
-| **pydantic_core** | `2.46.3` | version | (transitive in `.venv`) | [pydantic_core (PyPI)](https://pypi.org/project/pydantic-core/) |
-| **Pygments** | `2.20.0` | version | (transitive in `.venv`) | [Pygments (PyPI)](https://pypi.org/project/pygments/) |
-| **PyJWT** | `2.12.1` | version | (transitive in `.venv`) | [PyJWT (PyPI)](https://pypi.org/project/pyjwt/) |
-| **pykube-ng** | `23.6.0` | version | `pyproject.toml` line 12 (direct) | [pykube-ng (PyPI)](https://pypi.org/project/pykube-ng/) |
-| **pytest** | `9.0.3` | version | (transitive in `.venv`) | [pytest (PyPI)](https://pypi.org/project/pytest/) |
-| **python-dateutil** | `2.9.0.post0` | version | (transitive in `.venv`) | [python-dateutil (PyPI)](https://pypi.org/project/python-dateutil/) |
-| **python-discovery** | `1.3.0` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
-| **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
-| **python-multipart** | `0.0.27` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
-| **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
-| **regex** | `2026.4.4` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
-| **requests** | `2.33.1` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
-| **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
-| **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
-| **rich** | `15.0.0` | version | (transitive in `.venv`) | [rich (PyPI)](https://pypi.org/project/rich/) |
-| **safetensors** | `0.7.0` | version | (transitive in `.venv`) | [safetensors (PyPI)](https://pypi.org/project/safetensors/) |
-| **scipy** | `1.17.1` | version | (transitive in `.venv`) | [scipy (PyPI)](https://pypi.org/project/scipy/) |
-| **shellingham** | `1.5.4` | version | (transitive in `.venv`) | [shellingham (PyPI)](https://pypi.org/project/shellingham/) |
-| **six** | `1.17.0` | version | (transitive in `.venv`) | [six (PyPI)](https://pypi.org/project/six/) |
-| **smmap** | `5.0.3` | version | (transitive in `.venv`) | [smmap (PyPI)](https://pypi.org/project/smmap/) |
-| **sniffio** | `1.3.1` | version | (transitive in `.venv`) | [sniffio (PyPI)](https://pypi.org/project/sniffio/) |
-| **starlette** | `1.0.0` | version | (transitive in `.venv`) | [starlette (PyPI)](https://pypi.org/project/starlette/) |
-| **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
-| **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
-| **tqdm** | `4.67.3` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
-| **transformers** | `5.8.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
-| **typer** | `0.25.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
-| **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
-| **typing_extensions** | `4.15.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
-| **urllib3** | `2.6.3` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
-| **uvicorn** | `0.46.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
-| **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
-| **virtualenv** | `21.3.1` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
-| **watchfiles** | `1.1.1` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
-| **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
-| **websockets** | `16.0` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
-| **yarl** | `1.23.0` | version | (transitive in `.venv`) | [yarl (PyPI)](https://pypi.org/project/yarl/) |
-
-</details>

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -19,8 +19,6 @@ from llmdbenchmark.utilities.endpoint import (
     test_model_serving,
 )
 
-from llmdbenchmark.smoketests.curl_plat import get_curl_image
-
 _RETRYABLE_INDICATORS = ("502", "503", "504", "ServiceUnavailable", "not ready")
 
 # Roles whose pod count is HPA-managed when WVA is enabled. The replica
@@ -1146,7 +1144,7 @@ class BaseSmoketest:
         protocol = "https" if str(port) == "443" else "http"
         prefix = _normalize_url_prefix(url_path_prefix)
         url = f"{protocol}://{host}:{port}{prefix}/health"
-        curl_image = get_curl_image()
+        curl_image = "quay.io/fedora/fedora"
         override_args = _build_overrides(plan_config)
 
         context.logger.log_info(
@@ -1179,7 +1177,6 @@ class BaseSmoketest:
                 + override_args
                 + ["--command", "--", "sh", "-c", curl_cmd]
             )
-
             result = cmd.kube(*kubectl_args, check=False)
 
             if result.dry_run:
@@ -1470,7 +1467,7 @@ class BaseSmoketest:
         timeout_seconds: int = 120,
     ) -> tuple[str, str | None]:
         override_args = _build_overrides(plan_config)
-        curl_image = get_curl_image()
+        curl_image = "quay.io/fedora/fedora"
         pod_name = f"inference-test-{_rand_suffix()}"
         payload_json = json.dumps(payload)
         payload_b64 = base64.b64encode(payload_json.encode()).decode()

--- a/llmdbenchmark/standup/steps/step_10_smoketest.py
+++ b/llmdbenchmark/standup/steps/step_10_smoketest.py
@@ -16,8 +16,6 @@ from llmdbenchmark.utilities.endpoint import (
     test_model_serving,
 )
 
-from llmdbenchmark.smoketests.curl_plat import get_curl_image
-
 class SmoketestStep(Step):
     """Validate deployment health and model serving via smoketests."""
 
@@ -266,7 +264,7 @@ class SmoketestStep(Step):
         """
         protocol = "https" if str(port) == "443" else "http"
         url = f"{protocol}://{host}:{port}/health"
-        curl_image = get_curl_image()
+        curl_image = "quay.io/fedora/fedora"
         override_args = _build_overrides(plan_config)
 
         context.logger.log_info(

--- a/llmdbenchmark/standup/steps/step_11_inference_test.py
+++ b/llmdbenchmark/standup/steps/step_11_inference_test.py
@@ -29,8 +29,6 @@ from llmdbenchmark.utilities.endpoint import (
     find_gateway_endpoint,
 )
 
-from llmdbenchmark.smoketests.curl_plat import get_curl_image
-
 # Transient HTTP status codes / error substrings that warrant a retry.
 _RETRYABLE_INDICATORS = ("502", "503", "504", "ServiceUnavailable", "not ready")
 
@@ -417,7 +415,7 @@ class InferenceTestStep(Step):
         avoid shell quoting issues when passing through kubectl to sh -c.
         """
         override_args = _build_overrides(plan_config)
-        curl_image = get_curl_image()
+        curl_image = "quay.io/fedora/fedora"
         pod_name = f"inference-test-{_rand_suffix()}"
         payload_json = json.dumps(payload)
         payload_b64 = base64.b64encode(payload_json.encode()).decode()

--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -10,7 +10,6 @@ import string
 import time
 
 from llmdbenchmark.executor.command import CommandExecutor
-from llmdbenchmark.smoketests.curl_plat import get_curl_image
 
 def _rand_suffix(length: int = 8) -> str:
     """Generate a random lowercase alphanumeric suffix for pod names."""
@@ -503,7 +502,7 @@ def test_model_serving(
     protocol = "https" if str(port) == "443" else "http"
     prefix = _normalize_url_prefix(url_path_prefix)
     url = f"{protocol}://{host}:{port}{prefix}/v1/models"
-    
+
     # Auto-ensure service account and RBAC
     sa_name = service_account or (plan_config.get("serviceAccount", {}).get("name") if plan_config else "default")
     if sa_name:
@@ -512,7 +511,7 @@ def test_model_serving(
             if not sa_check.success or "not found" in (sa_check.stderr + sa_check.stdout).lower():
                 cmd.logger.log_info(f"ServiceAccount '{sa_name}' not found, auto-creating it...")
                 cmd.kube("create", "sa", sa_name, "--namespace", namespace, check=False)
-        
+
         # Always ensure the required RBAC role exists
         role_name = f"{sa_name}-role"
         role_check = cmd.kube("get", "role", role_name, "--namespace", namespace, check=False)
@@ -524,7 +523,7 @@ def test_model_serving(
                 "--namespace", namespace,
                 check=False
             )
-            
+
             # Always ensure RoleBinding
             binding_name = f"{sa_name}-binding"
             cmd.kube(
@@ -536,7 +535,7 @@ def test_model_serving(
             )
 
     override_args = _build_overrides(plan_config, service_account=service_account)
-    curl_image = get_curl_image()
+    curl_image = "quay.io/fedora/fedora"
     last_error: str | None = None
 
     for attempt in range(1, max_retries + 1):


### PR DESCRIPTION
This include standardize the mount name for stacks stood up by either method (`standalone` or `pvc`) and selecting a `smoketest` image with suppor for all relevant architectures (`quay.io/fedora/fedora`)

[Run] Additionally, upgraded the version for `inference-perf` and `GuideLLM`