### PR TITLE
workload, vllm-bench: add sonnet concurrent

### DIFF
--- a/workload/profiles/vllm-benchmark/sonnet_concurrent.yaml.in
+++ b/workload/profiles/vllm-benchmark/sonnet_concurrent.yaml.in
@@ -1,0 +1,16 @@
+executable: benchmark_serving.py
+model: REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL
+base-url: REPLACE_ENV_LLMDBENCH_HARNESS_STACK_ENDPOINT_URL
+max-concurrency: 32
+num-prompts: 500
+request-rate: 20
+backend: openai-chat
+endpoint: /v1/chat/completions
+dataset-name: sonnet
+dataset-path: /workspace/vllm/benchmarks/sonnet.txt
+sonnet-input-len: 8192
+sonnet-output-len: 512
+sonnet-prefix-len: 6144
+percentile-metrics: "ttft,tpot,itl,e2el"
+metric-percentiles: "0.1,1,5,10,25,75,90,95,99,99.9"
+ignore-eos: none


### PR DESCRIPTION
Add a quick shared prefix test with the already included sonnet dataset