### PR TITLE
fix: FMA nightly benchmark crash so removed --max-model-len and running standalone before FMA

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-cks.yaml
+++ b/.github/workflows/ci-nightly-benchmark-cks.yaml
@@ -40,14 +40,14 @@ jobs:
   benchmark-fma:
     name: Benchmark - FMA (CKS)
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [build-image, benchmark-standalone]
     timeout-minutes: 240
 
     env:
       LLMDBENCH_CICD_NS: llmdbenchcicdfns-cks
       LLMDBENCH_CICD_R: llmdbenchcicdrf-cks
       LLMDBENCH_CICD_TARGET: cicd/cks-fma
-      LLMDBENCH_CICD_METHOD: fma,standalone
+      LLMDBENCH_CICD_METHOD: fma
       LLMDBENCH_WORKSPACE: /tmp/llmdbenchcicdf-cks
       LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
 
@@ -145,15 +145,39 @@ jobs:
           echo "=== Events ==="
           kubectl get events -n "$NS" --sort-by='.lastTimestamp' | tail -30 || true
 
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip  >/dev/null 2>&1
+          sudo ./aws/install || sudo ./aws/install --update
+          aws --version
+
+#      - name: Upload results to IBM COS
+#        env:
+#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#        run: |
+#          aws configure set default.s3.signature_version s3v4
+#          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
+#            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
+
+      - name: Download standalone results
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results-cks-standalone
+          path: /tmp/standalone-results
+        continue-on-error: true
+
       - name: Display benchmark results
         if: always()
         run: |
           echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           found=0
-          for f in $(find "$LLMDBENCH_WORKSPACE" -path "*/analysis/result.txt" 2>/dev/null | sort); do
+          for f in $(find "$LLMDBENCH_WORKSPACE" /tmp/standalone-results -path "*/analysis/*" \( -name "result.txt" -o -name "summary.txt" \) 2>/dev/null | sort || true); do
             found=1
-            stack_dir=$(basename "$(dirname "$(dirname "$f")")")
+            stack_dir=$(basename "$(dirname "$f")")
             echo "### $stack_dir" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             cat "$f" >> "$GITHUB_STEP_SUMMARY"
@@ -166,11 +190,11 @@ jobs:
         shell: bash
 
       - name: Archive benchmark results as GitHub artifact
-        if: always()
-        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: benchmark-results-cks-fma
-          path: /tmp/llmdbenchcicdf-cks/runner-*/results/
+          path: ${{ env.LLMDBENCH_WORKSPACE }}
           retention-days: 14
 
   benchmark-standalone:
@@ -300,13 +324,13 @@ jobs:
 #          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
 #            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
 
-#      - name: Archive benchmark results as GitHub artifact
-#        if: success() || failure()
-#        uses: actions/upload-artifact@v7.0.1
-#        with:
-#          name: ${{ env.OUTPUT_DIR }}
-#          path: ${{ env.INPUT_DIR }}
-#          retention-days: 14
+      - name: Archive benchmark results as GitHub artifact
+        if: success() || failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: benchmark-results-cks-standalone
+          path: ${{ env.LLMDBENCH_WORKSPACE }}
+          retention-days: 14
 
   benchmark-modelservice:
     name: Benchmark - ModelService (CKS)

--- a/.github/workflows/ci-nightly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke.yaml
@@ -40,14 +40,14 @@ jobs:
   benchmark-fma:
     name: Benchmark - FMA (GKE)
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [build-image, benchmark-standalone]
     timeout-minutes: 240
 
     env:
       LLMDBENCH_CICD_NS: llmdbenchcicdfns-gke
       LLMDBENCH_CICD_R: llmdbenchcicdr-gke
       LLMDBENCH_CICD_TARGET: cicd/gke-fma
-      LLMDBENCH_CICD_METHOD: fma,standalone
+      LLMDBENCH_CICD_METHOD: fma
       LLMDBENCH_WORKSPACE: /tmp/llmdbenchcicdf-gke
       GCP_PROJECT_ID: llm-d-scale
       GKE_CLUSTER_NAME: llm-d-e2e-us-east5
