### PR TITLE
Fix harness.serviceAccount precedence in step_07_deploy_harness

### DIFF
--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -265,9 +265,12 @@ class DeployHarnessStep(Step):
                     template_values["model"]["name"] = model_name
                 template_values.setdefault("images", {}).setdefault("benchmark", {})
 
-                # Service account override (-q)
+                # Service account precedence: CLI override (-q) > scenario's
+                # harness.serviceAccount > global serviceAccount.name default.
                 if context.harness_service_account:
                     template_values["harness"]["serviceAccount"] = context.harness_service_account
+                elif plan_config and plan_config.get("harness", {}).get("serviceAccount"):
+                    template_values["harness"]["serviceAccount"] = plan_config["harness"]["serviceAccount"]
                 elif plan_config and "serviceAccount" in plan_config:
                     template_values["harness"]["serviceAccount"] = plan_config["serviceAccount"].get("name", "default")
 


### PR DESCRIPTION
## What this does

`DeployHarnessStep` (`llmdbenchmark/run/steps/step_07_deploy_harness.py`) only checked two sources when setting the harness service account:

1. The CLI `-q` override (`context.harness_service_account`)
2. The top-level `serviceAccount.name` global default

A scenario that sets `harness.serviceAccount` directly was therefore silently overwritten by the global default. The harness pod template already conditionally renders `harness.serviceAccount`, so the value was expected to flow through — only the precedence wiring in the deploy step was missing.

This adds the missing rung so the resolution order is:

> CLI override (`-q`) **>** scenario `harness.serviceAccount` **>** global `serviceAccount.name` default

## Change

A single `elif` branch between the existing two, plus an updated comment documenting the precedence.

## Testing

- `python -m pytest tests/ -q` → all green (`272 passed, 4 skipped`).
- No new regressions; change is isolated to the service-account precedence block.

Signed-off-by: Yarden Maymon <yarden.maymon@twodelta.com>