### PR TITLE
Modify OCP nightly standalone to run nop harness for FMA baseline

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-ocp-fma.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-fma.yaml
@@ -120,40 +120,75 @@ jobs:
       workload: ${{ inputs.workload || 'nop.yaml' }}
     secrets: inherit
 
-#     START - This should be deleted, and the contents accessed from GCS accessed directly
-#      - name: Download standalone results
-#        if: always()
-#        uses: actions/download-artifact@v8
-#        with:
-#          name: benchmark-results-ocp-standalone
-#          path: /tmp/standalone-results
-#        continue-on-error: true
-#
-#      - name: Display benchmark results
-#        if: always()
-#        run: |
-#          echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
-#          echo "" >> "$GITHUB_STEP_SUMMARY"
-#          found=0
-#          for f in $(find "$LLMDBENCH_WORKSPACE" /tmp/standalone-results -path "*/analysis/*" \( -name "result.txt" -o -name "summary.txt" \) 2>/dev/null | sort || true); do
-#            found=1
-#            stack_dir=$(basename "$(dirname "$f")")
-#            echo "### $stack_dir" >> "$GITHUB_STEP_SUMMARY"
-#            echo '```' >> "$GITHUB_STEP_SUMMARY"
-#            cat "$f" >> "$GITHUB_STEP_SUMMARY"
-#            echo '```' >> "$GITHUB_STEP_SUMMARY"
-#            echo "" >> "$GITHUB_STEP_SUMMARY"
-#          done
-#          if [ "$found" -eq 0 ]; then
-#            echo "_No analysis results found._" >> "$GITHUB_STEP_SUMMARY"
-#          fi
-#        shell: bash
-#
-#      - name: Archive benchmark results as GitHub artifact
-#        if: success() || failure()
-#        uses: actions/upload-artifact@v7.0.1
-#        with:
-#          name: benchmark-results-ocp-fma
-#          path: ${{ env.LLMDBENCH_WORKSPACE }}
-#          retention-days: 14
-#     END - This should be deleted, and the contents accessed from GCS accessed directly
+  display-results:
+    name: Display Results (OCP)
+    needs: [nightly]
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      GCS_PATH: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      GCP_PROJECT_ID: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      LLMDBENCH_CICD_TARGET: ${{ inputs.cluster_provider || 'ocp' }}
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        with:
+          credentials_json: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Display results
+        run: |
+          RUN_DATE=$(date +'%Y-%m-%d')
+          STANDALONE_DIR="/tmp/standalone-results"
+          FMA_DIR="/tmp/fma-results"
+          mkdir -p "$STANDALONE_DIR" "$FMA_DIR"
+          gcloud storage cp -r "gs://${GCS_PATH}/$LLMDBENCH_CICD_TARGET/standalone/$RUN_DATE/" "$STANDALONE_DIR/" || true
+          gcloud storage cp -r "gs://${GCS_PATH}/$LLMDBENCH_CICD_TARGET/fma/$RUN_DATE/" "$FMA_DIR/" || true
+
+          latest_standalone=$(find "$STANDALONE_DIR" -type d -name "runner-*" 2>/dev/null | sort | tail -1)
+          latest_fma=$(find "$FMA_DIR" -type d -name "runner-*" 2>/dev/null | sort | tail -1)
+
+          echo "## Standalone Baseline Metrics (OCP)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          found=0
+          if [ -n "$latest_standalone" ]; then
+            echo "_Latest run: $(basename "$latest_standalone")_" >> "$GITHUB_STEP_SUMMARY"
+            for f in $(find "$latest_standalone" -path "*/analysis/*" -name "result.txt" 2>/dev/null | sort); do
+              found=1
+              experiment_id=$(basename "$(dirname "$f")")
+              {
+                echo "### $experiment_id"
+                echo '```'
+                cat "$f"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+            done
+          fi
+          if [ "$found" -eq 0 ]; then
+            echo "_No standalone baseline results found._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "## FMA Metrics (OCP)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          found=0
+          if [ -n "$latest_fma" ]; then
+            echo "_Latest run: $(basename "$latest_fma")_" >> "$GITHUB_STEP_SUMMARY"
+            for f in $(find "$latest_fma" -path "*/analysis/*" -name "result.txt" 2>/dev/null | sort); do
+              found=1
+              experiment_id=$(basename "$(dirname "$f")")
+              {
+                echo "### $experiment_id"
+                echo '```'
+                cat "$f"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+            done
+          fi
+          if [ "$found" -eq 0 ]; then
+            echo "_No FMA results found._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+        shell: bash

--- a/.github/workflows/ci-nightly-benchmark-ocp-standalone.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-standalone.yaml
@@ -81,14 +81,12 @@ on:
       harness:
         description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
         required: false
-#        default: 'nop'
-        default: vllm-benchmark
+        default: 'nop'
         type: 'string'
       workload:
         description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
         required: false
-#        default: 'nop.yaml'
-        default: sanity_random.yaml
+        default: 'nop.yaml'
         type: 'string'
 
 #  push:
@@ -119,8 +117,6 @@ jobs:
       monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
       dry_run: ${{ inputs.dry_run || 'false' }}
       verbose: ${{ inputs.verbose || 'false' }}
-      harness: ${{ inputs.harness || 'vllm-benchmark' }}
-      workload: ${{ inputs.workload || 'sanity_random.yaml' }}
-#      harness: ${{ inputs.harness || 'nop' }}
-#      workload: ${{ inputs.workload || 'nop.yaml' }}
+      harness: ${{ inputs.harness || 'nop' }}
+      workload: ${{ inputs.workload || 'nop.yaml' }}
     secrets: inherit

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -47,7 +47,7 @@ on:
         description: 'Accelerator offloading connector (ONLY VALID FOR "kustomize" standyp method)'
         required: false
         type: 'string'
-        default: ''        
+        default: ''
       cluster_namespace:
         description: 'Cluster namespace'
         required: false
@@ -380,7 +380,7 @@ jobs:
             mkdir -p ~/work/llm-d/
             cd ~/work/llm-d/
             echo "### llm-d code NOT found, will clone now"
-            git clone https://github.com/llm-d/llm-d.git          
+            git clone https://github.com/llm-d/llm-d.git
           fi
           cd ~/work/llm-d/llm-d
           echo "### llm-d code is present (branch $(git branch --show-current))"
@@ -407,7 +407,7 @@ jobs:
             echo "### Setting \"INFRA_PROVIDER\" to \"$LLMDBENCH_CICD_INFRA_PROVIDER\""
             yq -i ".scenario[0].kustomize.guideVariableOverrides.INFRA_PROVIDER = \"$LLMDBENCH_CICD_INFRA_PROVIDER\"" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
             cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.INFRA_PROVIDER'
-            export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND/$LLMDBENCH_CICD_CONNECTOR/ | sed 's^//^/^g' 
+            export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND/$LLMDBENCH_CICD_CONNECTOR/ | sed 's^//^/^g')
             echo "### Setting \"acceleratorBackend\" to \"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\""
             yq -i ".scenario[0].kustomize.acceleratorBackend = \"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\"" ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml
             cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.acceleratorBackend'
@@ -469,6 +469,8 @@ jobs:
             echo "Temporarily unable to test \"fma\" on \"kind\" clusters"
           elif [[ "$LLMDBENCH_CICD_TARGET" == "gke" && "${{ inputs.standup_method }}" == "fma" ]]; then
             echo "Temporarily unable to test \"fma\" on \"gke\" clusters"
+          elif [[ "$LLMDBENCH_CICD_TARGET" == "cks" && "${{ inputs.standup_method }}" == "fma" ]]; then
+            echo "Temporarily unable to test \"fma\" on \"cks\" clusters"
           else
             LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD run --namespace $LLMDBENCH_CICD_NS --methods $LLMDBENCH_CICD_METHOD --harness $LLMDBENCH_CICD_HARNESS --workload $LLMDBENCH_CICD_WORKLOAD --data-access-timeout 1200"
             echo "### $LLMDBENCH_CMD ###"
@@ -506,7 +508,7 @@ jobs:
         shell: bash
 
       - name: Block waiting for Standalone baseline
-        if: env.LLMDBENCH_CICD_TARGET != 'kind' && inputs.bucket_provider == 'gcs' && inputs.standup_method == 'fma'
+        if: env.LLMDBENCH_CICD_TARGET == 'ocp' && inputs.bucket_provider == 'gcs' && inputs.standup_method == 'fma'
         run: |
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             echo "Skipping waiting for \"standalone baseline\", due to \"dry-run\" mode activated"
@@ -515,13 +517,14 @@ jobs:
             RUN_DATE=$(date +'%Y-%m-%d')
             POLL=30
             while true; do
-              brl=$(gcloud storage ls -l -r "gs://${GCS_BASE_PATH}/$LLMDBENCH_CICD_SCENARIO/$LLMDBENCH_CICD_TARGET/standalone/$RUN_DATE/*/results/*/benchmark_report_v0.2*")
+              # Match different standalone outputs
+              brl=$(gcloud storage ls -l -r "gs://${GCS_BASE_PATH}/$LLMDBENCH_CICD_SCENARIO/standalone/$RUN_DATE/*/results/*/benchmark_report*" 2>/dev/null)
               if [[ $? -ne 0 ]]; then
                 echo "Standalone baseline for \"$RUN_DATE\" still not present. Waiting $POLL seconds and trying again..."
                 sleep $POLL
               else
                 latest_entry=$(echo "$brl" | sort -k 2 | tail -n 2 | head -n 1 | awk '{ print $3 }')
-                latest_dir=$(echo "$latest_entry" | sed "s^gs://${GCS_BASE_PATH}/$LLMDBENCH_CICD_SCENARIO/$LLMDBENCH_CICD_TARGET/standalone/$RUN_DATE/^^g" | cut -d '/' -f 1)
+                latest_dir=$(echo "$latest_entry" | sed "s^gs://${GCS_BASE_PATH}/$LLMDBENCH_CICD_SCENARIO/standalone/$RUN_DATE/^^g" | cut -d '/' -f 1)
                 echo "Standalone baseline for \"$RUN_DATE\" is \"$latest_dir\"."
                 exit 0
               fi

--- a/build/requirements-analysis.txt
+++ b/build/requirements-analysis.txt
@@ -1,3 +1,4 @@
+kubernetes>=35.0.0
 matplotlib>=3.10.9
 numpy>=2.4.6
 seaborn>=0.13.2

--- a/config/templates/jinja/05_namespace_sa_rbac_secret.yaml.j2
+++ b/config/templates/jinja/05_namespace_sa_rbac_secret.yaml.j2
@@ -36,6 +36,14 @@ rules:
 - apiGroups: [""]
   resources: ["pods/log"]
   verbs: ["get"]
+{% if fma is defined and fma.enabled | default(false) %}
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "patch"]
+- apiGroups: ["fma.llm-d.ai"]
+  resources: ["inferenceserverconfigs"]
+  verbs: ["get"]
+{% endif %}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -63,6 +71,33 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: system:openshift:scc:restricted
+  apiGroup: rbac.authorization.k8s.io
+---
+# Cluster-scoped service viewer: nop harness uses
+# v1.list_service_for_all_namespaces() to find the standalone vLLM service
+# by ClusterIP. Namespace-scoped Role can't grant cluster-scope list, so
+# this ClusterRole + ClusterRoleBinding is required for the SA used by
+# the harness pod.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: inference-perf-service-viewer-{{ namespace.name }}
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: inference-perf-service-viewer-{{ namespace.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ serviceAccount.name }}
+  namespace: {{ namespace.name }}
+roleRef:
+  kind: ClusterRole
+  name: inference-perf-service-viewer-{{ namespace.name }}
   apiGroup: rbac.authorization.k8s.io
 {% if huggingface.enabled %}
 ---

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -146,7 +146,7 @@ class UninstallHelmStep(Step):
                 )
 
         # Wait for all FMA pods to terminate while the controller is still running.