@@ -132,6 +132,7 @@ jobs:
           llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" run -p "$LLMDBENCH_CICD_NS" -t "$LLMDBENCH_CICD_METHOD"
         shell: bash
 
+
       - name: Teardown (standalone)
         if: always()
         run: |
@@ -159,15 +160,39 @@ jobs:
           echo "=== Events ==="
           kubectl get events -n "$NS" --sort-by='.lastTimestamp' | tail -30 || true
 
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip  >/dev/null 2>&1
+          sudo ./aws/install || sudo ./aws/install --update
+          aws --version
+
+#      - name: Upload results to IBM COS
+#        env:
+#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#        run: |
+#          aws configure set default.s3.signature_version s3v4
+#          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
+#            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
+
+      - name: Download standalone results
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results-gke-standalone
+          path: /tmp/standalone-results
+        continue-on-error: true
+
       - name: Display benchmark results
         if: always()
         run: |
           echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           found=0
-          for f in $(find "$LLMDBENCH_WORKSPACE" -path "*/analysis/result.txt" 2>/dev/null | sort); do
+          for f in $(find "$LLMDBENCH_WORKSPACE" /tmp/standalone-results -path "*/analysis/*" \( -name "result.txt" -o -name "summary.txt" \) 2>/dev/null | sort || true); do
             found=1
-            stack_dir=$(basename "$(dirname "$(dirname "$f")")")
+            stack_dir=$(basename "$(dirname "$f")")
             echo "### $stack_dir" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             cat "$f" >> "$GITHUB_STEP_SUMMARY"
@@ -180,11 +205,11 @@ jobs:
         shell: bash
 
       - name: Archive benchmark results as GitHub artifact
-        if: always()
-        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: benchmark-results-gke-fma
-          path: /tmp/llmdbenchcicdf-gke/runner-*/results/
+          path: ${{ env.LLMDBENCH_WORKSPACE }}
           retention-days: 14
 
   benchmark-standalone:
@@ -328,13 +353,13 @@ jobs:
 #          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
 #            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
 
-#      - name: Archive benchmark results as GitHub artifact
-#        if: success() || failure()
-#        uses: actions/upload-artifact@v7.0.1
-#        with:
-#          name: ${{ env.OUTPUT_DIR }}
-#          path: ${{ env.INPUT_DIR }}
-#          retention-days: 14
+      - name: Archive benchmark results as GitHub artifact
+        if: success() || failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: benchmark-results-gke-standalone
+          path: ${{ env.LLMDBENCH_WORKSPACE }}
+          retention-days: 14
 
   benchmark-modelservice:
     name: Benchmark - ModelService (GKE)

--- a/.github/workflows/ci-nightly-benchmark-ocp.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp.yaml
@@ -40,14 +40,14 @@ jobs:
   benchmark-fma:
     name: Benchmark - FMA (OCP)
     runs-on: [self-hosted, openshift, pok-prod]
-    needs: build-image
+    needs: [build-image, benchmark-standalone]
     timeout-minutes: 240
 
     env:
       LLMDBENCH_CICD_NS: llmdbenchcicdfns-ocp
       LLMDBENCH_CICD_R: llmdbenchcicdr-ocp
       LLMDBENCH_CICD_TARGET: cicd/ocp-fma
-      LLMDBENCH_CICD_METHOD: fma,standalone
+      LLMDBENCH_CICD_METHOD: fma
       LLMDBENCH_WORKSPACE: /tmp/llmdbenchcicdf-ocp
       LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
 
@@ -118,7 +118,7 @@ jobs:
           llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" run -p "$LLMDBENCH_CICD_NS" -t "$LLMDBENCH_CICD_METHOD"
         shell: bash
 
-      - name: Teardown (standalone)
+      - name: Teardown
         if: always()
         run: |
           llmdbenchmark --spec "$LLMDBENCH_CICD_TARGET" teardown -p "$LLMDBENCH_CICD_NS" -r "$LLMDBENCH_CICD_R" -t "$LLMDBENCH_CICD_METHOD"
