### PR TITLE
fix: correct 31 typos across multiple files

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -811,7 +811,7 @@ Two ports are involved in the vLLM serving configuration:
 - **Port 8000** (`decode.vllm.servicePort` / `prefill.vllm.servicePort`) -- the inference/service port. Kubernetes probes (startup, liveness, readiness) always check this port. When routing proxy is enabled, the proxy listens on 8000. When routing proxy is disabled, vLLM binds directly to 8000.
 - **Port 8200** (`decode.vllm.port`) -- the vLLM backend port. Only used in the `--port` flag of the vLLM command when routing proxy is enabled (proxy on 8000 forwards to vLLM on 8200). Not used for probes.
 
-Probe port is overrideable via `decode.vllm.servicePort` or `prefill.vllm.servicePort` in the scenario YAML. Individual per-probe port overrides are not supported (matches the original bash implementation).
+Probe port is overridable via `decode.vllm.servicePort` or `prefill.vllm.servicePort` in the scenario YAML. Individual per-probe port overrides are not supported (matches the original bash implementation).
 
 When routing proxy is **enabled** (modelservice only), vLLM binds to `decode.vllm.port` (default 8200) and the proxy handles `servicePort` (8000) to `vllmPort` (8200) forwarding. When routing proxy is **disabled**, vLLM binds directly to `decode.vllm.servicePort` (8000). In both cases, probes target the `servicePort` (8000).
 

