### PR TITLE
AIPerf harness support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -111,10 +111,19 @@ RUN git clone --branch ${INFERENCEMAX_BRANCH} ${INFERENCEMAX_REPO}
 RUN cd bench_serving; \
     git checkout ${INFERENCEMAX_COMMIT}
 
+ARG AIPERF_REPO=https://github.com/ai-dynamo/aiperf.git
+ARG AIPERF_BRANCH=v0.8.0
+ARG AIPERF_COMMIT=v0.8.0
+RUN git clone --branch ${AIPERF_BRANCH} ${AIPERF_REPO}
+RUN cd aiperf; \
+    git checkout ${AIPERF_COMMIT}; \
+    pip install .
+
 RUN echo "inference-perf: ${INFERENCE_PERF_REPO} ${INFERENCE_PERF_BRANCH}" >> /workspace/repos.txt; \
     echo "vllm-benchmark: ${VLLM_BENCHMARK_REPO} ${VLLM_BENCHMARK_COMMIT}" >> /workspace/repos.txt; \
     echo "guidellm: ${GUIDELLM_REPO} ${GUIDELLM_COMMIT}" >> /workspace/repos.txt; \
-    echo "inferencemax: ${INFERENCEMAX_REPO} ${INFERENCEMAX_COMMIT}" >> /workspace/repos.txt;
+    echo "inferencemax: ${INFERENCEMAX_REPO} ${INFERENCEMAX_COMMIT}" >> /workspace/repos.txt; \
+    echo "aiperf: ${AIPERF_REPO} ${AIPERF_COMMIT}" >> /workspace/repos.txt;
 
 ADD workload/harnesses/ /usr/local/bin/
 ADD llmdbenchmark/analysis/scripts/ /tmp/analysis/

--- a/llmdbenchmark/analysis/benchmark_report/base.py
+++ b/llmdbenchmark/analysis/benchmark_report/base.py
@@ -19,6 +19,8 @@ class WorkloadGenerator(StrEnum):
     Enumeration of supported workload generators
 
     Attributes
+        AIPERF: str
+            AIPerf
         GUIDELLM: str
             GuideLLM
         INFERENCE_MAX: str
