### PR TITLE
fix: Add GKE Provider to Scenario

### DIFF
--- a/config/scenarios/cicd/gke-fma.yaml
+++ b/config/scenarios/cicd/gke-fma.yaml
@@ -5,6 +5,9 @@
 scenario:
   - name: "gke-cicd"
 
+    gateway:
+      className: gke
+
     affinity:
       enabled: true
       nodeSelector:

--- a/config/scenarios/cicd/gke.yaml
+++ b/config/scenarios/cicd/gke.yaml
@@ -9,6 +9,9 @@
 scenario:
   - name: "gke-cicd"
 
+    gateway:
+      className: gke
+
     # GPU affinity for GKE H100
     affinity:
       enabled: true


### PR DESCRIPTION
# Summary

Needs to be tested on a cluster with `gke` and validated, but this will stop silently using `isitio`.