### PR TITLE
Fix nightly workflow failures when triggered by schedule

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-build-image.yaml
+++ b/.github/workflows/ci-nightly-benchmark-build-image.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Build and push nightly image
         uses: ./.github/actions/docker-build-and-push
         with:
-          tag: ${{ inputs.tag_name }}
+          tag: ${{ inputs.tag_name || 'nightly' }}
           image-name: llm-d-benchmark
           registry: ghcr.io/llm-d
           github-token: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/ci-nightly-benchmark-cks-fma.yaml
+++ b/.github/workflows/ci-nightly-benchmark-cks-fma.yaml
@@ -69,19 +69,19 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'fma' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'cks' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdfns-cks' }}
+      helm_release: ${{ inputs.helm_release || 'lmdbenchcicdr-cks' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdf-cks' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit
 
 #     START - This should be deleted, and the contents accessed from GCS accessed directly

--- a/.github/workflows/ci-nightly-benchmark-cks-standalone.yaml
+++ b/.github/workflows/ci-nightly-benchmark-cks-standalone.yaml
@@ -69,17 +69,17 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'standalone' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'cks' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdsns-cks' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-cks' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-cks' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit

--- a/.github/workflows/ci-nightly-benchmark-gke-fma.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke-fma.yaml
@@ -69,19 +69,19 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'fma' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'gke' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdfns-gke' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdf-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit
 
 #     START - This should be deleted, and the contents accessed from GCS accessed directly

--- a/.github/workflows/ci-nightly-benchmark-gke-standalone.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke-standalone.yaml
@@ -69,17 +69,17 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'standalone' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'gke' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdsns-gke' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit

--- a/.github/workflows/ci-nightly-benchmark-ocp-fma.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-fma.yaml
@@ -69,19 +69,19 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'fma' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'ocp' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdfns-ocp' }}
+      helm_release: ${{ inputs.helm_release || 'lmdbenchcicdr-ocp' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdf-ocp' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit
 
 #     START - This should be deleted, and the contents accessed from GCS accessed directly

--- a/.github/workflows/ci-nightly-benchmark-ocp-standalone.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-standalone.yaml
@@ -69,17 +69,17 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'standalone' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'ocp' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdsns-ocp' }}
+      helm_release: ${{ inputs.helm_release || 'lmdbenchcicdr-ocp' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicds-ocp' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit


### PR DESCRIPTION
  Schedule triggers pass empty inputs which override the reusable
  workflow's defaults. Add || 'default' fallbacks to all workflow_call
  with: blocks and fix the build image tag being empty.