@@ -31,6 +33,7 @@ class WorkloadGenerator(StrEnum):
             vLLM Load times
     """
 
+    AIPERF = "aiperf"
     GUIDELLM = auto()
     INFERENCE_MAX = "inferencemax"
     INFERENCE_PERF = "inference-perf"

--- a/llmdbenchmark/analysis/benchmark_report/cli.py
+++ b/llmdbenchmark/analysis/benchmark_report/cli.py
@@ -81,6 +81,7 @@ def main() -> None:
 
     if args.br_version == "0.1":
         from .native_to_br0_1 import (
+            import_aiperf,
             import_nop,
             import_inference_max,
             import_vllm_benchmark,
@@ -91,6 +92,7 @@ def main() -> None:
         )
     elif args.br_version == "0.2":
         from .native_to_br0_2 import (
+            import_aiperf,
             import_inference_max,
             import_vllm_benchmark,
             import_inference_perf,
@@ -119,6 +121,11 @@ def main() -> None:
         sys.exit(0)
 
     match args.workload_generator:
+        case WorkloadGenerator.AIPERF:
+            if args.output_file:
+                import_aiperf(args.results_file).export_yaml(args.output_file)
+            else:
+                print(import_aiperf(args.results_file).get_yaml_str())
         case WorkloadGenerator.GUIDELLM:
             if args.index:
                 # Generate benchmark report for a specific index

--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_1.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_1.py
@@ -1965,6 +1965,122 @@ def import_inference_perf(results_file: str) -> BenchmarkReportV01:
     return load_benchmark_report(br_dict)
 
 
+def _aiperf_percentiles(data: dict, ms_to_s: bool = False) -> dict:
+    """Extract percentile stats from an aiperf metric block.
+
+    Args:
+        data: aiperf metric dict with keys avg, p1, p5, ..., p99, min, max.
+        ms_to_s: If True, convert milliseconds to seconds.
+
+    Returns:
+        dict with keys matching the benchmark report percentile schema.
+    """
+    scale = 0.001 if ms_to_s else 1.0
+
+    def val(key):
+        v = data.get(key)
+        return v * scale if v is not None else None
+
+    return {
+        "mean": val("avg"),
+        "min": val("min"),
+        "p1": val("p1"),
+        "p5": val("p5"),
+        "p10": val("p10"),
+        "p25": val("p25"),
+        "p50": val("p50"),
+        "p75": val("p75"),
+        "p90": val("p90"),
+        "p95": val("p95"),
+        "p99": val("p99"),
+        "max": val("max"),
+    }
+
+
+def import_aiperf(results_file: str) -> BenchmarkReportV01:
+    """Import data from an aiperf run as a BenchmarkReportV01.
+
+    Args:
+        results_file (str): Results file to import (profile_export_aiperf.json).
+
+    Returns:
+        BenchmarkReportV01: Imported data.
+    """
+    check_file(results_file)
+
+    results = import_yaml(results_file)
+
+    br_dict = _get_llmd_benchmark_envars()
+    if br_dict:
+        model_name = get_nested(br_dict, ["scenario", "model", "name"])
+    else:
+        model_name = get_nested(results, ["input_config", "endpoint", "model_names", 0], "unknown")
+
+    ttft = results.get("time_to_first_token", {})
+    itl = results.get("inter_token_latency", {})
+    req_lat = results.get("request_latency", {})
+    isl = results.get("input_sequence_length", {})
+    osl = results.get("output_sequence_length", {})
+
+    update_dict(
+        br_dict,
+        {
+            "version": "0.1",
+            "scenario": {
+                "model": {"name": model_name},
+                "load": {
+                    "name": WorkloadGenerator.AIPERF,
+                    "args": results.get("input_config", {}),
+                },
+            },
+            "metrics": {
+                "time": {
+                    "duration": get_nested(results, ["benchmark_duration", "avg"]),
+                },
+                "requests": {
+                    "total": int(get_nested(results, ["request_count", "avg"], 0)),
+                    "failures": len(results.get("error_summary", [])),
+                    "input_length": {
+                        "units": Units.COUNT,
+                        **_aiperf_percentiles(isl),
+                    },
+                    "output_length": {
+                        "units": Units.COUNT,
+                        **_aiperf_percentiles(osl),
+                    },
+                },
+                "latency": {
+                    "time_to_first_token": {
+                        "units": Units.S,
+                        **_aiperf_percentiles(ttft, ms_to_s=True),
+                    },
+                    "inter_token_latency": {
+                        "units": Units.S_PER_TOKEN,
+                        **_aiperf_percentiles(itl, ms_to_s=True),
+                    },
+                    "request_latency": {
+                        "units": Units.S,
+                        **_aiperf_percentiles(req_lat, ms_to_s=True),
+                    },
+                },
+                "throughput": {
+                    "output_tokens_per_sec": get_nested(
+                        results, ["output_token_throughput", "avg"]
+                    ),
+                    "total_tokens_per_sec": get_nested(
+                        results, ["total_token_throughput", "avg"]
+                    ),
+                    "requests_per_sec": get_nested(
+                        results, ["request_throughput", "avg"]
+                    ),
+                },
+            },
+        },
+    )
+
+    return load_benchmark_report(br_dict)
+
+
 def import_inference_max(results_file: str) -> BenchmarkReportV01:
     """Import data from an InferenceMAX benchmark run as a BenchmarkReportV01.
 

--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
@@ -898,6 +898,152 @@ def import_vllm_benchmark(results_file: str) -> BenchmarkReportV02:
     return load_benchmark_report(br_dict)
 
 
