### PR TITLE
ci: migrate GKE nightly benchmark uploads to GCS regressions layout

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-gke.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke.yaml
@@ -160,21 +160,12 @@ jobs:
           echo "=== Events ==="
           kubectl get events -n "$NS" --sort-by='.lastTimestamp' | tail -30 || true
 
-      - name: Install AWS CLI
+      - name: Upload results to GCS
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip  >/dev/null 2>&1
-          sudo ./aws/install || sudo ./aws/install --update
-          aws --version
-
-#      - name: Upload results to IBM COS
-#        env:
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#        run: |
-#          aws configure set default.s3.signature_version s3v4
-#          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
-#            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
+          REG_NAME=$(basename "$LLMDBENCH_CICD_TARGET")
+          RUN_DATE=$(date +'%Y-%m-%d')
+          cd "$LLMDBENCH_WORKSPACE" && gcloud storage cp -r . "gs://llm-d-benchmarks/regressions/$REG_NAME/$RUN_DATE" || true
+        shell: bash
 
       - name: Download standalone results
         if: always()
@@ -337,21 +328,12 @@ jobs:
           echo "=== Events ==="
           kubectl get events -n "$NS" --sort-by='.lastTimestamp' | tail -30 || true
 
-      - name: Install AWS CLI
+      - name: Upload results to GCS
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip  >/dev/null 2>&1
-          sudo ./aws/install || sudo ./aws/install --update
-          aws --version
-
-#      - name: Upload results to IBM COS
-#        env:
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#        run: |
-#          aws configure set default.s3.signature_version s3v4
-#          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
-#            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
+          REG_NAME=$(basename "$LLMDBENCH_CICD_TARGET")
+          RUN_DATE=$(date +'%Y-%m-%d')
+          cd "$LLMDBENCH_WORKSPACE" && gcloud storage cp -r . "gs://llm-d-benchmarks/regressions/$REG_NAME/$RUN_DATE" || true
+        shell: bash
 
       - name: Archive benchmark results as GitHub artifact
         if: success() || failure()
@@ -486,21 +468,12 @@ jobs:
           echo "=== Events ==="
           kubectl get events -n "$NS" --sort-by='.lastTimestamp' | tail -30 || true
 
-      - name: Install AWS CLI
+      - name: Upload results to GCS
         run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip  >/dev/null 2>&1
-          sudo ./aws/install || sudo ./aws/install --update
-          aws --version
-
-#      - name: Upload results to IBM COS
-#        env:
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#        run: |
-#          aws configure set default.s3.signature_version s3v4
-#          aws s3 cp "$INPUT_DIR" "s3://${{ secrets.COS_BUCKET_NAME }}/$OUTPUT_DIR/" \
-#            --recursive --endpoint-url ${{ secrets.COS_ENDPOINT_URL }} || true
+          REG_NAME=$(basename "$LLMDBENCH_CICD_TARGET")
+          RUN_DATE=$(date +'%Y-%m-%d')
+          cd "$LLMDBENCH_WORKSPACE" && gcloud storage cp -r . "gs://llm-d-benchmarks/regressions/$REG_NAME/$RUN_DATE" || true
+        shell: bash
 
 #      - name: Archive benchmark results as GitHub artifact
 #        if: success() || failure()


### PR DESCRIPTION
Add gcloud storage command to push to gs://llm-d-benchmarks under /regressions

@maugustosilva 