### PR TITLE
Add input fallbacks to modelservice nightly workflows

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-cks-modelservice.yaml
+++ b/.github/workflows/ci-nightly-benchmark-cks-modelservice.yaml
@@ -69,17 +69,17 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'modelservice' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'cks' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdmns-cks' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-cks' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdm-cks' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit

--- a/.github/workflows/ci-nightly-benchmark-gke-modelservice.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke-modelservice.yaml
@@ -69,17 +69,17 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'modelservice' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'gke' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdmns-gke' }}
+      helm_release: ${{ inputs.helm_release || 'llmdbenchcicdr-gke' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdm-gke' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'false' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit

--- a/.github/workflows/ci-nightly-benchmark-ocp-modelservice.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-modelservice.yaml
@@ -69,19 +69,19 @@ jobs:
   nightly:
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
-      scenario_dir: ${{ inputs.scenario_dir }}
-      standup_method: ${{ inputs.standup_method }}
-      cluster_provider: ${{ inputs.cluster_provider }}
-      cluster_namespace: ${{ inputs.cluster_namespace }}
-      helm_release: ${{ inputs.helm_release }}
-      workspace_dir: ${{ inputs.workspace_dir }}
-      bucket_project: ${{ inputs.bucket_project }}
-      bucket_provider: ${{ inputs.bucket_provider }}
-      bucket_path: ${{ inputs.bucket_path }}
-      gateway_class: ${{ inputs.gateway_class }}
-      monitoring_enabled: ${{ inputs.monitoring_enabled }}
-      dry_run: ${{ inputs.dry_run }}
-      verbose: ${{ inputs.verbose }}
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: ${{ inputs.standup_method || 'modelservice' }}
+      cluster_provider: ${{ inputs.cluster_provider || 'ocp' }}
+      cluster_namespace: ${{ inputs.cluster_namespace || 'llmdbenchcicdmns-ocp' }}
+      helm_release: ${{ inputs.helm_release || 'lmdbenchcicdr-ocp' }}
+      workspace_dir: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicdm-ocp' }}
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'istio' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
     secrets: inherit
 
 #      - name: Install AWS CLI


### PR DESCRIPTION
  Inputs are null on schedule triggers; without || defaults the
  reusable workflow receives empty strings that override its own
  defaults.  Matches the fix already applied to standalone and fma
  workflows.