+def _aiperf_percentiles(data: dict, ms_to_s: bool = False) -> dict:
+    """Extract percentile stats from an aiperf metric block."""
+    scale = 0.001 if ms_to_s else 1.0
+
+    def val(key):
+        v = data.get(key)
+        return v * scale if v is not None else None
+
+    return {
+        "mean": val("avg"),
+        "min": val("min"),
+        "p1": val("p1"),
+        "p5": val("p5"),
+        "p10": val("p10"),
+        "p25": val("p25"),
+        "p50": val("p50"),
+        "p75": val("p75"),
+        "p90": val("p90"),
+        "p95": val("p95"),
+        "p99": val("p99"),
+        "max": val("max"),
+    }
+
+
+def import_aiperf(results_file: str) -> BenchmarkReportV02:
+    """Import data from an aiperf run as a BenchmarkReportV02.
+
+    Args:
+        results_file (str): Results file to import (profile_export_aiperf.json).
+
+    Returns:
+        BenchmarkReportV02: Imported data.
+    """
+    check_file(results_file)
+
+    results = import_yaml(results_file)
+
+    br_dict = _populate_benchmark_report_from_envars()
+
+    model_name = get_nested(
+        br_dict, ["scenario", "model", "name"],
+        get_nested(results, ["input_config", "endpoint", "model_names", 0], "unknown"),
+    )
+
+    input_config = results.get("input_config", {})
+    cfg_id = config_hash(input_config)
+
+    concurrency = get_nested(input_config, ["loadgen", "concurrency"])
+    isl_mean = get_nested(results, ["input_sequence_length", "avg"])
+    osl_mean = get_nested(results, ["output_sequence_length", "avg"])
+
+    update_dict(
+        br_dict,
+        {
+            "scenario": {
+                "load": {
+                    "metadata": {
+                        "schema_version": "0.0.1",
+                        "cfg_id": cfg_id,
+                    },
+                    "standardized": {
+                        "tool": WorkloadGenerator.AIPERF,
+                        "concurrency": concurrency,
+                        "source": LoadSource.RANDOM,
+                        "input_seq_len": {
+                            "distribution": Distribution.FIXED,
+                            "value": isl_mean,
+                            "min": get_nested(results, ["input_sequence_length", "min"]),
+                            "max": get_nested(results, ["input_sequence_length", "max"]),
+                        },
+                        "output_seq_len": {
+                            "distribution": Distribution.FIXED,
+                            "value": osl_mean,
+                            "min": get_nested(results, ["output_sequence_length", "min"]),
+                            "max": get_nested(results, ["output_sequence_length", "max"]),
+                        },
+                    },
+                    "native": {
+                        "config": input_config,
+                    },
+                },
+            },
+        },
+    )
+
+    ttft = results.get("time_to_first_token", {})
+    itl = results.get("inter_token_latency", {})
+    req_lat = results.get("request_latency", {})
+    isl = results.get("input_sequence_length", {})
+    osl = results.get("output_sequence_length", {})
+
+    aggregate = {
+        "requests": {
+            "total": int(get_nested(results, ["request_count", "avg"], 0)),
+            "failures": len(results.get("error_summary", [])),
+            "input_length": {
+                "units": Units.COUNT,
+                **_aiperf_percentiles(isl),
+            },
+            "output_length": {
+                "units": Units.COUNT,
+                **_aiperf_percentiles(osl),
+            },
+        },
+        "latency": {
+            "time_to_first_token": {
+                "units": Units.S,
+                **_aiperf_percentiles(ttft, ms_to_s=True),
+            },
+            "inter_token_latency": {
+                "units": Units.S_PER_TOKEN,
+                **_aiperf_percentiles(itl, ms_to_s=True),
+            },
+            "request_latency": {
+                "units": Units.S,
+                **_aiperf_percentiles(req_lat, ms_to_s=True),
+            },
+        },
+        "throughput": {
+            "output_token_rate": {
+                "units": Units.TOKEN_PER_S,
+                "mean": get_nested(results, ["output_token_throughput", "avg"]),
+            },
+            "total_token_rate": {
+                "units": Units.TOKEN_PER_S,
+                "mean": get_nested(results, ["total_token_throughput", "avg"]),
+            },
+            "request_rate": {
+                "units": Units.QUERY_PER_S,
+                "mean": get_nested(results, ["request_throughput", "avg"]),
+            },
+        },
+    }
+
+    update_dict(
+        br_dict,
+        {
+            "results": {
+                "request_performance": {"aggregate": aggregate},
+            },
+        },
+    )
+
+    return load_benchmark_report(br_dict)
+
+
 def import_inference_max(results_file: str) -> BenchmarkReportV02:
     """Import data from an InferenceMAX benchmark run as a BenchmarkReportV01.
 

--- a/llmdbenchmark/analysis/scripts/aiperf-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/aiperf-analyze_results.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Convert results into universal format
+export LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC=0
+for result in $(find $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR -maxdepth 1 -name 'profile_export_aiperf.json'); do
+  result_fname=$(echo $result | rev | cut -d '/' -f 1 | rev)
+
+  echo "Converting $result_fname to Benchmark Report v0.1"
+  benchmark-report $result -b 0.1 -w aiperf $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/benchmark_report,_$result_fname.yaml 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+  rc=$?
+
+  # Report errors but don't quit
+  if [[ $rc -ne 0 ]]; then
+    echo "benchmark-report returned with error $rc converting: $result"
+    export LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC=$rc
+  fi
+  echo
+  echo "Converting $result_fname to Benchmark Report v0.2"
+  benchmark-report $result -b 0.2 -w aiperf $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/benchmark_report_v0.2,_$result_fname.yaml 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+  rc=$?
+  # Report errors but don't quit
+  if [[ $rc -ne 0 ]]; then
+    echo "benchmark-report returned with error $rc converting: $result"
+    export LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC=$rc
+  fi
+done
+
+if [[ $LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC -ne 0 ]]; then
+  echo "Results data conversion completed with errors."
+  exit $LLMDBENCH_RUN_EXPERIMENT_CONVERT_RC
+fi
+echo "Results data conversion completed successfully."
+
+mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis"
+if [[ -f "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log" ]]; then
+  cp "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log" \
+     "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/summary.txt"
+fi
+exit $?

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1227,11 +1227,13 @@ def _execute_experiment(args, logger):
             f"running a single cycle with spec defaults."
         )
 
-    # Wire experiment-level harness/profile as fallbacks for CLI args
+    # Wire experiment-level harness/profile/dataset as fallbacks for CLI args
     if experiment_plan.harness and not getattr(args, "harness", None):
         args.harness = experiment_plan.harness
     if experiment_plan.profile and not getattr(args, "workload", None):
         args.workload = experiment_plan.profile
+    if experiment_plan.dataset_url and not getattr(args, "dataset", None):
+        args.dataset = experiment_plan.dataset_url
 
     total_setup = len(experiment_plan.setup_treatments)
     total_run = experiment_plan.run_treatments_count

--- a/llmdbenchmark/experiment/parser.py
+++ b/llmdbenchmark/experiment/parser.py
@@ -40,6 +40,7 @@ class ExperimentPlan:
     name: str
     harness: str | None
     profile: str | None
+    dataset_url: str | None
     setup_treatments: list[SetupTreatment]
     run_treatments_count: int
     experiment_file: Path
@@ -157,6 +158,7 @@ def parse_experiment(path: Path) -> ExperimentPlan:
     name = experiment_meta.get("name", path.stem)
     harness = experiment_meta.get("harness")
     profile = experiment_meta.get("profile")
+    dataset_url = experiment_meta.get("datasetUrl")
 
     setup_data = data.get("setup")
     setup_treatments: list[SetupTreatment] = []
@@ -172,6 +174,7 @@ def parse_experiment(path: Path) -> ExperimentPlan:
         name=name,
         harness=harness,
         profile=profile,
+        dataset_url=dataset_url,
         setup_treatments=setup_treatments,
         run_treatments_count=run_count,
         experiment_file=path,

--- a/llmdbenchmark/run/steps/step_05_render_profiles.py
+++ b/llmdbenchmark/run/steps/step_05_render_profiles.py
@@ -87,15 +87,30 @@ class RenderProfilesStep(Step):
 
         dataset_file_override: str | None = None
         if context.dataset_url:
-            # Trailing slash => directory replay: DIR is the full path, FILE is empty.
-            # Otherwise (path ends with a filename/extension) => single-file replay:
-            # DIR is the parent, FILE is the basename.
+            # For s3:// URLs the harness shell script downloads the file into
+            # /requests/datasets/ at pod runtime, so DIR must point at the
+            # local landing path, not at the s3:// prefix. For local-style
+            # URLs we still treat them as filesystem paths.
+            #
+            # Trailing slash => directory replay: DIR is the (resolved) path,
+            # FILE is empty.
+            # Otherwise (path ends with a filename/extension) => single-file
+            # replay: DIR is the parent (or the local landing dir for s3://),
+            # FILE is the basename.
+            is_s3 = context.dataset_url.startswith("s3://")
+            s3_local_dir = "/requests/datasets"
             if context.dataset_url.endswith("/"):
-                runtime_values["LLMDBENCH_RUN_DATASET_DIR"] = context.dataset_url
+                if is_s3:
+                    runtime_values["LLMDBENCH_RUN_DATASET_DIR"] = s3_local_dir
+                else:
+                    runtime_values["LLMDBENCH_RUN_DATASET_DIR"] = context.dataset_url
                 dataset_file_override = ""
             else:
                 dir_part, file_part = posixpath.split(context.dataset_url)
-                runtime_values["LLMDBENCH_RUN_DATASET_DIR"] = dir_part
+                if is_s3:
+                    runtime_values["LLMDBENCH_RUN_DATASET_DIR"] = s3_local_dir
+                else:
+                    runtime_values["LLMDBENCH_RUN_DATASET_DIR"] = dir_part
                 runtime_values["LLMDBENCH_RUN_DATASET_FILE"] = file_part
 
         env_map = build_env_map(

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -221,6 +221,7 @@ class DeployHarnessStep(Step):
                         harness_name=harness_name,
                         results_dir=results_dir,
                         entrypoint=entrypoint,
+                        dataset_url=context.dataset_url,
                     )
 
                 # Build template values by merging plan_config with runtime values
@@ -646,6 +647,7 @@ class DeployHarnessStep(Step):
         harness_name: str,
         results_dir: str,
         entrypoint: str = "llm-d-benchmark.sh",
+        dataset_url: str | None = None,
     ) -> str:
         """Build the shell command that runs inside the harness pod.
 
