### PR TITLE
style: fix manual linting errors part 2

### DIFF
--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-05-19 14:18:11` (UTC)
-- Generated against git ref: `324bf0910689f6cef5f6e650f4c19b3f36f36264`
+- Generated at: `2026-05-20 18:14:02` (UTC)
+- Generated against git ref: `c678bc0349b2cabc36447f0ca44f365cbf1b2457`
 
 ## System Tool Dependencies
 
@@ -27,7 +27,7 @@ whatever the host's package manager provides.
 | **helmfile** | `1.5.1` | version | `install.sh` line 80 (`tool_version_for`) | [helmfile/helmfile](https://github.com/helmfile/helmfile) |
 | **jq** | `1.8.1` | version | `install.sh` line 87 (`tool_version_for`) | [jqlang/jq](https://github.com/jqlang/jq) |
 | **kustomize** | `v5.8.1` | version | `install.sh` line 84 (`tool_version_for`) | [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) |
-| **llm-d-planner (git)** | `92b14fe09fea0ec9ff36539326b7a8df00f1022c` | commit SHA | `install.sh` line 890 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
+| **llm-d-planner (git)** | `92b14fe09fea0ec9ff36539326b7a8df00f1022c` | commit SHA | `install.sh` line 913 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
 | **oc** | `4.18.0` | version | `install.sh` line 83 (`tool_version_for`) | [openshift/oc](https://github.com/openshift/oc) |
 | **skopeo** | `1.14.6` | version | `install.sh` line 86 (`tool_version_for`) | [containers/skopeo](https://github.com/containers/skopeo) |
 | **yq** | `v4.53.2` | version | `install.sh` line 79 (`tool_version_for`) | [mikefarah/yq](https://github.com/mikefarah/yq) |
@@ -117,57 +117,63 @@ annotated with their `pyproject.toml` line.
 | **cfgv** | `3.5.0` | version | (transitive in `.venv`) | [cfgv (PyPI)](https://pypi.org/project/cfgv/) |
 | **chardet** | `6.0.0.post1` | version | (transitive in `.venv`) | [chardet (PyPI)](https://pypi.org/project/chardet/) |
 | **charset-normalizer** | `3.4.7` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
-| **click** | `8.4.0` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
+| **click** | `8.3.3` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
+| **contourpy** | `1.3.3` | version | (transitive in `.venv`) | [contourpy (PyPI)](https://pypi.org/project/contourpy/) |
 | **cryptography** | `48.0.0` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
+| **cycler** | `0.12.1` | version | (transitive in `.venv`) | [cycler (PyPI)](https://pypi.org/project/cycler/) |
 | **detect_secrets** | `38ba7e335083e0a4db8c53e9be414795b27891e9` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
 | **distlib** | `0.4.0` | version | (transitive in `.venv`) | [distlib (PyPI)](https://pypi.org/project/distlib/) |
 | **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
 | **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
 | **fastapi** | `0.136.1` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
 | **filelock** | `3.29.0` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
+| **fonttools** | `4.62.1` | version | (transitive in `.venv`) | [fonttools (PyPI)](https://pypi.org/project/fonttools/) |
 | **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
 | **fsspec** | `2026.4.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
 | **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
-| **GitPython** | `3.1.50` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
+| **GitPython** | `3.1.49` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
 | **google-api-core** | `2.30.3` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
