### PR TITLE
[Run] Add all guide-specific workloads on this repo

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.9-slim-bookworm
+FROM ghcr.io/llm-d/python:3.12.9-slim-bookworm
 
 RUN apt-get update; \
     apt-get install -y \

--- a/build/llm-d-benchmark.sh
+++ b/build/llm-d-benchmark.sh
@@ -37,6 +37,10 @@ do
         ;;
         -h|--help)
         show_usage
+        mkdir -p ~/.kube
+        if [[ ! -z ${LLMDBENCH_BASE64_CONTEXT_CONTENTS} ]]; then
+            echo ${LLMDBENCH_BASE64_CONTEXT_CONTENTS} | base64 -d > ~/.kube/config
+        fi
         if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
         then
             exit 0

--- a/build/llm-d-benchmark.sh
+++ b/build/llm-d-benchmark.sh
@@ -40,6 +40,9 @@ do
         mkdir -p ~/.kube
         if [[ ! -z ${LLMDBENCH_BASE64_CONTEXT_CONTENTS} ]]; then
             echo ${LLMDBENCH_BASE64_CONTEXT_CONTENTS} | base64 -d > ~/.kube/config
+            if [[ $LLMDBENCH_CLUSTER_TYPE == "Kind" ]]; then
+              sed -i "s^127.0.0.1:.*^kubernetes.default^g" ~/.kube/config
+            fi
         fi
         if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
         then
@@ -82,6 +85,9 @@ export LLMDBENCH_RUN_EXPERIMENT_HARNESS_DIR=$(echo $LLMDBENCH_RUN_EXPERIMENT_HAR
 mkdir -p ~/.kube
 if [[ ! -z ${LLMDBENCH_BASE64_CONTEXT_CONTENTS} ]]; then
   echo ${LLMDBENCH_BASE64_CONTEXT_CONTENTS} | base64 -d > ~/.kube/config
+  if [[ $LLMDBENCH_CLUSTER_TYPE == "Kind" ]]; then
+    sed -i "s^127.0.0.1:.*^kubernetes.default^g" ~/.kube/config
+  fi
 fi
 
 if [[ -f ~/.bashrc ]]; then

--- a/config/templates/jinja/20_harness_pod.yaml.j2
+++ b/config/templates/jinja/20_harness_pod.yaml.j2
@@ -35,6 +35,8 @@ spec:
       value: "harness_pod"
     - name: LLMDBENCH_DEPLOY_METHODS
       value: "{{ deploy_method | default('modelservice') }}"
+    - name: LLMDBENCH_CLUSTER_TYPE
+      value: "{{ cluster_type | default('unrecognized') }}"
     - name: LLMDBENCH_RUN_WORKSPACE_DIR
       value: "{{ experiment.workspaceDir }}"
     - name: LLMDBENCH_CONTROL_WORK_DIR

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -180,7 +180,10 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
 
     @property
     def platform_type(self) -> str:
-        """Human-readable platform label (e.g. 'OpenShift', 'Kind')."""
+        """Human-readable platform label (e.g. 'OpenShift', 'Kind').
+
+        Returns 'unrecognized' when none of the detection signals matched.
+        """
         if self.is_openshift:
             return "OpenShift"
         if self.is_gke:
@@ -189,7 +192,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
             return "Kind"
         if self.is_minikube:
             return "Minikube"
-        return "Kubernetes"
+        return "unrecognized"
 
     def setup_commands_dir(self) -> Path:
         """Path to workspace/setup/commands, created on access."""

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -59,6 +59,13 @@ class DeployHarnessStep(Step):
                 errors=["stack_path is required"],
             )
 
+        if context.platform_type == "unrecognized":
+            context.logger.log_warning(
+                "Cluster platform type could not be identified "
+                "(detection in step 00 matched none of OpenShift/GKE/Kind/Minikube); "
+                "LLMDBENCH_CLUSTER_TYPE will be set to 'unrecognized' in the harness pod."
+            )
+
         stack_name = stack_path.name
         errors: list[str] = []
         cmd = context.require_cmd()
@@ -236,6 +243,7 @@ class DeployHarnessStep(Step):
                     "results_dir": results_dir,
                     "stack_type": stack_type,
                     "deploy_method": deploy_method,
+                    "cluster_type": context.platform_type,
                 })
 
                 # Inject base64-encoded kubeconfig so kubectl works inside the pod

--- a/workload/profiles/guidellm/guide_optimized-baseline_1.yaml.in
+++ b/workload/profiles/guidellm/guide_optimized-baseline_1.yaml.in
@@ -1,0 +1,9 @@
+target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+request_type: text_completions
+profile: constant
+rate: [1, 5]
+max_seconds: 30
+data:
+  prompt_tokens: 50
+  output_tokens: 50

--- a/workload/profiles/guidellm/guide_precise-prefix-cache-routing_1.yaml.in
+++ b/workload/profiles/guidellm/guide_precise-prefix-cache-routing_1.yaml.in
@@ -1,0 +1,9 @@
+target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+request_type: text_completions
+profile: constant
+rate: [1, 5]
+max_seconds: 30
+data:
+  prompt_tokens: 50
+  output_tokens: 50

--- a/workload/profiles/guidellm/guide_workload-autoscaling_1.yaml.in
+++ b/workload/profiles/guidellm/guide_workload-autoscaling_1.yaml.in
@@ -1,0 +1,16 @@
+target: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+request_type: text_completions
+profile: constant
+rate: [4,8,16,24]
+max_seconds: 300
+data:
+  prompt_tokens_min: 10
+  prompt_tokens_max: 8192
+  prompt_tokens: 4096
+  prompt_tokens_stdev: 2048
+  output_tokens_min: 10
+  output_tokens_max: 2048
+  output_tokens: 1024
+  output_tokens_stdev: 512
+  samples: 1000