@@ -702,6 +704,10 @@ class DeployHarnessStep(Step):
             f"export LLMDBENCH_HARNESS_VERSION=$(grep '^{harness_name}:' "
             f"/workspace/repos.txt 2>/dev/null | cut -d' ' -f3 || echo 'unknown')"
         )
+
+        # Propagate dataset URL so harness scripts can download from S3/etc.
+        if dataset_url:
+            parts.append(f"export LLMDBENCH_RUN_DATASET_URL={dataset_url}")
 
         # Call the entrypoint without --harness flag so NAME_AUTO stays 1
         # and the auto-discovery block is skipped (our exports are used as-is)

--- a/skills/convert-guide/references/harnesses.md
+++ b/skills/convert-guide/references/harnesses.md
@@ -9,6 +9,7 @@ This document lists the available load generators (harnesses) and their workload
 | `inference-perf` | Default harness, comprehensive performance testing |
 | `guidellm` | Alternative load generator |
 | `vllm-benchmark` | vLLM native benchmarking |
+| `aiperf` | NVIDIA AIPerf load generator (synthetic + dataset replay) |
 | `nop` | No-op harness for testing |
 
 ## Profiles by Harness
@@ -43,6 +44,13 @@ This document lists the available load generators (harnesses) and their workload
 | `sanity_random.yaml` | Basic validation |
 | `random_concurrent.yaml` | Concurrent stress test |
 | `sharegpt.yaml` | ShareGPT dataset |
