### PR TITLE
ci: add CKS nightly dispatch workflow

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-cks.yaml
+++ b/.github/workflows/ci-nightly-benchmark-cks.yaml
@@ -1,0 +1,72 @@
+name: CI - Nightly Run Benchmark on CKS
+
+on:
+  workflow_dispatch:
+    inputs:
+      # Retained for compatibility with llm-d/llm-d's nightly-benchmark-cks caller.
+      input_dir:
+        description: 'Input directory for benchmark results'
+        required: false
+        default: '/tmp/cicd/analysis'
+      output_dir:
+        description: 'Output directory name (S3 prefix and artifact name)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-cks-standalone:
+    name: Benchmark - Standalone (CKS)
+    uses: llm-d/llm-d-benchmark/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: cicd
+      standup_method: standalone
+      cluster_provider: cks
+      cluster_namespace: llmdbenchcicdsns-cks
+      helm_release: llmdbenchcicdr-cks
+      workspace_dir: /tmp/llmdbenchcicds-cks
+      bucket_project: llm-d-scale
+      bucket_provider: gcs
+      bucket_path: llm-d-benchmarks/regressions
+      gateway_class: istio
+      dry_run: 'false'
+      verbose: 'false'
+    secrets: inherit
+
+  benchmark-cks-modelservice:
+    name: Benchmark - ModelService (CKS)
+    uses: llm-d/llm-d-benchmark/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: cicd
+      standup_method: modelservice
+      cluster_provider: cks
+      cluster_namespace: llmdbenchcicdmns-cks
+      helm_release: llmdbenchcicdr-cks
+      workspace_dir: /tmp/llmdbenchcicdm-cks
+      bucket_project: llm-d-scale
+      bucket_provider: gcs
+      bucket_path: llm-d-benchmarks/regressions
+      gateway_class: istio
+      dry_run: 'false'
+      verbose: 'false'
+    secrets: inherit
+
+  benchmark-cks-fma:
+    name: Benchmark - FMA (CKS)
+    uses: llm-d/llm-d-benchmark/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: cicd
+      standup_method: fma
+      cluster_provider: cks
+      cluster_namespace: llmdbenchcicdfns-cks
+      helm_release: llmdbenchcicdrf-cks
+      workspace_dir: /tmp/llmdbenchcicdf-cks
+      bucket_project: llm-d-scale
+      bucket_provider: gcs
+      bucket_path: llm-d-benchmarks/regressions
+      gateway_class: istio
+      dry_run: 'false'
+      verbose: 'false'
+    secrets: inherit


### PR DESCRIPTION
## Description

Adds a ci-nightly-benchmark-cks.yaml workflow_dispatch entrypoint so the llm-d/llm-d nightly-benchmark-cks workflow can dispatch the CKS benchmark workflow in this repository without hitting:

    422: Workflow does not have 'workflow_dispatch' trigger

The new entrypoint preserves the current caller contract, input_dir and output_dir, and fans out to the existing reusable nightly benchmark workflow for the three CKS standup modes:

- Standalone
- ModelService
- FMA

Fixes #1365.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Parsed the new workflow YAML successfully with Python/PyYAML.
- Ran git diff --cached --check before commit.

This is a GitHub Actions dispatch wiring change, so I did not run a full CKS benchmark or cluster standup locally.


