### PR TITLE
Add nodeSelector and tolerations support for harness and data-access pods

### DIFF
--- a/config/templates/jinja/06_pod_access_to_harness_data.yaml.j2
+++ b/config/templates/jinja/06_pod_access_to_harness_data.yaml.j2
@@ -17,6 +17,27 @@ spec:
     volumeMounts:
     - name: requests
       mountPath: /requests
+{% if dataAccess.nodeSelector is defined and dataAccess.nodeSelector %}
+  nodeSelector:
+{% for key, value in dataAccess.nodeSelector.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+{% if dataAccess.tolerations is defined and dataAccess.tolerations %}
+  tolerations:
+{% for t in dataAccess.tolerations %}
+  - key: {{ t.key }}
+{% if t.operator is defined %}
+    operator: {{ t.operator }}
+{% endif %}
+{% if t.value is defined %}
+    value: "{{ t.value }}"
+{% endif %}
+{% if t.effect is defined %}
+    effect: {{ t.effect }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if vllmCommon.pullSecret is defined and vllmCommon.pullSecret %}
   imagePullSecrets:
   - name: {{ vllmCommon.pullSecret }}

--- a/config/templates/jinja/20_harness_pod.yaml.j2
+++ b/config/templates/jinja/20_harness_pod.yaml.j2
@@ -145,4 +145,25 @@ spec:
 {% if harness.serviceAccount is defined and harness.serviceAccount %}
   serviceAccountName: {{ harness.serviceAccount }}
 {% endif %}
+{% if harness.nodeSelector is defined and harness.nodeSelector %}
+  nodeSelector:
+{% for key, value in harness.nodeSelector.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+{% if harness.tolerations is defined and harness.tolerations %}
+  tolerations:
+{% for t in harness.tolerations %}
+  - key: {{ t.key }}
+{% if t.operator is defined %}
+    operator: {{ t.operator }}
+{% endif %}
+{% if t.value is defined %}
+    value: "{{ t.value }}"
+{% endif %}
+{% if t.effect is defined %}
+    effect: {{ t.effect }}
+{% endif %}
+{% endfor %}
+{% endif %}
   restartPolicy: Never

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1299,6 +1299,8 @@ downloadJob:
 dataAccess:
   rsyncPort: *rsync_port
   runAsUser: 0
+  nodeSelector: {}
+  tolerations: []
 
 # ============================================================================
 # LABELS
@@ -1433,6 +1435,8 @@ harness:
   resources:
     cpu: 16
     memory: 32Gi
+  nodeSelector: {}
+  tolerations: []
   output: local
   inferencePerf:
     rayonNumThreads: 4

--- a/llmdbenchmark/parser/config_schema.py
+++ b/llmdbenchmark/parser/config_schema.py
@@ -396,6 +396,8 @@ class HarnessConfig(BaseModel):
     podLabel: str
     debug: bool
     resources: HarnessResourcesConfig
+    nodeSelector: dict[str, str] = Field(default_factory=dict)
+    tolerations: list[dict[str, Any]] = Field(default_factory=list)
     output: str
     inferencePerf: InferencePerfConfig
     namespace: str | None = None


### PR DESCRIPTION
## Summary

Adds `nodeSelector` and `tolerations` fields to `harness:` and `dataAccess:` in scenarios, so the harness pod (load generator) and the data-access pod (rsync server for rendered profiles + results) can be scheduled on dedicated node pools.

Until now both pods relied on whatever untainted general-purpose nodes happened to exist in the cluster. On clusters where:
- the only untainted nodes are too small for the default 16 CPU / 32Gi harness resources, or
- a dedicated CPU pool (e.g. Karpenter `aiperf` pool with `aiperf=true:NoSchedule` taint) is the intended landing spot for benchmark workloads,

…the harness pod simply doesn't schedule and the run hangs. This change lets the scenario express its scheduling intent.

## Diff

3 files, 46 lines added:

- `config/templates/values/defaults.yaml` — adds `harness.nodeSelector: {}` + `harness.tolerations: []` and same on `dataAccess` (no behaviour change when unset).
- `config/templates/jinja/20_harness_pod.yaml.j2` — renders the new fields onto the harness pod spec when non-empty.
- `config/templates/jinja/06_pod_access_to_harness_data.yaml.j2` — same for the data-access pod.

Backwards-compatible: empty defaults mean unmodified scheduling for existing scenarios.

## Example usage

```yaml
harness:
  nodeSelector:
    type: aiperf
  tolerations:
    - key: aiperf
      operator: Equal
      value: "true"
      effect: NoSchedule

dataAccess:
  nodeSelector:
    type: infra-stable
  tolerations:
    - key: dedicated
      operator: Equal
      value: infra-stable
      effect: NoSchedule
```

## Motivation

Discovered while smoke-testing aiperf as a benchmark harness on an EKS cluster with Karpenter-managed dedicated node pools (one for aiperf benchmark workloads, one for stable infra). Aiperf in particular is CPU-heavy enough that running it on the same node as the data-access pod / gateway is a real concern; the dedicated-pool pattern is common for production benchmarking.

## Test plan

- [x] Scenario with empty defaults — harness/data-access pods schedule as before (regression check).
- [x] Scenario setting `harness.nodeSelector` + `harness.tolerations` — harness pod lands on the targeted node pool (Karpenter spun up an aiperf-pool node on demand).
- [x] Pydantic config validation accepts the new fields (warning-free) when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)