+
+### aiperf
+
+| Profile | Use Case |
+|---------|----------|
+| `synthetic.yaml` | Synthetic ISL/OSL workload |
+| `dataset.yaml` | Replay a custom dataset (e.g. Mooncake trace). Pass `--dataset s3://...` or set `experiment.datasetUrl` to download the dataset into the harness pod. |
 
 ## Default Values
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -313,6 +313,23 @@ class TestParseExperimentEdgeCases:
         plan = parse_experiment(p)
         assert plan.harness is None
         assert plan.profile is None
+        assert plan.dataset_url is None
+
+    def test_dataset_url_parsed(self, tmp_path: Path):
+        """experiment.datasetUrl is exposed on ExperimentPlan."""
+        p = tmp_path / "with-dataset.yaml"
+        p.write_text(textwrap.dedent("""\
+            experiment:
+              name: with-dataset
+              harness: aiperf
+              profile: dataset.yaml
+              datasetUrl: s3://bucket/path/to/trace.jsonl
+            treatments:
+              - name: t1
+                k: v
+        """))
+        plan = parse_experiment(p)
+        assert plan.dataset_url == "s3://bucket/path/to/trace.jsonl"
 
     def test_setup_without_treatments_key(self, tmp_path: Path):
         """Setup section without 'treatments' is ignored."""