@@ -145,15 +145,39 @@ jobs:
           echo "=== Events ==="
           kubectl get events -n "$NS" --sort-by='.lastTimestamp' | tail -30 || true
 
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip  >/dev/null 2>&1
+          sudo ./aws/install || sudo ./aws/install --update
+          aws --version
+
+#      - name: Upload results to IBM COS
+#        env:
+#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#        run: |
+#          aws configure set default.s3.signature_version s3v4
+#          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
+#            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
+
+      - name: Download standalone results
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results-ocp-standalone
+          path: /tmp/standalone-results
+        continue-on-error: true
+
       - name: Display benchmark results
         if: always()
         run: |
           echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           found=0
-          for f in $(find "$LLMDBENCH_WORKSPACE" -path "*/analysis/result.txt" 2>/dev/null | sort); do
+          for f in $(find "$LLMDBENCH_WORKSPACE" /tmp/standalone-results -path "*/analysis/*" \( -name "result.txt" -o -name "summary.txt" \) 2>/dev/null | sort || true); do
             found=1
-            stack_dir=$(basename "$(dirname "$(dirname "$f")")")
+            stack_dir=$(basename "$(dirname "$f")")
             echo "### $stack_dir" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
             cat "$f" >> "$GITHUB_STEP_SUMMARY"
@@ -166,11 +190,11 @@ jobs:
         shell: bash
 
       - name: Archive benchmark results as GitHub artifact
-        if: always()
-        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: benchmark-results-ocp-fma
-          path: /tmp/llmdbenchcicdf-ocp/runner-*/results/
+          path: ${{ env.LLMDBENCH_WORKSPACE }}
           retention-days: 14
 
   benchmark-standalone:
@@ -300,13 +324,13 @@ jobs:
 #          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
 #            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
 
-#      - name: Archive benchmark results as GitHub artifact
-#        if: success() || failure()
-#        uses: actions/upload-artifact@v7.0.1
-#        with:
-#          name: ${{ env.OUTPUT_DIR }}
-#          path: ${{ env.INPUT_DIR }}
-#          retention-days: 14
+      - name: Archive benchmark results as GitHub artifact
+        if: success() || failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: benchmark-results-ocp-standalone
+          path: ${{ env.LLMDBENCH_WORKSPACE }}
+          retention-days: 14
 
   benchmark-modelservice:
     name: Benchmark - ModelService (OCP)

--- a/config/scenarios/cicd/cks-fma.yaml
+++ b/config/scenarios/cicd/cks-fma.yaml
@@ -1,56 +1,9 @@
 # CKS (Cloud Kubernetes Service) CI/CD Scenario - FMA
-# Two scenarios: a standalone cold-start baseline, then FMA actuation.
-# Both use the nop harness to measure pod startup + TTFT.
+# Variant of cicd/cks.yaml for Fast Model Actuation (FMA) runs.
+# Uses nop harness since FMA manages its own endpoint discovery.
 
 scenario:
-  # Standalone cold-start baseline (no FMA, no launchers)
-  - name: "cks-cicd-baseline"
-
-    model:
-      name: facebook/opt-125m
-      shortName: facebook-opt-125m
-      path: models/facebook/opt-125m
-      huggingfaceId: facebook/opt-125m
-
-    modelservice:
-      enabled: false
-    standalone:
-      enabled: true
-      acceleratorType:
-        labelKey: gpu.nvidia.com/class
-        labelValue: H200
-    fma:
-      enabled: false
-
-    gateway:
-      className: agentgateway
-
-    affinity:
-      enabled: true
-      nodeSelector:
-        gpu.nvidia.com/class: H200
-
-    vllmCommon:
-      priorityClassName: nightly-gpu-critical
-
-    storage:
-      modelPvc:
-        storageClassName: shared-vast
-
-    workDir: /tmp/llmdbenchcicd-cks/
-
-    harness:
-      name: nop
-      experimentProfile: nop.yaml
-      executable: llm-d-benchmark.py
-
-    images:
-      benchmark:
-        repository: ghcr.io/llm-d/llm-d-benchmark
-        tag: nightly
-
-  # FMA actuation benchmark
-  - name: "cks-cicd-fma"
+  - name: "cks-cicd"
 
     model:
       name: facebook/opt-125m