-| **google-auth** | `2.53.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
+| **google-auth** | `2.51.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
 | **google-cloud-core** | `2.6.0` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
 | **google-cloud-storage** | `3.10.1` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
 | **google-crc32c** | `1.8.0` | version | (transitive in `.venv`) | [google-crc32c (PyPI)](https://pypi.org/project/google-crc32c/) |
 | **google-resumable-media** | `2.9.0` | version | (transitive in `.venv`) | [google-resumable-media (PyPI)](https://pypi.org/project/google-resumable-media/) |
 | **googleapis-common-protos** | `1.75.0` | version | (transitive in `.venv`) | [googleapis-common-protos (PyPI)](https://pypi.org/project/googleapis-common-protos/) |
 | **h11** | `0.16.0` | version | (transitive in `.venv`) | [h11 (PyPI)](https://pypi.org/project/h11/) |
-| **hf-xet** | `1.5.0` | version | (transitive in `.venv`) | [hf-xet (PyPI)](https://pypi.org/project/hf-xet/) |
+| **hf-xet** | `1.4.3` | version | (transitive in `.venv`) | [hf-xet (PyPI)](https://pypi.org/project/hf-xet/) |
 | **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
 | **httptools** | `0.7.1` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
 | **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
-| **huggingface_hub** | `1.15.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
+| **huggingface_hub** | `1.13.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
 | **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
-| **idna** | `3.15` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
+| **idna** | `3.13` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
 | **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
 | **Jinja2** | `3.1.6` | version | `pyproject.toml` line 8 (direct) | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
-| **jiter** | `0.15.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |
+| **jiter** | `0.14.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |
+| **kiwisolver** | `1.5.0` | version | (transitive in `.venv`) | [kiwisolver (PyPI)](https://pypi.org/project/kiwisolver/) |
 | **kubernetes** | `35.0.0` | version | `pyproject.toml` line 11 (direct) | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
 | **kubernetes_asyncio** | `35.0.1` | version | (transitive in `.venv`) | [kubernetes_asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
 | **llm-optimizer** | `bb82d22e8863b762e856be66e831d551d27576b1` | commit SHA | (transitive in `.venv`) | [llm-optimizer (PyPI)](https://pypi.org/project/llm-optimizer/) |
 | **llmdbenchmark** | `editable` | editable | (transitive in `.venv`) | [llmdbenchmark (PyPI)](https://pypi.org/project/llmdbenchmark/) |
-| **markdown-it-py** | `4.2.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
+| **markdown-it-py** | `4.0.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
 | **MarkupSafe** | `3.0.3` | version | (transitive in `.venv`) | [MarkupSafe (PyPI)](https://pypi.org/project/markupsafe/) |
+| **matplotlib** | `3.10.9` | version | (transitive in `.venv`) | [matplotlib (PyPI)](https://pypi.org/project/matplotlib/) |
 | **mdurl** | `0.1.2` | version | (transitive in `.venv`) | [mdurl (PyPI)](https://pypi.org/project/mdurl/) |
 | **multidict** | `6.7.1` | version | (transitive in `.venv`) | [multidict (PyPI)](https://pypi.org/project/multidict/) |
 | **nodeenv** | `1.10.0` | version | (transitive in `.venv`) | [nodeenv (PyPI)](https://pypi.org/project/nodeenv/) |
-| **numpy** | `2.4.6` | version | (transitive in `.venv`) | [numpy (PyPI)](https://pypi.org/project/numpy/) |
+| **numpy** | `2.4.4` | version | (transitive in `.venv`) | [numpy (PyPI)](https://pypi.org/project/numpy/) |
 | **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
 | **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
 | **ollama** | `0.6.1` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
-| **openai** | `2.37.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
+| **openai** | `2.34.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
 | **packaging** | `26.2` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
 | **pandas** | `3.0.2` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
-| **planner** | `92b14fe09fea0ec9ff36539326b7a8df00f1022c` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
+| **pillow** | `12.2.0` | version | (transitive in `.venv`) | [pillow (PyPI)](https://pypi.org/project/pillow/) |
+| **planner** | `e50305af90f0812e77e1827f3bc740fe75b76370` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
 | **platformdirs** | `4.9.6` | version | (transitive in `.venv`) | [platformdirs (PyPI)](https://pypi.org/project/platformdirs/) |
 | **pluggy** | `1.6.0` | version | (transitive in `.venv`) | [pluggy (PyPI)](https://pypi.org/project/pluggy/) |
 | **pre_commit** | `4.6.0` | version | (transitive in `.venv`) | [pre_commit (PyPI)](https://pypi.org/project/pre-commit/) |
-| **propcache** | `0.5.2` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
+| **propcache** | `0.4.1` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
 | **proto-plus** | `1.28.0` | version | (transitive in `.venv`) | [proto-plus (PyPI)](https://pypi.org/project/proto-plus/) |
 | **protobuf** | `7.34.1` | version | (transitive in `.venv`) | [protobuf (PyPI)](https://pypi.org/project/protobuf/) |
 | **psutil** | `7.2.2` | version | (transitive in `.venv`) | [psutil (PyPI)](https://pypi.org/project/psutil/) |
@@ -181,19 +187,21 @@ annotated with their `pyproject.toml` line.
 | **Pygments** | `2.20.0` | version | (transitive in `.venv`) | [Pygments (PyPI)](https://pypi.org/project/pygments/) |
 | **PyJWT** | `2.12.1` | version | (transitive in `.venv`) | [PyJWT (PyPI)](https://pypi.org/project/pyjwt/) |
 | **pykube-ng** | `23.6.0` | version | `pyproject.toml` line 12 (direct) | [pykube-ng (PyPI)](https://pypi.org/project/pykube-ng/) |
+| **pyparsing** | `3.3.2` | version | (transitive in `.venv`) | [pyparsing (PyPI)](https://pypi.org/project/pyparsing/) |
 | **pytest** | `9.0.3` | version | (transitive in `.venv`) | [pytest (PyPI)](https://pypi.org/project/pytest/) |
 | **python-dateutil** | `2.9.0.post0` | version | (transitive in `.venv`) | [python-dateutil (PyPI)](https://pypi.org/project/python-dateutil/) |
-| **python-discovery** | `1.3.1` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
+| **python-discovery** | `1.3.0` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
 | **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
-| **python-multipart** | `0.0.29` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
+| **python-multipart** | `0.0.27` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
 | **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
-| **regex** | `2026.5.9` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
+| **regex** | `2026.4.4` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
 | **requests** | `2.33.1` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
 | **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
 | **rich** | `15.0.0` | version | (transitive in `.venv`) | [rich (PyPI)](https://pypi.org/project/rich/) |
 | **safetensors** | `0.7.0` | version | (transitive in `.venv`) | [safetensors (PyPI)](https://pypi.org/project/safetensors/) |
 | **scipy** | `1.17.1` | version | (transitive in `.venv`) | [scipy (PyPI)](https://pypi.org/project/scipy/) |
+| **seaborn** | `0.13.2` | version | (transitive in `.venv`) | [seaborn (PyPI)](https://pypi.org/project/seaborn/) |
 | **shellingham** | `1.5.4` | version | (transitive in `.venv`) | [shellingham (PyPI)](https://pypi.org/project/shellingham/) |
 | **six** | `1.17.0` | version | (transitive in `.venv`) | [six (PyPI)](https://pypi.org/project/six/) |
 | **smmap** | `5.0.3` | version | (transitive in `.venv`) | [smmap (PyPI)](https://pypi.org/project/smmap/) |
@@ -202,15 +210,15 @@ annotated with their `pyproject.toml` line.
 | **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
 | **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
 | **tqdm** | `4.67.3` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
-| **transformers** | `5.8.1` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **transformers** | `5.8.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
 | **typer** | `0.25.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
 | **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
 | **typing_extensions** | `4.15.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
-| **urllib3** | `2.7.0` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
+| **urllib3** | `2.6.3` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
 | **uvicorn** | `0.46.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
 | **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
-| **virtualenv** | `21.3.3` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
-| **watchfiles** | `1.2.0` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
+| **virtualenv** | `21.3.1` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
+| **watchfiles** | `1.1.1` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
 | **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
 | **websockets** | `16.0` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
 | **yarl** | `1.23.0` | version | (transitive in `.venv`) | [yarl (PyPI)](https://pypi.org/project/yarl/) |

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from llmdbenchmark.executor.protocols import LoggerProtocol
-from llmdbenchmark.executor.step import Phase
 
 if TYPE_CHECKING:
     from llmdbenchmark.executor.command import CommandExecutor
@@ -34,7 +33,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     dry_run: bool = False
     verbose: bool = False
     non_admin: bool = False
-    current_phase: Phase = Phase.STANDUP
+    current_phase: Any = None  # Phase enum, set at runtime to avoid circular import
     deep_clean: bool = False  # teardown: wipe all resources in namespaces
     release: str = "llmdbench"  # Helm release name prefix
 

--- a/llmdbenchmark/executor/step.py
+++ b/llmdbenchmark/executor/step.py
@@ -9,6 +9,7 @@ import re
 
 import yaml
 
+from llmdbenchmark.executor.context import ExecutionContext
 
 class Phase(Enum):
     """Benchmark lifecycle phases."""
@@ -137,10 +138,10 @@ class Step(ABC):
         self.per_stack = per_stack
 
     @abstractmethod
-    def execute(self, context: "ExecutionContext", stack_path: Path | None = None) -> StepResult:
+    def execute(self, context: ExecutionContext, stack_path: Path | None = None) -> StepResult:
         """Execute this step and return a StepResult."""
 
-    def should_skip(self, context: "ExecutionContext") -> bool:  # pylint: disable=unused-argument
+    def should_skip(self, context: ExecutionContext) -> bool:  # pylint: disable=unused-argument
         """Override to implement conditional skip logic."""
         return False
 
@@ -197,7 +198,7 @@ class Step(ABC):
             current = current[key]
         return current
 
-    def _load_plan_config(self, context: "ExecutionContext") -> dict | None:
+    def _load_plan_config(self, context: ExecutionContext) -> dict | None:
         """Load the merged config.yaml from the first rendered stack."""
         for stack_path in context.rendered_stacks:
             config_file = stack_path / "config.yaml"
@@ -214,7 +215,7 @@ class Step(ABC):
                 return yaml.safe_load(f) or {}
         return {}
 
-    def _all_target_namespaces(self, context: "ExecutionContext") -> list[str]:
+    def _all_target_namespaces(self, context: ExecutionContext) -> list[str]:
         """Collect deduplicated namespaces from all rendered stacks, with context-level fallback."""
         seen: list[str] = []
 
@@ -239,7 +240,7 @@ class Step(ABC):
         return seen
 
     def _find_rendered_yaml(
-        self, context: "ExecutionContext", prefix: str
+        self, context: ExecutionContext, prefix: str
     ) -> Path | None:
         """Find a rendered YAML file by prefix across all stacks."""
         for stack_path in context.rendered_stacks:

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -185,7 +185,7 @@ metadata:
             return
 
         hf_token_name = self._require_config(plan_config, "huggingface", "secretName")
-        hf_token_key = self._require_config(plan_config, "huggingface", "tokenKey")
+        hf_token_key = self._require_config(plan_config, "huggingface", "tokenKey") # noqa: F841
 
         check = cmd.kube(
             "get", "secret", hf_token_name,
@@ -212,7 +212,7 @@ metadata:
                     secret_doc["metadata"].pop("resourceVersion", None)
                     secret_doc["metadata"].pop("uid", None)
                     secret_doc["metadata"].pop("creationTimestamp", None)
-                    managed = secret_doc["metadata"].pop("managedFields", None)
+                    managed = secret_doc["metadata"].pop("managedFields", None) # noqa: F841
 
                     yaml_path = (
                         context.setup_yamls_dir() / "harness-hf-secret.yaml"

--- a/llmdbenchmark/standup/steps/step_06_standalone_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_standalone_deploy.py
@@ -134,7 +134,7 @@ class StandaloneDeployStep(Step):
             pass
 
         if deploy_name and not errors:
-            replicas = int(
+            replicas = int( # noqa: F841
                 self._require_config(plan_config, "standalone", "replicas")
             )
 

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -45,7 +45,7 @@ class DeployModelserviceStep(Step):
         plan_config = self._load_stack_config(stack_path)
         release = self._require_config(plan_config, "release")
         model_id_label = plan_config.get("model_id_label", "")
-        inference_port = self._require_config(plan_config, "vllmCommon", "inferencePort")
+        inference_port = self._require_config(plan_config, "vllmCommon", "inferencePort") # noqa: F841
         timeout = context.modelservice_deploy_timeout # Generic timeout for all pods in step 9
 
         if not context.dry_run:
@@ -134,7 +134,7 @@ class DeployModelserviceStep(Step):
             if not decode_wait.success:
                 errors.append(f"Decode pods not ready: {decode_wait.stderr}")
 
-            decode_cfg = plan_config.get("decode", {})
+            decode_cfg = plan_config.get("decode", {}) # noqa: F841
             expected_replicas = int(self._require_config(plan_config, "decode", "replicas"))
             is_multinode = plan_config.get("multinode", {}).get("enabled", False)
             if is_multinode:

--- a/llmdbenchmark/teardown/steps/step_02_clean_harness.py
+++ b/llmdbenchmark/teardown/steps/step_02_clean_harness.py
@@ -22,7 +22,7 @@ class CleanHarnessStep(Step):
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
     ) -> StepResult:
-        errors = []
+        errors = [] # noqa: F841
         cmd = context.require_cmd()
 
         # Use the same context secret name that standup created

--- a/llmdbenchmark/teardown/steps/step_05_kustomize_teardown.py
+++ b/llmdbenchmark/teardown/steps/step_05_kustomize_teardown.py
@@ -9,7 +9,6 @@ from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.executor.command import CommandExecutor
 from llmdbenchmark.kustomize.readme_parser import (
-    CommandPhase,
     parse_guide_readme,
 )
 from llmdbenchmark.kustomize.variable_resolver import GuideVariableResolver

--- a/llmdbenchmark/telemetry/__init__.py
+++ b/llmdbenchmark/telemetry/__init__.py
@@ -1,7 +1,6 @@
 # Telemetry module
 
 import atexit
-from typing import Optional
 from llmdbenchmark.config import config
 from llmdbenchmark.logging.logger import get_logger
 
@@ -25,13 +24,16 @@ def init_telemetry(logger=None):
             
             # bearer_token is a function that returns the full Authorization header value or None.
             # It must include the "Bearer " prefix if a token is present.
-            bearer_token = lambda: None
             if config.telemetry_token:
-                bearer_token = lambda: f"Bearer {config.telemetry_token}"
+                def bearer_token():
+                    return f"Bearer {config.telemetry_token}"
             elif config.telemetry_auth_provider == "google":
                 from llmdbenchmark.telemetry.google_auth_provider import get_google_bearer_token_provider
                 bearer_token = get_google_bearer_token_provider(config.telemetry_endpoint, logger)
-                
+            else:
+                def bearer_token():
+                    return None
+                    
             _telemetry_instance = HttpTelemetryProvider(
                 config.telemetry_endpoint, 
                 logger,

--- a/llmdbenchmark/utilities/cluster.py
+++ b/llmdbenchmark/utilities/cluster.py
@@ -316,7 +316,7 @@ def _kube_api_connect(context: ExecutionContext) -> None:
 
     try:
         api = client.ApisApi(api_client)
-        groups = api.get_api_versions()
+        groups = api.get_api_versions() # noqa: F841
     except Exception as exc:
         raise RuntimeError(
             f"Cluster is unreachable: {exc}. "

--- a/tests/test_shared_block_and_identity.py
+++ b/tests/test_shared_block_and_identity.py
@@ -388,7 +388,7 @@ class TestPrintEndpointsTable:
 
     def _capturing_logger(self):
         lines: list[str] = []
-        logger = MagicMock = type("L", (), {})()
+        logger = MagicMock = type("L", (), {})() # noqa: F841
         logger.log_info = lambda msg: lines.append(str(msg))
         logger.log_warning = lambda msg: lines.append("WARN:" + str(msg))
         logger.log_plain = lambda msg: lines.append(str(msg))

--- a/util/generate_sbom.py
+++ b/util/generate_sbom.py
@@ -214,7 +214,7 @@ def parse_install_sh(install_sh_path: Path) -> list[Entry]:
     helm_diff_line: int | None = None
 
     current_fn: str | None = None
-    current_fn_line: int = 0
+    current_fn_line: int = 0 # noqa: F841
     in_tvf: bool = False
     rel = install_sh_path.name
 
@@ -235,7 +235,7 @@ def parse_install_sh(install_sh_path: Path) -> list[Entry]:
         m = _INSTALL_FN_RE.match(raw)
         if m:
             current_fn = m.group("tool")
-            current_fn_line = i
+            current_fn_line = i # noqa: F841
             continue
 
         if current_fn:


### PR DESCRIPTION
This is a redo of #1276, I closed that PR since the rebase was too messy and remade my changes again here. Hopefully DCO will pass now.

Part 2 of fixing lint errors manually that were unable to be fixed automatically by ruff.

To resolve the ExecutionContext circular imports, I needed to defer the import of Phase to only be checked at type checking time.

The following fixes were made:

```bash
F821 Undefined name `ExecutionContext`
   --> llmdbenchmark/executor/step.py:140:33
    |
139 |     @AbstractMethod
140 |     def execute(self, context: "ExecutionContext", stack_path: Path | None = None) -> StepResult:
    |                                 ^^^^^^^^^^^^^^^^
141 |         """Execute this step and return a StepResult."""
    |

F821 Undefined name `ExecutionContext`
   --> llmdbenchmark/executor/step.py:143:37
    |
141 |         """Execute this step and return a StepResult."""
142 |
143 |     def should_skip(self, context: "ExecutionContext") -> bool:  # pylint: disable=unused-argument
    |                                     ^^^^^^^^^^^^^^^^
144 |         """Override to implement conditional skip logic."""
145 |         return False
    |

F821 Undefined name `ExecutionContext`
   --> llmdbenchmark/executor/step.py:200:43
    |
198 |         return current
199 |
200 |     def _load_plan_config(self, context: "ExecutionContext") -> dict | None:
    |                                           ^^^^^^^^^^^^^^^^
201 |         """Load the merged config.yaml from the first rendered stack."""
202 |         for stack_path in context.rendered_stacks:
    |

F821 Undefined name `ExecutionContext`
   --> llmdbenchmark/executor/step.py:217:48
    |
215 |         return {}
216 |
217 |     def _all_target_namespaces(self, context: "ExecutionContext") -> list[str]:
    |                                                ^^^^^^^^^^^^^^^^
218 |         """Collect deduplicated namespaces from all rendered stacks, with context-level fallback."""
219 |         seen: list[str] = []
    |

F821 Undefined name `ExecutionContext`
   --> llmdbenchmark/executor/step.py:242:25
    |
241 |     def _find_rendered_yaml(
242 |         self, context: "ExecutionContext", prefix: str
    |                         ^^^^^^^^^^^^^^^^
243 |     ) -> Path | None:
244 |         """Find a rendered YAML file by prefix across all stacks."""
    |

E731 Do not assign a `lambda` expression, use a `def`
  --> llmdbenchmark/telemetry/__init__.py:27:13
   |
25 |             # bearer_token is a function that returns the full Authorization header value or None.
26 |             # It must include the "Bearer " prefix if a token is present.
27 |             bearer_token = lambda: None
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
28 |             if config.telemetry_token:
29 |                 bearer_token = lambda: f"Bearer {config.telemetry_token}"
   |
help: Rewrite `bearer_token` as a `def`

E731 Do not assign a `lambda` expression, use a `def`
  --> llmdbenchmark/telemetry/__init__.py:29:17
   |
27 |             bearer_token = lambda: None
28 |             if config.telemetry_token:
29 |                 bearer_token = lambda: f"Bearer {config.telemetry_token}"
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
30 |             elif config.telemetry_auth_provider == "google":
31 |                 from llmdbenchmark.telemetry.google_auth_provider import get_google_bearer_token_provider
   |
help: Rewrite `bearer_token` as a `def`

  --> llmdbenchmark/teardown/steps/step_05_kustomize_teardown.py:12:5
   |
10 | from llmdbenchmark.executor.command import CommandExecutor 11 | from llmdbenchmark.kustomize.readme_parser import (
12 |     CommandPhase,
   |     ^^^^^^^^^^^^
13 |     parse_guide_readme,
14 | )
   |
help: Remove unused import: `llmdbenchmark.kustomize.readme_parser.CommandPhase`
```

The following unused variables were ignored for now:
- hf_token_key in llmdbenchmark/standup/steps/step_05_harness_namespace.py:184
- managed in llmdbenchmark/standup/steps/step_05_harness_namespace.py211 -replicas in llmdbenchmark/standup/steps/step_06_standalone_deploy.py:137
- inference_port in llmdbenchmark/standup/steps/step_09_deploy_modelservice.py:48
- decode_cfg in llmdbenchmark/standup/steps/step_09_deploy_modelservice.py:137
- errors in llmdbenchmark/teardown/steps/step_02_clean_harness.py:25
- groups in llmdbenchmark/utilities/cluster.py:319 -logger in tests/test_shared_block_and_identity.py:391
- current_fn_line in util/generate_sbom.py:204
- current_fn_line in util/generate_sbom.py:211