### PR TITLE
Fix vLLM serve model reference for HF protocol

### DIFF
--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -129,7 +129,9 @@
 {% set proxy_disabled = (routing is defined and routing.proxy is defined and routing.proxy.enabled is defined and not routing.proxy.enabled) -%}
 {% set use_inference_port = proxy_disabled or mode == 'prefill' -%}
 {% set port_var = '$VLLM_INFERENCE_PORT' if use_inference_port else '$VLLM_METRICS_PORT' -%}
-{{ preprocess_script }}; vllm serve {{ model.cacheBase }}/{{ model.path }} \
+{% set use_hf_id = (modelservice is defined and modelservice.uriProtocol is defined and modelservice.uriProtocol == 'hf') -%}
+{% set model_ref = model.huggingfaceId | default(model.name) if use_hf_id else model.cacheBase ~ '/' ~ model.path -%}
+{{ preprocess_script }}; vllm serve {{ model_ref }} \
   --host {{ vllmCommon.host }} \
   --served-model-name {{ model.name }} \
   --port {{ port_var }} \


### PR DESCRIPTION
## Summary

When `modelservice.uriProtocol: hf` is set, vLLM is supposed to download the model directly from HuggingFace at container startup — no PVC, no model download job. The framework correctly skips PVC/download-job creation in HF mode, but the auto-generated vLLM serve command still points at `{{ model.cacheBase }}/{{ model.path }}` — a local path that only exists when the PVC pipeline runs. The vLLM pod therefore fails at startup with "model path does not exist."

Fix: when `modelservice.uriProtocol == 'hf'`, use `model.huggingfaceId` (e.g. `Qwen/Qwen3-32B`) as the serve target instead of the local cache path.

## Diff

`config/templates/jinja/_macros.j2`, 6 lines added, 1 removed:

```jinja
{% set use_hf_id = (modelservice is defined and modelservice.uriProtocol is defined and modelservice.uriProtocol == 'hf') -%}
{% set model_ref = model.huggingfaceId | default(model.name) if use_hf_id else model.cacheBase ~ '/' ~ model.path -%}
{{ preprocess_script }}; vllm serve {{ model_ref }} \
```

Behaviour preserved for default `uriProtocol: pvc`; only changes when `hf` is selected.

## Repro

Scenario with `modelservice.uriProtocol: hf` against a public model:

```yaml
model:
  name: Qwen/Qwen2.5-1.5B-Instruct
  huggingfaceId: Qwen/Qwen2.5-1.5B-Instruct
  path: models/Qwen/Qwen2.5-1.5B-Instruct
modelservice:
  enabled: true
  uriProtocol: hf
decode:
  mountModelVolume: false
```

Without the fix: decode pod crash-loops at startup with vLLM unable to find `/model-cache/models/Qwen/Qwen2.5-1.5B-Instruct`.
With the fix: vLLM pulls `Qwen/Qwen2.5-1.5B-Instruct` from HuggingFace and serves cleanly.

## Test plan

- [x] Decode pod with `uriProtocol: hf` + `mountModelVolume: false` starts vLLM successfully (smoke-tested on B200 with Qwen2.5-1.5B-Instruct).
- [x] Decode pod with default `uriProtocol: pvc` is unaffected (regression check: same rendered command as before for PVC mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)