@@ -64,7 +17,7 @@ scenario:
       enabled: false
     fma:
       enabled: true
-      iterations: 3
+      iterations: 5
 
     gateway:
       className: agentgateway

--- a/config/scenarios/cicd/gke-fma.yaml
+++ b/config/scenarios/cicd/gke-fma.yaml
@@ -1,55 +1,9 @@
 # GKE H100 CI/CD Scenario - FMA
-# Two scenarios: a standalone cold-start baseline, then FMA actuation.
-# Both use the nop harness to measure pod startup + TTFT.
+# Variant of cicd/gke.yaml for Fast Model Actuation (FMA) runs.
+# Uses nop harness since FMA manages its own endpoint discovery.
 
 scenario:
-  # Standalone cold-start baseline (no FMA, no launchers)
-  - name: "gke-cicd-baseline"
-
-    affinity:
-      enabled: true
-      nodeSelector:
-        cloud.google.com/gke-accelerator: nvidia-h100-80gb
-
-    inferenceExtension:
-      monitoring:
-        prometheus:
-          enabled: false
-
-    modelservice:
-      enabled: false
-    standalone:
-      enabled: true
-      acceleratorType:
-        labelKey: cloud.google.com/gke-accelerator
-        labelValue: nvidia-h100-80gb
-    fma:
-      enabled: false
-
-    vllmCommon:
-      priorityClassName: nightly-gpu-critical
-
-    storage:
-      modelPvc:
-        storageClassName: standard-rwx
-        size: 1Ti
-      workloadPvc:
-        storageClassName: standard-rwx
-
-    workDir: /tmp/llmdbenchcicd-gke/
-
-    harness:
-      name: nop
-      experimentProfile: nop.yaml
-      executable: llm-d-benchmark.py
-
-    images:
-      benchmark:
-        repository: ghcr.io/llm-d/llm-d-benchmark
-        tag: nightly
-
-  # FMA actuation benchmark
-  - name: "gke-cicd-fma"
+  - name: "gke-cicd"
 
     affinity:
       enabled: true
@@ -67,7 +21,7 @@ scenario:
       enabled: false
     fma:
       enabled: true
-      iterations: 3
+      iterations: 5
       launcher:
         customPreprocessCommands:
           - export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}

--- a/config/scenarios/cicd/ocp-fma.yaml
+++ b/config/scenarios/cicd/ocp-fma.yaml
@@ -1,49 +1,9 @@
 # OpenShift Container Platform CI/CD Scenario - FMA
-# Two scenarios: a standalone cold-start baseline, then FMA actuation.
-# Both use the nop harness to measure pod startup + TTFT.
+# Variant of cicd/ocp.yaml for Fast Model Actuation (FMA) runs.
+# Uses nop harness since FMA manages its own endpoint discovery.
 
 scenario:
-  # Standalone cold-start baseline (no FMA, no launchers)
-  - name: "ocp-cicd-baseline"
-
-    model:
-      name: facebook/opt-125m
-      shortName: facebook-opt-125m
-      path: models/facebook/opt-125m
-      huggingfaceId: facebook/opt-125m
-
-    affinity:
-      enabled: true
-      nodeSelector:
-        nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
-
-    modelservice:
-      enabled: false
-    standalone:
-      enabled: true
-      acceleratorType:
-        labelKey: nvidia.com/gpu.product
-        labelValue: NVIDIA-H100-80GB-HBM3
-    fma:
-      enabled: false
-
-    vllmCommon:
-      priorityClassName: nightly-gpu-critical
-
-    workDir: /tmp/llmdbenchcicd-ocp/
-
-    harness:
-      name: nop
-      experimentProfile: nop.yaml
-      executable: llm-d-benchmark.py
-
-    images:
-      benchmark:
-        repository: ghcr.io/llm-d/llm-d-benchmark
-        tag: nightly
-
-  # FMA actuation benchmark
-  - name: "ocp-cicd-fma"
+  - name: "ocp-cicd"
 
     model:
       name: facebook/opt-125m