@@ -572,6 +589,7 @@ class TestExperimentPlanProperties:
             name="test",
             harness=None,
             profile=None,
+            dataset_url=None,
             setup_treatments=[
                 SetupTreatment(name="s1"),
                 SetupTreatment(name="s2"),
@@ -588,6 +606,7 @@ class TestExperimentPlanProperties:
             name="test",
             harness=None,
             profile=None,
+            dataset_url=None,
             setup_treatments=[],
             run_treatments_count=6,
             experiment_file=Path("test.yaml"),
@@ -601,6 +620,7 @@ class TestExperimentPlanProperties:
             name="test",
             harness=None,
             profile=None,
+            dataset_url=None,
             setup_treatments=[SetupTreatment(name="s1")],
             run_treatments_count=0,
             experiment_file=Path("test.yaml"),

--- a/workload/harnesses/aiperf-llm-d-benchmark.sh
+++ b/workload/harnesses/aiperf-llm-d-benchmark.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
+
+# Download dataset from S3 if configured
+if [[ -n "${LLMDBENCH_RUN_DATASET_URL:-}" && "${LLMDBENCH_RUN_DATASET_URL}" == s3://* ]]; then
+  DATASET_DIR="${LLMDBENCH_RUN_DATASET_DIR:-/requests/datasets}"
+  DATASET_FILE=$(basename "$LLMDBENCH_RUN_DATASET_URL")
+  DATASET_PATH="$DATASET_DIR/$DATASET_FILE"
+  if [[ ! -f "$DATASET_PATH" ]]; then
+    echo "Downloading dataset from $LLMDBENCH_RUN_DATASET_URL ..."
+    mkdir -p "$DATASET_DIR"
+    python3 -c "
+import boto3, os
+url = os.environ['LLMDBENCH_RUN_DATASET_URL']
+parts = url.replace('s3://', '').split('/', 1)
+bucket, key = parts[0], parts[1]
+dest = '$DATASET_PATH'
+print(f'Downloading s3://{bucket}/{key} -> {dest}')
+boto3.client('s3').download_file(bucket, key, dest)
+print(f'Download complete ({os.path.getsize(dest)} bytes)')
+"
+    if [[ $? -ne 0 ]]; then
+      echo "ERROR: Failed to download dataset from S3"
+      exit 1
+    fi
+  else
+    echo "Dataset already exists at $DATASET_PATH, skipping download"
+  fi
+fi
+cp -f ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/aiperf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
+
+# Start metrics collection in background if enabled
+if [[ "${LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED:-false}" == "true" ]]; then
+  echo "Starting metrics collection..."
+  /usr/local/bin/collect_metrics.sh start >> $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics_collection.log 2>&1 &
+  METRICS_COLLECTOR_PID=$!
+  echo "Metrics collector started with PID: $METRICS_COLLECTOR_PID"
+  echo "Metrics collection logs: $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics_collection.log"
+fi
+
+# Wait for endpoint to be ready before running benchmark
+ENDPOINT_URL=$(cat ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/aiperf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r '.url')
+if [[ -n "$ENDPOINT_URL" && "$ENDPOINT_URL" != "null" ]]; then
+  MAX_WAIT=60
+  INTERVAL=10
+  echo "Waiting for endpoint at ${ENDPOINT_URL}/v1/models ..."
+  for i in $(seq 1 $MAX_WAIT); do
+    if curl -sf -o /dev/null --max-time 5 "${ENDPOINT_URL}/v1/models" 2>/dev/null; then
+      echo "Endpoint is ready (attempt $i/${MAX_WAIT})"
+      break
+    fi
+    if [[ $i -eq $MAX_WAIT ]]; then
+      echo "ERROR: Endpoint not ready after ${MAX_WAIT} attempts ($((MAX_WAIT * INTERVAL))s)"
+      exit 1
+    fi
+    echo "Attempt $i/${MAX_WAIT}: endpoint not ready, retrying in ${INTERVAL}s..."
+    sleep $INTERVAL
+  done
+fi
+
+# Build CLI args from YAML profile, skipping empty values
+export LLMDBENCH_HARNESS_ARGS="--$(cat ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/aiperf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} \
+  | yq -r 'to_entries | map(select(.value != null and .value != "")) | map("\(.key)=\(.value)") | join(" --")' \
+  | sed -e 's^=none ^ ^g' -e 's^=none$^^g')"
+
+# Inject output-artifact-dir (framework-managed, not in profile)
+LLMDBENCH_HARNESS_ARGS="$LLMDBENCH_HARNESS_ARGS --output-artifact-dir=${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}"
+
+# Append extra pass-through args if provided
+if [[ -n "${LLMDBENCH_AIPERF_EXTRA_ARGS:-}" ]]; then
+  LLMDBENCH_HARNESS_ARGS="$LLMDBENCH_HARNESS_ARGS $LLMDBENCH_AIPERF_EXTRA_ARGS"
+fi
+
+echo "Running aiperf benchmark"
+echo "Args: $LLMDBENCH_HARNESS_ARGS"
+AIPERF_BIN=$(command -v aiperf 2>/dev/null)
+if [[ -z "$AIPERF_BIN" ]]; then
+  echo "ERROR: aiperf not found in PATH. Ensure the container image includes aiperf."
+  exit 1
+fi
+start=$(date +%s.%N)
+$AIPERF_BIN profile $LLMDBENCH_HARNESS_ARGS > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
+stop=$(date +%s.%N)
+
+# Stop metrics collection
+if [[ "${LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED:-false}" == "true" ]] && [[ -n "${METRICS_COLLECTOR_PID:-}" ]]; then
+  echo "Stopping metrics collection..."
+  /usr/local/bin/collect_metrics.sh stop >> $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics_collection.log 2>&1
+  wait $METRICS_COLLECTOR_PID 2>/dev/null || true
+
+  # Process collected metrics
+  echo "Processing collected metrics..."
+  /usr/local/bin/collect_metrics.sh process >> $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics_collection.log 2>&1
+
+  echo "Metrics collection complete. Check metrics_collection.log for details."
+fi
+
+export LLMDBENCH_HARNESS_START=$(date -d "@${start}" --iso-8601=seconds)
+export LLMDBENCH_HARNESS_STOP=$(date -d "@${stop}" --iso-8601=seconds)
+export LLMDBENCH_HARNESS_DELTA=PT$(echo "$stop - $start" | bc)S
+export LLMDBENCH_HARNESS_VERSION=$(${AIPERF_BIN:-aiperf} --version 2>/dev/null || echo "unknown")
+
+# Write run metadata to a file so the analyzer can read it.
+# Environment variables exported here are lost when this subshell exits,
+# so the file serves as the handoff mechanism to the analysis phase.
+cat > "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/run_metadata.yaml" <<METADATA
+harness_start: "${LLMDBENCH_HARNESS_START}"
+harness_stop: "${LLMDBENCH_HARNESS_STOP}"
+harness_delta: "${LLMDBENCH_HARNESS_DELTA}"
+harness_args: "${LLMDBENCH_HARNESS_ARGS}"
+harness_version: "${LLMDBENCH_HARNESS_VERSION}"
+harness_name: "${LLMDBENCH_HARNESS_NAME:-aiperf}"
+harness_workload: "${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME:-}"
+harness_rc: "${LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC}"
+model: "${LLMDBENCH_DEPLOY_CURRENT_MODEL:-}"
+endpoint_url: "${LLMDBENCH_HARNESS_STACK_ENDPOINT_URL:-}"
+namespace: "${LLMDBENCH_VLLM_COMMON_NAMESPACE:-}"
+METADATA
+echo "Run metadata written to $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/run_metadata.yaml"
+
+# If benchmark harness returned with an error, exit here
+if [[ $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC -ne 0 ]]; then
+  echo "Harness returned with error $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC"
+  exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC
+fi
+echo "Harness completed successfully."
+
+exit $LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC

--- a/workload/profiles/aiperf/dataset.yaml.in
+++ b/workload/profiles/aiperf/dataset.yaml.in
@@ -1,0 +1,11 @@
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+endpoint-type: chat
+streaming: none
+concurrency: 16
+request-count: 500
+input-file: REPLACE_ENV_LLMDBENCH_RUN_DATASET_DIR/REPLACE_ENV_LLMDBENCH_RUN_DATASET_FILE
+custom-dataset-type: mooncake_trace
+use-server-token-count: none
+tokenizer-trust-remote-code: none
+no-server-metrics: none

--- a/workload/profiles/aiperf/synthetic.yaml.in
+++ b/workload/profiles/aiperf/synthetic.yaml.in
@@ -1,0 +1,12 @@
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+endpoint-type: chat
+streaming: none
+concurrency: 16
+request-count: 500
+isl: 1000
+osl: 200
+extra-inputs: ignore_eos:true
+use-server-token-count: none
+tokenizer-trust-remote-code: none
+no-server-metrics: none


### PR DESCRIPTION
## Summary

Add NVIDIA [AIPerf](https://github.com/ai-dynamo/aiperf) v0.8.0 as a benchmark harness alongside the existing `inference-perf`, `guidellm`, `vllm-benchmark`, `inferencemax`, and `nop` harnesses. AIPerf is a high-throughput, configurable load generator that natively supports concurrency-based scheduling and replay of custom datasets (including the mooncake trace format), filling the gap left by guidellm (rate-based only) and the inference-perf bench-serving harnesses (synthetic only).

Two commits:

1. **Add aiperf as a benchmark harness** — Dockerfile install pinned to `ai-dynamo/aiperf` v0.8.0 with configurable `AIPERF_REPO`/`BRANCH`/`COMMIT` ARGs; the harness execution script (`workload/harnesses/aiperf-llm-d-benchmark.sh`); two profile templates (`synthetic.yaml.in` for ISL/OSL load and `dataset.yaml.in` for custom-dataset replay); analyze script that converts aiperf's `profile_export_aiperf.json` into Benchmark Report v0.1 and v0.2; `WorkloadGenerator.AIPERF` enum value + CLI dispatch + `import_aiperf` in both `native_to_br0_1.py` and `native_to_br0_2.py`; documentation row in `skills/convert-guide/references/harnesses.md`.

2. **Wire `experiment.datasetUrl` through to the harness pod** — extends `ExperimentPlan` with `dataset_url`, mirrors the existing `experiment.harness` / `experiment.profile` fallback pattern in `_execute_experiment`, and exports `LLMDBENCH_RUN_DATASET_URL` into the harness pod via `_build_harness_command` so the dataset profile's S3-download block can resolve the URL. Includes a parser test.

The aiperf integration follows upstream conventions:
- Metrics gate matches `inferencemax` / `guidellm`: `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED == \"true\"`.
- Profile defaults are inline literals (matches the `inferencemax` pattern); users override via the `-o` flag.
- Dataset profile uses the existing `LLMDBENCH_RUN_DATASET_DIR` / `LLMDBENCH_RUN_DATASET_FILE` tokens — no new token registration required.

## Why a new harness

AIPerf brings two capabilities not currently available in the existing harness set:

- **Native concurrency-based load generation** — the existing guidellm `concurrent` profile is the closest analogue, but AIPerf's worker model and request scheduling are more representative of high-QPS production traffic.
- **First-class custom-dataset replay**, including the mooncake-trace format used for multi-turn conversation traces.

## Test plan

End-to-end smoke-tested on a B200 cluster (EKS, us-east-2) with `Qwen/Qwen2.5-1.5B-Instruct` on a single B200 GPU, modelservice deployment, routed through agentgateway → GAIE/EPP → decode.

- [x] Image builds with the new `AIPERF_REPO` / `AIPERF_BRANCH` / `AIPERF_COMMIT` ARGs (default `v0.8.0`).
- [x] `aiperf` binary on PATH inside the container; `aiperf --version` reports `0.8.0`.
- [x] **Synthetic profile** (`concurrency=16`, ISL=1000, OSL=200, 500 reqs): 500/500 requests succeeded through the kgateway+EPP path, ~22s wall time, output throughput 4603 tok/s. ITL agrees with guidellm's measurement of the same backend within 1.3% (`2.41 ms/tok` vs `2.38 ms/tok`).
- [x] **Dataset profile** (mooncake-trace replay, 5 turns / 2 sessions): 5/5 requests succeeded, ISL mean 20.5K tokens (multi-turn context), OSL mean 260, TTFT mean 349 ms.
- [x] Both `import_aiperf` parsers produce valid Benchmark Report v0.1 and v0.2 YAML.
- [x] `pytest tests/test_experiment.py` — 88 tests pass including the new `test_dataset_url_parsed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)