--- a/llmdbenchmark/analysis/per_request_plots.py
+++ b/llmdbenchmark/analysis/per_request_plots.py
@@ -28,7 +28,7 @@ def generate_per_request_plots(
 
     Args:
         results_dir: Directory containing per_request_lifecycle_metrics.json.
-        output_dir: Where to write PNGs (default: results_dir/analysis/distributions).
+        output_dir: Where to write ONGs (default: results_dir/analysis/distributions).
         context: Optional execution context for logging.
 
     Returns:

--- a/llmdbenchmark/analysis/scripts/nop-analyze_results.py
+++ b/llmdbenchmark/analysis/scripts/nop-analyze_results.py
@@ -156,21 +156,21 @@ def write_benchmark_reports(file: io.TextIOWrapper, benchmark_report: BenchmarkR
 
     left_padding = 4
     for metadata in benchmark_report.metrics.metadata:
-        metadatas = metadata["value"]
+        metadata = metadata["value"]
         if metadata["name"] == "vllm_metrics":
-            write_vllm_metrics(file, metadatas, left_padding)
+            write_vllm_metrics(file, metadata, left_padding)
         elif metadata["name"] == "extra_metrics":
-            write_extra_metrics(file, metadatas)
+            write_extra_metrics(file, metadata)
         else:
             logger.info("Unhandled metrics name '%s'", metadata["name"])
 
 
 def write_vllm_metrics(  # pylint: disable=too-many-locals,too-many-statements
-    file: io.TextIOWrapper, metadatas: list[dict], left_padding: int
+    file: io.TextIOWrapper, metadata: list[dict], left_padding: int
 ):
     """prints vLLM metrics"""
 
-    for metrics_metadata in metadatas:
+    for metrics_metadata in metadata:
         name = metrics_metadata["name"]
         pod_start = metrics_metadata["pod_start"]["value"]
         vllm_start = (
@@ -227,7 +227,7 @@ def write_vllm_metrics(  # pylint: disable=too-many-locals,too-many-statements
             file.write(
                 "    Elapsed: Time it took to transition to vLLM sleep or wait\n\n"
             )
-            pandas_datas = []
+            pandas_data = []
             prev_timestamp = metrics_metadata["vllm_ready_timestamp"]["value"]
             for sleep_wake in metrics_sleep_wake:
                 curr_timestamp = sleep_wake["timestamp"]["value"]
@@ -243,9 +243,9 @@ def write_vllm_metrics(  # pylint: disable=too-many-locals,too-many-statements
                 if sleep_wake["type"] == "sleep":
                     data["GPU Freed(GiB)"] = sleep_wake["gpu_freed"]["value"]
                     data["GPU In Use(GiB)"] = sleep_wake["gpu_in_use"]["value"]
-                pandas_datas.append(data)
+                pandas_data.append(data)
 
-            df = pd.DataFrame(pandas_datas)
+            df = pd.DataFrame(pandas_data)
             file.write("\n")
             header = (
                 f"{'Type':<6} "
@@ -276,10 +276,10 @@ def write_vllm_metrics(  # pylint: disable=too-many-locals,too-many-statements
             )
 
 
-def write_extra_metrics(file: io.TextIOWrapper, metadatas: list[dict]):
+def write_extra_metrics(file: io.TextIOWrapper, metadata: list[dict]):
     """prints extra metrics"""
 
-    for metrics_metadata in metadatas:
+    for metrics_metadata in metadata:
         if metrics_metadata["name"] == "fma":
             write_fma_metrics(file, metrics_metadata["iterations"], 0)
         else:
@@ -307,7 +307,7 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
 
     hot_starts = 0
     total_iterations = len(iterations)
-    pandas_datas = []
+    pandas_data = []
     for iteration in iterations:
         for launcher_info in iteration["launcher_infos"]:
             ct = float(launcher_info["requester_info"]["creation_timestamp"]["value"])
@@ -320,7 +320,7 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
             if actuation_condition == "T_hot":
                 hot_starts += 1
 
-            pandas_datas.append(
+            pandas_data.append(
                 {
                     "Iteration": iteration["iteration"]["value"],
                     "vLLM Name": launcher_info["name"],
@@ -334,7 +334,7 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
 
     hit_rate = hot_starts / total_iterations if total_iterations > 0 else 0.0
 
-    df = pd.DataFrame(pandas_datas)
+    df = pd.DataFrame(pandas_data)
 
     file.write("\n")
 

--- a/llmdbenchmark/executor/step.py
+++ b/llmdbenchmark/executor/step.py
@@ -279,7 +279,7 @@ class Step(ABC):
 
         Returns True if the PVC exists (caller should skip creation),
         False if it doesn't exist (caller should create it).
-        Appends to *errors* if existing size is too small or unparseable.
+        Appends to *errors* if existing size is too small or unparsable.
         """
         result = cmd.kube(
             "get", "pvc", pvc_name,

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -946,7 +946,7 @@ class RenderPlans:
     def _validate_shared_block(self, defaults: dict, shared: dict) -> None:
         """Pre-validate defaults+shared against the config schema.
 
-        A typo at the root of `shared:` (e.g. ``modle:`` instead of
+        A typo at the root of `shared:` (e.g. ``model:`` instead of
         ``model:``) silently merges into every stack's root where
         ``extra="allow"`` accepts it, so the typo propagates without a
         visible error and the misspelled value never takes effect. By

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -136,7 +136,7 @@ class ModelNamespaceStep(Step):
     def _parse_size_to_gib(raw: str | None) -> float:
         """Parse a k8s resource-size string to GiB as a float.
 
-        Returns 0.0 when input is empty or unparseable - caller treats
+        Returns 0.0 when input is empty or unparsable - caller treats
         that as "unknown, skip comparison", which is the right fallback
         for a warn-only pre-flight.
         """
@@ -190,7 +190,7 @@ class ModelNamespaceStep(Step):
             total_gib += self._parse_size_to_gib(model_size)
 
         if total_gib == 0:
-            return  # all model.size unset/unparseable - skip quietly
+            return  # all model.size unset/unparsable - skip quietly
 
         if total_gib > capacity_gib * 0.9:
             breakdown = ", ".join(f"{n}={s}" for n, s in per_stack_sizes)

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -139,10 +139,10 @@ class TestTypoDetection:
         )
 
     def test_model_typo_caught(self, defaults_copy: dict) -> None:
-        defaults_copy["model"]["naem"] = "test"
+        defaults_copy["model"]["name"] = "test"
         warnings = validate_config(defaults_copy)
-        assert any("naem" in w for w in warnings), (
-            f"Expected 'naem' typo to be caught, got: {warnings}"
+        assert any("name" in w for w in warnings), (
+            f"Expected 'name' typo to be caught, got: {warnings}"
         )
 
     def test_vllm_common_typo_caught(self, defaults_copy: dict) -> None:
@@ -153,17 +153,17 @@ class TestTypoDetection:
         )
 
     def test_harness_typo_caught(self, defaults_copy: dict) -> None:
-        defaults_copy["harness"]["waitTimout"] = 3600
+        defaults_copy["harness"]["waitTimeout"] = 3600
         warnings = validate_config(defaults_copy)
-        assert any("waitTimout" in w for w in warnings), (
-            f"Expected 'waitTimout' typo to be caught, got: {warnings}"
+        assert any("waitTimeout" in w for w in warnings), (
+            f"Expected 'waitTimeout' typo to be caught, got: {warnings}"
         )
 
     def test_prefill_vllm_typo_caught(self, defaults_copy: dict) -> None:
-        defaults_copy["prefill"]["vllm"]["addtionalFlags"] = []
+        defaults_copy["prefill"]["vllm"]["additionalFlags"] = []
         warnings = validate_config(defaults_copy)
-        assert any("addtionalFlags" in w for w in warnings), (
-            f"Expected 'addtionalFlags' typo to be caught, got: {warnings}"
+        assert any("additionalFlags" in w for w in warnings), (
+            f"Expected 'additionalFlags' typo to be caught, got: {warnings}"
         )
 
 
@@ -204,7 +204,7 @@ class TestNonBlocking:
         assert isinstance(result, list)
 
     def test_returns_list_on_invalid(self, defaults_copy: dict) -> None:
-        defaults_copy["model"]["naem"] = "bad"
+        defaults_copy["model"]["name"] = "bad"
         result = validate_config(defaults_copy)
         assert isinstance(result, list)
         assert len(result) > 0


### PR DESCRIPTION
## Typo Fixes

Fixed **31 typos** across 7 files:

- `overrideable` → `overridable` (config/README.md)
- `PN` → `ON` (analysis files)
- `datas` → `data` (analysis scripts)
- `unparseable` → `unparsable` (executor, standup)
- `modle` → `model` (parser)
- `naem` → `name` (tests)
- `Timout` → `Timeout` (tests)
- `addtional` → `additional` (tests)

Fixes issue #1201