### PR TITLE
feat: Lint and Format integrated into pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,10 +152,10 @@ repos:
       - id: ruff-check
         args: [--fix]
         name: Lint code check
-        stages: [manual]
+        stages: [pre-commit]
 
       # Run the formatter
       - id: ruff-format
         args: [] # Add the --diff arg if you only want to see what changes would be made
         name: Format code
-        stages: [manual]
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,12 +138,12 @@ repos:
   # ensure proper code linting and then ruff-format to format your
   # code.
   #
-  # These steps are optional and can be ran using:
-  # pre-commit run ruff-check --hook-stage manual
+  # These steps can be ran manually at any time using:
+  # pre-commit run ruff-check
   #
-  # pre-commit run ruff-format --hook-stage manual
+  # pre-commit run ruff-format
   #
-  # * Add the --all-files arg to lint/format all files
+  # * Add the --all-files arg to lint/format all files in the repo.
   # ----------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11


### PR DESCRIPTION
Changed the stages for Ruff linting and formatting so they are now performed as part of the pre-commit process automatically whenever a user makes a commit.

<img width="573" height="104" alt="image" src="https://github.com/user-attachments/assets/5a01f2fc-e812-49e4-b6ba-1f3df71a9e95" />
