### PR TITLE
Fix GAIE EPP image name for custom scheduler repositories

### DIFF
--- a/config/templates/jinja/12_gaie-values.yaml.j2
+++ b/config/templates/jinja/12_gaie-values.yaml.j2
@@ -3,9 +3,14 @@
 inferenceExtension:
   replicas: {{ inferenceExtension.replicas }}
   image:
+{% set scheduler_repo = images.inferenceScheduler.repository %}
+{% if '/llm-d-inference-scheduler' in scheduler_repo %}
     name: llm-d-inference-scheduler
+{% else %}
+    name: {{ scheduler_repo.split('/')[-1] }}
+{% endif %}
     registry: {{ registry }}
-    repository: {{ images.inferenceScheduler.repository | replace(registry ~ '/', '') }}
+    repository: {{ scheduler_repo | replace(registry ~ '/', '') }}
     tag: {{ images.inferenceScheduler.tag }}
     pullPolicy: {{ images.inferenceScheduler.pullPolicy }}
   extProcPort: {{ inferenceExtension.extProcPort }}


### PR DESCRIPTION
## Summary

The GAIE EPP image `name` field was hardcoded to `llm-d-inference-scheduler`, so when a custom inference scheduler repository is configured, the generated image name was incorrect.

This change dynamically extracts the image name from the last path segment of the repository URL. When the repository ends in `/llm-d-inference-scheduler`, behavior is unchanged; otherwise the name is derived from the repo's final path segment (e.g. `custom-llm-d-inference-scheduler` now resolves correctly).

## Changes

- `config/templates/jinja/12_gaie-values.yaml.j2`: derive `image.name` from `images.inferenceScheduler.repository` instead of hardcoding it.