### PR TITLE
docs: fix omitted help text typo

### DIFF
--- a/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
+++ b/llmdbenchmark/standup/preprocess/set_llmdbench_environment.py
@@ -78,7 +78,7 @@ _parser.add_option("-i" , "--initcontainermode", \
 _parser.add_option("-o" , "--omitenvvars", \
                     dest="omitenvvars", \
                     default="", \
-                    help="List of environment variables which should be ommitted")
+                    help="List of environment variables which should be omitted")
 
 _parser.set_defaults()
 (options, _args) = _parser.parse_args()


### PR DESCRIPTION
## Problem
Issue #1201 tracks typo-checker findings. The latest nightly comments identify `ommitted` in the `--omitenvvars` help text.

## Solution
Correct the help text spelling from `ommitted` to `omitted`.

I intentionally scoped this PR to the newly reported help-text typo because earlier typo batches already have open PRs (#1230/#1236).

## Validation
- `git diff --check`
- Reviewed open PR file lists to avoid duplicating the existing broader typo PRs

Confidence: 85/100 (docs/help-text typo)

Related: #1201