### PR TITLE
Fix modelservice acceleratorType selector and tolerations rendering

### DIFF
--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -237,7 +237,7 @@ decode:
 
 {% if decode.nodeSelector is defined and decode.nodeSelector %}
   nodeSelector:
-{{ decode.nodeSelector | toyaml | indent(4) }}
+{{ decode.nodeSelector | toyaml | indent(4, true) }}
 {% endif %}
 
 {% if decode.schedulerName is defined %}
@@ -260,10 +260,10 @@ decode:
     labelValues:
 {% if d_accel_type.labelValues is defined %}
 {% for value in d_accel_type.labelValues %}
-    - {{ value }}
+    - "{{ value }}"
 {% endfor %}
 {% elif d_accel_type.labelValue is defined %}
-    - {{ d_accel_type.labelValue }}
+    - "{{ d_accel_type.labelValue }}"
 {% endif %}
 {% endif %}
 {% endif %}
@@ -314,7 +314,7 @@ decode:
 
 {% if decode.tolerations is defined and decode.tolerations %}
   tolerations:
-{{ decode.tolerations | toyaml | indent(4) }}
+{{ decode.tolerations | toyaml | indent(4, first=True) }}
 {% endif %}
 
 {% if decode.accelerator is defined %}
@@ -643,7 +643,7 @@ prefill:
 
 {% if prefill.nodeSelector is defined and prefill.nodeSelector %}
   nodeSelector:
-{{ prefill.nodeSelector | toyaml | indent(4) }}
+{{ prefill.nodeSelector | toyaml | indent(4, true) }}
 {% endif %}
 
 {% if prefill.schedulerName is defined %}
@@ -666,10 +666,10 @@ prefill:
     labelValues:
 {% if p_accel_type.labelValues is defined %}
 {% for value in p_accel_type.labelValues %}
-    - {{ value }}
+    - "{{ value }}"
 {% endfor %}
 {% elif p_accel_type.labelValue is defined %}
-    - {{ p_accel_type.labelValue }}
+    - "{{ p_accel_type.labelValue }}"
 {% endif %}
 {% endif %}
 {% endif %}
@@ -720,7 +720,7 @@ prefill:
 
 {% if prefill.tolerations is defined and prefill.tolerations %}
   tolerations:
-{{ prefill.tolerations | toyaml | indent(4) }}
+{{ prefill.tolerations | toyaml | indent(4, first=True) }}
 {% endif %}
 
 {% if prefill.accelerator is defined %}

--- a/llmdbenchmark/parser/config_schema.py
+++ b/llmdbenchmark/parser/config_schema.py
@@ -227,6 +227,7 @@ class DeploymentBaseConfig(BaseModel):
     vllmVariants: list[dict[str, Any]] = Field(default_factory=list)
 
     annotations: dict[str, str] | None = None
+    tolerations: list[dict[str, Any]] | None = None
 
     hostIPC: bool | None = None
     hostPID: bool | None = None


### PR DESCRIPTION
## Summary

Three small fixes that together restore `decode.tolerations` and `decode.acceleratorType` to working order in modelservice deployments. Each is needed on its own; bundled here because the first two are different aspects of the same broken rendering path.

1. **`acceleratorType.labelValue` quoted in decode/prefill templates** (`config/templates/jinja/13_ms-values.yaml.j2`). When the value is the bare string `true`, the YAML parser interprets it as a boolean and downstream node selectors silently fail to match — pods stay Pending with no obvious diagnostic. Quoting forces it to remain a string.

2. **`toyaml | indent(4)` → `indent(4, true)` for `decode.tolerations` / `prefill.tolerations`** (same file). Jinja's `indent` filter by default does NOT indent the first line, so the rendered output had the first list item at column 0:
   ```yaml
   tolerations:
   - effect: NoSchedule    # ← wrong: 0-space indent
       key: nvidia.com/gpu
   ```
   The `indent(4, true)` form indents the first line too, producing valid YAML.

3. **Add `tolerations` field to `DeploymentBaseConfig` Pydantic schema** (`llmdbenchmark/parser/config_schema.py`). The strict config schema previously rejected `decode.tolerations` with `Extra inputs are not permitted`, even though the jinja template already had logic to render it. The field was always intended to be supported.

## Repro

Without these fixes, the following minimal scenario fails to deploy any vLLM pod:

```yaml
decode:
  acceleratorType:
    labelKey: type
    labelValue: gpu     # without quote-fix: bare "true" → bool → no match
  tolerations:          # without schema-fix: rejected by Pydantic
    - key: nvidia.com/gpu
      value: "true"
      effect: NoSchedule
```

Discovered while smoke-testing on a B200 EKS cluster that requires `nvidia.com/gpu=true:NoSchedule` toleration on decode pods.

## Test plan

- [x] Scenario with `decode.acceleratorType: {labelKey: type, labelValue: gpu}` + `decode.tolerations` renders valid `13_ms-values.yaml` and the decode pod schedules on B200 nodes.
- [x] Pydantic config validation passes (warning-free) for scenarios using `decode.tolerations`.
- [x] `pytest tests/test_config_schema.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)