-        # Then force-remove any remaining finalizers: this handles
+        # Then force-remove any remaining finalizers and force-delete: this handles
         # pods left stuck from a previous teardown.
         timeout = context.fma_teardown_timeout
         for selector in [
@@ -155,6 +155,7 @@ class UninstallHelmStep(Step):
         ]:
             wait_for_pods_deleted(cmd, selector, namespace, timeout, context)
             force_remove_finalizers_by_selector(cmd, selector, namespace, context)
+            wait_for_pods_deleted(cmd, selector, namespace, 30, context)
 
     def _collect_model_labels(self, context: ExecutionContext) -> list[str]:
         """Collect model ID labels used to match helm releases."""

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -92,7 +92,8 @@ def force_remove_finalizers_by_selector(
     namespace: str,
     context: ExecutionContext,
 ) -> None:
-    """Force-remove all finalizers from pods matching a label selector.
+    """Force-remove all finalizers from pods matching a label selector,
+    then force-delete them so they don't linger in the namespace.
     """
     result = cmd.kube(
         "get", "pod",
@@ -114,6 +115,17 @@ def force_remove_finalizers_by_selector(
             "--namespace", namespace,
             "--type=merge",
             "-p", '{"metadata":{"finalizers":null}}',
+            check=False,
+        )
+        context.logger.log_info(
+            f"  Force-deleting stuck pod {pod}",
+            emoji="🗑️",
+        )
+        cmd.kube(
+            "delete", pod,
+            "--namespace", namespace,
+            "--grace-period=0", "--force",
+            "--ignore-not-found=true",
             check=False,
         )
 

--- a/workload/harnesses/nop-llm-d-benchmark.py
+++ b/workload/harnesses/nop-llm-d-benchmark.py
@@ -113,8 +113,14 @@ def main():
     if fma_enabled:
         deploy_methods.append("fma")
 
-    # Load Kubernetes configuration
-    config.load_kube_config()
+    # Load Kubernetes configuration: prefer in-cluster (harness pod runs in cluster),
+    # fall back to local kubeconfig for out-of-cluster invocations.
+    try:
+        config.load_incluster_config()
+        logger.info("Using in-cluster Kubernetes config")
+    except config.ConfigException as e:
+        logger.warning("In-cluster config failed (%s), falling back to kubeconfig", e)
+        config.load_kube_config()
     v1 = client.CoreV1Api()
     apps_v1 = client.AppsV1Api()
     api = client.CustomObjectsApi()


### PR DESCRIPTION
**Changes  standalone to use nop harness as baseline so FMA startup timing can be compared against standalone vLLM startup timing on the same cluster.**

**Other changes in this PR:**

-   Reusable workflow (`reusable-ci-nightly-benchmark.yaml`) changes need to be moved to `llm-d-infra`:

      - "Block waiting for Standalone baseline" step: added `&& inputs.standup_method == 'fma'` condition, fixed GCS glob pattern to accomodate nop output `benchmark_report/result.yaml`
  
-   FMA workflows (OCP): Added `display-results` job that downloads results from GCS and renders them in GitHub Step Summary.

-   FMA RBAC (`05_namespace_sa_rbac_secret.yaml.j2`): Added permissions for FMA CRD objects.
 
  **Current status**

  **- OCP FMA: Works correctly (produces metrics)**
  **- CKS/GKE FMA: Workflow is disabled because launcher pod can't see GPUs. FMA team investigating...**
  
  **Related issues**
  
  - llm-d-incubation/llm-d-fast-model-actuation#500 — Launcher pod reports Available UUIDs: [] on GKE/CKS
  - llm-d-incubation/llm-d-fast-model-actuation#525 — GPU device strategy comparison (CKS vs GKE vs OCP)

 
   🤖 Generated with [Claude Code](https://claude.ai/claude-code) 
   