--- a/workload/profiles/inference-perf/guide_optimized-baseline_1.yaml.in
+++ b/workload/profiles/inference-perf/guide_optimized-baseline_1.yaml.in
@@ -1,0 +1,71 @@
+load:
+  type: poisson
+  interval: 30.0
+  stages:
+    # Warmup — seat residents (~1×S)
+    - rate: 15
+      duration: 50            # 15*50  = 750
+
+    # Main ladder
+    - rate: 3
+      duration: 20
+    - rate: 10
+      duration: 20
+    - rate: 15
+      duration: 20
+    - rate: 20
+      duration: 38
+    - rate: 22
+      duration: 34
+    - rate: 25
+      duration: 30
+    - rate: 30
+      duration: 25
+    - rate: 35
+      duration: 21
+    - rate: 40
+      duration: 38
+    - rate: 43
+      duration: 36
+    - rate: 46
+      duration: 33
+    - rate: 49
+      duration: 30
+    - rate: 52
+      duration: 29
+    - rate: 55
+      duration: 27
+    - rate: 57
+      duration: 26
+    - rate: 60
+      duration: 25
+  request_timeout: 30
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: shared_prefix
+  shared_prefix:
+    num_groups: 150                 # Number of distinct prefix, Note: the number of users is num_groups * num_prompts_per_group
+    num_prompts_per_group: 5        # Number of unique questions per group (prefix)
+    system_prompt_len: 6000         # Length of the first prefix (in tokens), simulate initialization of a system prompt
+    question_len: 1200              # Length of the unique question part (in tokens)
+    # question_len_std=9
+    output_len: 1000              # Target length for the model's generated output (in tokens)
+    # output_len_std=300
+    enable_multi_turn_chat: false  # If enabled, the chat context will be appended for the each request.
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace

--- a/workload/profiles/inference-perf/guide_pd-disaggregation_1.yaml.in
+++ b/workload/profiles/inference-perf/guide_pd-disaggregation_1.yaml.in
@@ -1,0 +1,39 @@
+load:
+  type: constant
+  stages:
+  - rate: 45
+    duration: 120
+    num_requests: null
+    concurrency_level: null
+  num_workers: 45
+  worker_max_concurrency: 100
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: random
+  input_distribution:
+    min: 5000
+    max: 5000
+    mean: 5000
+    std_dev: 0
+  output_distribution:
+    min: 250
+    max: 250
+    mean: 250
+    std_dev: 0
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace

--- a/workload/profiles/inference-perf/guide_pd-disaggregation_2.yaml.in
+++ b/workload/profiles/inference-perf/guide_pd-disaggregation_2.yaml.in
@@ -1,0 +1,39 @@
+load:
+  type: constant
+  stages:
+  - rate: 1
+    duration: 120
+    num_requests: null
+    concurrency_level: null
+  num_workers: 100
+  worker_max_concurrency: 100
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: random
+  input_distribution:
+    min: 1024
+    max: 1024
+    mean: 1024
+    std_dev: 0
+  output_distribution:
+    min: 1024
+    max: 1024
+    mean: 1024
+    std_dev: 0
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace

--- a/workload/profiles/inference-perf/guide_precise-prefix-cache-routing_1.yaml.in
+++ b/workload/profiles/inference-perf/guide_precise-prefix-cache-routing_1.yaml.in
@@ -1,0 +1,70 @@
+load:
+  type: poisson
+  interval: 30.0
+  stages:
+  # Warmup — seat residents (~1×S)
+  - rate: 15
+    duration: 50            # 15*50  = 750
+
+  # Main ladder
+  - rate: 3
+    duration: 20
+  - rate: 10
+    duration: 20
+  - rate: 15
+    duration: 20
+  - rate: 20
+    duration: 38
+  - rate: 22
+    duration: 34
+  - rate: 25
+    duration: 30
+  - rate: 30
+    duration: 25
+  - rate: 35
+    duration: 21
+  - rate: 40
+    duration: 38
+  - rate: 43
+    duration: 36
+  - rate: 46
+    duration: 33
+  - rate: 49
+    duration: 30
+  - rate: 52
+    duration: 29
+  - rate: 55
+    duration: 27
+  - rate: 57
+    duration: 26
+  - rate: 60
+    duration: 25
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: shared_prefix
+  shared_prefix:
+    num_groups: 150                 # Number of distinct prefix, Note: the number of users is num_groups * num_prompts_per_group
+    num_prompts_per_group: 5        # Number of unique questions per group (prefix)
+    system_prompt_len: 6000         # Length of the first prefix (in tokens), simulate initialization of a system prompt
+    question_len: 1200              # Length of the unique question part (in tokens)
+    #question_len_std=9
+    output_len: 1000              # Target length for the model's generated output (in tokens)
+    #output_len_std=300
+    enable_multi_turn_chat: false  # If enabled, the chat context will be appended for the each request.
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace

--- a/workload/profiles/inference-perf/guide_wide-ep-lws_1.yaml.in
+++ b/workload/profiles/inference-perf/guide_wide-ep-lws_1.yaml.in
@@ -1,0 +1,35 @@
+load:
+  type: concurrent
+  stages:
+    - concurrency_level: 2048
+      num_requests: 8192
+api:
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+  base_url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+data:
+  type: random
+  input_distribution:
+    min: 2000
+    max: 2000
+    mean: 2000
+    std_dev: 0
+  output_distribution:
+    min: 2000
+    max: 2000
+    mean: 2000
+    std_dev: 0
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+storage:
+  local_storage:
+    path: /workspace


### PR DESCRIPTION
As part of the integration process between `llm-d` and `llm-d-benchmark` (where benchmarks are run nightly), all "guide-specific" workloads were copied here.