@@ -62,7 +22,7 @@ scenario:
       enabled: false
     fma:
       enabled: true
-      iterations: 3
+      iterations: 5
 
     vllmCommon:
       priorityClassName: nightly-gpu-critical

--- a/config/templates/jinja/24_fma-deployment.yaml.j2
+++ b/config/templates/jinja/24_fma-deployment.yaml.j2
@@ -28,7 +28,7 @@ spec:
       VLLM_LOGGING_LEVEL: DEBUG
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_USE_V1: "1"
-    options: "--model {{ model.name }} --enable-sleep-mode --no-enable-prefix-caching --load-format auto --max-model-len 16384 --gpu-memory-utilization 0.95 --tensor-parallel-size 1"
+    options: "--model {{ model.name }} --enable-sleep-mode --no-enable-prefix-caching --load-format auto --gpu-memory-utilization 0.95 --tensor-parallel-size 1"
     port: 8005
 ---
 apiVersion: fma.llm-d.ai/v1alpha1

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-05-06 17:39:38` (UTC)
-- Generated against git ref: `3da85b8644d889ad48f823da422a1825fea86c37`
+- Generated at: `2026-05-11 07:49:54` (UTC)
+- Generated against git ref: `fabddc8f08611efb5c2f7b958b6bfd7f7cb60d26`
 
 ## System Tool Dependencies
 
@@ -60,7 +60,7 @@ generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **benchmark** | `v0.6.0` | tag | `config/templates/values/defaults.yaml` line 345 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
+| **benchmark** | `v0.6.2` | tag | `config/templates/values/defaults.yaml` line 345 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
 | **inferenceScheduler** | `v0.7.1` | tag | `config/templates/values/defaults.yaml` line 364 (`images.inferenceScheduler`) | [llm-d/llm-d-inference-scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`ghcr.io/llm-d/llm-d-inference-scheduler`) |
 | **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 383 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
 | **routingSidecar** | `v0.7.1` | tag | `config/templates/values/defaults.yaml` line 370 (`images.routingSidecar`) | [llm-d/llm-d-routing-sidecar](https://github.com/llm-d/llm-d-routing-sidecar) (`ghcr.io/llm-d/llm-d-routing-sidecar`) |
@@ -79,6 +79,7 @@ captured in the snapshot table below.
 |---|---|---|---|---|
 | **GitPython** | `(unpinned)` | (unpinned) | `pyproject.toml` line 14 | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
 | **google-auth** | `(unpinned)` | (unpinned) | `pyproject.toml` line 18 | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
+| **google-cloud-storage** | `>=2.10.0` | constraint | `pyproject.toml` line 19 | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
 | **huggingface_hub** | `(unpinned)` | (unpinned) | `pyproject.toml` line 15 | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
 | **Jinja2** | `(unpinned)` | (unpinned) | `pyproject.toml` line 8 | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
 | **kubernetes** | `(unpinned)` | (unpinned) | `pyproject.toml` line 11 | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
@@ -89,3 +90,138 @@ captured in the snapshot table below.
 | **PyYAML** | `(unpinned)` | (unpinned) | `pyproject.toml` line 7 | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
 | **requests** | `(unpinned)` | (unpinned) | `pyproject.toml` line 9 | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **transformers** | `(unpinned)` | (unpinned) | `pyproject.toml` line 16 | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+
+
+## Python Package Dependencies (installed snapshot)
+
+Output of `pip freeze` against the project venv (`.venv`). Includes
+every transitive dependency actually installed; direct deps are
+annotated with their `pyproject.toml` line.
+
+<details>
+<summary>Click to expand the full pip-freeze snapshot</summary>
+
+| Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
+|---|---|---|---|---|
+| **aiohappyeyeballs** | `2.6.1` | version | (transitive in `.venv`) | [aiohappyeyeballs (PyPI)](https://pypi.org/project/aiohappyeyeballs/) |
+| **aiohttp** | `3.13.3` | version | (transitive in `.venv`) | [aiohttp (PyPI)](https://pypi.org/project/aiohttp/) |
+| **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
+| **annotated-doc** | `0.0.4` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
+| **annotated-types** | `0.7.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
+| **anyio** | `4.12.1` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
+| **attrs** | `25.4.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
+| **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
+| **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
+| **certifi** | `2026.2.25` | version | (transitive in `.venv`) | [certifi (PyPI)](https://pypi.org/project/certifi/) |
+| **cffi** | `2.0.0` | version | (transitive in `.venv`) | [cffi (PyPI)](https://pypi.org/project/cffi/) |
+| **cfgv** | `3.5.0` | version | (transitive in `.venv`) | [cfgv (PyPI)](https://pypi.org/project/cfgv/) |
+| **chardet** | `6.0.0.post1` | version | (transitive in `.venv`) | [chardet (PyPI)](https://pypi.org/project/chardet/) |
+| **charset-normalizer** | `3.4.4` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
+| **click** | `8.3.1` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
+| **config_explorer** | `(unknown)` | commit SHA | (transitive in `.venv`) | [config_explorer (PyPI)](https://pypi.org/project/config-explorer/) |
+| **contourpy** | `1.3.3` | version | (transitive in `.venv`) | [contourpy (PyPI)](https://pypi.org/project/contourpy/) |
+| **cryptography** | `46.0.7` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
+| **cycler** | `0.12.1` | version | (transitive in `.venv`) | [cycler (PyPI)](https://pypi.org/project/cycler/) |
+| **detect_secrets** | `76a765c2b1a8928824a3d937ebeacf88354b86bb` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
+| **distlib** | `0.4.0` | version | (transitive in `.venv`) | [distlib (PyPI)](https://pypi.org/project/distlib/) |
+| **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
+| **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
+| **fastapi** | `0.136.0` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
+| **filelock** | `3.24.3` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
+| **fonttools** | `4.61.1` | version | (transitive in `.venv`) | [fonttools (PyPI)](https://pypi.org/project/fonttools/) |
+| **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
+| **fsspec** | `2026.2.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
+| **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
+| **GitPython** | `3.1.46` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
+| **google-api-core** | `2.30.3` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
+| **google-auth** | `2.52.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
+| **google-cloud-core** | `2.6.0` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
+| **google-cloud-storage** | `3.10.1` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
+| **google-crc32c** | `1.8.0` | version | (transitive in `.venv`) | [google-crc32c (PyPI)](https://pypi.org/project/google-crc32c/) |
+| **google-resumable-media** | `2.9.0` | version | (transitive in `.venv`) | [google-resumable-media (PyPI)](https://pypi.org/project/google-resumable-media/) |
+| **googleapis-common-protos** | `1.75.0` | version | (transitive in `.venv`) | [googleapis-common-protos (PyPI)](https://pypi.org/project/googleapis-common-protos/) |
+| **h11** | `0.16.0` | version | (transitive in `.venv`) | [h11 (PyPI)](https://pypi.org/project/h11/) |
+| **hf-xet** | `1.3.1` | version | (transitive in `.venv`) | [hf-xet (PyPI)](https://pypi.org/project/hf-xet/) |
+| **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
+| **httptools** | `0.7.1` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
+| **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
+| **huggingface_hub** | `1.4.1` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
+| **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
+| **idna** | `3.11` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
+| **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
+| **Jinja2** | `3.1.6` | version | `pyproject.toml` line 8 (direct) | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
+| **jiter** | `0.13.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |
+| **kiwisolver** | `1.4.9` | version | (transitive in `.venv`) | [kiwisolver (PyPI)](https://pypi.org/project/kiwisolver/) |
+| **kubernetes** | `35.0.0` | version | `pyproject.toml` line 11 (direct) | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
+| **kubernetes_asyncio** | `35.0.1` | version | (transitive in `.venv`) | [kubernetes_asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
+| **llm-optimizer** | `bb82d22e8863b762e856be66e831d551d27576b1` | commit SHA | (transitive in `.venv`) | [llm-optimizer (PyPI)](https://pypi.org/project/llm-optimizer/) |
+| **llmdbenchmark** | `editable` | editable | (transitive in `.venv`) | [llmdbenchmark (PyPI)](https://pypi.org/project/llmdbenchmark/) |
+| **markdown-it-py** | `4.0.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
+| **MarkupSafe** | `3.0.3` | version | (transitive in `.venv`) | [MarkupSafe (PyPI)](https://pypi.org/project/markupsafe/) |
+| **matplotlib** | `3.10.8` | version | (transitive in `.venv`) | [matplotlib (PyPI)](https://pypi.org/project/matplotlib/) |
+| **mdurl** | `0.1.2` | version | (transitive in `.venv`) | [mdurl (PyPI)](https://pypi.org/project/mdurl/) |
+| **multidict** | `6.7.1` | version | (transitive in `.venv`) | [multidict (PyPI)](https://pypi.org/project/multidict/) |
+| **nodeenv** | `1.10.0` | version | (transitive in `.venv`) | [nodeenv (PyPI)](https://pypi.org/project/nodeenv/) |
+| **numpy** | `2.4.2` | version | (transitive in `.venv`) | [numpy (PyPI)](https://pypi.org/project/numpy/) |
+| **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
+| **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
+| **ollama** | `0.6.1` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
+| **openai** | `2.24.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
+| **packaging** | `26.0` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
+| **pandas** | `3.0.2` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
+| **pillow** | `12.1.1` | version | (transitive in `.venv`) | [pillow (PyPI)](https://pypi.org/project/pillow/) |
+| **planner** | `f51812bebca30e0291ec541bd2ef2acf0572e8a4` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
+| **platformdirs** | `4.9.6` | version | (transitive in `.venv`) | [platformdirs (PyPI)](https://pypi.org/project/platformdirs/) |
+| **pluggy** | `1.6.0` | version | (transitive in `.venv`) | [pluggy (PyPI)](https://pypi.org/project/pluggy/) |
+| **pre_commit** | `4.6.0` | version | (transitive in `.venv`) | [pre_commit (PyPI)](https://pypi.org/project/pre-commit/) |
+| **propcache** | `0.4.1` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
+| **proto-plus** | `1.28.0` | version | (transitive in `.venv`) | [proto-plus (PyPI)](https://pypi.org/project/proto-plus/) |
+| **protobuf** | `7.34.1` | version | (transitive in `.venv`) | [protobuf (PyPI)](https://pypi.org/project/protobuf/) |
+| **psutil** | `7.2.2` | version | (transitive in `.venv`) | [psutil (PyPI)](https://pypi.org/project/psutil/) |
+| **psycopg2-binary** | `2.9.11` | version | (transitive in `.venv`) | [psycopg2-binary (PyPI)](https://pypi.org/project/psycopg2-binary/) |
+| **pyasn1** | `0.6.3` | version | (transitive in `.venv`) | [pyasn1 (PyPI)](https://pypi.org/project/pyasn1/) |
+| **pyasn1_modules** | `0.4.2` | version | (transitive in `.venv`) | [pyasn1_modules (PyPI)](https://pypi.org/project/pyasn1-modules/) |
+| **pycparser** | `3.0` | version | (transitive in `.venv`) | [pycparser (PyPI)](https://pypi.org/project/pycparser/) |
+| **pydantic** | `2.12.5` | version | `pyproject.toml` line 17 (direct) | [pydantic (PyPI)](https://pypi.org/project/pydantic/) |
+| **pydantic-settings** | `2.13.1` | version | (transitive in `.venv`) | [pydantic-settings (PyPI)](https://pypi.org/project/pydantic-settings/) |
+| **pydantic_core** | `2.41.5` | version | (transitive in `.venv`) | [pydantic_core (PyPI)](https://pypi.org/project/pydantic-core/) |
+| **Pygments** | `2.19.2` | version | (transitive in `.venv`) | [Pygments (PyPI)](https://pypi.org/project/pygments/) |
+| **PyJWT** | `2.12.1` | version | (transitive in `.venv`) | [PyJWT (PyPI)](https://pypi.org/project/pyjwt/) |
+| **pykube-ng** | `23.6.0` | version | `pyproject.toml` line 12 (direct) | [pykube-ng (PyPI)](https://pypi.org/project/pykube-ng/) |
+| **pyparsing** | `3.3.2` | version | (transitive in `.venv`) | [pyparsing (PyPI)](https://pypi.org/project/pyparsing/) |
+| **pytest** | `9.0.3` | version | (transitive in `.venv`) | [pytest (PyPI)](https://pypi.org/project/pytest/) |
+| **python-dateutil** | `2.9.0.post0` | version | (transitive in `.venv`) | [python-dateutil (PyPI)](https://pypi.org/project/python-dateutil/) |
+| **python-discovery** | `1.2.2` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
+| **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
+| **python-multipart** | `0.0.26` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
+| **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
+| **regex** | `2026.2.19` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
+| **requests** | `2.33.1` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
+| **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
+| **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
+| **rich** | `14.3.3` | version | (transitive in `.venv`) | [rich (PyPI)](https://pypi.org/project/rich/) |
+| **safetensors** | `0.7.0` | version | (transitive in `.venv`) | [safetensors (PyPI)](https://pypi.org/project/safetensors/) |
+| **scipy** | `1.17.1` | version | (transitive in `.venv`) | [scipy (PyPI)](https://pypi.org/project/scipy/) |
+| **shellingham** | `1.5.4` | version | (transitive in `.venv`) | [shellingham (PyPI)](https://pypi.org/project/shellingham/) |
+| **six** | `1.17.0` | version | (transitive in `.venv`) | [six (PyPI)](https://pypi.org/project/six/) |
+| **smmap** | `5.0.2` | version | (transitive in `.venv`) | [smmap (PyPI)](https://pypi.org/project/smmap/) |
+| **sniffio** | `1.3.1` | version | (transitive in `.venv`) | [sniffio (PyPI)](https://pypi.org/project/sniffio/) |
+| **starlette** | `1.0.0` | version | (transitive in `.venv`) | [starlette (PyPI)](https://pypi.org/project/starlette/) |
+| **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
+| **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
+| **tqdm** | `4.67.3` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
+| **transformers** | `5.2.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **typer** | `0.24.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
+| **typer-slim** | `0.24.0` | version | (transitive in `.venv`) | [typer-slim (PyPI)](https://pypi.org/project/typer-slim/) |
+| **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
+| **typing_extensions** | `4.15.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
+| **urllib3** | `2.6.3` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
+| **uvicorn** | `0.44.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
+| **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
+| **virtualenv** | `21.2.4` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
+| **watchfiles** | `1.1.1` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
+| **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
+| **websockets** | `16.0` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
+| **yarl** | `1.22.0` | version | (transitive in `.venv`) | [yarl (PyPI)](https://pypi.org/project/yarl/) |
+
+</details>


### PR DESCRIPTION
1. PR #1134 had a parser error with combined methods (`-t fma,standalone`): The FMA scenario files contained both standalone and fma scenario entries, and the workflow passed LLMDBENCH_CICD_METHOD: fma,standalone. The parser raised "Cannot enable both standalone and fma" because a single scenario file can't have both methods enabled simultaneously. Fix: *-fma.yaml now contains only the FMA scenario, with the standalone baseline running in its own job. FMA job now needs: [build-image, benchmark-standalone]

2. Modified artifact collection to enable standalone result archiving, download standalone results into FMA job for combined summary display, use LLMDBENCH_WORKSPACE env var for artifact path  
                                                                                                                                                                                                                                             
3. PR #1134 added displaying of FMA nightly benchmark results that exposed vLLM crash issue on startup: The ISC template (`24_fma-deployment.yaml.j2`) included --max-model-len 16384 in the vLLM options, but the benchmark model facebook/opt-125m has max_position_embeddings=2048. vLLM validates this on startup and crashes 
  immediately with ```ValidationError: User-specified max_model_len (16384) is greater than the derived max_model_len (max_position_embeddings=2048).``` Every iteration timed out waiting for a requester pod that could never become ready because the vLLM instance kept crashing and the results.txt was always empty!!
  
  
Test run with `cifix3` branch: https://github.com/llm-d/llm-d-benchmark/actions/runs/25661220432                                                                                                                                                                                                           