### PR TITLE
feat: Enable llm-d standalone (epp-only mode) for Optimized Baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ llmdbenchmark --version
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) to render into the plan |
 | `-m MODELS` | `LLMDBENCH_MODELS` | Model to render the plan for |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment method (`standalone`, `modelservice`) |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className`. Accepted on the modelservice path: `epponly`, `istio`, `agentgateway`, `gke`, `data-science-gateway-class`. Ignored (any value accepted, including `none`) when the active deploy method is `kustomize`, `standalone`, or `fma`. |
 | `-f` / `--monitoring` | | Enable monitoring in rendered templates (PodMonitor, EPP verbosity) |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path (used for cluster resource auto-detection) |
 
@@ -424,6 +425,7 @@ llmdbenchmark --version
 | `-m MODELS` | `LLMDBENCH_MODELS` | Models to deploy |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment methods (`standalone`, `modelservice`) |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className`. See [Plan Options](#plan-options) for accepted values and method-aware behavior. |
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
@@ -441,6 +443,7 @@ llmdbenchmark --version
 | `-s STEPS` | | Step filter |
 | `-m MODELS` | `LLMDBENCH_MODELS` | Model that was deployed (for resource name resolution) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Methods to tear down (`standalone`, `modelservice`) |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` if teardown re-renders. See [Plan Options](#plan-options) for accepted values. |
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name (default: `llmdbench`) |
 | `-d` / `--deep` | `LLMDBENCH_DEEP_CLEAN` | Deep clean: delete ALL resources in both namespaces |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Comma-separated namespaces (model,harness) |
@@ -454,6 +457,7 @@ llmdbenchmark --version
 | `-e FILE` | `LLMDBENCH_EXPERIMENTS` | Experiment YAML with setup and run treatments (required) |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deploy method |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` during standup. See [Plan Options](#plan-options) for accepted values. |
 | `-m MODELS` | `LLMDBENCH_MODELS` | Models to deploy |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
@@ -477,6 +481,7 @@ llmdbenchmark --version
 | `-m MODEL` | `LLMDBENCH_MODEL` | Model name override (e.g. facebook/opt-125m) |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespaces (deploy,benchmark) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deploy method used during standup |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` if the run phase re-renders templates for setup overrides. See [Plan Options](#plan-options) for accepted values. |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `-l HARNESS` | `LLMDBENCH_HARNESS` | Harness name (inference-perf, guidellm, vllm-benchmark) |
 | `-w PROFILE` | `LLMDBENCH_WORKLOAD` | Workload profile YAML |
@@ -512,6 +517,7 @@ llmdbenchmark --spec gpu smoketest -p my-namespace -s 2   # config validation on
 | `-s STEPS` | | Step filter (e.g., `0,1,2` or `0-2`) |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment methods (standalone, modelservice, fma) |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` if the smoketest re-renders templates. See [Plan Options](#plan-options) for accepted values. |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4). Smoketest pins this to 1 regardless - parallel probes across stacks are confusing. |
 | `--stack NAME[,NAME...]` | `LLMDBENCH_STACK` | Restrict smoketest to the named subset of stacks. |

--- a/config/scenarios/guides/optimized-baseline.yaml
+++ b/config/scenarios/guides/optimized-baseline.yaml
@@ -130,10 +130,36 @@ scenario:
     standalone:
       enabled: false
 
-      # NOTE: the `kustomize` deploy method is configured at the TOP of this
-      # stack (see the "KUSTOMIZE DEPLOY METHOD" banner). It lives there
-      # because enabling it overrides this entire scenario -- see
-      # docs/kustomize.md.
+    # =========================================================================
+    # GATEWAY -- toggle the router topology
+    # -------------------------------------------------------------------------
+    # `epponly` is the llm-d "Standalone Mode" router topology
+    # (see https://github.com/llm-d/llm-d/blob/main/guides/recipes/router/README.md):
+    # no Kubernetes Gateway is installed, the GAIE Helm chart is swapped
+    # from `inferencepool` to `standalone`, and the EPP pod runs an Envoy
+    # sidecar that serves HTTP directly on the `{model_id_label}-gaie-epp`
+    # Service (port 80 -> 8081). HTTPRoute and `llm-d-infra` are not
+    # rendered, no gateway-provider control plane is installed.
+    #
+    # Flip this to any of the gateway-backed options to switch topology
+    # without changing anything else in the scenario:
+    #   epponly                     -- no Gateway (default here)
+    #   istio                       -- istio-base + istiod + Gateway + HTTPRoute
+    #   agentgateway                -- agentgateway controller + Gateway + HTTPRoute
+    #   gke                         -- GKE-managed Gateway + HTTPRoute
+    #   data-science-gateway-class  -- OpenDataHub managed Gateway + HTTPRoute
+    #
+    # This setting is ignored when `kustomize.enabled: true` (or when
+    # `-t kustomize` is passed) -- in that mode the upstream llm-d guide
+    # manifests are applied verbatim and define their own router topology.
+    # =========================================================================
+    gateway:
+      className: epponly
+
+    # NOTE: the `kustomize` deploy method is configured at the TOP of this
+    # stack (see the "KUSTOMIZE DEPLOY METHOD" banner). It lives there
+    # because enabling it overrides this entire scenario -- see
+    # docs/kustomize.md.
 
     # =========================================================================
     # MODELSERVICE -- Only applies when modelservice.enabled: true

--- a/config/templates/jinja/08_httproute.yaml.j2
+++ b/config/templates/jinja/08_httproute.yaml.j2
@@ -22,7 +22,13 @@
    `siblingStacks` and `stackIndex` are injected by
    llmdbenchmark.parser.render_plans._process_stack.
 #}
-{% if standalone.enabled is defined and not standalone.enabled %}
+{# Modelservice-only template. Two skip conditions:
+     1. -t kustomize -- upstream guide manifests define their own routing.
+     2. gateway.className == 'epponly' -- no Gateway exists, so an HTTPRoute
+        would be unresolvable; clients hit the EPP service directly. #}
+{% if standalone.enabled is defined and not standalone.enabled
+      and not (kustomize.enabled | default(false))
+      and gateway.className | default('') != 'epponly' %}
 {% set _mode = (httpRoute.mode if httpRoute is defined and httpRoute.mode is defined else 'per-stack') %}
 {% if _mode == 'shared' %}
 {% set _owner_index = sharedInfraStackIndex | default(1) | int %}

--- a/config/templates/jinja/09_helmfile-gateway-provider.yaml.j2
+++ b/config/templates/jinja/09_helmfile-gateway-provider.yaml.j2
@@ -5,9 +5,13 @@
     - istio     (istio-base + istiod from the istio helm repo)
     - agentgateway  (agentgateway-crds + agentgateway from the upstream OCI registry)
 
-  Other providers (gke, data-science-gateway-class) are platform-managed
-  and emit an empty helmfile here -- the step consumer treats an empty
-  rendered file as "nothing to install" via _has_yaml_content().
+  Other providers (gke, data-science-gateway-class, epponly) are platform-
+  managed or sidecar-only and emit an empty helmfile here -- the step consumer
+  treats an empty rendered file as "nothing to install" via _has_yaml_content().
+
+  ``epponly`` is the llm-d "standalone" router topology (see llm-d/guides/
+  recipes/router/README.md): the EPP runs with an Envoy sidecar that serves
+  HTTP directly, so no Kubernetes Gateway / control plane is needed.
 
   The agentgateway release layout mirrors the canonical upstream helmfile:
     https://raw.githubusercontent.com/llm-d-incubation/llm-d-infra/refs/heads/main/quickstart/gateway-control-plane-providers/agentgateway.helmfile.yaml
@@ -26,6 +30,8 @@
    `render_plans._resolve_shared_infra_stack_index`. This correctly
    promotes ownership past any leading standalone stacks (which can't
    install istio themselves). #}
+{# -t kustomize uses upstream guide manifests; skip the entire helmfile. #}
+{% if not (kustomize.enabled | default(false)) %}
 {% if stackIndex is defined and stackIndex | int != sharedInfraStackIndex | default(1) | int %}
 {% else %}
 {% set gw_class = gateway.className %}
@@ -109,5 +115,6 @@ releases:
     labels:
       type: gateway-provider
       kind: gateway-control-plane
+{% endif %}
 {% endif %}
 {% endif %}

--- a/config/templates/jinja/10_helmfile-main.yaml.j2
+++ b/config/templates/jinja/10_helmfile-main.yaml.j2
@@ -1,7 +1,18 @@
-{% if standalone.enabled is defined and not standalone.enabled %}
+{# Modelservice-only template. With -t kustomize the upstream llm-d guide
+   manifests are applied verbatim, so we render nothing here even though
+   the legacy `standalone.enabled = False` guard would otherwise pass. #}
+{% if standalone.enabled is defined and not standalone.enabled and not (kustomize.enabled | default(false)) %}
 helmDefaults:
   createNamespace: false
 ---
+
+{# When gateway.className is "epponly" we skip the Gateway / HTTPRoute /
+   provider entirely and run the EPP in llm-d's "standalone" router topology
+   (Envoy sidecar inside the EPP pod). The chart switches from
+   `inferencepool` to `standalone` and the `infra-llmdbench` release is not
+   installed (no Gateway resource is needed). #}
+{% set _epponly = (gateway.className | default('') == 'epponly') %}
+{% set _gaie_chart = 'oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone' if _epponly else 'oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool' %}
 
 repositories:
   - name: llm-d-modelservice
@@ -20,10 +31,12 @@ releases:
    Owner is computed by render_plans._resolve_shared_infra_stack_index
    (1-indexed position of the first non-standalone stack) so scenarios
    that mix standalone + modelservice still install shared infra via the
-   first modelservice stack, not a leading standalone one that can't. #}
+   first modelservice stack, not a leading standalone one that can't.
+
+   `epponly` skips this release entirely - there is no Gateway resource. #}
 {% set _is_shared_infra_owner = (stackIndex is not defined or stackIndex | int == sharedInfraStackIndex | default(1) | int) %}
 {% set _is_first_stack = _is_shared_infra_owner %}
-{% if _is_first_stack %}
+{% if _is_first_stack and not _epponly %}
   - name: infra-llmdbench
     namespace: {{ gateway.namespace }}
     chart: llm-d-infra/llm-d-infra
@@ -42,7 +55,7 @@ releases:
     version: {{ chartVersions.llmDModelservice }}
     installed: true
     needs:
-{% if _is_first_stack %}
+{% if _is_first_stack and not _epponly %}
       - {{ gateway.namespace }}/infra-llmdbench
 {% endif %}
       - {{ gateway.namespace }}/{{ model_id_label }}-gaie
@@ -53,10 +66,10 @@ releases:
 
   - name: {{ model_id_label }}-gaie
     namespace: {{ gateway.namespace }}
-    chart: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
+    chart: {{ _gaie_chart }}
     version: {{ chartVersions.inferencePool }}
     installed: true
-{% if _is_first_stack %}
+{% if _is_first_stack and not _epponly %}
     needs:
       - {{ gateway.namespace }}/infra-llmdbench
 {% endif %}

--- a/config/templates/jinja/11_infra.yaml.j2
+++ b/config/templates/jinja/11_infra.yaml.j2
@@ -1,6 +1,10 @@
-{% if standalone.enabled is defined and not standalone.enabled %}
+{# Modelservice-only template. -t kustomize uses upstream guide manifests. #}
+{% if standalone.enabled is defined and not standalone.enabled and not (kustomize.enabled | default(false)) %}
 {% set gw_class = gateway.className %}
-{% if gw_class == 'gke' %}
+{# `epponly` renders no infra values: no Gateway is installed, the standalone
+   GAIE chart provides HTTP service directly via the EPP Envoy sidecar. #}
+{% if gw_class == 'epponly' %}
+{% elif gw_class == 'gke' %}
 {# ── GKE: managed gateway with destinationRule ── #}
 gateway:
   gatewayClassName: gke-l7-regional-external-managed

--- a/config/templates/jinja/12_gaie-values.yaml.j2
+++ b/config/templates/jinja/12_gaie-values.yaml.j2
@@ -1,5 +1,7 @@
-{% if standalone.enabled is defined and not standalone.enabled %}
+{# Modelservice-only template. -t kustomize uses upstream guide manifests. #}
+{% if standalone.enabled is defined and not standalone.enabled and not (kustomize.enabled | default(false)) %}
 {% set registry = images.inferenceScheduler.repository.split('/')[0] %}
+{% set _epponly = (gateway.className | default('') == 'epponly') %}
 inferenceExtension:
   replicas: {{ inferenceExtension.replicas }}
   image:
@@ -18,6 +20,16 @@ inferenceExtension:
       port: {{ inferenceExtension.zmqPort }}
       targetPort: {{ inferenceExtension.zmqPort }}
       protocol: TCP
+{% if _epponly %}
+    {# epponly: the standalone chart runs an Envoy sidecar inside the EPP
+       pod that serves HTTP on 8081. Expose port 80 on the service so
+       benchmark clients can hit the EPP service directly without a
+       Kubernetes Gateway in front. #}
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+{% endif %}
 {% if huggingface.enabled %}
   env:
     - name: HF_TOKEN
@@ -27,6 +39,9 @@ inferenceExtension:
           key: {{ huggingface.tokenKey }}
 {% endif %}
   pluginsConfigFile: "{{ inferenceExtension.pluginsConfigFile }}"
+{% if inferenceExtension.failureMode is defined and inferenceExtension.failureMode %}
+  failureMode: "{{ inferenceExtension.failureMode }}"
+{% endif %}
 {% if inferenceExtension.resources is defined and inferenceExtension.resources %}
   resources:
 {{ inferenceExtension.resources | toyaml | indent(4, true) }}
@@ -62,7 +77,29 @@ inferenceExtension:
     v: "{{ inferenceExtension.verbosity | default('1') }}"
 {% endif %}
 {% endif %}
-{% if inferenceExtension.sidecar is defined and inferenceExtension.sidecar.enabled is defined and inferenceExtension.sidecar.enabled %}
+{# Envoy sidecar config for the standalone chart (gateway.className=epponly).
+   The chart's built-in Envoy sidecar exposes `args` and `resources` knobs
+   under `inferenceExtension.sidecar`. We surface them via the dedicated
+   `inferenceExtension.envoySidecar` scenario key to avoid clashing with
+   the UDS-tokenizer sidecar block below (which reuses
+   `inferenceExtension.sidecar.enabled`). The two are mutually exclusive
+   in practice: UDS tokenizer is only enabled for precise-prefix-cache
+   routing, which is incompatible with the epponly topology. #}
+{% if (gateway.className | default('') == 'epponly')
+      and inferenceExtension.envoySidecar is defined
+      and inferenceExtension.envoySidecar %}
+  sidecar:
+{% if inferenceExtension.envoySidecar.args is defined and inferenceExtension.envoySidecar.args %}
+    args:
+{% for arg in inferenceExtension.envoySidecar.args %}
+      - "{{ arg }}"
+{% endfor %}
+{% endif %}
+{% if inferenceExtension.envoySidecar.resources is defined and inferenceExtension.envoySidecar.resources %}
+    resources:
+{{ inferenceExtension.envoySidecar.resources | toyaml | indent(6, true) }}
+{% endif %}
+{% elif inferenceExtension.sidecar is defined and inferenceExtension.sidecar.enabled is defined and inferenceExtension.sidecar.enabled %}
   sidecar:
     enabled: true
     image: "{{ images.udsTokenizer.repository }}:{{ images.udsTokenizer.tag }}"
@@ -135,7 +172,8 @@ inferencePool:
 {% endif %}
 
 {# Only istio and gke need a provider hint for the inference-pool chart.
-   agentgateway, and data-science-gateway-class don't require one. #}
+   agentgateway, data-science-gateway-class, and epponly don't require one
+   (epponly uses the standalone chart, which has no provider concept). #}
 {% set gw_class = gateway.className %}
 {% if gw_class in ['gke', 'istio'] %}
 provider:

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -1,4 +1,5 @@
-{% if standalone.enabled is defined and not standalone.enabled %}
+{# Modelservice-only template. -t kustomize uses upstream guide manifests. #}
+{% if standalone.enabled is defined and not standalone.enabled and not (kustomize.enabled | default(false)) %}
 
 {# ============================================================================
    ms-values.yaml.j2

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -547,6 +547,15 @@ annotations:
 gateway:
   name: infra-llmdbench-inference-gateway
   namespace: auto  # Synced with namespace.name; resolved at plan time
+  # Gateway implementation. Supported values:
+  #   istio                      - default; istio-base + istiod control plane
+  #   agentgateway               - agentgateway-crds + agentgateway controller
+  #   gke                        - GKE-managed Gateway
+  #   data-science-gateway-class - OpenDataHub / OpenShift AI managed Gateway
+  #   epponly                    - llm-d "standalone" router topology: no
+  #                                Kubernetes Gateway is deployed, the EPP
+  #                                runs with an Envoy sidecar that serves
+  #                                HTTP directly (single-stack only).
   className: istio
   providerNamespace: istio-system
   # Gateway version is derived from chartVersions.istiod at plan time
@@ -1184,6 +1193,16 @@ standalone:
 
   # Extra pod config (merged into pod spec)
   extraPodConfig: {}
+
+# ============================================================================
+# KUSTOMIZE DEPLOYMENT CONFIGURATION
+# Opt-in via `kustomize.enabled: true` in a scenario or `-t kustomize` on
+# the CLI. Defined here (matching modelservice/standalone/fma) so the
+# structural key is always present in merged values and template guards
+# can use `kustomize.enabled` directly.
+# ============================================================================
+kustomize:
+  enabled: false
 
 # ============================================================================
 # FMA DEPLOYMENT CONFIGURATION

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -141,7 +141,17 @@ The scenario parameters can be roughly categorized in four groups:
 
 | Variable                                     | Meaning                                                                | Note                                                                                                     |
 | -------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| LLMDBENCH_VLLM_MODELSERVICE_GATEWAY_CLASS_NAME | Gateway implementation used for the inference gateway                 | Default=`istio`. Set to `agentgateway` to use the agentgateway data plane instead of Istio               |
+| LLMDBENCH_VLLM_MODELSERVICE_GATEWAY_CLASS_NAME | Gateway implementation used for the inference gateway                 | Default=`istio`. Supported: `istio`, `agentgateway`, `gke`, `data-science-gateway-class`, `epponly`.     |
+
+Gateway class options (set via `gateway.className` in the scenario YAML):
+
+| `className`                  | What it deploys                                                                                                  | Use when                                                          |
+|------------------------------|------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `istio` (default)            | istio-base + istiod control plane, a Gateway + HTTPRoute, the `inferencepool` GAIE chart                         | Default; most flexible / production deployments                   |
+| `agentgateway`               | agentgateway-crds + agentgateway controller, a Gateway + HTTPRoute, the `inferencepool` GAIE chart               | Want agentgateway's data plane instead of Envoy/Istio             |
+| `gke`                        | Uses GKE-managed Gateway controller; same `inferencepool` GAIE chart                                             | Running on GKE                                                    |
+| `data-science-gateway-class` | OpenDataHub / OpenShift AI managed Gateway                                                                       | Running on OpenShift AI                                           |
+| `epponly`                    | **No** Kubernetes Gateway, **no** HTTPRoute, the `standalone` GAIE chart (EPP with an Envoy sidecar serving HTTP) | You want llm-d's standalone router topology without any gateway   |
 
 ### Switching from Istio to agentgateway
 
@@ -177,6 +187,71 @@ That single change is all that's needed.  The benchmark tool handles everything 
 
 - [`config/scenarios/examples/cpu.yaml`](../config/scenarios/examples/cpu.yaml) -- CPU-only deployment
 - [`config/scenarios/guides/optimized-baseline.yaml`](../config/scenarios/guides/optimized-baseline.yaml) -- inference scheduling guide
+
+### EPP-only (llm-d standalone router) mode (`gateway.className: epponly`)
+
+`epponly` mirrors the **Standalone Mode** documented in llm-d
+([guides/recipes/router/README.md](https://github.com/llm-d/llm-d/blob/main/guides/recipes/router/README.md))
+and used by every well-lit-path guide (e.g.
+[optimized-baseline](https://github.com/llm-d/llm-d/blob/main/guides/optimized-baseline/README.md)).
+The EPP is deployed via the upstream
+`oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone`
+chart, which adds an Envoy sidecar to the EPP pod so HTTP traffic can hit
+the EPP service directly -- no Kubernetes Gateway, no HTTPRoute, no
+`llm-d-infra` Helm release.
+
+```yaml
+scenario:
+  - name: "my-stack"
+    gateway:
+      className: epponly      # default is "istio"
+
+    modelservice:
+      enabled: true
+    # ... rest of scenario config
+```
+
+When `epponly` is selected, standup automatically:
+
+1. **Skips the gateway provider install** -- step 02 does not install istio
+   or agentgateway CRDs / controllers.
+2. **Skips the `llm-d-infra` Helm release** -- no Gateway resource is created.
+3. **Skips HTTPRoute rendering** -- nothing references a Gateway.
+4. **Swaps the GAIE chart** to the upstream `standalone` chart, which
+   bundles the EPP + Envoy sidecar in a single pod.
+5. **Adds a `port 80 -> targetPort 8081` extraServicePort** to the EPP
+   service so HTTP requests reach the Envoy sidecar.
+6. **Points endpoint discovery at `{model_id_label}-gaie-epp:80`** -- the
+   smoketest and run phase resolve to the EPP service directly instead
+   of a Gateway IP.
+
+#### Restrictions
+
+- **Single-stack only.** `epponly` cannot multiplex multiple models since
+  it has no shared Gateway / HTTPRoute. Multi-stack scenarios fail at
+  render time with a clear error.
+- **`httpRoute.mode: shared` is rejected** -- shared HTTPRoute requires a
+  Gateway that `epponly` does not deploy.
+- **Only the `modelservice` deploy method.** Combining `epponly` with
+  `standalone.enabled: true`, `fma.enabled: true`, or
+  `kustomize.enabled: true` is rejected at render time.
+
+#### Differences from a gateway-based deployment
+
+| Aspect                   | Gateway-based (istio / agentgateway / gke)             | `epponly`                                                    |
+|--------------------------|--------------------------------------------------------|--------------------------------------------------------------|
+| GAIE Helm chart          | `inferencepool`                                        | `standalone`                                                 |
+| `llm-d-infra` release    | Installed (creates `Gateway`)                          | **Skipped** (no Gateway needed)                              |
+| HTTPRoute                | Rendered                                               | **Not rendered**                                             |
+| Provider control plane   | istio / agentgateway controller installed via helmfile | **Not installed**                                            |
+| Endpoint                 | `Gateway` resource IP                                  | `{model_id_label}-gaie-epp` Service ClusterIP, port 80       |
+| Number of EPP replicas   | Configurable                                           | **1** (matches default `inferenceExtension.replicas: 1`)     |
+| Multi-stack support      | Yes                                                    | **No** (single-stack only)                                   |
+
+#### Example scenario using epponly
+
+- [`config/scenarios/examples/epponly.yaml`](../config/scenarios/examples/epponly.yaml)
+  -- minimal CPU-only deployment using the inference-sim image.
 
 - "llm-d"-specific VLLM paramaters
 

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -250,8 +250,10 @@ When `epponly` is selected, standup automatically:
 
 #### Example scenario using epponly
 
-- [`config/scenarios/examples/epponly.yaml`](../config/scenarios/examples/epponly.yaml)
-  -- minimal CPU-only deployment using the inference-sim image.
+- [`config/scenarios/guides/optimized-baseline.yaml`](../config/scenarios/guides/optimized-baseline.yaml)
+  -- ships with `gateway.className: epponly` as the default. Flip it to
+  `istio`/`agentgateway`/`gke`/`data-science-gateway-class` to switch
+  topology without touching anything else in the scenario.
 
 - "llm-d"-specific VLLM paramaters
 

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -153,6 +153,49 @@ Gateway class options (set via `gateway.className` in the scenario YAML):
 | `data-science-gateway-class` | OpenDataHub / OpenShift AI managed Gateway                                                                       | Running on OpenShift AI                                           |
 | `epponly`                    | **No** Kubernetes Gateway, **no** HTTPRoute, the `standalone` GAIE chart (EPP with an Envoy sidecar serving HTTP) | You want llm-d's standalone router topology without any gateway   |
 
+### Overriding `gateway.className` from the CLI
+
+Every subcommand that renders templates (`plan`, `standup`, `experiment`,
+and the `run`/`smoketest`/`teardown` paths that re-render for setup
+overrides) accepts a `--gateway-class` flag that overrides the
+scenario's `gateway.className` for that invocation. The same value can
+be supplied via the `LLMDBENCH_GATEWAY_CLASS` environment variable.
+
+```bash
+# Scenario default is epponly -- flip to istio without editing YAML
+llmdbenchmark --spec guides/optimized-baseline standup -p my-ns --gateway-class istio
+
+# env-var form (matches the LLMDBENCH_* convention)
+LLMDBENCH_GATEWAY_CLASS=agentgateway \
+  llmdbenchmark --spec guides/optimized-baseline standup -p my-ns
+```
+
+Precedence (highest wins): `--gateway-class` CLI flag → scenario
+`gateway.className` → `defaults.yaml` (`istio`).
+
+#### Method-aware validation
+
+`gateway.className` only affects rendering when the active deploy
+method is `modelservice`. For `kustomize`, `standalone`, and `fma` the
+gateway block is ignored by every rendered template, so the CLI accepts
+**any** value (including sentinels like `none` or `n/a` that CI scripts
+often pass uniformly across deploy methods). The banner shows it as
+`Gateway: <value> (ignored -- modelservice is not the active deploy method)`.
+
+When `modelservice` is the active method, the override is checked
+against the whitelist of supported values above and a typo fails fast
+at plan time:
+
+```text
+ValueError: --gateway-class='isto' is not a supported value for the
+modelservice deploy method. Choose one of: epponly, istio, agentgateway,
+gke, data-science-gateway-class.
+```
+
+This lets CI workflows pass `--gateway-class=$SOME_VAR` for every
+deploy method without per-method special-casing, while still catching
+typos when the value actually matters.
+
 ### Switching from Istio to agentgateway
 
 By default, `llm-d-benchmark` deploys [Istio](https://istio.io/) as the gateway provider for the `modelservice` deployment method.  To use [agentgateway](https://agentgateway.dev/) instead, add a `gateway` block to your scenario YAML:

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-05-28 00:10:54` (UTC)
-- Generated against git ref: `62491518d0198504b6ed91587d09a365aaf030b8`
+- Generated at: `2026-05-28 21:13:36` (UTC)
+- Generated against git ref: `aa7a64a641f2d1c90bba7d4871651f1e09f8fda5`
 
 ## System Tool Dependencies
 
@@ -90,3 +90,129 @@ captured in the snapshot table below.
 | **PyYAML** | `(unpinned)` | (unpinned) | `pyproject.toml` line 7 | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
 | **requests** | `(unpinned)` | (unpinned) | `pyproject.toml` line 9 | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **transformers** | `(unpinned)` | (unpinned) | `pyproject.toml` line 16 | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+
+
+## Python Package Dependencies (installed snapshot)
+
+Output of `pip freeze` against the project venv (`.venv`). Includes
+every transitive dependency actually installed; direct deps are
+annotated with their `pyproject.toml` line.
+
+<details>
+<summary>Click to expand the full pip-freeze snapshot</summary>
+
+| Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
+|---|---|---|---|---|
+| **aiohappyeyeballs** | `2.6.2` | version | (transitive in `.venv`) | [aiohappyeyeballs (PyPI)](https://pypi.org/project/aiohappyeyeballs/) |
+| **aiohttp** | `3.13.5` | version | (transitive in `.venv`) | [aiohttp (PyPI)](https://pypi.org/project/aiohttp/) |
+| **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
+| **annotated-doc** | `0.0.4` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
+| **annotated-types** | `0.7.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
+| **anyio** | `4.13.0` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
+| **attrs** | `26.1.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
+| **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
+| **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
+| **certifi** | `2026.5.20` | version | (transitive in `.venv`) | [certifi (PyPI)](https://pypi.org/project/certifi/) |
+| **cffi** | `2.0.0` | version | (transitive in `.venv`) | [cffi (PyPI)](https://pypi.org/project/cffi/) |
+| **cfgv** | `3.5.0` | version | (transitive in `.venv`) | [cfgv (PyPI)](https://pypi.org/project/cfgv/) |
+| **chardet** | `6.0.0.post1` | version | (transitive in `.venv`) | [chardet (PyPI)](https://pypi.org/project/chardet/) |
+| **charset-normalizer** | `3.4.7` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
+| **click** | `8.4.1` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
+| **cryptography** | `48.0.0` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
+| **detect_secrets** | `38ba7e335083e0a4db8c53e9be414795b27891e9` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
+| **distlib** | `0.4.0` | version | (transitive in `.venv`) | [distlib (PyPI)](https://pypi.org/project/distlib/) |
+| **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
+| **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
+| **fastapi** | `0.136.3` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
+| **filelock** | `3.29.0` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
+| **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
+| **fsspec** | `2026.4.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
+| **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
+| **GitPython** | `3.1.50` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
+| **google-api-core** | `2.30.3` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
+| **google-auth** | `2.53.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
+| **google-cloud-core** | `2.6.0` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
+| **google-cloud-storage** | `3.10.1` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
+| **google-crc32c** | `1.8.0` | version | (transitive in `.venv`) | [google-crc32c (PyPI)](https://pypi.org/project/google-crc32c/) |
+| **google-resumable-media** | `2.9.0` | version | (transitive in `.venv`) | [google-resumable-media (PyPI)](https://pypi.org/project/google-resumable-media/) |
+| **googleapis-common-protos** | `1.75.0` | version | (transitive in `.venv`) | [googleapis-common-protos (PyPI)](https://pypi.org/project/googleapis-common-protos/) |
+| **h11** | `0.16.0` | version | (transitive in `.venv`) | [h11 (PyPI)](https://pypi.org/project/h11/) |
+| **hf-xet** | `1.5.0` | version | (transitive in `.venv`) | [hf-xet (PyPI)](https://pypi.org/project/hf-xet/) |
+| **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
+| **httptools** | `0.8.0` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
+| **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
+| **huggingface_hub** | `1.17.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
+| **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
+| **idna** | `3.17` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
+| **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
+| **Jinja2** | `3.1.6` | version | `pyproject.toml` line 8 (direct) | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
+| **jiter** | `0.15.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |
+| **kubernetes** | `35.0.0` | version | `pyproject.toml` line 11 (direct) | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
+| **kubernetes_asyncio** | `35.0.1` | version | (transitive in `.venv`) | [kubernetes_asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
+| **llm-optimizer** | `bb82d22e8863b762e856be66e831d551d27576b1` | commit SHA | (transitive in `.venv`) | [llm-optimizer (PyPI)](https://pypi.org/project/llm-optimizer/) |
+| **llmdbenchmark** | `editable` | editable | (transitive in `.venv`) | [llmdbenchmark (PyPI)](https://pypi.org/project/llmdbenchmark/) |
+| **markdown-it-py** | `4.2.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
+| **MarkupSafe** | `3.0.3` | version | (transitive in `.venv`) | [MarkupSafe (PyPI)](https://pypi.org/project/markupsafe/) |
+| **mdurl** | `0.1.2` | version | (transitive in `.venv`) | [mdurl (PyPI)](https://pypi.org/project/mdurl/) |
+| **multidict** | `6.7.1` | version | (transitive in `.venv`) | [multidict (PyPI)](https://pypi.org/project/multidict/) |
+| **nodeenv** | `1.10.0` | version | (transitive in `.venv`) | [nodeenv (PyPI)](https://pypi.org/project/nodeenv/) |
+| **numpy** | `2.4.6` | version | (transitive in `.venv`) | [numpy (PyPI)](https://pypi.org/project/numpy/) |
+| **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
+| **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
+| **ollama** | `0.6.2` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
+| **openai** | `2.38.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
+| **packaging** | `26.2` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
+| **pandas** | `3.0.3` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
+| **planner** | `92b14fe09fea0ec9ff36539326b7a8df00f1022c` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
+| **platformdirs** | `4.10.0` | version | (transitive in `.venv`) | [platformdirs (PyPI)](https://pypi.org/project/platformdirs/) |
+| **pluggy** | `1.6.0` | version | (transitive in `.venv`) | [pluggy (PyPI)](https://pypi.org/project/pluggy/) |
+| **pre_commit** | `4.6.0` | version | (transitive in `.venv`) | [pre_commit (PyPI)](https://pypi.org/project/pre-commit/) |
+| **propcache** | `0.5.2` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
+| **proto-plus** | `1.28.0` | version | (transitive in `.venv`) | [proto-plus (PyPI)](https://pypi.org/project/proto-plus/) |
+| **protobuf** | `7.35.0` | version | (transitive in `.venv`) | [protobuf (PyPI)](https://pypi.org/project/protobuf/) |
+| **psutil** | `7.2.2` | version | (transitive in `.venv`) | [psutil (PyPI)](https://pypi.org/project/psutil/) |
+| **psycopg2-binary** | `2.9.12` | version | (transitive in `.venv`) | [psycopg2-binary (PyPI)](https://pypi.org/project/psycopg2-binary/) |
+| **pyasn1** | `0.6.3` | version | (transitive in `.venv`) | [pyasn1 (PyPI)](https://pypi.org/project/pyasn1/) |
+| **pyasn1_modules** | `0.4.2` | version | (transitive in `.venv`) | [pyasn1_modules (PyPI)](https://pypi.org/project/pyasn1-modules/) |
+| **pycparser** | `3.0` | version | (transitive in `.venv`) | [pycparser (PyPI)](https://pypi.org/project/pycparser/) |
+| **pydantic** | `2.13.4` | version | `pyproject.toml` line 17 (direct) | [pydantic (PyPI)](https://pypi.org/project/pydantic/) |
+| **pydantic-settings** | `2.14.1` | version | (transitive in `.venv`) | [pydantic-settings (PyPI)](https://pypi.org/project/pydantic-settings/) |
+| **pydantic_core** | `2.46.4` | version | (transitive in `.venv`) | [pydantic_core (PyPI)](https://pypi.org/project/pydantic-core/) |
+| **Pygments** | `2.20.0` | version | (transitive in `.venv`) | [Pygments (PyPI)](https://pypi.org/project/pygments/) |
+| **PyJWT** | `2.13.0` | version | (transitive in `.venv`) | [PyJWT (PyPI)](https://pypi.org/project/pyjwt/) |
+| **pykube-ng** | `23.6.0` | version | `pyproject.toml` line 12 (direct) | [pykube-ng (PyPI)](https://pypi.org/project/pykube-ng/) |
+| **pytest** | `9.0.3` | version | (transitive in `.venv`) | [pytest (PyPI)](https://pypi.org/project/pytest/) |
+| **python-dateutil** | `2.9.0.post0` | version | (transitive in `.venv`) | [python-dateutil (PyPI)](https://pypi.org/project/python-dateutil/) |
+| **python-discovery** | `1.4.0` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
+| **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
+| **python-multipart** | `0.0.29` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
+| **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
+| **regex** | `2026.5.9` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
+| **requests** | `2.34.2` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
+| **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
+| **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
+| **rich** | `15.0.0` | version | (transitive in `.venv`) | [rich (PyPI)](https://pypi.org/project/rich/) |
+| **safetensors** | `0.7.0` | version | (transitive in `.venv`) | [safetensors (PyPI)](https://pypi.org/project/safetensors/) |
+| **scipy** | `1.17.1` | version | (transitive in `.venv`) | [scipy (PyPI)](https://pypi.org/project/scipy/) |
+| **shellingham** | `1.5.4` | version | (transitive in `.venv`) | [shellingham (PyPI)](https://pypi.org/project/shellingham/) |
+| **six** | `1.17.0` | version | (transitive in `.venv`) | [six (PyPI)](https://pypi.org/project/six/) |
+| **smmap** | `5.0.3` | version | (transitive in `.venv`) | [smmap (PyPI)](https://pypi.org/project/smmap/) |
+| **sniffio** | `1.3.1` | version | (transitive in `.venv`) | [sniffio (PyPI)](https://pypi.org/project/sniffio/) |
+| **starlette** | `1.2.0` | version | (transitive in `.venv`) | [starlette (PyPI)](https://pypi.org/project/starlette/) |
+| **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
+| **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
+| **tqdm** | `4.67.3` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
+| **transformers** | `5.9.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **typer** | `0.25.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
+| **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
+| **typing_extensions** | `4.15.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
+| **urllib3** | `2.7.0` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
+| **uvicorn** | `0.47.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
+| **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
+| **virtualenv** | `21.4.1` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
+| **watchfiles** | `1.2.0` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
+| **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
+| **websockets** | `16.0` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
+| **yarl** | `1.24.2` | version | (transitive in `.venv`) | [yarl (PyPI)](https://pypi.org/project/yarl/) |
+
+</details>

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -86,7 +86,6 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
         Command.TEARDOWN.value,
         Command.RUN.value,
     ):
-
         # Resolve templates, scenarios, and values into the workspace
         specification_as_dict = RenderSpecification(
             specification_file=args.specification_file,
@@ -237,9 +236,11 @@ def _render_helm_manifests(plan_dir: Path, logger) -> None:
             logger=logger,
         )
         result = cmd.helmfile(
-            "--selector", f"name={model_id}-ms",
+            "--selector",
+            f"name={model_id}-ms",
             "template",
-            "-f", str(helm_dir / "helmfile.yaml"),
+            "-f",
+            str(helm_dir / "helmfile.yaml"),
             "--skip-schema-validation",
             use_kubeconfig=False,
         )
@@ -280,9 +281,7 @@ def _load_stack_info_from_config(config_file, stack_name=""):
                 "standalone_enabled": (
                     plan_config.get("standalone", {}).get("enabled", False)
                 ),
-                "fma_enabled": (
-                    plan_config.get("fma", {}).get("enabled", False)
-                ),
+                "fma_enabled": (plan_config.get("fma", {}).get("enabled", False)),
                 "modelservice_enabled": (
                     plan_config.get("modelservice", {}).get("enabled", False)
                 ),
@@ -417,7 +416,8 @@ def _do_standup(args, logger, render_plan_errors):
     deployed_methods = _resolve_deploy_methods(args, plan_info, logger)
 
     namespace, harness_ns = _parse_namespaces(
-        getattr(args, "namespace", None), plan_info,
+        getattr(args, "namespace", None),
+        plan_info,
     )
 
     if not namespace:
@@ -441,11 +441,17 @@ def _do_standup(args, logger, render_plan_errors):
         harness_namespace=harness_ns,
         model_name=plan_info.get("model_name"),
         logger=logger,
-        standalone_deploy_timeout=int(getattr(args, "standalone_deploy_timeout", 900) or 900),
+        standalone_deploy_timeout=int(
+            getattr(args, "standalone_deploy_timeout", 900) or 900
+        ),
         gateway_deploy_timeout=int(getattr(args, "gateway_deploy_timeout", 120) or 120),
-        modelservice_deploy_timeout=int(getattr(args, "modelservice_deploy_timeout", 1500) or 1500),
+        modelservice_deploy_timeout=int(
+            getattr(args, "modelservice_deploy_timeout", 1500) or 1500
+        ),
         pvc_bind_timeout=int(getattr(args, "pvc_bind_timeout", 240) or 240),
-        kustomize_deploy_timeout=int(getattr(args, "kustomize_deploy_timeout", 900) or 900),
+        kustomize_deploy_timeout=int(
+            getattr(args, "kustomize_deploy_timeout", 900) or 900
+        ),
         llmd_repo_path=getattr(args, "llmd_repo_path", None),
         kustomize_skip_infra=not getattr(args, "full_infra", False),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
@@ -499,10 +505,13 @@ def _do_smoketest(args, logger, render_plan_errors):
     rendered_paths = getattr(render_plan_errors, "rendered_paths", [])
     all_stacks_info = _load_all_stacks_info(rendered_paths)
     plan_info = all_stacks_info[0] if all_stacks_info else {}
-    deployed_methods = _resolve_deploy_methods(args, plan_info, logger, phase="smoketest")
+    deployed_methods = _resolve_deploy_methods(
+        args, plan_info, logger, phase="smoketest"
+    )
 
     namespace, harness_ns = _parse_namespaces(
-        getattr(args, "namespace", None), plan_info,
+        getattr(args, "namespace", None),
+        plan_info,
     )
 
     if not namespace:
@@ -650,6 +659,14 @@ def _print_standup_summary(context, result, logger):
     if harness_ns != ns:
         logger.log_info(f"  Harness NS: {harness_ns}")
     logger.log_info(f"  Methods:    {methods}")
+    # Gateway class only takes effect on the modelservice path; for the
+    # other deploy methods the label says "n/a (...)" so the operator
+    # isn't misled by the scenario's default value.
+    from llmdbenchmark.utilities.cluster import resolve_phase_gateway_label
+
+    gateway_label = resolve_phase_gateway_label(context)
+    if gateway_label:
+        logger.log_info(f"  Gateway:    {gateway_label}")
     logger.log_info(f"  Stacks:     {stacks}")
 
     total_steps = len(result.global_results)
@@ -688,7 +705,8 @@ def _do_teardown(args, logger, render_plan_errors):
     )
 
     namespace, harness_ns = _parse_namespaces(
-        getattr(args, "namespace", None), plan_info,
+        getattr(args, "namespace", None),
+        plan_info,
     )
 
     if not namespace:
@@ -764,7 +782,8 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
     deployed_methods = _resolve_deploy_methods(args, plan_info, logger, phase="run")
 
     namespace, harness_ns = _parse_namespaces(
-        getattr(args, "namespace", None), plan_info,
+        getattr(args, "namespace", None),
+        plan_info,
     )
 
     endpoint_url = getattr(args, "endpoint_url", None)
@@ -803,8 +822,7 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         harness_wait_timeout=int(
             getattr(args, "wait_timeout", None)
             if getattr(args, "wait_timeout", None) is not None
-            else (plan_info.get("harness", {}) or {}).get("waitTimeout")
-            or 3600
+            else (plan_info.get("harness", {}) or {}).get("waitTimeout") or 3600
         ),
         harness_debug=getattr(args, "debug", False),
         harness_skip_run=getattr(args, "skip", False),
@@ -815,7 +833,9 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         run_config_file=run_config_file,
         generate_config_only=getattr(args, "generate_config", False),
         dataset_url=getattr(args, "dataset", None),
-        harness_data_access_timeout=int(getattr(args, "data_access_timeout", 120) or 120),
+        harness_data_access_timeout=int(
+            getattr(args, "data_access_timeout", 120) or 120
+        ),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
@@ -930,9 +950,7 @@ def _print_endpoints_table(context, logger, args) -> None:
         f"  {'STACK'.ljust(col_stack)}  "
         f"{'MODEL'.ljust(col_model)}  {'ENDPOINT URL'.ljust(col_url)}"
     )
-    logger.log_info(
-        f"  {'-' * col_stack}  {'-' * col_model}  {'-' * col_url}"
-    )
+    logger.log_info(f"  {'-' * col_stack}  {'-' * col_model}  {'-' * col_url}")
     for stack_name, model_name, url in rows:
         logger.log_info(
             f"  {stack_name.ljust(col_stack)}  "
@@ -951,7 +969,7 @@ def _print_endpoints_table(context, logger, args) -> None:
         parent = os.path.basename(os.path.dirname(spec)) if "/" in spec else ""
         stem = os.path.basename(spec)
         if stem.endswith(".yaml.j2"):
-            stem = stem[:-len(".yaml.j2")]
+            stem = stem[: -len(".yaml.j2")]
         spec = f"{parent}/{stem}" if parent else stem
     namespace = context.namespace or "<namespace>"
     logger.log_info("💡 Copy-paste to benchmark one pool:")
@@ -1032,7 +1050,9 @@ def _execute_run(args, logger, render_plan_errors):
                 local_path = results_dir / f"{eid}_{i}"
                 if local_path.exists():
                     file_count = sum(1 for f in local_path.rglob("*") if f.is_file())
-                    logger.log_info(f"      [{i}/{parallelism}] {local_path.name} ({file_count} files)")
+                    logger.log_info(
+                        f"      [{i}/{parallelism}] {local_path.name} ({file_count} files)"
+                    )
     kube_bin = "oc" if context.is_openshift else "kubectl"
     logger.log_info(f"  Local results: {results_dir}")
     logger.log_info(
@@ -1048,7 +1068,9 @@ def _execute_run(args, logger, render_plan_errors):
 
     # --- Store run parameters as ConfigMap in namespace ---
     if not context.dry_run:
-        _store_run_parameters_configmap(context, harness, workload, experiment_ids, logger)
+        _store_run_parameters_configmap(
+            context, harness, workload, experiment_ids, logger
+        )
 
 
 def _store_run_parameters_configmap(context, harness, workload, experiment_ids, logger):
@@ -1074,7 +1096,7 @@ def _store_run_parameters_configmap(context, harness, workload, experiment_ids, 
         parallelism = context.harness_parallelism or 1
         results_dir_prefix = "/requests"
         pvc_paths = []
-        for eid in (experiment_ids or []):
+        for eid in experiment_ids or []:
             for i in range(1, parallelism + 1):
                 pvc_paths.append(f"{results_dir_prefix}/{eid}_{i}")
 
@@ -1102,8 +1124,11 @@ def _store_run_parameters_configmap(context, harness, workload, experiment_ids, 
         # Try to read existing ConfigMap to append
         existing_data = {}
         get_result = cmd.kube(
-            "get", "configmap", cm_name,
-            "-o", "jsonpath={.data}",
+            "get",
+            "configmap",
+            cm_name,
+            "-o",
+            "jsonpath={.data}",
             namespace=namespace,
             check=False,
         )
@@ -1134,7 +1159,9 @@ def _store_run_parameters_configmap(context, harness, workload, experiment_ids, 
         cm_path.write_text(_yaml.dump(cm, default_flow_style=False), encoding="utf-8")
 
         cmd.kube(
-            "apply", "-f", str(cm_path),
+            "apply",
+            "-f",
+            str(cm_path),
             namespace=namespace,
             check=False,
         )
@@ -1314,14 +1341,10 @@ def _execute_experiment(args, logger):
         # --- Phase 2b: Smoketest ---
         try:
             _do_smoketest(args, logger, render_plan_errors)
-            logger.log_info(
-                f"Smoketest complete for {treatment_name}", emoji="✅"
-            )
+            logger.log_info(f"Smoketest complete for {treatment_name}", emoji="✅")
         except PhaseError as e:
             error_msg = str(e)
-            logger.log_error(
-                f"Smoketest failed for {treatment_name}: {error_msg}"
-            )
+            logger.log_error(f"Smoketest failed for {treatment_name}: {error_msg}")
             if not skip_teardown:
                 try:
                     _do_teardown(args, logger, render_plan_errors)
@@ -1427,7 +1450,10 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_TELEMETRY_ENABLED": ("telemetry_enabled", "--telemetry-enabled"),
         "LLMDBENCH_TELEMETRY_PROVIDER": ("telemetry_provider", "--telemetry-provider"),
         "LLMDBENCH_TELEMETRY_ENDPOINT": ("telemetry_endpoint", "--telemetry-endpoint"),
-        "LLMDBENCH_TELEMETRY_AUTH_PROVIDER": ("telemetry_auth_provider", "--telemetry-auth-provider"),
+        "LLMDBENCH_TELEMETRY_AUTH_PROVIDER": (
+            "telemetry_auth_provider",
+            "--telemetry-auth-provider",
+        ),
         "LLMDBENCH_TELEMETRY_TOKEN": ("telemetry_token", "--telemetry-token"),
         "LLMDBENCH_DRY_RUN": ("dry_run", "--dry-run"),
         "LLMDBENCH_VERBOSE": ("verbose", "--verbose"),
@@ -1458,14 +1484,32 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_WVA": ("wva", "--wva"),
         "LLMDBENCH_SERVICE_ACCOUNT": ("serviceaccount", "--serviceaccount"),
         "LLMDBENCH_HARNESS_ENVVARS_TO_YAML": ("envvarspod", "--envvarspod"),
-        "LLMDBENCH_DATA_ACCESS_TIMEOUT": ("data_access_timeout", "--data-access-timeout"),
-        "LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT": ("standalone_deploy_timeout", "--standalone-deploy-timeout"),
-        "LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT": ("gateway_deploy_timeout", "--gateway-deploy-timeout"),
-        "LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT": ("modelservice_deploy_timeout", "--modelservice-deploy-timeout"),
+        "LLMDBENCH_DATA_ACCESS_TIMEOUT": (
+            "data_access_timeout",
+            "--data-access-timeout",
+        ),
+        "LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT": (
+            "standalone_deploy_timeout",
+            "--standalone-deploy-timeout",
+        ),
+        "LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT": (
+            "gateway_deploy_timeout",
+            "--gateway-deploy-timeout",
+        ),
+        "LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT": (
+            "modelservice_deploy_timeout",
+            "--modelservice-deploy-timeout",
+        ),
         "LLMDBENCH_PVC_BIND_TIMEOUT": ("pvc_bind_timeout", "--pvc-bind-timeout"),
-        "LLMDBENCH_FMA_TEARDOWN_TIMEOUT": ("fma_teardown_timeout", "--fma-teardown-timeout"),
+        "LLMDBENCH_FMA_TEARDOWN_TIMEOUT": (
+            "fma_teardown_timeout",
+            "--fma-teardown-timeout",
+        ),
         "LLMDBENCH_LLMD_REPO_PATH": ("llmd_repo_path", "--llmd-repo-path"),
-        "LLMDBENCH_KUSTOMIZE_DEPLOY_TIMEOUT": ("kustomize_deploy_timeout", "--kustomize-deploy-timeout"),
+        "LLMDBENCH_KUSTOMIZE_DEPLOY_TIMEOUT": (
+            "kustomize_deploy_timeout",
+            "--kustomize-deploy-timeout",
+        ),
     }
 
     active = {k: v for k, v in os.environ.items() if k in _ENV_TO_CLI}
@@ -1744,7 +1788,9 @@ def cli() -> None:
     if hasattr(args, "wva") and not args.wva:
         args.wva = env_bool("LLMDBENCH_WVA")
     if not args.specification_file:
-        parser.error("the following arguments are required: --specification_file/--spec")
+        parser.error(
+            "the following arguments are required: --specification_file/--spec"
+        )
 
     # Results command is handled separately
     if args.command == Command.RESULTS.value:
@@ -1782,7 +1828,7 @@ def cli() -> None:
             store_root = StoreManager.find_store_root(".", silent=True)
         except Exception:
             store_root = None
-            
+
         if store_root:
             overall_workspace = store_root / "workspaces"
         elif scenario_work_dir := _extract_workspace_from_scenario(
@@ -1861,7 +1907,7 @@ def cli() -> None:
             },
             "environment": {
                 "LLMDBENCH_BASE_DIR": str(args.base_dir),
-            }
+            },
         }
         telemetry.push(telemetry_data)
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -119,6 +119,7 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
             cli_methods=getattr(args, "methods", None),
             cli_monitoring=getattr(args, "monitoring", None),
             cli_wva=getattr(args, "wva", False),
+            cli_gateway_class=getattr(args, "gateway_class", None),
             cli_stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
         ).eval()
 
@@ -1197,6 +1198,7 @@ def _render_plans_for_experiment(args, logger, setup_overrides=None):
         cli_methods=getattr(args, "methods", None),
         cli_monitoring=getattr(args, "monitoring", None),
         cli_wva=getattr(args, "wva", False),
+        cli_gateway_class=getattr(args, "gateway_class", None),
         setup_overrides=setup_overrides,
     ).eval()
 
@@ -1461,6 +1463,7 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_NAMESPACE": ("namespace", "--namespace"),
         "LLMDBENCH_MODELS": ("models", "--models"),
         "LLMDBENCH_METHODS": ("methods", "--methods"),
+        "LLMDBENCH_GATEWAY_CLASS": ("gateway_class", "--gateway-class"),
         "LLMDBENCH_RELEASE": ("release", "--release"),
         "LLMDBENCH_KUBECONFIG": ("kubeconfig", "--kubeconfig"),
         "LLMDBENCH_PARALLEL": ("parallel", "--parallel"),
@@ -1558,6 +1561,7 @@ def _all_flag_forms(flag: str) -> list[str]:
         "--namespace": ["--namespace", "-p"],
         "--models": ["--models", "-m"],
         "--methods": ["--methods", "-t"],
+        "--gateway-class": ["--gateway-class"],
         "--release": ["--release", "-r"],
         "--kubeconfig": ["--kubeconfig", "-k"],
         "--parallel": ["--parallel"],

--- a/llmdbenchmark/interface/experiment.py
+++ b/llmdbenchmark/interface/experiment.py
@@ -6,7 +6,9 @@ from llmdbenchmark.interface.commands import Command
 from llmdbenchmark.interface.env import env, env_int
 
 
-def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []):
+def add_subcommands(
+    parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []
+):
     """Register the ``experiment`` subcommand and its arguments."""
     exp_parser = parser.add_parser(
         Command.EXPERIMENT.value,
@@ -39,6 +41,15 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         "--methods",
         default=env("LLMDBENCH_METHODS"),
         help="Deploy method (standalone, modelservice, fma).",
+    )
+    exp_parser.add_argument(
+        "--gateway-class",
+        default=env("LLMDBENCH_GATEWAY_CLASS"),
+        help=(
+            "Override the scenario's gateway.className. Supported values: "
+            "epponly, istio, agentgateway, gke, data-science-gateway-class. "
+            "Only takes effect on the modelservice deploy path."
+        ),
     )
     exp_parser.add_argument(
         "-m",

--- a/llmdbenchmark/interface/plan.py
+++ b/llmdbenchmark/interface/plan.py
@@ -5,7 +5,9 @@ from llmdbenchmark.interface.commands import Command
 from llmdbenchmark.interface.env import env
 
 
-def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []):
+def add_subcommands(
+    parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []
+):
     """Register the ``plan`` subcommand and its arguments.
 
     The plan subcommand renders templates without applying anything to the
@@ -31,14 +33,25 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         help="Namespaces to use (deploy_namespace, benchmark_namespace).",
     )
     plan_parser.add_argument(
-        "-m", "--models",
+        "-m",
+        "--models",
         default=env("LLMDBENCH_MODELS"),
         help="Model to render the plan for.",
     )
     plan_parser.add_argument(
-        "-t", "--methods",
+        "-t",
+        "--methods",
         default=env("LLMDBENCH_METHODS"),
         help="Deployment method (standalone, modelservice, fma).",
+    )
+    plan_parser.add_argument(
+        "--gateway-class",
+        default=env("LLMDBENCH_GATEWAY_CLASS"),
+        help=(
+            "Override the scenario's gateway.className. Supported values: "
+            "epponly, istio, agentgateway, gke, data-science-gateway-class. "
+            "Only takes effect on the modelservice deploy path."
+        ),
     )
     plan_parser.add_argument(
         "-f",

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -5,7 +5,9 @@ from llmdbenchmark.interface.commands import Command
 from llmdbenchmark.interface.env import env, env_int
 
 
-def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []):
+def add_subcommands(
+    parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []
+):
     """Register the ``run`` subcommand and its arguments."""
     run_parser = parser.add_parser(
         Command.RUN.value,
@@ -35,6 +37,15 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         "--methods",
         default=env("LLMDBENCH_METHODS"),
         help="Deploy method used during standup (standalone, modelservice, or custom resource name).",
+    )
+    run_parser.add_argument(
+        "--gateway-class",
+        default=env("LLMDBENCH_GATEWAY_CLASS"),
+        help=(
+            "Override the scenario's gateway.className when the run phase "
+            "re-renders templates for setup overrides. Supported values: "
+            "epponly, istio, agentgateway, gke, data-science-gateway-class."
+        ),
     )
     run_parser.add_argument(
         "--kubeconfig",

--- a/llmdbenchmark/interface/smoketest.py
+++ b/llmdbenchmark/interface/smoketest.py
@@ -5,7 +5,9 @@ from llmdbenchmark.interface.commands import Command
 from llmdbenchmark.interface.env import env, env_int
 
 
-def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []):
+def add_subcommands(
+    parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []
+):
     """Register the ``smoketest`` subcommand and its arguments."""
     smoketest_parser = parser.add_parser(
         Command.SMOKETEST.value,
@@ -29,9 +31,18 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         help="Namespaces to use (deploy_namespace, benchmark_namespace).",
     )
     smoketest_parser.add_argument(
-        "-t", "--methods",
+        "-t",
+        "--methods",
         default=env("LLMDBENCH_METHODS"),
         help="Deployment methods (standalone, modelservice, fma).",
+    )
+    smoketest_parser.add_argument(
+        "--gateway-class",
+        default=env("LLMDBENCH_GATEWAY_CLASS"),
+        help=(
+            "Override the scenario's gateway.className (only meaningful "
+            "if the smoketest re-renders templates)."
+        ),
     )
     smoketest_parser.add_argument(
         "--parallel",

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -5,7 +5,9 @@ from llmdbenchmark.interface.commands import Command
 from llmdbenchmark.interface.env import env, env_int
 
 
-def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []):
+def add_subcommands(
+    parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []
+):
     """Register the ``standup`` subcommand and its arguments."""
     standup_parser = parser.add_parser(
         Command.STANDUP.value,
@@ -44,6 +46,16 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         "--methods",
         default=env("LLMDBENCH_METHODS"),
         help="Standup methods (standalone, modelservice, fma, kustomize).",
+    )
+    standup_parser.add_argument(
+        "--gateway-class",
+        default=env("LLMDBENCH_GATEWAY_CLASS"),
+        help=(
+            "Override the scenario's gateway.className. Supported values: "
+            "epponly, istio, agentgateway, gke, data-science-gateway-class. "
+            "Only takes effect on the modelservice deploy path -- ignored "
+            "by kustomize/standalone/fma."
+        ),
     )
     standup_parser.add_argument(
         "-a",
@@ -127,10 +139,10 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         type=int,
         default=env_int("LLMDBENCH_PVC_BIND_TIMEOUT"),
         help="Seconds to wait for each PVC (workload, model, extra) to reach "
-             "the Bound phase during standup. A PVC that never binds (e.g. no "
-             "default StorageClass on the cluster) fails fast instead of "
-             "masquerading as a downstream pod/job timeout. Default: 240 "
-             "(some dynamic provisioners take 1-3 minutes per volume).",
+        "the Bound phase during standup. A PVC that never binds (e.g. no "
+        "default StorageClass on the cluster) fails fast instead of "
+        "masquerading as a downstream pod/job timeout. Default: 240 "
+        "(some dynamic provisioners take 1-3 minutes per volume).",
     )
     standup_parser.add_argument(
         "--llmd-repo-path",

--- a/llmdbenchmark/interface/teardown.py
+++ b/llmdbenchmark/interface/teardown.py
@@ -5,7 +5,9 @@ from llmdbenchmark.interface.commands import Command
 from llmdbenchmark.interface.env import env, env_int
 
 
-def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []):
+def add_subcommands(
+    parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []
+):
     """Register the ``teardown`` subcommand and its arguments."""
     teardown_parser = parser.add_parser(
         Command.TEARDOWN.value,
@@ -30,22 +32,34 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         help="Step list (comma-separated values or ranges, e.g. 0,1,3 or 0-4).",
     )
     teardown_parser.add_argument(
-        "-m", "--models",
+        "-m",
+        "--models",
         default=env("LLMDBENCH_MODELS"),
         help="Model that was deployed (used for resource name resolution).",
     )
     teardown_parser.add_argument(
-        "-t", "--methods",
+        "-t",
+        "--methods",
         default=env("LLMDBENCH_METHODS"),
         help="Deployment methods to tear down (standalone, modelservice, fma, kustomize).",
     )
     teardown_parser.add_argument(
-        "-r", "--release",
+        "--gateway-class",
+        default=env("LLMDBENCH_GATEWAY_CLASS"),
+        help=(
+            "Override the scenario's gateway.className (only meaningful "
+            "if teardown re-renders templates)."
+        ),
+    )
+    teardown_parser.add_argument(
+        "-r",
+        "--release",
         default=env("LLMDBENCH_RELEASE", "llmdbench"),
         help="Modelservice Helm chart release name (default: llmdbench).",
     )
     teardown_parser.add_argument(
-        "-d", "--deep",
+        "-d",
+        "--deep",
         action="store_true",
         help=(
             "Deep cleaning: delete ALL resources in both namespaces. "
@@ -55,7 +69,8 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         ),
     )
     teardown_parser.add_argument(
-        "-p", "--namespace",
+        "-p",
+        "--namespace",
         default=env("LLMDBENCH_NAMESPACE"),
         help="Comma-separated namespaces to tear down (model,harness). "
         "Overrides namespace from the plan config. If only one namespace is "
@@ -85,7 +100,7 @@ def add_subcommands(parser: argparse._SubParsersAction, parents: list[argparse.A
         type=int,
         default=env_int("LLMDBENCH_FMA_TEARDOWN_TIMEOUT"),
         help="Seconds to wait for FMA launcher and requester pods to terminate "
-             "before the Helm chart uninstall removes the controller. Default: 120.",
+        "before the Helm chart uninstall removes the controller. Default: 120.",
     )
     teardown_parser.add_argument(
         "--llmd-repo-path",

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -49,6 +49,7 @@ class RenderPlans:
         cli_methods: str | None = None,
         cli_monitoring: bool | None = None,
         cli_wva: bool = False,
+        cli_gateway_class: str | None = None,
         setup_overrides: dict | None = None,
         cli_stack_filter: list[str] | None = None,
     ):
@@ -63,6 +64,11 @@ class RenderPlans:
         self.cli_methods = cli_methods
         self.cli_monitoring = cli_monitoring
         self.cli_wva = cli_wva
+        # CLI override for `gateway.className`. Applied per-stack in
+        # `_resolve_gateway_class` ahead of `_validate_epponly_constraints`
+        # so the validator sees the post-override value. Only affects
+        # rendering on the modelservice path; ignored by kustomize/standalone/fma.
+        self.cli_gateway_class = cli_gateway_class
         self.setup_overrides = setup_overrides
         # When --stack selects exactly one stack, -m/--models scopes to
         # that stack only (sibling stacks keep their scenario-defined
@@ -573,6 +579,54 @@ class RenderPlans:
             kustomize_config["enabled"] = True
             self.logger.log_info("Deploy method from CLI: kustomize")
 
+        return result
+
+    # Whitelist for the --gateway-class CLI override. Reject anything else
+    # at render time so a typo doesn't silently produce a broken Gateway /
+    # InferencePool chart configuration.
+    _SUPPORTED_GATEWAY_CLASSES: tuple[str, ...] = (
+        "epponly",
+        "istio",
+        "agentgateway",
+        "gke",
+        "data-science-gateway-class",
+    )
+
+    def _resolve_gateway_class(self, values: dict) -> dict:
+        """Apply ``--gateway-class`` CLI override to ``gateway.className``.
+
+        Only meaningful on the modelservice deploy path (kustomize /
+        standalone / fma ignore the scenario's gateway block entirely).
+        The override is applied unconditionally so it shows up in the
+        rendered config and gets surfaced by the standup banner; the
+        deploy steps gate on the active method themselves.
+
+        Raises ``ValueError`` on an unknown gateway class so a typo
+        fails fast at plan time rather than silently producing a
+        broken deploy.
+        """
+        if not self.cli_gateway_class:
+            return values
+
+        candidate = self.cli_gateway_class.strip()
+        if candidate not in self._SUPPORTED_GATEWAY_CLASSES:
+            supported = ", ".join(self._SUPPORTED_GATEWAY_CLASSES)
+            raise ValueError(
+                f"--gateway-class={candidate!r} is not a supported value. "
+                f"Choose one of: {supported}."
+            )
+
+        result = deepcopy(values)
+        gateway_config = result.setdefault("gateway", {})
+        previous = gateway_config.get("className")
+        gateway_config["className"] = candidate
+
+        if previous and previous != candidate:
+            self.logger.log_info(
+                f"Gateway class override from CLI: {previous} -> {candidate}"
+            )
+        else:
+            self.logger.log_info(f"Gateway class from CLI: {candidate}")
         return result
 
     @staticmethod
@@ -1123,6 +1177,7 @@ class RenderPlans:
         )
         self._warn_custom_command_conflicts(merged_values)
         merged_values = self._resolve_deploy_method(merged_values)
+        merged_values = self._resolve_gateway_class(merged_values)
         merged_values = self._resolve_monitoring(merged_values)
         merged_values = self._resolve_wva(merged_values)
         merged_values = self._resolve_hf_token(merged_values)

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -353,7 +353,10 @@ class RenderPlans:
         return f"{first8}-{hash8}-{last8}".lower()
 
     def _resolve_model(
-        self, values: dict, total_stacks: int = 1, stack_name: str = "",
+        self,
+        values: dict,
+        total_stacks: int = 1,
+        stack_name: str = "",
     ) -> dict:
         """Resolve model configuration from CLI ``--models`` override.
 
@@ -439,11 +442,7 @@ class RenderPlans:
             return
 
         for role in ("decode", "prefill"):
-            cmd = (
-                values.get(role, {})
-                .get("vllm", {})
-                .get("customCommand")
-            )
+            cmd = values.get(role, {}).get("vllm", {}).get("customCommand")
             if cmd:
                 self.logger.log_warning(
                     f"CLI --models override ({self.cli_model}) will not "
@@ -526,8 +525,7 @@ class RenderPlans:
             methods = ["modelservice"]
         if "standalone" in methods and "fma" in methods:
             self.logger.log_warning(
-                "Cannot enable both standalone and fma -- "
-                "choose one. Using standalone."
+                "Cannot enable both standalone and fma -- choose one. Using standalone."
             )
             methods = ["standalone"]
         if "modelservice" in methods and "fma" in methods:
@@ -576,6 +574,68 @@ class RenderPlans:
             self.logger.log_info("Deploy method from CLI: kustomize")
 
         return result
+
+    @staticmethod
+    def _validate_epponly_constraints(
+        values: dict,
+        total_stacks: int,
+        stack_name: str,
+    ) -> list[str]:
+        """Reject incompatible options when ``gateway.className == 'epponly'``.
+
+        ``epponly`` is the llm-d "standalone" router topology: no Kubernetes
+        Gateway is deployed and the EPP runs with an Envoy sidecar that
+        serves HTTP directly. The setting only takes effect on the
+        ``modelservice`` deploy path (it controls how the GAIE Helm chart is
+        wired). Some scenario features become meaningless or actively broken
+        when ``epponly`` is paired with modelservice:
+
+          - multi-stack scenarios (no shared Gateway / HTTPRoute -- each
+            stack would need its own EPP, but standup currently can't
+            advertise N independent EPP endpoints cleanly).
+          - shared HTTPRoute mode (HTTPRoute references a Gateway that
+            does not exist).
+
+        When a non-modelservice deploy method is active (``kustomize``,
+        ``standalone``, ``fma``) the ``gateway.*`` block is ignored
+        entirely by the rendering pipeline, so we no-op rather than
+        flagging an error: this lets a single scenario file ship
+        ``gateway.className: epponly`` as the modelservice default while
+        still being usable verbatim with ``-t kustomize`` (or any other
+        deploy method override).
+
+        Returns a list of fatal error strings. An empty list means the
+        configuration is compatible.
+        """
+        gw_class = (values.get("gateway") or {}).get("className", "")
+        if gw_class != "epponly":
+            return []
+
+        modelservice_enabled = (values.get("modelservice") or {}).get("enabled", True)
+        if not modelservice_enabled:
+            # Another deploy method owns the stack -- gateway.className is
+            # a no-op for kustomize/standalone/fma, so silently accept.
+            return []
+
+        errors: list[str] = []
+
+        if total_stacks > 1:
+            errors.append(
+                f"[{stack_name}] gateway.className=epponly is single-stack "
+                "only (the standalone router topology has no shared "
+                "Gateway / HTTPRoute to multiplex multiple models). "
+                f"This scenario has {total_stacks} stacks."
+            )
+
+        http_route_mode = (values.get("httpRoute") or {}).get("mode")
+        if http_route_mode == "shared":
+            errors.append(
+                f"[{stack_name}] gateway.className=epponly cannot be used "
+                "with httpRoute.mode=shared (shared HTTPRoute requires a "
+                "Gateway that epponly does not deploy)."
+            )
+
+        return errors
 
     def _log_image_overrides(self, values: dict) -> None:
         """Log images that have been explicitly set (not 'auto').
@@ -647,13 +707,13 @@ class RenderPlans:
         # SA access to the user-workload-monitoring Prometheus. Two gaie
         # Helm releases sharing this Secret name in one namespace fail
         # with "owned by another helm release".
-        (("inferenceExtension", "monitoring", "secretName"),
-         "inference-gateway-sa-metrics-reader-secret"),
+        (
+            ("inferenceExtension", "monitoring", "secretName"),
+            "inference-gateway-sa-metrics-reader-secret",
+        ),
     )
 
-    def _resolve_per_stack_identity(
-        self, values: dict, total_stacks: int = 1
-    ) -> dict:
+    def _resolve_per_stack_identity(self, values: dict, total_stacks: int = 1) -> dict:
         """Auto-suffix stack-scoped resource names with ``model_id_label``.
 
         Multi-stack scenarios need per-model PVCs, Download Jobs, and EPP
@@ -713,8 +773,7 @@ class RenderPlans:
         scenario authors don't need to compute the hashed label by hand.
         """
         dest_rule = (
-            values
-            .get("inferenceExtension", {})
+            values.get("inferenceExtension", {})
             .get("inferencePoolProviderConfig", {})
             .get("destinationRule")
         )
@@ -723,8 +782,7 @@ class RenderPlans:
             if model_id_label:
                 dest_rule["host"] = f"{model_id_label}-gaie-epp"
                 self.logger.log_info(
-                    f"Auto-resolved destinationRule.host to "
-                    f"'{dest_rule['host']}'"
+                    f"Auto-resolved destinationRule.host to '{dest_rule['host']}'"
                 )
         return values
 
@@ -760,6 +818,7 @@ class RenderPlans:
 
     def _substitute_string(self, text: str, root: dict) -> str:
         """Replace all ``${dotted.path}`` patterns in a single string."""
+
         def _replace(match: re.Match) -> str:
             path = match.group(1)
             value = self._resolve_dotted_path(path, root)
@@ -918,7 +977,9 @@ class RenderPlans:
         return errors
 
     def _build_sibling_stacks(
-        self, stacks: list[dict], shared: dict | None = None,
+        self,
+        stacks: list[dict],
+        shared: dict | None = None,
     ) -> list[dict]:
         """Build a minimal per-stack summary list the HTTPRoute template can
         iterate over to emit one backendRef per sibling stack.
@@ -950,15 +1011,15 @@ class RenderPlans:
             # otherwise None (undetermined -> treat as non-standalone).
             stack_standalone = (stack.get("standalone") or {}).get("enabled")
             is_standalone = bool(
-                stack_standalone
-                if stack_standalone is not None
-                else shared_standalone
+                stack_standalone if stack_standalone is not None else shared_standalone
             )
-            siblings.append({
-                "name": stack.get("name", ""),
-                "modelName": model_name,
-                "standalone": is_standalone,
-            })
+            siblings.append(
+                {
+                    "name": stack.get("name", ""),
+                    "modelName": model_name,
+                    "standalone": is_standalone,
+                }
+            )
         return siblings
 
     def _validate_shared_block(self, defaults: dict, shared: dict) -> None:
@@ -1052,9 +1113,7 @@ class RenderPlans:
 
         # Raises RuntimeError if "auto" values are present but cluster is unreachable
         if self.cluster_resource_resolver:
-            merged_values = self.cluster_resource_resolver.resolve_all(
-                merged_values
-            )
+            merged_values = self.cluster_resource_resolver.resolve_all(merged_values)
 
         merged_values = self._resolve_namespace(merged_values)
         merged_values = self._resolve_model(
@@ -1077,6 +1136,15 @@ class RenderPlans:
         merged_values["siblingStacks"] = sibling_stacks or []
         merged_values["stackIndex"] = stack_index
         merged_values["sharedInfraStackIndex"] = shared_infra_stack_index
+
+        epponly_errors = self._validate_epponly_constraints(
+            merged_values,
+            total_stacks=total_stacks,
+            stack_name=stack_name,
+        )
+        for msg in epponly_errors:
+            self.logger.log_error(msg)
+            stack_errors.render_errors.append(msg)
 
         validation_warnings = validate_config(merged_values, self.logger)
         if validation_warnings:
@@ -1183,8 +1251,7 @@ class RenderPlans:
         # catch now - fails fast with a list of known names.
         if self.cli_stack_filter:
             known_stack_names = {
-                s.get("name") for s in stacks
-                if isinstance(s, dict) and s.get("name")
+                s.get("name") for s in stacks if isinstance(s, dict) and s.get("name")
             }
             unknown = [n for n in self.cli_stack_filter if n not in known_stack_names]
             if unknown:

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -595,24 +595,42 @@ class RenderPlans:
     def _resolve_gateway_class(self, values: dict) -> dict:
         """Apply ``--gateway-class`` CLI override to ``gateway.className``.
 
-        Only meaningful on the modelservice deploy path (kustomize /
-        standalone / fma ignore the scenario's gateway block entirely).
-        The override is applied unconditionally so it shows up in the
-        rendered config and gets surfaced by the standup banner; the
-        deploy steps gate on the active method themselves.
+        ``gateway.className`` only affects rendering on the modelservice
+        path. Kustomize / standalone / fma ignore the gateway block
+        entirely, so we accept any string there (including sentinels like
+        ``none`` that CI scripts pass uniformly across deploy methods)
+        without validation.
 
-        Raises ``ValueError`` on an unknown gateway class so a typo
-        fails fast at plan time rather than silently producing a
-        broken deploy.
+        On the modelservice path we enforce a whitelist so a typo fails
+        fast at plan time rather than silently producing a broken Gateway
+        / InferencePool chart configuration.
         """
         if not self.cli_gateway_class:
             return values
 
         candidate = self.cli_gateway_class.strip()
+
+        modelservice_enabled = (values.get("modelservice") or {}).get("enabled", True)
+
+        if not modelservice_enabled:
+            # Non-modelservice deploy method is active -- the gateway
+            # block is ignored by every rendered template. Store the
+            # value verbatim (so the banner / config.yaml are honest about
+            # what the CLI requested) and skip validation.
+            result = deepcopy(values)
+            gateway_config = result.setdefault("gateway", {})
+            gateway_config["className"] = candidate
+            self.logger.log_info(
+                f"Gateway class from CLI: {candidate} "
+                f"(ignored -- modelservice is not the active deploy method)"
+            )
+            return result
+
         if candidate not in self._SUPPORTED_GATEWAY_CLASSES:
             supported = ", ".join(self._SUPPORTED_GATEWAY_CLASSES)
             raise ValueError(
-                f"--gateway-class={candidate!r} is not a supported value. "
+                f"--gateway-class={candidate!r} is not a supported value "
+                f"for the modelservice deploy method. "
                 f"Choose one of: {supported}."
             )
 

--- a/llmdbenchmark/run/steps/step_03_detect_endpoint.py
+++ b/llmdbenchmark/run/steps/step_03_detect_endpoint.py
@@ -8,6 +8,7 @@ from llmdbenchmark.utilities.endpoint import (
     find_standalone_endpoint,
     find_fma_endpoint,
     find_gateway_endpoint,
+    find_epponly_endpoint,
     find_custom_endpoint,
     find_kustomize_endpoint,
     discover_hf_token_secret,
@@ -63,19 +64,21 @@ class DetectEndpointStep(Step):
         namespace = context.namespace or self._require_config(
             plan_config, "namespace", "name"
         )
-        is_standalone = (
-            "standalone" in context.deployed_methods
-            or self._resolve(plan_config, "standalone.enabled", default=False)
+        is_standalone = "standalone" in context.deployed_methods or self._resolve(
+            plan_config, "standalone.enabled", default=False
         )
-        is_fma = (
-            "fma" in context.deployed_methods
-            or self._resolve(plan_config, "fma.enabled", default=False)
+        is_fma = "fma" in context.deployed_methods or self._resolve(
+            plan_config, "fma.enabled", default=False
         )
         inference_port = self._resolve(
-            plan_config, "vllmCommon.inferencePort", default=8000,
+            plan_config,
+            "vllmCommon.inferencePort",
+            default=8000,
         )
         release = self._resolve(
-            plan_config, "release", context_value=context.release,
+            plan_config,
+            "release",
+            context_value=context.release,
         )
 
         service_ip = None
@@ -102,19 +105,21 @@ class DetectEndpointStep(Step):
             service_name = service_ip
             gateway_port = 0
         elif is_kustomize:
-            guide_name = self._resolve(
-                plan_config, "kustomize.guideName", default=""
-            )
+            guide_name = self._resolve(plan_config, "kustomize.guideName", default="")
             context.logger.log_info(
                 f"Kustomize deployment -- looking for service '{guide_name}-epp'",
             )
             if guide_name:
                 service_ip, service_name, gateway_port = find_kustomize_endpoint(
-                    cmd, namespace, guide_name,
+                    cmd,
+                    namespace,
+                    guide_name,
                 )
             else:
                 service_ip, service_name, gateway_port = find_custom_endpoint(
-                    cmd, namespace, "epp",
+                    cmd,
+                    namespace,
+                    "epp",
                 )
             stack_type = "vllm-prod"
         elif deploy_method:
@@ -124,13 +129,26 @@ class DetectEndpointStep(Step):
                 emoji="🔍",
             )
             service_ip, service_name, gateway_port = find_custom_endpoint(
-                cmd, namespace, deploy_method,
+                cmd,
+                namespace,
+                deploy_method,
             )
             stack_type = "vllm-prod"
         else:
-            service_ip, service_name, gateway_port = find_gateway_endpoint(
-                cmd, namespace, release
-            )
+            # epponly: no Kubernetes Gateway exists; clients hit the EPP
+            # service directly (port 80 -> Envoy sidecar 8081 in the EPP pod).
+            gateway_class = self._resolve(plan_config, "gateway.className", default="")
+            if gateway_class == "epponly":
+                model_id_label = plan_config.get("model_id_label", "")
+                service_ip, service_name, gateway_port = find_epponly_endpoint(
+                    cmd,
+                    namespace,
+                    model_id_label,
+                )
+            else:
+                service_ip, service_name, gateway_port = find_gateway_endpoint(
+                    cmd, namespace, release
+                )
             stack_type = "llm-d"
 
         if not service_ip:
@@ -157,7 +175,9 @@ class DetectEndpointStep(Step):
         protocol = "https" if gateway_port == "443" else "http"
         endpoint_url = f"{protocol}://{service_ip}:{gateway_port}"
         path_prefix = compute_gateway_path_prefix(
-            plan_config, stack_name, is_standalone=is_standalone,
+            plan_config,
+            stack_name,
+            is_standalone=is_standalone,
         )
         if path_prefix:
             endpoint_url = f"{endpoint_url}{path_prefix}"
@@ -199,8 +219,7 @@ class DetectEndpointStep(Step):
             return
 
         context.logger.log_info(
-            "Trying to find a matching HuggingFace token "
-            "secret in the cluster...",
+            "Trying to find a matching HuggingFace token secret in the cluster...",
             emoji="🔍",
         )
 
@@ -213,9 +232,7 @@ class DetectEndpointStep(Step):
             )
             return
 
-        context.logger.log_info(
-            f"HuggingFace token secret detected: '{secret_name}'"
-        )
+        context.logger.log_info(f"HuggingFace token secret detected: '{secret_name}'")
 
         token = extract_hf_token_from_secret(cmd, namespace, secret_name)
         if token:

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -15,6 +15,7 @@ from llmdbenchmark.utilities.endpoint import (
     _rand_suffix,
     compute_gateway_path_prefix,
     find_custom_endpoint,
+    find_epponly_endpoint,
     find_gateway_endpoint,
     find_kustomize_endpoint,
     find_standalone_endpoint,
@@ -65,7 +66,9 @@ class BaseSmoketest:
         validator needs scenario-specific routing logic.
         """
         return compute_gateway_path_prefix(
-            plan_config, stack_name, is_standalone=is_standalone,
+            plan_config,
+            stack_name,
+            is_standalone=is_standalone,
         )
 
     @staticmethod
@@ -104,8 +107,12 @@ class BaseSmoketest:
         is_kustomize = "kustomize" in context.deployed_methods
         namespace = context.require_namespace()
 
-        inference_port = _nested_get(plan_config, "vllmCommon", "inferencePort") or "8000"
+        inference_port = (
+            _nested_get(plan_config, "vllmCommon", "inferencePort") or "8000"
+        )
         release = _nested_get(plan_config, "release") or ""
+        gateway_class = _nested_get(plan_config, "gateway", "className") or ""
+        model_id_label = plan_config.get("model_id_label", "") or ""
 
         if is_standalone:
             service_ip, _, gateway_port = find_standalone_endpoint(
@@ -117,16 +124,28 @@ class BaseSmoketest:
             guide_name = _nested_get(plan_config, "kustomize", "guideName") or ""
             if guide_name:
                 service_ip, _, gateway_port = find_kustomize_endpoint(
-                    cmd, namespace, guide_name,
+                    cmd,
+                    namespace,
+                    guide_name,
                 )
             else:
                 service_ip, _, gateway_port = find_custom_endpoint(
-                    cmd, namespace, "epp",
+                    cmd,
+                    namespace,
+                    "epp",
                 )
-        else:
-            service_ip, _, gateway_port = find_gateway_endpoint(
-                cmd, namespace, release
+        elif gateway_class == "epponly":
+            # No Kubernetes Gateway -- the EPP service is the data plane.
+            # Hit `{model_id_label}-gaie-epp:80` directly (port 80 is the
+            # extraServicePort we add for the standalone chart's Envoy
+            # sidecar).
+            service_ip, _, gateway_port = find_epponly_endpoint(
+                cmd,
+                namespace,
+                model_id_label,
             )
+        else:
+            service_ip, _, gateway_port = find_gateway_endpoint(cmd, namespace, release)
 
         if not service_ip and context.dry_run:
             service_ip = "<dry-run-endpoint>"
@@ -148,7 +167,11 @@ class BaseSmoketest:
         plan_config = _load_config(stack_path)
 
         model_name = _nested_get(plan_config, "model", "name") or ""
-        model_id_label = plan_config.get("model_id_label", "") or _nested_get(plan_config, "model", "shortName") or ""
+        model_id_label = (
+            plan_config.get("model_id_label", "")
+            or _nested_get(plan_config, "model", "shortName")
+            or ""
+        )
         standalone_role = _nested_get(plan_config, "standalone", "role") or "standalone"
         is_kustomize = "kustomize" in context.deployed_methods
         guide_name = _nested_get(plan_config, "kustomize", "guideName") or ""
@@ -158,7 +181,9 @@ class BaseSmoketest:
             return report
 
         service_ip, gateway_port, is_standalone = self.discover_endpoint(
-            cmd, context, plan_config,
+            cmd,
+            context,
+            plan_config,
         )
 
         # 1. Check pods running for each configured role
@@ -175,67 +200,97 @@ class BaseSmoketest:
             if decode_enabled is not False and int(decode_replicas) > 0:
                 roles_to_check.append(("decode", "decode"))
             else:
-                context.logger.log_info("No decode pods configured -- skipping decode health check")
+                context.logger.log_info(
+                    "No decode pods configured -- skipping decode health check"
+                )
             prefill_enabled = _nested_get(plan_config, "prefill", "enabled")
             prefill_replicas = _nested_get(plan_config, "prefill", "replicas") or 0
             if prefill_enabled and int(prefill_replicas) > 0:
                 roles_to_check.append(("prefill", "prefill"))
             else:
-                context.logger.log_info("No prefill pods configured -- skipping prefill health check")
+                context.logger.log_info(
+                    "No prefill pods configured -- skipping prefill health check"
+                )
 
         if not roles_to_check:
-            report.add(CheckResult(
-                "pods_configured", False,
-                message="No decode, prefill, or standalone pods configured",
-            ))
+            report.add(
+                CheckResult(
+                    "pods_configured",
+                    False,
+                    message="No decode, prefill, or standalone pods configured",
+                )
+            )
 
         for pod_type, role_label in roles_to_check:
             if is_kustomize and guide_name:
-                role_selector = f"llm-d.ai/guide={guide_name},llm-d.ai/role={role_label}"
+                role_selector = (
+                    f"llm-d.ai/guide={guide_name},llm-d.ai/role={role_label}"
+                )
             else:
-                role_selector = f"llm-d.ai/model={model_id_label},llm-d.ai/role={role_label}"
+                role_selector = (
+                    f"llm-d.ai/model={model_id_label},llm-d.ai/role={role_label}"
+                )
             context.logger.log_info(
                 f"Checking {pod_type} pod status (selector: {role_selector})..."
             )
             pod_check = cmd.kube(
-                "get", "pods", "-l", role_selector,
-                "--namespace", namespace,
-                "-o", "jsonpath={.items[*].status.phase}",
+                "get",
+                "pods",
+                "-l",
+                role_selector,
+                "--namespace",
+                namespace,
+                "-o",
+                "jsonpath={.items[*].status.phase}",
                 check=False,
             )
             if not pod_check.dry_run:
                 if pod_check.success:
                     phases = pod_check.stdout.strip().split()
                     if not phases:
-                        report.add(CheckResult(
-                            f"{pod_type}_pods_exist", False,
-                            message=f"No {pod_type} pods found with selector '{role_selector}'",
-                        ))
+                        report.add(
+                            CheckResult(
+                                f"{pod_type}_pods_exist",
+                                False,
+                                message=f"No {pod_type} pods found with selector '{role_selector}'",
+                            )
+                        )
                     elif not all(p == "Running" for p in phases):
-                        report.add(CheckResult(
-                            f"{pod_type}_pods_running", False,
-                            expected="all Running",
-                            actual=", ".join(phases),
-                            message=f"Not all {pod_type} pods running (found: {', '.join(phases)})",
-                        ))
+                        report.add(
+                            CheckResult(
+                                f"{pod_type}_pods_running",
+                                False,
+                                expected="all Running",
+                                actual=", ".join(phases),
+                                message=f"Not all {pod_type} pods running (found: {', '.join(phases)})",
+                            )
+                        )
                     else:
                         context.logger.log_info(
                             f"All {len(phases)} {pod_type} pod(s) running (ok)"
                         )
-                        report.add(CheckResult(
-                            f"{pod_type}_pods_running", True,
-                            message=f"{len(phases)} {pod_type} pod(s) running",
-                        ))
+                        report.add(
+                            CheckResult(
+                                f"{pod_type}_pods_running",
+                                True,
+                                message=f"{len(phases)} {pod_type} pod(s) running",
+                            )
+                        )
                         # Check pod Ready condition -- catches crash-looping
                         # sidecar containers (e.g., routing-proxy native
                         # sidecar with restartPolicy: Always). The Ready
                         # condition is True only when ALL containers pass
                         # their readiness probes.
                         ready_check = cmd.kube(
-                            "get", "pods", "-l", role_selector,
-                            "--namespace", namespace,
+                            "get",
+                            "pods",
+                            "-l",
+                            role_selector,
+                            "--namespace",
+                            namespace,
                             "--no-headers",
-                            "-o", "custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready",
+                            "-o",
+                            "custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready",
                             check=False,
                         )
                         if ready_check.success and ready_check.stdout.strip():
@@ -250,25 +305,34 @@ class BaseSmoketest:
                                 elif parts:
                                     not_ready.append(parts[0])
                             if not_ready:
-                                report.add(CheckResult(
-                                    f"{pod_type}_containers_ready", False,
-                                    message=f"Not all {pod_type} pods ready (containers may be crash-looping): {', '.join(not_ready)}",
-                                ))
+                                report.add(
+                                    CheckResult(
+                                        f"{pod_type}_containers_ready",
+                                        False,
+                                        message=f"Not all {pod_type} pods ready (containers may be crash-looping): {', '.join(not_ready)}",
+                                    )
+                                )
                             else:
                                 context.logger.log_info(
                                     f"All {pod_type} containers ready (ok)"
                                 )
                 else:
-                    report.add(CheckResult(
-                        f"{pod_type}_pods_check", False,
-                        message=f"Failed to check {pod_type} pod status: {pod_check.stderr}",
-                    ))
+                    report.add(
+                        CheckResult(
+                            f"{pod_type}_pods_check",
+                            False,
+                            message=f"Failed to check {pod_type} pod status: {pod_check.stderr}",
+                        )
+                    )
 
         if not service_ip:
-            report.add(CheckResult(
-                "endpoint_discovery", False,
-                message="Could not find service/gateway IP",
-            ))
+            report.add(
+                CheckResult(
+                    "endpoint_discovery",
+                    False,
+                    message="Could not find service/gateway IP",
+                )
+            )
             return report
 
         # When the scenario uses a shared HTTPRoute with path-based routing
@@ -277,7 +341,9 @@ class BaseSmoketest:
         # the InferencePool for THIS stack. Returns "" for the usual case
         # (single-model scenarios, standalone) - unchanged behavior.
         url_path_prefix = self._gateway_path_prefix_for_stack(
-            plan_config, is_standalone, stack_name=stack_path.name,
+            plan_config,
+            is_standalone,
+            stack_name=stack_path.name,
         )
 
         # 2. Health check (/health) - skip when the endpoint doesn't
@@ -289,10 +355,13 @@ class BaseSmoketest:
                 "(/v1/*) only. /v1/models + direct-pod-IP health check "
                 "still run."
             )
-            report.add(CheckResult(
-                "health_endpoint_skipped", True,
-                message="/health not served by EPP; relying on /v1/models + direct-pod-IP probe",
-            ))
+            report.add(
+                CheckResult(
+                    "health_endpoint_skipped",
+                    True,
+                    message="/health not served by EPP; relying on /v1/models + direct-pod-IP probe",
+                )
+            )
         elif url_path_prefix and not self._gateway_routes_health(plan_config):
             context.logger.log_info(
                 f"Skipping /health probe: gateway rewriteTo="
@@ -300,28 +369,43 @@ class BaseSmoketest:
                 "deliberately narrows routing to /v1/* paths. /v1/models "
                 "probe + direct-pod-IP health check still run."
             )
-            report.add(CheckResult(
-                "health_endpoint_skipped", True,
-                message=(
-                    "/health not routable via gateway (by design); "
-                    "relying on /v1/models + direct-pod-IP probe"
-                ),
-            ))
+            report.add(
+                CheckResult(
+                    "health_endpoint_skipped",
+                    True,
+                    message=(
+                        "/health not routable via gateway (by design); "
+                        "relying on /v1/models + direct-pod-IP probe"
+                    ),
+                )
+            )
         else:
             health_err = self._check_health(
-                cmd, context, namespace, service_ip, gateway_port, plan_config,
+                cmd,
+                context,
+                namespace,
+                service_ip,
+                gateway_port,
+                plan_config,
                 url_path_prefix=url_path_prefix,
             )
             if health_err:
                 report.add(CheckResult("health_endpoint", False, message=health_err))
             else:
-                report.add(CheckResult("health_endpoint", True, message="/health responding"))
+                report.add(
+                    CheckResult("health_endpoint", True, message="/health responding")
+                )
 
         # 3. Wait for model ready (/v1/models)
         if report.passed:
             self._wait_for_model_ready(
-                cmd, context, namespace, service_ip, gateway_port,
-                model_name, plan_config,
+                cmd,
+                context,
+                namespace,
+                service_ip,
+                gateway_port,
+                model_name,
+                plan_config,
                 url_path_prefix=url_path_prefix,
             )
 
@@ -329,42 +413,69 @@ class BaseSmoketest:
         service_test_passed = False
         context.logger.log_info(
             f'Testing service/gateway "{service_ip}" (port {gateway_port})'
-            f'{" [prefix=" + url_path_prefix + "]" if url_path_prefix else ""}...'
+            f"{' [prefix=' + url_path_prefix + ']' if url_path_prefix else ''}..."
         )
         test_result = test_model_serving(
-            cmd, namespace, service_ip, gateway_port,
-            model_name, plan_config, max_retries=1,
+            cmd,
+            namespace,
+            service_ip,
+            gateway_port,
+            model_name,
+            plan_config,
+            max_retries=1,
             url_path_prefix=url_path_prefix,
         )
         if test_result:
-            report.add(CheckResult(
-                "service_endpoint", False, message=f"Service test failed: {test_result}",
-            ))
+            report.add(
+                CheckResult(
+                    "service_endpoint",
+                    False,
+                    message=f"Service test failed: {test_result}",
+                )
+            )
         else:
             service_test_passed = True
             context.logger.log_info(
                 f"Service {service_ip}:{gateway_port} responding (ok)"
             )
-            report.add(CheckResult("service_endpoint", True, message="Service responding"))
+            report.add(
+                CheckResult("service_endpoint", True, message="Service responding")
+            )
 
         # 5. Test pod IPs directly (use the first role -- decode for ms, standalone for standalone)
-        inference_port = _nested_get(plan_config, "vllmCommon", "inferencePort") or "8000"
+        inference_port = (
+            _nested_get(plan_config, "vllmCommon", "inferencePort") or "8000"
+        )
         primary_role = roles_to_check[0] if roles_to_check else ("decode", "decode")
         if is_kustomize and guide_name:
-            primary_selector = f"llm-d.ai/guide={guide_name},llm-d.ai/role={primary_role[1]}"
+            primary_selector = (
+                f"llm-d.ai/guide={guide_name},llm-d.ai/role={primary_role[1]}"
+            )
         else:
-            primary_selector = f"llm-d.ai/model={model_id_label},llm-d.ai/role={primary_role[1]}"
+            primary_selector = (
+                f"llm-d.ai/model={model_id_label},llm-d.ai/role={primary_role[1]}"
+            )
         pod_ips_result = cmd.kube(
-            "get", "pods", "-l", primary_selector,
-            "--namespace", namespace,
-            "-o", "jsonpath={.items[*].status.podIP}",
+            "get",
+            "pods",
+            "-l",
+            primary_selector,
+            "--namespace",
+            namespace,
+            "-o",
+            "jsonpath={.items[*].status.podIP}",
             check=False,
         )
 
         if context.dry_run:
             test_model_serving(
-                cmd, namespace, "<dry-run-pod-ip>", inference_port,
-                model_name, plan_config, max_retries=1,
+                cmd,
+                namespace,
+                "<dry-run-pod-ip>",
+                inference_port,
+                model_name,
+                plan_config,
+                max_retries=1,
             )
         elif pod_ips_result.success and pod_ips_result.stdout.strip():
             pod_ips = pod_ips_result.stdout.strip().split()
@@ -373,8 +484,12 @@ class BaseSmoketest:
                     f"Testing pod {i}/{len(pod_ips)} at {pod_ip}:{inference_port}..."
                 )
                 test_result = test_model_serving(
-                    cmd, namespace, pod_ip, inference_port,
-                    model_name, plan_config,
+                    cmd,
+                    namespace,
+                    pod_ip,
+                    inference_port,
+                    model_name,
+                    plan_config,
                 )
                 if test_result:
                     if service_test_passed:
@@ -383,10 +498,13 @@ class BaseSmoketest:
                             f"test passed): {test_result}"
                         )
                     else:
-                        report.add(CheckResult(
-                            f"pod_ip_{pod_ip}", False,
-                            message=f"Curl to {pod_ip}:{inference_port} failed: {test_result}",
-                        ))
+                        report.add(
+                            CheckResult(
+                                f"pod_ip_{pod_ip}",
+                                False,
+                                message=f"Curl to {pod_ip}:{inference_port} failed: {test_result}",
+                            )
+                        )
                 else:
                     context.logger.log_info(f"Pod {pod_ip} responding (ok)")
 
@@ -394,8 +512,14 @@ class BaseSmoketest:
         if context.is_openshift and not is_standalone and not is_kustomize:
             context.logger.log_info("Testing OpenShift route...")
             self._test_openshift_route(
-                cmd, context, namespace, model_name, plan_config,
-                gateway_port, report, service_test_passed,
+                cmd,
+                context,
+                namespace,
+                model_name,
+                plan_config,
+                gateway_port,
+                report,
+                service_test_passed,
             )
 
         return report
@@ -418,14 +542,19 @@ class BaseSmoketest:
             return report
 
         service_ip, gateway_port, _is_standalone = self.discover_endpoint(
-            cmd, context, plan_config,
+            cmd,
+            context,
+            plan_config,
         )
 
         if not service_ip:
-            report.add(CheckResult(
-                "inference_endpoint", False,
-                message="Could not find service/gateway IP for inference test",
-            ))
+            report.add(
+                CheckResult(
+                    "inference_endpoint",
+                    False,
+                    message="Could not find service/gateway IP for inference test",
+                )
+            )
             return report
 
         protocol = "https" if str(gateway_port) == "443" else "http"
@@ -436,7 +565,9 @@ class BaseSmoketest:
         # /pool-a/* -> /* before the request reaches vLLM. Empty string for
         # every other scenario, preserving existing behavior.
         prefix = self._gateway_path_prefix_for_stack(
-            plan_config, _is_standalone, stack_name=stack_path.name,
+            plan_config,
+            _is_standalone,
+            stack_name=stack_path.name,
         )
         base_url = f"{protocol}://{service_ip}:{gateway_port}{prefix}"
 
@@ -445,19 +576,32 @@ class BaseSmoketest:
         # Try /v1/completions first
         context.logger.log_info("Trying /v1/completions endpoint...")
         result = self._try_completions(
-            cmd, context, namespace, base_url, model_name, plan_config,
+            cmd,
+            context,
+            namespace,
+            base_url,
+            model_name,
+            plan_config,
         )
 
         if result["success"]:
             self._print_demo_command(
-                context, cmd, namespace, plan_config,
-                base_url, "/v1/completions",
-                result["payload"], result["generated_text"],
+                context,
+                cmd,
+                namespace,
+                plan_config,
+                base_url,
+                "/v1/completions",
+                result["payload"],
+                result["generated_text"],
             )
-            report.add(CheckResult(
-                "inference_completions", True,
-                message=f'Inference passed via /v1/completions -- Generated: "{result["generated_text"]}"',
-            ))
+            report.add(
+                CheckResult(
+                    "inference_completions",
+                    True,
+                    message=f'Inference passed via /v1/completions -- Generated: "{result["generated_text"]}"',
+                )
+            )
             return report
 
         # Fallback to /v1/chat/completions
@@ -467,32 +611,51 @@ class BaseSmoketest:
                 f"{result['error'][:100]}. Falling back to /v1/chat/completions..."
             )
             chat_result = self._try_chat_completions(
-                cmd, context, namespace, base_url, model_name, plan_config,
+                cmd,
+                context,
+                namespace,
+                base_url,
+                model_name,
+                plan_config,
             )
             if chat_result["success"]:
                 self._print_demo_command(
-                    context, cmd, namespace, plan_config,
-                    base_url, "/v1/chat/completions",
-                    chat_result["payload"], chat_result["generated_text"],
+                    context,
+                    cmd,
+                    namespace,
+                    plan_config,
+                    base_url,
+                    "/v1/chat/completions",
+                    chat_result["payload"],
+                    chat_result["generated_text"],
                 )
-                report.add(CheckResult(
-                    "inference_chat", True,
-                    message=f'Inference passed via /v1/chat/completions -- Generated: "{chat_result["generated_text"]}"',
-                ))
+                report.add(
+                    CheckResult(
+                        "inference_chat",
+                        True,
+                        message=f'Inference passed via /v1/chat/completions -- Generated: "{chat_result["generated_text"]}"',
+                    )
+                )
                 return report
 
-            report.add(CheckResult(
-                "inference_test", False,
-                message=(
-                    f"/v1/completions failed: {result['error']}; "
-                    f"/v1/chat/completions also failed: {chat_result['error']}"
-                ),
-            ))
+            report.add(
+                CheckResult(
+                    "inference_test",
+                    False,
+                    message=(
+                        f"/v1/completions failed: {result['error']}; "
+                        f"/v1/chat/completions also failed: {chat_result['error']}"
+                    ),
+                )
+            )
         else:
-            report.add(CheckResult(
-                "inference_test", False,
-                message=result.get("error", "Inference test failed"),
-            ))
+            report.add(
+                CheckResult(
+                    "inference_test",
+                    False,
+                    message=result.get("error", "Inference test failed"),
+                )
+            )
 
         return report
 
@@ -507,10 +670,13 @@ class BaseSmoketest:
         validators override this to add scenario-specific checks.
         """
         report = SmoketestReport()
-        report.add(CheckResult(
-            "config_validation", True,
-            message="No scenario-specific validator configured -- skipping config validation",
-        ))
+        report.add(
+            CheckResult(
+                "config_validation",
+                True,
+                message="No scenario-specific validator configured -- skipping config validation",
+            )
+        )
         return report
 
     @staticmethod
@@ -524,9 +690,14 @@ class BaseSmoketest:
         Returns a list of pod dicts (items from ``kubectl get pods -o json``).
         """
         result = cmd.kube(
-            "get", "pods", "-l", selector,
-            "--namespace", namespace,
-            "-o", "json",
+            "get",
+            "pods",
+            "-l",
+            selector,
+            "--namespace",
+            namespace,
+            "-o",
+            "json",
             check=False,
         )
         if not result.success or not result.stdout.strip():
@@ -570,8 +741,7 @@ class BaseSmoketest:
     def get_pod_containers(pod_spec: dict) -> list[str]:
         """Return names of all containers in the pod."""
         return [
-            c.get("name", "")
-            for c in pod_spec.get("spec", {}).get("containers", [])
+            c.get("name", "") for c in pod_spec.get("spec", {}).get("containers", [])
         ]
 
     @staticmethod
@@ -585,10 +755,7 @@ class BaseSmoketest:
     @staticmethod
     def get_pod_volumes(pod_spec: dict) -> list[str]:
         """Return names of all volumes in the pod."""
-        return [
-            v.get("name", "")
-            for v in pod_spec.get("spec", {}).get("volumes", [])
-        ]
+        return [v.get("name", "") for v in pod_spec.get("spec", {}).get("volumes", [])]
 
     @staticmethod
     def get_pod_annotations(pod_spec: dict) -> dict[str, str]:
@@ -608,36 +775,46 @@ class BaseSmoketest:
         """Check that *flag* appears in pod args (ignores value)."""
         if flag not in pod_args:
             return CheckResult(
-                f"arg_{flag.lstrip('-')}", False,
+                f"arg_{flag.lstrip('-')}",
+                False,
                 expected=f"{flag} present",
                 actual="not found",
                 message=f"{flag} not found in container vllm args",
             )
         return CheckResult(
-            f"arg_{flag.lstrip('-')}", True,
+            f"arg_{flag.lstrip('-')}",
+            True,
             message=f"{flag} present in container vllm args",
         )
 
     @staticmethod
     def assert_arg_contains(
-        pod_args: str, flag: str, value: str | None = None,
+        pod_args: str,
+        flag: str,
+        value: str | None = None,
     ) -> CheckResult:
         """Check that *flag* (and optionally *value*) appears in pod args."""
         if flag not in pod_args:
             return CheckResult(
-                f"arg_{flag.lstrip('-')}", False,
+                f"arg_{flag.lstrip('-')}",
+                False,
                 expected=f"{flag} present",
                 actual="not found",
                 message=f"{flag} not found in container vllm args",
             )
         if value is not None and value not in pod_args:
             return CheckResult(
-                f"arg_{flag.lstrip('-')}", False,
+                f"arg_{flag.lstrip('-')}",
+                False,
                 expected=f"{flag} with {value}",
                 actual=f"{flag} present but value mismatch",
                 message=f"{flag} found in container vllm args but expected value '{value}' not present",
             )
-        msg = f"{flag} present" + (f" with {value}" if value else "") + " in container vllm args"
+        msg = (
+            f"{flag} present"
+            + (f" with {value}" if value else "")
+            + " in container vllm args"
+        )
         return CheckResult(f"arg_{flag.lstrip('-')}", True, message=msg)
 
     @staticmethod
@@ -645,39 +822,52 @@ class BaseSmoketest:
         """Check that *flag* does not appear in pod args."""
         if flag in pod_args:
             return CheckResult(
-                f"no_{flag.lstrip('-')}", False,
+                f"no_{flag.lstrip('-')}",
+                False,
                 expected=f"{flag} absent",
                 actual="present",
                 message=f"{flag} should not be in container vllm args",
             )
         return CheckResult(
-            f"no_{flag.lstrip('-')}", True,
+            f"no_{flag.lstrip('-')}",
+            True,
             message=f"{flag} correctly absent from container vllm args",
         )
 
     @staticmethod
     def assert_env_equals(
-        pod_env: dict[str, str], var_name: str, expected: str,
+        pod_env: dict[str, str],
+        var_name: str,
+        expected: str,
         container: str = "vllm",
         pod_name: str = "",
     ) -> CheckResult:
         """Check that env var *var_name* equals *expected* in the given container."""
-        loc = f"pod/{pod_name} container/{container}" if pod_name else f"container/{container}"
+        loc = (
+            f"pod/{pod_name} container/{container}"
+            if pod_name
+            else f"container/{container}"
+        )
         actual = pod_env.get(var_name)
         if actual is None:
             return CheckResult(
-                f"env_{var_name}", False,
-                expected=expected, actual="not set",
+                f"env_{var_name}",
+                False,
+                expected=expected,
+                actual="not set",
                 message=f"{var_name} not set in {loc} env (expected {expected})",
             )
         if str(actual) != str(expected):
             return CheckResult(
-                f"env_{var_name}", False,
-                expected=expected, actual=str(actual),
+                f"env_{var_name}",
+                False,
+                expected=expected,
+                actual=str(actual),
                 message=f"{var_name}={actual} in {loc} env (expected {expected})",
             )
         return CheckResult(
-            f"env_{var_name}", True,
+            f"env_{var_name}",
+            True,
             message=f"{var_name}={actual} in {loc} env",
         )
 
@@ -686,12 +876,15 @@ class BaseSmoketest:
         """Check that a container named *name* exists in the pod."""
         if name in containers:
             return CheckResult(
-                f"container_{name}", True,
+                f"container_{name}",
+                True,
                 message=f"Container '{name}' present in [{', '.join(containers)}]",
             )
         return CheckResult(
-            f"container_{name}", False,
-            expected=name, actual=str(containers),
+            f"container_{name}",
+            False,
+            expected=name,
+            actual=str(containers),
             message=f"Container '{name}' not found in [{', '.join(containers)}]",
         )
 
@@ -700,11 +893,13 @@ class BaseSmoketest:
         """Check that no container named *name* exists in the pod."""
         if name not in containers:
             return CheckResult(
-                f"no_container_{name}", True,
+                f"no_container_{name}",
+                True,
                 message=f"Container '{name}' correctly absent from [{', '.join(containers)}]",
             )
         return CheckResult(
-            f"no_container_{name}", False,
+            f"no_container_{name}",
+            False,
             expected=f"no {name}",
             actual=f"{name} present",
             message=f"Container '{name}' should not be in [{', '.join(containers)}]",
@@ -716,12 +911,15 @@ class BaseSmoketest:
         actual = len(pods)
         if actual == expected:
             return CheckResult(
-                "replica_count", True,
+                "replica_count",
+                True,
                 message=f"{actual} replica(s) (expected {expected})",
             )
         return CheckResult(
-            "replica_count", False,
-            expected=str(expected), actual=str(actual),
+            "replica_count",
+            False,
+            expected=str(expected),
+            actual=str(actual),
             message=f"{actual} replica(s) (expected {expected})",
         )
 
@@ -741,18 +939,23 @@ class BaseSmoketest:
 
         if val is None:
             return CheckResult(
-                f"resource_{resource_path}", False,
-                expected=expected_value, actual="not set",
+                f"resource_{resource_path}",
+                False,
+                expected=expected_value,
+                actual="not set",
                 message=f"container vllm resources.{resource_path} not set (expected {expected_value})",
             )
         if str(val) != str(expected_value):
             return CheckResult(
-                f"resource_{resource_path}", False,
-                expected=expected_value, actual=str(val),
+                f"resource_{resource_path}",
+                False,
+                expected=expected_value,
+                actual=str(val),
                 message=f"container vllm resources.{resource_path}={val} (expected {expected_value})",
             )
         return CheckResult(
-            f"resource_{resource_path}", True,
+            f"resource_{resource_path}",
+            True,
             message=f"container vllm resources.{resource_path}={val}",
         )
 
@@ -778,7 +981,8 @@ class BaseSmoketest:
 
         # --- Replica count ---
         pods = self.get_pod_specs(
-            cmd, namespace,
+            cmd,
+            namespace,
             f"llm-d.ai/model={model_short},llm-d.ai/role={role}",
         )
         expected_replicas = role_config.get("replicas")
@@ -788,16 +992,17 @@ class BaseSmoketest:
             # ``workers`` pods (1 leader + N-1 workers).
             multinode_enabled = _nested_get(config, "multinode", "enabled")
             if multinode_enabled:
-                workers = int(
-                    role_config.get("parallelism", {}).get("workers", 1)
-                )
+                workers = int(role_config.get("parallelism", {}).get("workers", 1))
                 expected_pods = expected_replicas * workers
             else:
                 expected_pods = expected_replicas
-            pod_details = ", ".join(
-                f"{p.get('metadata', {}).get('name', '?')}@{p.get('spec', {}).get('nodeName', '?')}"
-                for p in pods
-            ) or "none"
+            pod_details = (
+                ", ".join(
+                    f"{p.get('metadata', {}).get('name', '?')}@{p.get('spec', {}).get('nodeName', '?')}"
+                    for p in pods
+                )
+                or "none"
+            )
 
             # If WVA + HPA owns the replica count for this role, the
             # actual pod count is HPA-driven and may legitimately differ
@@ -821,31 +1026,37 @@ class BaseSmoketest:
             )
             if hpa_managed:
                 hpa_min = int(_nested_get(config, "wva", "hpa", "minReplicas") or 1)
-                hpa_max = int(_nested_get(config, "wva", "hpa", "maxReplicas") or expected_pods)
+                hpa_max = int(
+                    _nested_get(config, "wva", "hpa", "maxReplicas") or expected_pods
+                )
                 in_range = hpa_min <= len(pods) <= hpa_max
-                report.add(CheckResult(
-                    f"{prefix}_replicas",
-                    in_range,
-                    expected=f"{hpa_min}..{hpa_max} (HPA window)",
-                    actual=str(len(pods)),
-                    message=(
-                        f"{role} pods in ns/{namespace}: "
-                        f"{len(pods)} (HPA min={hpa_min} max={hpa_max}, "
-                        f"scenario.{role}.replicas={expected_pods}) "
-                        f"[{pod_details}]"
-                    ),
-                ))
+                report.add(
+                    CheckResult(
+                        f"{prefix}_replicas",
+                        in_range,
+                        expected=f"{hpa_min}..{hpa_max} (HPA window)",
+                        actual=str(len(pods)),
+                        message=(
+                            f"{role} pods in ns/{namespace}: "
+                            f"{len(pods)} (HPA min={hpa_min} max={hpa_max}, "
+                            f"scenario.{role}.replicas={expected_pods}) "
+                            f"[{pod_details}]"
+                        ),
+                    )
+                )
             else:
-                report.add(CheckResult(
-                    f"{prefix}_replicas",
-                    len(pods) == expected_pods,
-                    expected=str(expected_pods),
-                    actual=str(len(pods)),
-                    message=(
-                        f"{role} pods in ns/{namespace}: "
-                        f"{len(pods)} (expected {expected_pods}) [{pod_details}]"
-                    ),
-                ))
+                report.add(
+                    CheckResult(
+                        f"{prefix}_replicas",
+                        len(pods) == expected_pods,
+                        expected=str(expected_pods),
+                        actual=str(len(pods)),
+                        message=(
+                            f"{role} pods in ns/{namespace}: "
+                            f"{len(pods)} (expected {expected_pods}) [{pod_details}]"
+                        ),
+                    )
+                )
 
         if not pods:
             return pods
@@ -857,13 +1068,15 @@ class BaseSmoketest:
         group_name = role
 
         # Emit a header check so the step renderer can group output
-        report.add(CheckResult(
-            name=f"{prefix}_header",
-            passed=True,
-            message=f"Inspecting {role} pod: {pod_name} (node: {pod_node}, ns: {pod_ns})",
-            group=group_name,
-            is_header=True,
-        ))
+        report.add(
+            CheckResult(
+                name=f"{prefix}_header",
+                passed=True,
+                message=f"Inspecting {role} pod: {pod_name} (node: {pod_node}, ns: {pod_ns})",
+                group=group_name,
+                is_header=True,
+            )
+        )
 
         def _tag(check: CheckResult) -> CheckResult:
             """Tag a CheckResult with its group for indented rendering."""
@@ -883,23 +1096,43 @@ class BaseSmoketest:
             for field in ("memory", "cpu", "ephemeral-storage"):
                 expected = _nested_get(role_config, "resources", section, field)
                 if expected is not None:
-                    report.add(_tag(self.assert_resource_matches(
-                        resources, str(expected), f"{section}.{field}",
-                    )))
+                    report.add(
+                        _tag(
+                            self.assert_resource_matches(
+                                resources,
+                                str(expected),
+                                f"{section}.{field}",
+                            )
+                        )
+                    )
 
         # --- Parallelism ---
         parallelism = role_config.get("parallelism", {})
         tp = parallelism.get("tensor")
         if tp is not None and "VLLM_TENSOR_PARALLELISM" in env:
-            report.add(_tag(self.assert_env_equals(env, "VLLM_TENSOR_PARALLELISM", str(tp), pod_name=pod_name)))
+            report.add(
+                _tag(
+                    self.assert_env_equals(
+                        env, "VLLM_TENSOR_PARALLELISM", str(tp), pod_name=pod_name
+                    )
+                )
+            )
 
         dp = parallelism.get("data")
         if dp is not None and "DP_SIZE" in env:
-            report.add(_tag(self.assert_env_equals(env, "DP_SIZE", str(dp), pod_name=pod_name)))
+            report.add(
+                _tag(self.assert_env_equals(env, "DP_SIZE", str(dp), pod_name=pod_name))
+            )
 
         dp_local = parallelism.get("dataLocal")
         if dp_local is not None and "DP_SIZE_LOCAL" in env:
-            report.add(_tag(self.assert_env_equals(env, "DP_SIZE_LOCAL", str(dp_local), pod_name=pod_name)))
+            report.add(
+                _tag(
+                    self.assert_env_equals(
+                        env, "DP_SIZE_LOCAL", str(dp_local), pod_name=pod_name
+                    )
+                )
+            )
 
         # --- Extra env vars ---
         extra_env = role_config.get("extraEnvVars", [])
@@ -907,7 +1140,13 @@ class BaseSmoketest:
             ev_name = ev.get("name")
             ev_value = ev.get("value")
             if ev_name and ev_value is not None:
-                report.add(_tag(self.assert_env_equals(env, ev_name, str(ev_value), pod_name=pod_name)))
+                report.add(
+                    _tag(
+                        self.assert_env_equals(
+                            env, ev_name, str(ev_value), pod_name=pod_name
+                        )
+                    )
+                )
 
         # --- Init containers ---
         expected_init = role_config.get("initContainers", [])
@@ -915,28 +1154,38 @@ class BaseSmoketest:
             ic_name = ic.get("name")
             if ic_name:
                 found = ic_name in init_containers
-                report.add(_tag(CheckResult(
-                    f"{prefix}_init_{ic_name}",
-                    found,
-                    expected=f"'{ic_name}' in initContainers",
-                    actual=f"initContainers: [{', '.join(init_containers)}]",
-                    message=f"initContainer '{ic_name}' {'present' if found else 'not found'} in [{', '.join(init_containers)}]",
-                )))
+                report.add(
+                    _tag(
+                        CheckResult(
+                            f"{prefix}_init_{ic_name}",
+                            found,
+                            expected=f"'{ic_name}' in initContainers",
+                            actual=f"initContainers: [{', '.join(init_containers)}]",
+                            message=f"initContainer '{ic_name}' {'present' if found else 'not found'} in [{', '.join(init_containers)}]",
+                        )
+                    )
+                )
 
         # --- Security context capabilities ---
         extra_config = role_config.get("extraContainerConfig", {})
-        expected_caps = _nested_get(extra_config, "securityContext", "capabilities", "add")
+        expected_caps = _nested_get(
+            extra_config, "securityContext", "capabilities", "add"
+        )
         if expected_caps:
             actual_caps = self._get_container_security_caps(pod)
             for cap in expected_caps:
                 has_cap = cap in actual_caps
-                report.add(_tag(CheckResult(
-                    f"{prefix}_cap_{cap}",
-                    has_cap,
-                    expected=cap,
-                    actual=f"capabilities.add: [{', '.join(actual_caps)}]",
-                    message=f"securityContext capability {cap} {'present' if has_cap else 'not found'} in [{', '.join(actual_caps)}]",
-                )))
+                report.add(
+                    _tag(
+                        CheckResult(
+                            f"{prefix}_cap_{cap}",
+                            has_cap,
+                            expected=cap,
+                            actual=f"capabilities.add: [{', '.join(actual_caps)}]",
+                            message=f"securityContext capability {cap} {'present' if has_cap else 'not found'} in [{', '.join(actual_caps)}]",
+                        )
+                    )
+                )
 
         # --- Routing proxy (may be a regular container or init container) ---
         # The helm chart only injects the routing proxy on decode pods,
@@ -946,24 +1195,38 @@ class BaseSmoketest:
             in_containers = "routing-proxy" in containers
             in_init = "routing-proxy" in init_containers
             found = in_containers or in_init
-            location = "containers" if in_containers else ("initContainers" if in_init else "")
-            report.add(_tag(CheckResult(
-                f"{prefix}_routing_proxy", found,
-                expected="routing-proxy in containers or initContainers",
-                actual=f"{'found in ' + location if found else 'not found'}",
-                message=f"routing-proxy {'present in ' + location if found else 'not found in containers or initContainers'}",
-            )))
+            location = (
+                "containers" if in_containers else ("initContainers" if in_init else "")
+            )
+            report.add(
+                _tag(
+                    CheckResult(
+                        f"{prefix}_routing_proxy",
+                        found,
+                        expected="routing-proxy in containers or initContainers",
+                        actual=f"{'found in ' + location if found else 'not found'}",
+                        message=f"routing-proxy {'present in ' + location if found else 'not found in containers or initContainers'}",
+                    )
+                )
+            )
         elif routing_enabled is False and role in ("decode", "standalone"):
             in_containers = "routing-proxy" in containers
             in_init = "routing-proxy" in init_containers
             found = in_containers or in_init
-            location = "containers" if in_containers else ("initContainers" if in_init else "")
-            report.add(_tag(CheckResult(
-                f"{prefix}_no_routing_proxy", not found,
-                expected="routing-proxy absent",
-                actual=f"{'found in ' + location if found else 'absent'}",
-                message=f"routing-proxy {'should not be present but found in ' + location if found else 'correctly absent'}",
-            )))
+            location = (
+                "containers" if in_containers else ("initContainers" if in_init else "")
+            )
+            report.add(
+                _tag(
+                    CheckResult(
+                        f"{prefix}_no_routing_proxy",
+                        not found,
+                        expected="routing-proxy absent",
+                        actual=f"{'found in ' + location if found else 'absent'}",
+                        message=f"routing-proxy {'should not be present but found in ' + location if found else 'correctly absent'}",
+                    )
+                )
+            )
 
         # --- Volumes from vllmCommon ---
         expected_volumes = _nested_get(config, "vllmCommon", "volumes") or []
@@ -971,13 +1234,17 @@ class BaseSmoketest:
             vol_name = vol.get("name")
             if vol_name:
                 found = vol_name in volumes
-                report.add(_tag(CheckResult(
-                    f"{prefix}_volume_{vol_name}",
-                    found,
-                    expected=f"'{vol_name}' in spec.volumes",
-                    actual=f"spec.volumes: [{', '.join(volumes)}]",
-                    message=f"volume '{vol_name}' {'present' if found else 'not found'} in spec.volumes [{', '.join(volumes)}]",
-                )))
+                report.add(
+                    _tag(
+                        CheckResult(
+                            f"{prefix}_volume_{vol_name}",
+                            found,
+                            expected=f"'{vol_name}' in spec.volumes",
+                            actual=f"spec.volumes: [{', '.join(volumes)}]",
+                            message=f"volume '{vol_name}' {'present' if found else 'not found'} in spec.volumes [{', '.join(volumes)}]",
+                        )
+                    )
+                )
 
         # --- Volume mounts from vllmCommon ---
         expected_mounts = _nested_get(config, "vllmCommon", "volumeMounts") or []
@@ -989,13 +1256,17 @@ class BaseSmoketest:
                 has_mount = mount_name in actual_mounts
                 actual_path = actual_mounts.get(mount_name, "N/A")
                 mount_names = list(actual_mounts.keys())
-                report.add(_tag(CheckResult(
-                    f"{prefix}_mount_{mount_name}",
-                    has_mount,
-                    expected=f"'{mount_name}' at {mount_path}",
-                    actual=f"{'at ' + actual_path if has_mount else 'not found'} in [{', '.join(mount_names)}]",
-                    message=f"volumeMount '{mount_name}' {'at ' + actual_path if has_mount else 'not found in [' + ', '.join(mount_names) + ']'}",
-                )))
+                report.add(
+                    _tag(
+                        CheckResult(
+                            f"{prefix}_mount_{mount_name}",
+                            has_mount,
+                            expected=f"'{mount_name}' at {mount_path}",
+                            actual=f"{'at ' + actual_path if has_mount else 'not found'} in [{', '.join(mount_names)}]",
+                            message=f"volumeMount '{mount_name}' {'at ' + actual_path if has_mount else 'not found in [' + ', '.join(mount_names) + ']'}",
+                        )
+                    )
+                )
 
         # --- Probes ---
         probe_config = role_config.get("probes", {})
@@ -1012,11 +1283,17 @@ class BaseSmoketest:
             if flags.get("enforceEager") is True:
                 report.add(_tag(self.assert_arg_contains(args, "--enforce-eager")))
             if flags.get("noPrefixCaching") is True:
-                report.add(_tag(self.assert_arg_contains(args, "--no-enable-prefix-caching")))
+                report.add(
+                    _tag(self.assert_arg_contains(args, "--no-enable-prefix-caching"))
+                )
             if flags.get("disableLogRequests") is True:
-                report.add(_tag(self.assert_arg_contains(args, "--no-enable-log-requests")))
+                report.add(
+                    _tag(self.assert_arg_contains(args, "--no-enable-log-requests"))
+                )
             if flags.get("disableUvicornAccessLog") is True:
-                report.add(_tag(self.assert_arg_contains(args, "--disable-uvicorn-access-log")))
+                report.add(
+                    _tag(self.assert_arg_contains(args, "--disable-uvicorn-access-log"))
+                )
 
             # --- Model args (block size, max model len) ---
             # The auto-generated command uses env var references ($VLLM_BLOCK_SIZE,
@@ -1029,16 +1306,30 @@ class BaseSmoketest:
                 # Check flag present (either $VLLM_BLOCK_SIZE or literal value)
                 report.add(_tag(self.assert_arg_present(args, "--block-size")))
                 # Check env var has the right value
-                report.add(_tag(self.assert_env_equals(
-                    env, "VLLM_BLOCK_SIZE", str(block_size), pod_name=pod_name,
-                )))
+                report.add(
+                    _tag(
+                        self.assert_env_equals(
+                            env,
+                            "VLLM_BLOCK_SIZE",
+                            str(block_size),
+                            pod_name=pod_name,
+                        )
+                    )
+                )
 
             max_model_len = model_config.get("maxModelLen")
             if max_model_len is not None:
                 report.add(_tag(self.assert_arg_present(args, "--max-model-len")))
-                report.add(_tag(self.assert_env_equals(
-                    env, "VLLM_MAX_MODEL_LEN", str(max_model_len), pod_name=pod_name,
-                )))
+                report.add(
+                    _tag(
+                        self.assert_env_equals(
+                            env,
+                            "VLLM_MAX_MODEL_LEN",
+                            str(max_model_len),
+                            pod_name=pod_name,
+                        )
+                    )
+                )
 
             # --- Additional flags from role config ---
             additional_flags = _nested_get(role_config, "vllm", "additionalFlags") or []
@@ -1051,9 +1342,15 @@ class BaseSmoketest:
         if kv_transfer.get("enabled"):
             kv_connector = kv_transfer.get("connector")
             if kv_connector:
-                report.add(_tag(self.assert_arg_contains(
-                    args, "--kv-transfer-config", str(kv_connector),
-                )))
+                report.add(
+                    _tag(
+                        self.assert_arg_contains(
+                            args,
+                            "--kv-transfer-config",
+                            str(kv_connector),
+                        )
+                    )
+                )
 
         # --- KV events (checked for both auto-generated and custom commands) ---
         kv_events = _nested_get(config, "vllmCommon", "kvEvents") or {}
@@ -1061,38 +1358,54 @@ class BaseSmoketest:
             kv_port = kv_events.get("port")
             if kv_port is not None:
                 has_port = any(p.get("containerPort") == int(kv_port) for p in ports)
-                report.add(_tag(CheckResult(
-                    f"{prefix}_kv_events_port",
-                    has_port,
-                    expected=str(kv_port),
-                    message=f"KV events containerPort {kv_port} {'present' if has_port else 'not found'} in container ports",
-                )))
+                report.add(
+                    _tag(
+                        CheckResult(
+                            f"{prefix}_kv_events_port",
+                            has_port,
+                            expected=str(kv_port),
+                            message=f"KV events containerPort {kv_port} {'present' if has_port else 'not found'} in container ports",
+                        )
+                    )
+                )
 
         # --- Role env vars (injected by helm chart, not from config) ---
         if role == "decode":
-            report.add(_tag(self.assert_env_equals(env, "VLLM_IS_DECODE", "1", pod_name=pod_name)))
+            report.add(
+                _tag(
+                    self.assert_env_equals(
+                        env, "VLLM_IS_DECODE", "1", pod_name=pod_name
+                    )
+                )
+            )
         elif role == "prefill":
-            report.add(_tag(self.assert_env_equals(env, "VLLM_IS_PREFILL", "1", pod_name=pod_name)))
+            report.add(
+                _tag(
+                    self.assert_env_equals(
+                        env, "VLLM_IS_PREFILL", "1", pod_name=pod_name
+                    )
+                )
+            )
 
         return pods
 
     @staticmethod
     def _get_container_security_caps(
-        pod_spec: dict, container: str = "vllm",
+        pod_spec: dict,
+        container: str = "vllm",
     ) -> list[str]:
         """Extract security context capabilities for a container."""
         for c in pod_spec.get("spec", {}).get("containers", []):
             if c.get("name") == container:
                 return (
-                    c.get("securityContext", {})
-                    .get("capabilities", {})
-                    .get("add", [])
+                    c.get("securityContext", {}).get("capabilities", {}).get("add", [])
                 )
         return []
 
     @staticmethod
     def _get_container_volume_mounts(
-        pod_spec: dict, container: str = "vllm",
+        pod_spec: dict,
+        container: str = "vllm",
     ) -> dict[str, str]:
         """Return volume mount names mapped to mount paths."""
         for c in pod_spec.get("spec", {}).get("containers", []):
@@ -1124,40 +1437,51 @@ class BaseSmoketest:
 
                 actual_probe = c.get(f"{probe_type}Probe", {})
                 if not actual_probe:
-                    report.add(CheckResult(
-                        f"{prefix}_{probe_type}_probe",
-                        False,
-                        message=f"{probe_type}Probe not configured on container",
-                        group=group,
-                    ))
+                    report.add(
+                        CheckResult(
+                            f"{prefix}_{probe_type}_probe",
+                            False,
+                            message=f"{probe_type}Probe not configured on container",
+                            group=group,
+                        )
+                    )
                     continue
 
                 # Check path
                 expected_path = expected.get("path")
                 if expected_path:
                     actual_path = actual_probe.get("httpGet", {}).get("path")
-                    report.add(CheckResult(
-                        f"{prefix}_{probe_type}_path",
-                        actual_path == expected_path,
-                        expected=expected_path,
-                        actual=str(actual_path),
-                        message=f"{probe_type}Probe path: {actual_path} (expected {expected_path})",
-                        group=group,
-                    ))
+                    report.add(
+                        CheckResult(
+                            f"{prefix}_{probe_type}_path",
+                            actual_path == expected_path,
+                            expected=expected_path,
+                            actual=str(actual_path),
+                            message=f"{probe_type}Probe path: {actual_path} (expected {expected_path})",
+                            group=group,
+                        )
+                    )
 
                 # Check key numeric fields
-                for field in ("failureThreshold", "periodSeconds", "initialDelaySeconds", "timeoutSeconds"):
+                for field in (
+                    "failureThreshold",
+                    "periodSeconds",
+                    "initialDelaySeconds",
+                    "timeoutSeconds",
+                ):
                     expected_val = expected.get(field)
                     if expected_val is not None:
                         actual_val = actual_probe.get(field)
-                        report.add(CheckResult(
-                            f"{prefix}_{probe_type}_{field}",
-                            str(actual_val) == str(expected_val),
-                            expected=str(expected_val),
-                            actual=str(actual_val),
-                            message=f"{probe_type}Probe.{field}: {actual_val} (expected {expected_val})",
-                            group=group,
-                        ))
+                        report.add(
+                            CheckResult(
+                                f"{prefix}_{probe_type}_{field}",
+                                str(actual_val) == str(expected_val),
+                                expected=str(expected_val),
+                                actual=str(actual_val),
+                                message=f"{probe_type}Probe.{field}: {actual_val} (expected {expected_val})",
+                                group=group,
+                            )
+                        )
             break
 
     def _check_health(
@@ -1194,14 +1518,18 @@ class BaseSmoketest:
 
             attempt += 1
             pod_name = f"healthcheck-{_rand_suffix()}"
-            curl_cmd = (
-                f"'curl -sk --max-time 10 -o /dev/null -w %{{http_code}} {url}'"
-            )
+            curl_cmd = f"'curl -sk --max-time 10 -o /dev/null -w %{{http_code}} {url}'"
 
             kubectl_args = (
                 [
-                    "run", pod_name, "--rm", "--attach", "--quiet",
-                    "--restart=Never", "--namespace", namespace,
+                    "run",
+                    pod_name,
+                    "--rm",
+                    "--attach",
+                    "--quiet",
+                    "--restart=Never",
+                    "--namespace",
+                    namespace,
                     f"--image={curl_image}",
                 ]
                 + _ephemeral_label_args()
@@ -1242,8 +1570,7 @@ class BaseSmoketest:
         url_path_prefix: str = "",
     ):
         context.logger.log_info(
-            f"Waiting for model to be ready at {host}:{port} "
-            f"(timeout {timeout}s)..."
+            f"Waiting for model to be ready at {host}:{port} (timeout {timeout}s)..."
         )
         start = time.time()
         attempt = 0
@@ -1259,7 +1586,12 @@ class BaseSmoketest:
 
             attempt += 1
             result = test_model_serving(
-                cmd, namespace, host, port, expected_model, plan_config,
+                cmd,
+                namespace,
+                host,
+                port,
+                expected_model,
+                plan_config,
                 max_retries=1,
                 url_path_prefix=url_path_prefix,
             )
@@ -1275,8 +1607,7 @@ class BaseSmoketest:
 
             remaining = int(timeout - elapsed)
             context.logger.log_info(
-                f"Model not ready yet (attempt {attempt}, "
-                f"{remaining}s remaining)..."
+                f"Model not ready yet (attempt {attempt}, {remaining}s remaining)..."
             )
             time.sleep(poll_interval)
 
@@ -1295,8 +1626,13 @@ class BaseSmoketest:
         route_name = f"{release}-inference-gateway-route"
 
         route_result = cmd.kube(
-            "get", "route", route_name, "-n", namespace,
-            "-o", "jsonpath={.spec.host}:{.spec.tls.termination}",
+            "get",
+            "route",
+            route_name,
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.spec.host}:{.spec.tls.termination}",
             check=False,
         )
         if route_result.success and route_result.stdout.strip():
@@ -1309,8 +1645,12 @@ class BaseSmoketest:
                 f"Testing route {route_host} (port {route_port})..."
             )
             test_result = test_model_serving(
-                cmd, namespace, route_host, route_port,
-                model_name, plan_config,
+                cmd,
+                namespace,
+                route_host,
+                route_port,
+                model_name,
+                plan_config,
             )
             if test_result:
                 if service_test_passed:
@@ -1318,16 +1658,22 @@ class BaseSmoketest:
                         f"Route test failed (non-fatal): {test_result}"
                     )
                 else:
-                    report.add(CheckResult(
-                        "openshift_route", False,
-                        message=f"Route test failed: {test_result}",
-                    ))
+                    report.add(
+                        CheckResult(
+                            "openshift_route",
+                            False,
+                            message=f"Route test failed: {test_result}",
+                        )
+                    )
             else:
                 context.logger.log_info(f"Route {route_host} responding (ok)")
-                report.add(CheckResult(
-                    "openshift_route", True,
-                    message="Route responding",
-                ))
+                report.add(
+                    CheckResult(
+                        "openshift_route",
+                        True,
+                        message="Route responding",
+                    )
+                )
         else:
             context.logger.log_warning(
                 f"Unable to fetch OpenShift route '{route_name}'"
@@ -1357,7 +1703,8 @@ class BaseSmoketest:
 
             if cmd.dry_run:
                 return {
-                    "success": True, "payload": payload,
+                    "success": True,
+                    "payload": payload,
                     "generated_text": "<dry-run>",
                 }
 
@@ -1387,7 +1734,8 @@ class BaseSmoketest:
                 if isinstance(error_msg, dict):
                     error_msg = error_msg.get("message", str(error_msg))
                 return {
-                    "success": False, "error": str(error_msg),
+                    "success": False,
+                    "error": str(error_msg),
                     "should_fallback": True,
                 }
 
@@ -1404,7 +1752,10 @@ class BaseSmoketest:
                 if attempt < max_retries:
                     time.sleep(retry_interval)
                     continue
-                return {"success": False, "error": f"Missing choices in response from {url}"}
+                return {
+                    "success": False,
+                    "error": f"Missing choices in response from {url}",
+                }
 
             first = resp["choices"][0]
             if not first.get("text") and not first.get("message"):
@@ -1432,7 +1783,9 @@ class BaseSmoketest:
         url = f"{base_url}/v1/chat/completions"
         payload = {
             "model": model_name,
-            "messages": [{"role": "user", "content": "What is the capital of the United States?"}],
+            "messages": [
+                {"role": "user", "content": "What is the capital of the United States?"}
+            ],
             "max_tokens": 5,
             "temperature": 0,
         }
@@ -1507,14 +1860,20 @@ class BaseSmoketest:
             f"'echo {payload_b64} | base64 -d | "
             f"curl -sk --max-time {timeout_seconds} "
             f"-X POST {url} "
-            f"-H \"Content-Type: application/json\" "
+            f'-H "Content-Type: application/json" '
             f"-d @- 2>&1'"
         )
 
         kubectl_args = (
             [
-                "run", pod_name, "--rm", "--attach", "--quiet",
-                "--restart=Never", "--namespace", namespace,
+                "run",
+                pod_name,
+                "--rm",
+                "--attach",
+                "--quiet",
+                "--restart=Never",
+                "--namespace",
+                namespace,
                 f"--image={curl_image}",
             ]
             + _ephemeral_label_args()
@@ -1544,7 +1903,7 @@ class BaseSmoketest:
         payload: dict,
         generated_text: str,
     ):
-        payload_compact = json.dumps(payload, separators=(",", ":")) # noqa: F841
+        payload_compact = json.dumps(payload, separators=(",", ":"))  # noqa: F841
 
         context.logger.log_info(f"✅ Inference test passed via {endpoint}")
         if generated_text:
@@ -1552,7 +1911,10 @@ class BaseSmoketest:
         context.logger.log_info("")
 
         external_url = self._detect_external_url(
-            cmd, namespace, plan_config, endpoint,
+            cmd,
+            namespace,
+            plan_config,
+            endpoint,
         )
 
         demo_url = external_url or f"{base_url}{endpoint}"
@@ -1576,7 +1938,11 @@ class BaseSmoketest:
     ) -> str | None:
         try:
             release = _nested_get(plan_config, "release") or ""
-            model_id_label = plan_config.get("model_id_label", "") or _nested_get(plan_config, "model", "shortName") or ""
+            model_id_label = (
+                plan_config.get("model_id_label", "")
+                or _nested_get(plan_config, "model", "shortName")
+                or ""
+            )
         except KeyError:
             return None
 
@@ -1585,9 +1951,13 @@ class BaseSmoketest:
 
         route_name = f"{release}-inference-gateway-route"
         result = cmd.kube(
-            "get", "route", route_name,
-            "-n", namespace,
-            "-o", "jsonpath={.spec.host}:{.spec.tls.termination}",
+            "get",
+            "route",
+            route_name,
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.spec.host}:{.spec.tls.termination}",
             check=False,
         )
 
@@ -1616,6 +1986,7 @@ def _nested_get(d: dict, *keys: str):
 def _load_config(stack_path: Path) -> dict:
     """Load the rendered config.yaml from a stack directory."""
     import yaml
+
     config_file = stack_path / "config.yaml"
     if config_file.exists():
         with open(config_file) as f:

--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -21,7 +21,7 @@ GATEWAY_API_CRDS = [
     "httproutes.gateway.networking.k8s.io",
     "listenersets.gateway.networking.k8s.io",
     "referencegrants.gateway.networking.k8s.io",
-    "tlsroutes.gateway.networking.k8s.io"
+    "tlsroutes.gateway.networking.k8s.io",
 ]
 
 # Inference extension CRDs may use the graduated (.k8s.io) or
@@ -37,13 +37,13 @@ GATEWAY_API_EXTENSION_CRDS_XK8S = [
     "inferencemodelrewrites.inference.networking.x-k8s.io",
     "inferenceobjectives.inference.networking.x-k8s.io",
     "inferencepoolimports.inference.networking.x-k8s.io",
-    "inferencepools.inference.networking.x-k8s.io"
+    "inferencepools.inference.networking.x-k8s.io",
 ]
 
 AGENTGATEWAY_CRDS = [
     "agentgatewaybackends.agentgateway.dev",
     "agentgatewayparameters.agentgateway.dev",
-    "agentgatewaypolicies.agentgateway.dev"
+    "agentgatewaypolicies.agentgateway.dev",
 ]
 
 ISTIO_CRDS = [
@@ -93,10 +93,7 @@ class AdminPrerequisitesStep(Step):
     @staticmethod
     def _kustomize_only(context: ExecutionContext) -> bool:
         methods = context.deployed_methods or []
-        return (
-            methods == ["kustomize"]
-            and context.kustomize_skip_infra
-        )
+        return methods == ["kustomize"] and context.kustomize_skip_infra
 
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
@@ -150,20 +147,26 @@ class AdminPrerequisitesStep(Step):
             )
 
             self._install_prometheus_crds_if_needed(
-                cmd, plan_config, existing_crds,
+                cmd,
+                plan_config,
+                existing_crds,
             )
 
         # Also install Prometheus CRDs for standalone (outside modelservice block)
         if not modelservice_active:
             self._install_prometheus_crds_if_needed(
-                cmd, plan_config, existing_crds,
+                cmd,
+                plan_config,
+                existing_crds,
             )
 
         # After any auto-install attempt, validate that monitoring CRDs are
         # present when monitoring is enabled.  Re-fetch CRDs so we pick up
         # anything that was just installed above.
         refreshed_crds = self._get_existing_crds(cmd, context)
-        self._validate_monitoring_crds(cmd, context, plan_config, refreshed_crds, errors)
+        self._validate_monitoring_crds(
+            cmd, context, plan_config, refreshed_crds, errors
+        )
 
         self._apply_namespace_yaml(cmd, context, errors)
         self._apply_openshift_sccs(cmd, context, plan_config)
@@ -256,7 +259,9 @@ class AdminPrerequisitesStep(Step):
         # truth (gatewayApiCrd.crdUrlTemplate). Fail loudly if missing -- we
         # don't want a stale hardcoded URL silently substituting in.
         crd_url_template = self._require_config(
-            plan_config, "gatewayApiCrd", "crdUrlTemplate",
+            plan_config,
+            "gatewayApiCrd",
+            "crdUrlTemplate",
         )
         crd_url = crd_url_template.format(revision=gw_revision)
         result = cmd.kube("apply", "--server-side", "-k", crd_url)
@@ -292,20 +297,21 @@ class AdminPrerequisitesStep(Step):
             return
 
         cmd.logger.log_info(
-            f"📦 Installing inference extension CRDs "
-            f"(revision {inf_ext_revision})..."
+            f"📦 Installing inference extension CRDs (revision {inf_ext_revision})..."
         )
         # URL template lives in defaults.yaml so it has a single source of
         # truth (gatewayApiCrd.inferenceExtensionUrlTemplate). Fail loudly if
         # missing -- silent fallback would hide config drift.
         ext_url_template = self._require_config(
-            plan_config, "gatewayApiCrd", "inferenceExtensionUrlTemplate",
+            plan_config,
+            "gatewayApiCrd",
+            "inferenceExtensionUrlTemplate",
         )
         ext_url = ext_url_template.format(revision=inf_ext_revision)
         result = cmd.kube("apply", "-f", ext_url)
         if not result.success:
             errors.append(
-                f"Failed to install inference extension CRDs: " f"{result.stderr}"
+                f"Failed to install inference extension CRDs: {result.stderr}"
             )
 
     def _install_gateway_provider(
@@ -317,14 +323,13 @@ class AdminPrerequisitesStep(Step):
         existing_crds: list[str],
     ):
         """Install the gateway provider only if its CRDs are missing."""
-        gateway_config = plan_config.get("gateway", {}) # noqa: F841
+        gateway_config = plan_config.get("gateway", {})  # noqa: F841
         gateway_class = self._require_config(plan_config, "gateway", "className")
 
         if gateway_class == "agentgateway":
             if not _any_crds_missing(AGENTGATEWAY_CRDS, existing_crds):
                 cmd.logger.log_info(
-                    "✅ agentgateway already installed "
-                    "(*.agentgateway.dev CRDs found)"
+                    "✅ agentgateway already installed (*.agentgateway.dev CRDs found)"
                 )
                 return
             self._install_agentgateway(cmd, context, errors)
@@ -332,13 +337,20 @@ class AdminPrerequisitesStep(Step):
         elif gateway_class == "istio":
             if not _any_crds_missing(ISTIO_CRDS, existing_crds):
                 cmd.logger.log_info(
-                    "✅ Istio already installed " "(*.istio.io CRDs found)"
+                    "✅ Istio already installed (*.istio.io CRDs found)"
                 )
                 return
             self._install_istio(cmd, context, plan_config, errors)
 
         elif gateway_class == "gke":
             cmd.logger.log_info("✅ GKE gateway is managed -- nothing to install")
+
+        elif gateway_class == "epponly":
+            cmd.logger.log_info(
+                "✅ gateway.className=epponly -- no Kubernetes Gateway / "
+                "provider control plane is needed (EPP runs llm-d's "
+                "standalone router topology with an Envoy sidecar)"
+            )
 
     def _install_lws_if_needed(
         self,
@@ -433,9 +445,7 @@ class AdminPrerequisitesStep(Step):
         step records an error with platform-aware remediation guidance.
         """
         if context.dry_run:
-            cmd.logger.log_info(
-                "Skipping monitoring CRD validation (dry-run)"
-            )
+            cmd.logger.log_info("Skipping monitoring CRD validation (dry-run)")
             return
 
         monitoring = plan_config.get("monitoring", {})
@@ -451,9 +461,7 @@ class AdminPrerequisitesStep(Step):
         ]
         missing = [c for c in required_crds if c not in existing_crds]
         if not missing:
-            cmd.logger.log_info(
-                "✅ Monitoring CRDs present on cluster"
-            )
+            cmd.logger.log_info("✅ Monitoring CRDs present on cluster")
             return
 
         missing_str = ", ".join(missing)
@@ -468,9 +476,7 @@ class AdminPrerequisitesStep(Step):
     @staticmethod
     def _monitoring_guidance(context: ExecutionContext) -> str:
         """Return platform-specific remediation guidance for missing monitoring CRDs."""
-        common_tail = (
-            "Alternatively, pass '--no-monitoring' to disable monitoring."
-        )
+        common_tail = "Alternatively, pass '--no-monitoring' to disable monitoring."
 
         if context.is_gke:
             return (
@@ -545,7 +551,9 @@ class AdminPrerequisitesStep(Step):
         if context.is_openshift:
             namespace = plan_config.get("namespace", {}).get("name", "")
             if namespace:
-                service_account = self._require_config(plan_config, "serviceAccount", "name")
+                service_account = self._require_config(
+                    plan_config, "serviceAccount", "name"
+                )
                 for scc in ["anyuid", "privileged"]:
                     cmd.kube(
                         "adm",
@@ -587,22 +595,17 @@ class AdminPrerequisitesStep(Step):
         # Apply the rendered SCC template.
         scc_yaml = self._find_rendered_yaml(context, "05a_agentgateway_scc")
         if not scc_yaml or not self._has_yaml_content(scc_yaml):
-            cmd.logger.log_info(
-                "    No agentgateway SCC template rendered -- skipping"
-            )
+            cmd.logger.log_info("    No agentgateway SCC template rendered -- skipping")
             return
 
         result = cmd.kube("apply", "-f", str(scc_yaml))
         if not result.success:
             cmd.logger.log_warning(
-                f"    Failed to apply SCC '{_AGENTGATEWAY_SCC_NAME}': "
-                f"{result.stderr}"
+                f"    Failed to apply SCC '{_AGENTGATEWAY_SCC_NAME}': {result.stderr}"
             )
             return
 
-        cmd.logger.log_info(
-            f"    ✅ SCC '{_AGENTGATEWAY_SCC_NAME}' applied"
-        )
+        cmd.logger.log_info(f"    ✅ SCC '{_AGENTGATEWAY_SCC_NAME}' applied")
 
         # Bind the SCC to the gateway service account.
         cmd.logger.log_info(
@@ -661,7 +664,9 @@ class AdminPrerequisitesStep(Step):
             use_kubeconfig=False,
         )
         if not result.success:
-            errors.append(f"Failed to install agentgateway via helmfile: {result.stderr}")
+            errors.append(
+                f"Failed to install agentgateway via helmfile: {result.stderr}"
+            )
 
     def _install_istio(
         self,
@@ -693,7 +698,13 @@ class AdminPrerequisitesStep(Step):
         if not result.success:
             errors.append(f"Failed to install Istio via helmfile: {result.stderr}")
 
-    def _install_lws(self, cmd: CommandExecutor, lws_config: dict, errors: list, plan_config: dict | None = None):
+    def _install_lws(
+        self,
+        cmd: CommandExecutor,
+        lws_config: dict,
+        errors: list,
+        plan_config: dict | None = None,
+    ):
         version = ""
         if plan_config:
             version = plan_config.get("chartVersions", {}).get("lws", "")

--- a/llmdbenchmark/standup/steps/step_08_deploy_gaie.py
+++ b/llmdbenchmark/standup/steps/step_08_deploy_gaie.py
@@ -63,10 +63,15 @@ class DeployGaieStep(Step):
         if helmfile_work.exists():
             model_id_label = plan_config.get("model_id_label", "")
             result = cmd.helmfile(
-                "--namespace", namespace,
-                "--selector", f"name={model_id_label}-gaie",
-                "apply", "-f", str(helmfile_work),
-                "--skip-diff-on-install", "--skip-schema-validation",
+                "--namespace",
+                namespace,
+                "--selector",
+                f"name={model_id_label}-gaie",
+                "apply",
+                "-f",
+                str(helmfile_work),
+                "--skip-diff-on-install",
+                "--skip-schema-validation",
             )
             if not result.success:
                 errors.append(f"Failed to deploy GAIE: {result.stderr}")
@@ -75,10 +80,15 @@ class DeployGaieStep(Step):
             if main_helmfile:
                 model_id_label = plan_config.get("model_id_label", "")
                 result = cmd.helmfile(
-                    "--namespace", namespace,
-                    "--selector", f"name={model_id_label}-gaie",
-                    "apply", "-f", str(main_helmfile),
-                    "--skip-diff-on-install", "--skip-schema-validation",
+                    "--namespace",
+                    namespace,
+                    "--selector",
+                    f"name={model_id_label}-gaie",
+                    "apply",
+                    "-f",
+                    str(main_helmfile),
+                    "--skip-diff-on-install",
+                    "--skip-schema-validation",
                 )
                 if not result.success:
                     errors.append(f"Failed to deploy GAIE: {result.stderr}")
@@ -86,34 +96,42 @@ class DeployGaieStep(Step):
         # Wait for gateway pod only (not EPP -- it stays NOT_SERVING until step 09)
         if not errors and not context.dry_run:
             gateway_class = self._require_config(plan_config, "gateway", "className")
-            if gateway_class == "data-science-gateway-class":
-                gw_label = "gateway.istio.io/managed=istio.io-gateway-controller"
-            elif gateway_class == "agentgateway":
-                # agentgateway controller creates pods with the gateway name
-                # as the app.kubernetes.io/name label, not "llm-d-infra".
-                gw_label = (
-                    f"app.kubernetes.io/name=infra-{release}-inference-gateway"
-                )
-            else:
-                gw_label = "app.kubernetes.io/name=llm-d-infra"
-
-            timeout = context.gateway_deploy_timeout
-            gateway_wait = cmd.wait_for_pods(
-                label=gw_label,
-                namespace=namespace,
-                timeout=timeout,
-                poll_interval=10,
-                description="gateway infra",
-            )
-            if not gateway_wait.success:
-                errors.append(
-                    f"Gateway infra pod not ready: {gateway_wait.stderr}"
-                )
-            else:
+            if gateway_class == "epponly":
+                # No Gateway resource is deployed in epponly mode; the EPP
+                # pod itself is the data-plane proxy and is waited on by
+                # step_09 once the model servers come up.
                 context.logger.log_info(
-                    "GAIE deployed -- EPP pod will become Ready after "
-                    "model servers are deployed in step 09"
+                    "gateway.className=epponly -- no Gateway pod to wait "
+                    "for; EPP readiness is verified in step 09 after the "
+                    "model servers are deployed"
                 )
+            else:
+                if gateway_class == "data-science-gateway-class":
+                    gw_label = "gateway.istio.io/managed=istio.io-gateway-controller"
+                elif gateway_class == "agentgateway":
+                    # agentgateway controller creates pods with the gateway name
+                    # as the app.kubernetes.io/name label, not "llm-d-infra".
+                    gw_label = (
+                        f"app.kubernetes.io/name=infra-{release}-inference-gateway"
+                    )
+                else:
+                    gw_label = "app.kubernetes.io/name=llm-d-infra"
+
+                timeout = context.gateway_deploy_timeout
+                gateway_wait = cmd.wait_for_pods(
+                    label=gw_label,
+                    namespace=namespace,
+                    timeout=timeout,
+                    poll_interval=10,
+                    description="gateway infra",
+                )
+                if not gateway_wait.success:
+                    errors.append(f"Gateway infra pod not ready: {gateway_wait.stderr}")
+                else:
+                    context.logger.log_info(
+                        "GAIE deployed -- EPP pod will become Ready after "
+                        "model servers are deployed in step 09"
+                    )
 
         if errors:
             for err in errors:
@@ -135,9 +153,7 @@ class DeployGaieStep(Step):
             stack_name=stack_path.name,
         )
 
-    def _patch_gaie_for_non_admin(
-        self, context: ExecutionContext, stack_name: str
-    ):
+    def _patch_gaie_for_non_admin(self, context: ExecutionContext, stack_name: str):
         """Disable cluster-admin features (Prometheus monitoring, InferencePool) in GAIE values."""
         helm_dir = context.setup_helm_dir() / stack_name
         gaie_file = helm_dir / "gaie-values.yaml"

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -45,8 +45,12 @@ class DeployModelserviceStep(Step):
         plan_config = self._load_stack_config(stack_path)
         release = self._require_config(plan_config, "release")
         model_id_label = plan_config.get("model_id_label", "")
-        inference_port = self._require_config(plan_config, "vllmCommon", "inferencePort") # noqa: F841
-        timeout = context.modelservice_deploy_timeout # Generic timeout for all pods in step 9
+        inference_port = self._require_config(  # noqa: F841
+            plan_config, "vllmCommon", "inferencePort"
+        )
+        timeout = (
+            context.modelservice_deploy_timeout
+        )  # Generic timeout for all pods in step 9
 
         if not context.dry_run:
             pc_error = self._check_priority_class(cmd, plan_config, context)
@@ -120,7 +124,11 @@ class DeployModelserviceStep(Step):
                 # each referenced pool to exist so the route doesn't
                 # linger in ResolvedRefs=False after step 09 returns.
                 self._wait_for_sibling_inference_pools(
-                    cmd, context, errors, plan_config, namespace,
+                    cmd,
+                    context,
+                    errors,
+                    plan_config,
+                    namespace,
                 )
 
         if not errors:
@@ -134,11 +142,17 @@ class DeployModelserviceStep(Step):
             if not decode_wait.success:
                 errors.append(f"Decode pods not ready: {decode_wait.stderr}")
 
-            decode_cfg = plan_config.get("decode", {}) # noqa: F841
-            expected_replicas = int(self._require_config(plan_config, "decode", "replicas"))
+            decode_cfg = plan_config.get("decode", {})  # noqa: F841
+            expected_replicas = int(
+                self._require_config(plan_config, "decode", "replicas")
+            )
             is_multinode = plan_config.get("multinode", {}).get("enabled", False)
             if is_multinode:
-                workers = int(self._require_config(plan_config, "decode", "parallelism", "workers"))
+                workers = int(
+                    self._require_config(
+                        plan_config, "decode", "parallelism", "workers"
+                    )
+                )
                 expected_replicas = expected_replicas * workers
             if expected_replicas > 1 and not context.dry_run:
                 pod_count_result = cmd.kube(
@@ -168,7 +182,9 @@ class DeployModelserviceStep(Step):
                         )
 
             prefill_enabled = self._require_config(plan_config, "prefill", "enabled")
-            prefill_replicas = int(self._require_config(plan_config, "prefill", "replicas"))
+            prefill_replicas = int(
+                self._require_config(plan_config, "prefill", "replicas")
+            )
 
             if prefill_enabled and prefill_replicas > 0:
                 prefill_wait = cmd.wait_for_pods(
@@ -208,7 +224,9 @@ class DeployModelserviceStep(Step):
             if podmonitor_yaml and self._has_yaml_content(podmonitor_yaml):
                 # Check if PodMonitor CRD exists before attempting to apply
                 crd_check = cmd.kube(
-                    "get", "crd", "podmonitors.monitoring.coreos.com",
+                    "get",
+                    "crd",
+                    "podmonitors.monitoring.coreos.com",
                     check=False,
                 )
                 if crd_check.success:
@@ -237,55 +255,62 @@ class DeployModelserviceStep(Step):
         if gateway_class in ("kgateway", "agentgateway"):
             service_name = f"infra-{release}-inference-gateway"
         else:
+            # Covers istio / gke / data-science-gateway-class / epponly.
+            # For epponly there is no Gateway, so the EPP service is the
+            # endpoint clients hit directly (port 80 -> Envoy sidecar 8081).
             service_name = f"{model_id_label}-gaie-epp"
 
         context.deployed_endpoints[stack_name] = service_name
 
-        username = context.username or "unknown"
-        cmd.kube(
-            "label",
-            f"gateway/infra-{release}-inference-gateway",
-            f"stood-up-by={username}",
-            "stood-up-from=llm-d-benchmark",
-            "stood-up-via=modelservice",
-            "--namespace",
-            namespace,
-            "--overwrite",
-        )
-
-        # GAIE Helm chart creates a route to the EPP gRPC port (wrong for
-        # inference). We replace it with one targeting the gateway on port 80.
-        # data-science-gateway-class manages its own route.
-        if context.is_openshift and gateway_class != "data-science-gateway-class":
-            route_name = f"{release}-inference-gateway-route"
-
-            if gateway_class == "agentgateway":
-                route_service = f"infra-{release}-inference-gateway"
-            else:  # istio
-                route_service = f"infra-{release}-inference-gateway-istio"
-
+        # In epponly mode there is no Gateway resource to label, and the
+        # GAIE chart's auto-generated route is to the EPP gRPC port which
+        # we'd otherwise rewrite to point at the Gateway. Skip both.
+        if gateway_class != "epponly":
+            username = context.username or "unknown"
             cmd.kube(
-                "delete",
-                "route",
-                route_name,
-                "-n",
+                "label",
+                f"gateway/infra-{release}-inference-gateway",
+                f"stood-up-by={username}",
+                "stood-up-from=llm-d-benchmark",
+                "stood-up-via=modelservice",
+                "--namespace",
                 namespace,
-                "--ignore-not-found",
-                check=False,
+                "--overwrite",
             )
 
-            cmd.kube(
-                "expose",
-                f"service/{route_service}",
-                f"--name={route_name}",
-                "--port=80",
-                "-n",
-                namespace,
-            )
-            context.logger.log_info(
-                f"OpenShift route '{route_name}' created to "
-                f"service/{route_service}:80"
-            )
+            # GAIE Helm chart creates a route to the EPP gRPC port (wrong for
+            # inference). We replace it with one targeting the gateway on
+            # port 80. data-science-gateway-class manages its own route.
+            if context.is_openshift and gateway_class != "data-science-gateway-class":
+                route_name = f"{release}-inference-gateway-route"
+
+                if gateway_class == "agentgateway":
+                    route_service = f"infra-{release}-inference-gateway"
+                else:  # istio
+                    route_service = f"infra-{release}-inference-gateway-istio"
+
+                cmd.kube(
+                    "delete",
+                    "route",
+                    route_name,
+                    "-n",
+                    namespace,
+                    "--ignore-not-found",
+                    check=False,
+                )
+
+                cmd.kube(
+                    "expose",
+                    f"service/{route_service}",
+                    f"--name={route_name}",
+                    "--port=80",
+                    "-n",
+                    namespace,
+                )
+                context.logger.log_info(
+                    f"OpenShift route '{route_name}' created to "
+                    f"service/{route_service}:80"
+                )
 
         # WVA controller + prometheus-adapter are installed up-front by
         # step_02 (admin prerequisites). Here we only apply this stack's
@@ -390,9 +415,13 @@ class DeployModelserviceStep(Step):
             still_missing = []
             for name in missing:
                 check = cmd.kube(
-                    "get", "inferencepool", name,
-                    "--namespace", namespace,
-                    "-o", "name",
+                    "get",
+                    "inferencepool",
+                    name,
+                    "--namespace",
+                    namespace,
+                    "-o",
+                    "name",
                     check=False,
                 )
                 if not check.success:
@@ -495,9 +524,8 @@ class DeployModelserviceStep(Step):
                 break
             # Check securityContext inside extraContainerConfig (used by
             # modelservice Helm chart for container-level security settings)
-            extra_sc = (
-                section.get("extraContainerConfig", {})
-                .get("securityContext", {})
+            extra_sc = section.get("extraContainerConfig", {}).get(
+                "securityContext", {}
             )
             if extra_sc.get("runAsUser") == 0 or extra_sc.get("runAsGroup") == 0:
                 needs_elevated = True
@@ -597,9 +625,8 @@ class DeployModelserviceStep(Step):
         ``oc get``. Best-effort - failures here don't fail step_09.
         """
         wva_cfg = plan_config.get("wva", {}) or {}
-        wva_ns = (
-            wva_cfg.get("namespace")
-            or plan_config.get("namespace", {}).get("name", "")
+        wva_ns = wva_cfg.get("namespace") or plan_config.get("namespace", {}).get(
+            "name", ""
         )
         model_id_label = plan_config.get("model_id_label", "")
         if not (wva_ns and model_id_label):
@@ -612,14 +639,15 @@ class DeployModelserviceStep(Step):
             ("hpa", "HorizontalPodAutoscaler"),
         ):
             result = cmd.kube(
-                "get", kind, resource_name,
-                "--namespace", wva_ns,
+                "get",
+                kind,
+                resource_name,
+                "--namespace",
+                wva_ns,
                 check=False,
             )
             if result.success and result.stdout.strip():
-                context.logger.log_info(
-                    f"📋 {label} state in ns/{wva_ns}:"
-                )
+                context.logger.log_info(f"📋 {label} state in ns/{wva_ns}:")
                 # Indent each line so it visually groups with the
                 # header above it in the standup log.
                 for line in result.stdout.rstrip().splitlines():
@@ -654,8 +682,12 @@ class DeployModelserviceStep(Step):
 
         if plan_config:
             params["model_name"] = self._require_config(plan_config, "model", "name")
-            params["model_short_name"] = self._require_config(plan_config, "model", "shortName")
-            params["model_huggingface_id"] = plan_config.get("model", {}).get("huggingfaceId", "")
+            params["model_short_name"] = self._require_config(
+                plan_config, "model", "shortName"
+            )
+            params["model_huggingface_id"] = plan_config.get("model", {}).get(
+                "huggingfaceId", ""
+            )
             params["inference_port"] = str(
                 self._require_config(plan_config, "vllmCommon", "inferencePort")
             )

--- a/llmdbenchmark/standup/steps/step_10_smoketest.py
+++ b/llmdbenchmark/standup/steps/step_10_smoketest.py
@@ -13,8 +13,10 @@ from llmdbenchmark.utilities.endpoint import (
     cleanup_ephemeral_pods,
     find_standalone_endpoint,
     find_gateway_endpoint,
+    find_epponly_endpoint,
     test_model_serving,
 )
+
 
 class SmoketestStep(Step):
     """Validate deployment health and model serving via smoketests."""
@@ -49,7 +51,9 @@ class SmoketestStep(Step):
 
         plan_config = self._load_stack_config(stack_path)
         model_name = self._require_config(plan_config, "model", "name")
-        inference_port = self._require_config(plan_config, "vllmCommon", "inferencePort")
+        inference_port = self._require_config(
+            plan_config, "vllmCommon", "inferencePort"
+        )
         release = self._require_config(plan_config, "release")
 
         if "fma" in context.deployed_methods:
@@ -58,14 +62,22 @@ class SmoketestStep(Step):
         gateway_port = "80"
         service_ip = None
 
+        gateway_class = plan_config.get("gateway", {}).get("className", "")
+        is_epponly = gateway_class == "epponly"
+        model_id_label = plan_config.get("model_id_label", "")
+
         if is_standalone:
             service_ip, _, gateway_port = find_standalone_endpoint(
                 cmd, namespace, inference_port
             )
-        else:
-            service_ip, _, gateway_port = find_gateway_endpoint(
-                cmd, namespace, release
+        elif is_epponly:
+            service_ip, _, gateway_port = find_epponly_endpoint(
+                cmd,
+                namespace,
+                model_id_label,
             )
+        else:
+            service_ip, _, gateway_port = find_gateway_endpoint(cmd, namespace, release)
 
         if not service_ip:
             if context.dry_run:
@@ -74,7 +86,6 @@ class SmoketestStep(Step):
             else:
                 errors.append("Could not find service/gateway IP for smoketest")
 
-        model_id_label = plan_config.get("model_id_label", "")
         standalone_role = self._require_config(plan_config, "standalone", "role")
         if is_standalone:
             pod_selector = (
@@ -103,7 +114,7 @@ class SmoketestStep(Step):
                 if not phases:
                     errors.append(f"No pods found with selector '{pod_selector}'")
                 elif not all(p == "Running" for p in phases):
-                    errors.append("Not all pods running " f"(found: {', '.join(phases)})")
+                    errors.append(f"Not all pods running (found: {', '.join(phases)})")
                 else:
                     context.logger.log_info(f"All {len(phases)} pod(s) running ✓")
             else:
@@ -111,7 +122,12 @@ class SmoketestStep(Step):
 
         if service_ip and not errors:
             health_err = self._check_health(
-                cmd, context, namespace, service_ip, gateway_port, plan_config,
+                cmd,
+                context,
+                namespace,
+                service_ip,
+                gateway_port,
+                plan_config,
             )
             if health_err:
                 errors.append(health_err)
@@ -121,15 +137,19 @@ class SmoketestStep(Step):
         # until it actually serves the model before running assertions.
         if service_ip and not errors:
             self._wait_for_model_ready(
-                cmd, context, namespace, service_ip, gateway_port,
-                model_name, plan_config,
+                cmd,
+                context,
+                namespace,
+                service_ip,
+                gateway_port,
+                model_name,
+                plan_config,
             )
 
         service_test_passed = False
         if service_ip:
             context.logger.log_info(
-                f'Testing service/gateway "{service_ip}" '
-                f"(port {gateway_port})..."
+                f'Testing service/gateway "{service_ip}" (port {gateway_port})...'
             )
             test_result = test_model_serving(
                 cmd,
@@ -167,15 +187,19 @@ class SmoketestStep(Step):
         if context.dry_run:
             # Log a representative pod IP test command
             test_model_serving(
-                cmd, namespace, "<dry-run-pod-ip>", inference_port,
-                model_name, plan_config, max_retries=1,
+                cmd,
+                namespace,
+                "<dry-run-pod-ip>",
+                inference_port,
+                model_name,
+                plan_config,
+                max_retries=1,
             )
         elif pod_ips_result.success and pod_ips_result.stdout.strip():
             pod_ips = pod_ips_result.stdout.strip().split()
             for i, pod_ip in enumerate(pod_ips, 1):
                 context.logger.log_info(
-                    f"Testing pod {i}/{len(pod_ips)} "
-                    f"at {pod_ip}:{inference_port}..."
+                    f"Testing pod {i}/{len(pod_ips)} at {pod_ip}:{inference_port}..."
                 )
                 test_result = test_model_serving(
                     cmd,
@@ -283,14 +307,18 @@ class SmoketestStep(Step):
 
             attempt += 1
             pod_name = f"healthcheck-{_rand_suffix()}"
-            curl_cmd = (
-                f"'curl -sk --max-time 10 -o /dev/null -w %{{http_code}} {url}'"
-            )
+            curl_cmd = f"'curl -sk --max-time 10 -o /dev/null -w %{{http_code}} {url}'"
 
             kubectl_args = (
                 [
-                    "run", pod_name, "--rm", "--attach", "--quiet",
-                    "--restart=Never", "--namespace", namespace,
+                    "run",
+                    pod_name,
+                    "--rm",
+                    "--attach",
+                    "--quiet",
+                    "--restart=Never",
+                    "--namespace",
+                    namespace,
                     f"--image={curl_image}",
                 ]
                 + _ephemeral_label_args()
@@ -318,7 +346,7 @@ class SmoketestStep(Step):
             )
             time.sleep(poll_interval)
 
-    def _wait_for_model_ready( # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _wait_for_model_ready(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         cmd: CommandExecutor,
         context: ExecutionContext,
@@ -337,8 +365,7 @@ class SmoketestStep(Step):
         ``/v1/models`` returns the expected model name, up to *timeout* seconds.
         """
         context.logger.log_info(
-            f"Waiting for model to be ready at {host}:{port} "
-            f"(timeout {timeout}s)..."
+            f"Waiting for model to be ready at {host}:{port} (timeout {timeout}s)..."
         )
         start = time.time()
         attempt = 0
@@ -354,7 +381,12 @@ class SmoketestStep(Step):
 
             attempt += 1
             result = test_model_serving(
-                cmd, namespace, host, port, expected_model, plan_config,
+                cmd,
+                namespace,
+                host,
+                port,
+                expected_model,
+                plan_config,
                 max_retries=1,
             )
 
@@ -363,15 +395,13 @@ class SmoketestStep(Step):
 
             if result is None:
                 context.logger.log_info(
-                    f"Model ready at {host}:{port} ✓ "
-                    f"({int(elapsed)}s elapsed)"
+                    f"Model ready at {host}:{port} ✓ ({int(elapsed)}s elapsed)"
                 )
                 return
 
             remaining = int(timeout - elapsed)
             context.logger.log_info(
-                f"Model not ready yet (attempt {attempt}, "
-                f"{remaining}s remaining)..."
+                f"Model not ready yet (attempt {attempt}, {remaining}s remaining)..."
             )
             time.sleep(poll_interval)
 
@@ -426,10 +456,9 @@ class SmoketestStep(Step):
                 f"Unable to fetch OpenShift route '{route_name}'"
             )
 
-    def _check_deployment_fma(self,
-                              context: ExecutionContext,
-                              plan_config: dict,
-                              stack_name: str) -> StepResult:
+    def _check_deployment_fma(
+        self, context: ExecutionContext, plan_config: dict, stack_name: str
+    ) -> StepResult:
         """
         Checking if current FMA deployment was successful
         """
@@ -438,12 +467,13 @@ class SmoketestStep(Step):
         cmd = context.require_cmd()
         namespace = context.require_namespace()
         model_label = plan_config.get("model_id_label", "")
-        for resource, name in [("InferenceServerConfig",  f"fma-{model_label}"),
-                         ("LauncherrConfig",  f"fma-{model_label}"),
-                         ("LauncherPopulationPolicy",  f"fma-{model_label}"),
-                         ("ReplicaSet",  f"fma-requester-{model_label}")
-                         ]:
-            result = cmd.kube("get", resource ,"-n", namespace, name, check=False)
+        for resource, name in [
+            ("InferenceServerConfig", f"fma-{model_label}"),
+            ("LauncherrConfig", f"fma-{model_label}"),
+            ("LauncherPopulationPolicy", f"fma-{model_label}"),
+            ("ReplicaSet", f"fma-requester-{model_label}"),
+        ]:
+            result = cmd.kube("get", resource, "-n", namespace, name, check=False)
             if not result.success:
                 errors.append(f"Failed to query {resource} {name}: {result.stderr}")
             elif result.stdout.strip().split() == "":

--- a/llmdbenchmark/standup/steps/step_11_inference_test.py
+++ b/llmdbenchmark/standup/steps/step_11_inference_test.py
@@ -27,6 +27,7 @@ from llmdbenchmark.utilities.endpoint import (
     _ephemeral_label_args,
     find_standalone_endpoint,
     find_gateway_endpoint,
+    find_epponly_endpoint,
 )
 
 # Transient HTTP status codes / error substrings that warrant a retry.
@@ -96,14 +97,20 @@ class InferenceTestStep(Step):
         release = self._require_config(plan_config, "release")
 
         # Discover endpoint (same logic as smoketest)
+        gateway_class = plan_config.get("gateway", {}).get("className", "")
+        model_id_label = plan_config.get("model_id_label", "")
         if is_standalone:
             service_ip, _, gateway_port = find_standalone_endpoint(
                 cmd, namespace, inference_port
             )
-        else:
-            service_ip, _, gateway_port = find_gateway_endpoint(
-                cmd, namespace, release
+        elif gateway_class == "epponly":
+            service_ip, _, gateway_port = find_epponly_endpoint(
+                cmd,
+                namespace,
+                model_id_label,
             )
+        else:
+            service_ip, _, gateway_port = find_gateway_endpoint(cmd, namespace, release)
 
         if not service_ip:
             if context.dry_run:
@@ -123,21 +130,29 @@ class InferenceTestStep(Step):
         protocol = "https" if str(gateway_port) == "443" else "http"
         base_url = f"{protocol}://{service_ip}:{gateway_port}"
 
-        context.logger.log_info(
-            f"Running sample inference against {base_url}..."
-        )
+        context.logger.log_info(f"Running sample inference against {base_url}...")
 
         # --- Try /v1/completions first (universal in vLLM) ---
         context.logger.log_info("Trying /v1/completions endpoint...")
         completions_result = self._try_completions(
-            cmd, context, namespace, base_url, model_name, plan_config,
+            cmd,
+            context,
+            namespace,
+            base_url,
+            model_name,
+            plan_config,
         )
 
         if completions_result.success:
             self._print_demo_command(
-                context, cmd, namespace, plan_config,
-                base_url, "/v1/completions",
-                completions_result.payload, completions_result.generated_text,
+                context,
+                cmd,
+                namespace,
+                plan_config,
+                base_url,
+                "/v1/completions",
+                completions_result.payload,
+                completions_result.generated_text,
             )
             return StepResult(
                 step_number=self.number,
@@ -155,14 +170,24 @@ class InferenceTestStep(Step):
                 f"Falling back to /v1/chat/completions..."
             )
             chat_result = self._try_chat_completions(
-                cmd, context, namespace, base_url, model_name, plan_config,
+                cmd,
+                context,
+                namespace,
+                base_url,
+                model_name,
+                plan_config,
             )
 
             if chat_result.success:
                 self._print_demo_command(
-                    context, cmd, namespace, plan_config,
-                    base_url, "/v1/chat/completions",
-                    chat_result.payload, chat_result.generated_text,
+                    context,
+                    cmd,
+                    namespace,
+                    plan_config,
+                    base_url,
+                    "/v1/chat/completions",
+                    chat_result.payload,
+                    chat_result.generated_text,
                 )
                 return StepResult(
                     step_number=self.number,
@@ -201,8 +226,7 @@ class InferenceTestStep(Step):
     class _InferenceResult:
         """Encapsulates the outcome of a single inference attempt."""
 
-        __slots__ = ("success", "error", "should_fallback",
-                     "generated_text", "payload")
+        __slots__ = ("success", "error", "should_fallback", "generated_text", "payload")
 
         def __init__(
             self,
@@ -244,12 +268,17 @@ class InferenceTestStep(Step):
 
         for attempt in range(1, max_retries + 1):
             stdout, err = self._curl_post(
-                cmd, namespace, url, payload, plan_config,
+                cmd,
+                namespace,
+                url,
+                payload,
+                plan_config,
             )
 
             if cmd.dry_run:
                 return self._InferenceResult(
-                    success=True, payload=payload,
+                    success=True,
+                    payload=payload,
                     generated_text="<dry-run>",
                 )
 
@@ -310,9 +339,7 @@ class InferenceTestStep(Step):
                 payload=payload,
             )
 
-        return self._InferenceResult(
-            error=f"Exhausted {max_retries} retries for {url}"
-        )
+        return self._InferenceResult(error=f"Exhausted {max_retries} retries for {url}")
 
     # ------------------------------------------------------------------
     # /v1/chat/completions
@@ -333,14 +360,20 @@ class InferenceTestStep(Step):
         url = f"{base_url}/v1/chat/completions"
         payload = {
             "model": model_name,
-            "messages": [{"role": "user", "content": "What is the capital of the United States?"}],
+            "messages": [
+                {"role": "user", "content": "What is the capital of the United States?"}
+            ],
             "max_tokens": 5,
             "temperature": 0,
         }
 
         for attempt in range(1, max_retries + 1):
             stdout, err = self._curl_post(
-                cmd, namespace, url, payload, plan_config,
+                cmd,
+                namespace,
+                url,
+                payload,
+                plan_config,
             )
 
             if err:
@@ -390,9 +423,7 @@ class InferenceTestStep(Step):
                 payload=payload,
             )
 
-        return self._InferenceResult(
-            error=f"Exhausted {max_retries} retries for {url}"
-        )
+        return self._InferenceResult(error=f"Exhausted {max_retries} retries for {url}")
 
     # ------------------------------------------------------------------
     # Shared helpers
@@ -426,14 +457,20 @@ class InferenceTestStep(Step):
             f"'echo {payload_b64} | base64 -d | "
             f"curl -sk --max-time {timeout_seconds} "
             f"-X POST {url} "
-            f"-H \"Content-Type: application/json\" "
+            f'-H "Content-Type: application/json" '
             f"-d @- 2>&1'"
         )
 
         kubectl_args = (
             [
-                "run", pod_name, "--rm", "--attach", "--quiet",
-                "--restart=Never", "--namespace", namespace,
+                "run",
+                pod_name,
+                "--rm",
+                "--attach",
+                "--quiet",
+                "--restart=Never",
+                "--namespace",
+                namespace,
                 f"--image={curl_image}",
             ]
             + _ephemeral_label_args()
@@ -498,12 +535,15 @@ class InferenceTestStep(Step):
 
         context.logger.log_info(f"✅ Inference test passed via {endpoint}")
         if generated_text:
-            context.logger.log_info(f"   Generated: \"{generated_text[:80]}\"")
+            context.logger.log_info(f'   Generated: "{generated_text[:80]}"')
         context.logger.log_info("")
 
         # Try to detect the OpenShift route for an external URL
         external_url = self._detect_external_url(
-            cmd, namespace, plan_config, endpoint,
+            cmd,
+            namespace,
+            plan_config,
+            endpoint,
         )
 
         if external_url:
@@ -543,9 +583,13 @@ class InferenceTestStep(Step):
 
         route_name = f"{release}-inference-gateway-route"
         result = cmd.kube(
-            "get", "route", route_name,
-            "-n", namespace,
-            "-o", "jsonpath={.spec.host}:{.spec.tls.termination}",
+            "get",
+            "route",
+            route_name,
+            "-n",
+            namespace,
+            "-o",
+            "jsonpath={.spec.host}:{.spec.tls.termination}",
             check=False,
         )
 

--- a/llmdbenchmark/utilities/cluster.py
+++ b/llmdbenchmark/utilities/cluster.py
@@ -86,7 +86,8 @@ def kube_connect(
 
     if kubeconfig:
         k8s_config.load_kube_config(
-            config_file=kubeconfig, context=kube_context,
+            config_file=kubeconfig,
+            context=kube_context,
         )
         _silence_insecure_tls_warnings_if_disabled()
         return client.ApiClient()
@@ -139,9 +140,7 @@ def get_service_endpoint(
         return None
     v1 = client.CoreV1Api(api_client)
     try:
-        service = v1.read_namespaced_service(
-            name=service_name, namespace=namespace
-        )
+        service = v1.read_namespaced_service(name=service_name, namespace=namespace)
         cluster_ip = service.spec.cluster_ip
         if service.spec.ports:
             port = service.spec.ports[0].port
@@ -205,11 +204,65 @@ def load_stacks_info(context: ExecutionContext) -> list[dict]:
                         or cfg.get("model", {}).get("name", "unknown")
                     ),
                     "method": method,
+                    "gateway_class": _format_gateway_label(
+                        method,
+                        cfg.get("gateway", {}).get("className", ""),
+                    ),
                 }
             )
         except (OSError, yaml.YAMLError):
             continue
     return stacks
+
+
+def _format_gateway_label(method: str, gateway_class: str) -> str:
+    """Return the banner label for the gateway class.
+
+    ``gateway.className`` only takes effect on the modelservice deploy
+    path (it switches the GAIE chart + Gateway/HTTPRoute rendering).
+    For other deploy methods it's ignored entirely, so the banner makes
+    that explicit instead of showing a misleading value.
+    """
+    if method == "modelservice":
+        return gateway_class or "unknown"
+    if method == "kustomize":
+        return "n/a (defined by upstream guide manifests)"
+    if method == "standalone":
+        return "n/a (plain vLLM, no EPP)"
+    if method == "fma":
+        return "n/a (managed by FMA)"
+    return gateway_class or "unknown"
+
+
+def resolve_phase_gateway_label(context: ExecutionContext) -> str | None:
+    """Single-stack helper: derive the gateway label for the banner.
+
+    Reads the first rendered stack's config and combines it with the
+    active deploy method to produce a human-friendly label. Returns
+    ``None`` when no rendered stack is available (e.g. run-only mode
+    with --endpoint-url) so the banner can omit the line cleanly.
+    """
+    method = "unknown"
+    if context.deployed_methods:
+        for m in ("kustomize", "standalone", "fma", "modelservice"):
+            if m in context.deployed_methods:
+                method = m
+                break
+
+    for stack_path in context.rendered_stacks or []:
+        config_file = stack_path / "config.yaml"
+        if not config_file.exists():
+            continue
+        try:
+            with open(config_file, encoding="utf-8") as f:
+                cfg = yaml.safe_load(f) or {}
+            return _format_gateway_label(
+                method,
+                (cfg.get("gateway") or {}).get("className", ""),
+            )
+        except (OSError, yaml.YAMLError):
+            continue
+    return None
 
 
 def print_phase_banner(
@@ -263,6 +316,9 @@ def print_phase_banner(
     if num_stacks <= 1:
         log.log_info(f"  Model:       {model}")
         log.log_info(f"  Methods:     {methods}")
+        gateway_label = resolve_phase_gateway_label(context)
+        if gateway_label:
+            log.log_info(f"  Gateway:     {gateway_label}")
         log.log_info(f"  Namespace:   {namespace}")
     else:
         log.log_info(f"  Stacks:      {num_stacks}")
@@ -271,11 +327,14 @@ def print_phase_banner(
             s_model = si.get("model_name", "unknown")
             s_ns = si.get("namespace", "unknown")
             s_method = si.get("method", "unknown")
+            s_gateway = si.get("gateway_class", "")
             s_name = si.get("stack_name", f"stack-{i}")
             log.log_info(f"  Stack {i}: {s_name}")
             log.log_info(f"    Model:     {s_model}")
             log.log_info(f"    Namespace: {s_ns}")
             log.log_info(f"    Method:    {s_method}")
+            if s_gateway:
+                log.log_info(f"    Gateway:   {s_gateway}")
             if i < len(stacks_info):
                 log.log_info("")
 
@@ -316,7 +375,7 @@ def _kube_api_connect(context: ExecutionContext) -> None:
 
     try:
         api = client.ApisApi(api_client)
-        groups = api.get_api_versions() # noqa: F841
+        groups = api.get_api_versions()  # noqa: F841
     except Exception as exc:
         raise RuntimeError(
             f"Cluster is unreachable: {exc}. "

--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -11,6 +11,7 @@ import time
 
 from llmdbenchmark.executor.command import CommandExecutor
 
+
 def _rand_suffix(length: int = 8) -> str:
     """Generate a random lowercase alphanumeric suffix for pod names."""
     return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
@@ -63,7 +64,9 @@ def compute_gateway_path_prefix(
     return _normalize_url_prefix(tmpl.replace("{stack.name}", stack_name))
 
 
-def _build_overrides(plan_config: dict | None, service_account: str | None = None) -> list[str]:
+def _build_overrides(
+    plan_config: dict | None, service_account: str | None = None
+) -> list[str]:
     """Build --overrides args for ephemeral curl pods (imagePullSecrets, serviceAccount)."""
     overrides: dict = {}
     if plan_config:
@@ -73,7 +76,9 @@ def _build_overrides(plan_config: dict | None, service_account: str | None = Non
                 {"name": pull_secret}
             ]
 
-    sa_name = service_account or (plan_config.get("serviceAccount", {}).get("name") if plan_config else None)
+    sa_name = service_account or (
+        plan_config.get("serviceAccount", {}).get("name") if plan_config else None
+    )
     if sa_name:
         overrides.setdefault("spec", {})["serviceAccountName"] = sa_name
 
@@ -88,7 +93,9 @@ def _ephemeral_label_args() -> list[str]:
 
 
 def cleanup_ephemeral_pods(
-    cmd: CommandExecutor, namespace: str, logger=None,
+    cmd: CommandExecutor,
+    namespace: str,
+    logger=None,
 ) -> None:
     """Delete all completed ephemeral pods created by smoketest/endpoint checks.
 
@@ -97,13 +104,20 @@ def cleanup_ephemeral_pods(
     """
     for phase in ("Succeeded", "Failed"):
         result = cmd.kube(
-            "delete", "pods",
-            "-l", EPHEMERAL_POD_LABEL,
+            "delete",
+            "pods",
+            "-l",
+            EPHEMERAL_POD_LABEL,
             f"--field-selector=status.phase={phase}",
-            "--namespace", namespace,
+            "--namespace",
+            namespace,
             check=False,
         )
-        if result.success and result.stdout.strip() and "No resources" not in result.stdout:
+        if (
+            result.success
+            and result.stdout.strip()
+            and "No resources" not in result.stdout
+        ):
             if logger:
                 logger.log_info(
                     f"Cleaned up ephemeral pods ({phase}) in ns/{namespace}"
@@ -139,6 +153,7 @@ def find_standalone_endpoint(
         return ip, name, svc_port
     return None, None, "80"
 
+
 def find_fma_endpoint(cmd: CommandExecutor, namespace: str) -> str | None:
     """Find FMA replicaset name.
 
@@ -163,6 +178,75 @@ def find_fma_endpoint(cmd: CommandExecutor, namespace: str) -> str | None:
         return f"{result.stdout.strip()}.{namespace}.cluster.local"
 
     return None
+
+
+def find_epponly_endpoint(
+    cmd: CommandExecutor,
+    namespace: str,
+    model_id_label: str,
+) -> tuple[str | None, str | None, str]:
+    """Find the EPP service for an ``epponly`` modelservice deployment.
+
+    In llm-d's standalone router topology (``gateway.className: epponly``)
+    no Kubernetes Gateway is deployed; the EPP pod runs an Envoy sidecar
+    that serves HTTP on the same service as the gRPC ExtProc port.
+    Clients hit ``{model_id_label}-gaie-epp:80`` directly.
+
+    Returns:
+        (clusterIP, serviceName, port) or (None, expected_name, "80") if
+        the service does not exist yet.
+    """
+    if not model_id_label:
+        return None, None, "80"
+
+    svc_name = f"{model_id_label}-gaie-epp"
+    # Fetch the whole service as JSON and pick the HTTP port in Python.
+    # Earlier this used a `jsonpath` filter (``?(@.port==80)``) but that
+    # syntax is not reliably handled by every kubectl/oc version we ship
+    # against - some return the entire ports list or silently drop the
+    # filter, leaving service_ip empty and the smoketest unable to find
+    # the endpoint. JSON-parsing the response keeps us in plain Python.
+    result = cmd.kube(
+        "get",
+        "service",
+        svc_name,
+        "--namespace",
+        namespace,
+        "-o",
+        "json",
+        check=False,
+    )
+    if not (result.success and result.stdout.strip()):
+        return None, svc_name, "80"
+
+    try:
+        svc = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None, svc_name, "80"
+
+    spec = svc.get("spec", {}) or {}
+    ip = spec.get("clusterIP") or None
+    ports = spec.get("ports") or []
+
+    # Prefer port 80 (the extraServicePort we add for the standalone
+    # chart's Envoy sidecar). Fall back to the named ``http`` port, then
+    # to the first port on the service.
+    port: str | None = None
+    for p in ports:
+        if p.get("port") == 80 or str(p.get("port")) == "80":
+            port = "80"
+            break
+    if port is None:
+        for p in ports:
+            if p.get("name") == "http":
+                port = str(p.get("port"))
+                break
+    if port is None and ports:
+        port = str(ports[0].get("port", "80"))
+    if port is None:
+        port = "80"
+
+    return ip, svc_name, port
 
 
 def find_gateway_endpoint(
@@ -242,16 +326,20 @@ def discover_hf_token_secret(
         The secret name (e.g. ``llm-d-hf-token``) if found, else None.
     """
     result = cmd.kube(
-        "get", "secrets",
-        "--namespace", namespace,
+        "get",
+        "secrets",
+        "--namespace",
+        namespace,
         "--no-headers",
-        "-o", "custom-columns=NAME:.metadata.name",
+        "-o",
+        "custom-columns=NAME:.metadata.name",
         check=False,
     )
     if not result.success or not result.stdout.strip():
         return None
 
     import re
+
     pattern = re.compile(r"llm-d-hf.*token", re.IGNORECASE)
     for line in result.stdout.strip().splitlines():
         secret_name = line.strip()
@@ -279,9 +367,13 @@ def extract_hf_token_from_secret(
 
     # Try the explicit key
     result = cmd.kube(
-        "get", "secret", secret_name,
-        "--namespace", namespace,
-        "-o", f"jsonpath={{.data.{key}}}",
+        "get",
+        "secret",
+        secret_name,
+        "--namespace",
+        namespace,
+        "-o",
+        f"jsonpath={{.data.{key}}}",
         check=False,
     )
     if result.success and result.stdout.strip():
@@ -294,9 +386,13 @@ def extract_hf_token_from_secret(
 
     # Fallback: dump all data values
     result = cmd.kube(
-        "get", "secret", secret_name,
-        "--namespace", namespace,
-        "-o", "jsonpath={.data}",
+        "get",
+        "secret",
+        secret_name,
+        "--namespace",
+        namespace,
+        "-o",
+        "jsonpath={.data}",
         check=False,
     )
     if result.success and result.stdout.strip():
@@ -320,9 +416,12 @@ def find_kustomize_endpoint(
     """Find the ``{guide_name}-epp`` service and pick the HTTP port."""
     svc_name = f"{guide_name}-epp"
     result = cmd.kube(
-        "get", f"service/{svc_name}",
-        "--namespace", namespace,
-        "-o", "json",
+        "get",
+        f"service/{svc_name}",
+        "--namespace",
+        namespace,
+        "-o",
+        "json",
         check=False,
     )
     if not result.success:
@@ -362,10 +461,13 @@ def find_custom_endpoint(
 ) -> tuple[str | None, str | None, str]:
     """Find a service or pod matching *method_pattern* and return ``(ip, name, port)``."""
     svc_result = cmd.kube(
-        "get", "service",
-        "--namespace", namespace,
+        "get",
+        "service",
+        "--namespace",
+        namespace,
         "--no-headers",
-        "-o", "custom-columns=NAME:.metadata.name",
+        "-o",
+        "custom-columns=NAME:.metadata.name",
         check=False,
     )
     if svc_result.success and svc_result.stdout.strip():
@@ -376,36 +478,39 @@ def find_custom_endpoint(
 
             if preferred_port is not None:
                 port_result = cmd.kube(
-                    "get", f"service/{svc_name}",
-                    "--namespace", namespace,
-                    "-o", f"jsonpath={{.spec.ports[?(@.port=={preferred_port})].port}}",
+                    "get",
+                    f"service/{svc_name}",
+                    "--namespace",
+                    namespace,
+                    "-o",
+                    f"jsonpath={{.spec.ports[?(@.port=={preferred_port})].port}}",
                     check=False,
                 )
-                port_val = (
-                    port_result.stdout.strip()
-                    if port_result.success else ""
-                )
+                port_val = port_result.stdout.strip() if port_result.success else ""
                 if port_val and port_val != "null":
                     return svc_name, svc_name, port_val
 
             for port_name in ("http", "https", "default"):
                 port_result = cmd.kube(
-                    "get", f"service/{svc_name}",
-                    "--namespace", namespace,
-                    "-o", f"jsonpath={{.spec.ports[?(@.name==\"{port_name}\")].port}}",
+                    "get",
+                    f"service/{svc_name}",
+                    "--namespace",
+                    namespace,
+                    "-o",
+                    f'jsonpath={{.spec.ports[?(@.name=="{port_name}")].port}}',
                     check=False,
                 )
-                port_val = (
-                    port_result.stdout.strip()
-                    if port_result.success else ""
-                )
+                port_val = port_result.stdout.strip() if port_result.success else ""
                 if port_val and port_val != "null":
                     return svc_name, svc_name, port_val
 
             port_result = cmd.kube(
-                "get", f"service/{svc_name}",
-                "--namespace", namespace,
-                "-o", "jsonpath={.spec.ports[0].port}",
+                "get",
+                f"service/{svc_name}",
+                "--namespace",
+                namespace,
+                "-o",
+                "jsonpath={.spec.ports[0].port}",
                 check=False,
             )
             port_val = port_result.stdout.strip() if port_result.success else ""
@@ -413,10 +518,13 @@ def find_custom_endpoint(
                 return svc_name, svc_name, port_val
 
     pod_result = cmd.kube(
-        "get", "pod",
-        "--namespace", namespace,
+        "get",
+        "pod",
+        "--namespace",
+        namespace,
         "--no-headers",
-        "-o", "custom-columns=NAME:.metadata.name",
+        "-o",
+        "custom-columns=NAME:.metadata.name",
         check=False,
     )
     if pod_result.success and pod_result.stdout.strip():
@@ -428,9 +536,12 @@ def find_custom_endpoint(
             port_val = None
             for probe in ("livenessProbe", "readinessProbe"):
                 probe_result = cmd.kube(
-                    "get", f"pod/{pod_name}",
-                    "--namespace", namespace,
-                    "-o", f"jsonpath={{.spec.containers[0].{probe}.httpGet.port}}",
+                    "get",
+                    f"pod/{pod_name}",
+                    "--namespace",
+                    namespace,
+                    "-o",
+                    f"jsonpath={{.spec.containers[0].{probe}.httpGet.port}}",
                     check=False,
                 )
                 pv = probe_result.stdout.strip() if probe_result.success else ""
@@ -441,9 +552,12 @@ def find_custom_endpoint(
             # Fall back to metrics container port
             if not port_val:
                 metrics_result = cmd.kube(
-                    "get", f"pod/{pod_name}",
-                    "--namespace", namespace,
-                    "-o", 'jsonpath={.spec.containers[0].ports[?(@.name=="metrics")].containerPort}',
+                    "get",
+                    f"pod/{pod_name}",
+                    "--namespace",
+                    namespace,
+                    "-o",
+                    'jsonpath={.spec.containers[0].ports[?(@.name=="metrics")].containerPort}',
                     check=False,
                 )
                 pv = metrics_result.stdout.strip() if metrics_result.success else ""
@@ -455,9 +569,12 @@ def find_custom_endpoint(
 
             # Resolve pod IP
             ip_result = cmd.kube(
-                "get", f"pod/{pod_name}",
-                "--namespace", namespace,
-                "-o", "jsonpath={.status.podIP}",
+                "get",
+                f"pod/{pod_name}",
+                "--namespace",
+                namespace,
+                "-o",
+                "jsonpath={.status.podIP}",
                 check=False,
             )
             pod_ip = ip_result.stdout.strip() if ip_result.success else None
@@ -543,34 +660,57 @@ def test_model_serving(
     url = f"{protocol}://{host}:{port}{prefix}/v1/models"
 
     # Auto-ensure service account and RBAC
-    sa_name = service_account or (plan_config.get("serviceAccount", {}).get("name") if plan_config else "default")
+    sa_name = service_account or (
+        plan_config.get("serviceAccount", {}).get("name") if plan_config else "default"
+    )
     if sa_name:
         if sa_name != "default":
-            sa_check = cmd.kube("get", "sa", sa_name, "--namespace", namespace, check=False)
-            if not sa_check.success or "not found" in (sa_check.stderr + sa_check.stdout).lower():
-                cmd.logger.log_info(f"ServiceAccount '{sa_name}' not found, auto-creating it...")
+            sa_check = cmd.kube(
+                "get", "sa", sa_name, "--namespace", namespace, check=False
+            )
+            if (
+                not sa_check.success
+                or "not found" in (sa_check.stderr + sa_check.stdout).lower()
+            ):
+                cmd.logger.log_info(
+                    f"ServiceAccount '{sa_name}' not found, auto-creating it..."
+                )
                 cmd.kube("create", "sa", sa_name, "--namespace", namespace, check=False)
 
         # Always ensure the required RBAC role exists
         role_name = f"{sa_name}-role"
-        role_check = cmd.kube("get", "role", role_name, "--namespace", namespace, check=False)
-        if not role_check.success or "not found" in (role_check.stderr + role_check.stdout).lower():
-            cmd.logger.log_info(f"RBAC Role '{role_name}' missing for ServiceAccount '{sa_name}', auto-creating it...")
+        role_check = cmd.kube(
+            "get", "role", role_name, "--namespace", namespace, check=False
+        )
+        if (
+            not role_check.success
+            or "not found" in (role_check.stderr + role_check.stdout).lower()
+        ):
+            cmd.logger.log_info(
+                f"RBAC Role '{role_name}' missing for ServiceAccount '{sa_name}', auto-creating it..."
+            )
             cmd.kube(
-                "create", "role", role_name,
-                "--verb=get,list", "--resource=configmaps,pods,pods/log",
-                "--namespace", namespace,
-                check=False
+                "create",
+                "role",
+                role_name,
+                "--verb=get,list",
+                "--resource=configmaps,pods,pods/log",
+                "--namespace",
+                namespace,
+                check=False,
             )
 
             # Always ensure RoleBinding
             binding_name = f"{sa_name}-binding"
             cmd.kube(
-                "create", "rolebinding", binding_name,
+                "create",
+                "rolebinding",
+                binding_name,
                 f"--role={role_name}",
                 f"--serviceaccount={namespace}:{sa_name}",
-                "--namespace", namespace,
-                check=False
+                "--namespace",
+                namespace,
+                check=False,
             )
 
     override_args = _build_overrides(plan_config, service_account=service_account)
@@ -638,9 +778,7 @@ def test_model_serving(
 
         # Validate the model is being served
         if expected_model and stdout:
-            check_err = validate_model_response(
-                stdout, expected_model, host, port
-            )
+            check_err = validate_model_response(stdout, expected_model, host, port)
             if check_err:
                 # If it looks retryable, keep trying
                 if _is_retryable(stdout) and attempt < max_retries:


### PR DESCRIPTION
## Summary

Added `gateway.className: epponly` toggle that switches the `modelservice` deploy into llm-d's `standalone mode` router topology (no Gateway, no HTTPRoute, no istio/agentgateway, the EPP runs Envoy as a sidecar and serves HTTP directly on the EPP service).

## What it does:

- Swaps GAIE chart inferencepool, standalone
- Skips llm-d-infra Helm release, HTTPRoute, and gateway-provider control plane
- Endpoint discovery + smoketest + inference test now resolve to {model_id_label}-gaie-epp directly

## How it's exposed:

- Set in `optimized-baseline.yaml` scenario as the default (with a comment listing alternatives: istio / agentgateway / gke / data-science-gateway-class)