### PR TITLE
fix: Reduce Scope of Gateway Knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,6 @@ llmdbenchmark --version
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) to render into the plan |
 | `-m MODELS` | `LLMDBENCH_MODELS` | Model to render the plan for |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment method (`standalone`, `modelservice`) |
-| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className`. Accepted on the modelservice path: `epponly`, `istio`, `agentgateway`, `gke`, `data-science-gateway-class`. Ignored (any value accepted, including `none`) when the active deploy method is `kustomize`, `standalone`, or `fma`. |
 | `-f` / `--monitoring` | | Enable monitoring in rendered templates (PodMonitor, EPP verbosity) |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path (used for cluster resource auto-detection) |
 
@@ -425,7 +424,7 @@ llmdbenchmark --version
 | `-m MODELS` | `LLMDBENCH_MODELS` | Models to deploy |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment methods (`standalone`, `modelservice`) |
-| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className`. See [Plan Options](#plan-options) for accepted values and method-aware behavior. |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className`. Accepted on the modelservice path: `epponly`, `istio`, `agentgateway`, `gke`, `data-science-gateway-class`. Ignored (any value accepted, including `none`) when the active deploy method is `kustomize`, `standalone`, or `fma`. |
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
@@ -443,7 +442,7 @@ llmdbenchmark --version
 | `-s STEPS` | | Step filter |
 | `-m MODELS` | `LLMDBENCH_MODELS` | Model that was deployed (for resource name resolution) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Methods to tear down (`standalone`, `modelservice`) |
-| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` if teardown re-renders. See [Plan Options](#plan-options) for accepted values. |
+| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` when teardown re-renders templates to resolve the resource names it must delete. See [Standup Options](#standup-options) for accepted values and method-aware behavior. |
 | `-r NAME` | `LLMDBENCH_RELEASE` | Helm release name (default: `llmdbench`) |
 | `-d` / `--deep` | `LLMDBENCH_DEEP_CLEAN` | Deep clean: delete ALL resources in both namespaces |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Comma-separated namespaces (model,harness) |
@@ -457,7 +456,6 @@ llmdbenchmark --version
 | `-e FILE` | `LLMDBENCH_EXPERIMENTS` | Experiment YAML with setup and run treatments (required) |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deploy method |
-| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` during standup. See [Plan Options](#plan-options) for accepted values. |
 | `-m MODELS` | `LLMDBENCH_MODELS` | Models to deploy |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4) |
@@ -481,7 +479,6 @@ llmdbenchmark --version
 | `-m MODEL` | `LLMDBENCH_MODEL` | Model name override (e.g. facebook/opt-125m) |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespaces (deploy,benchmark) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deploy method used during standup |
-| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` if the run phase re-renders templates for setup overrides. See [Plan Options](#plan-options) for accepted values. |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `-l HARNESS` | `LLMDBENCH_HARNESS` | Harness name (inference-perf, guidellm, vllm-benchmark) |
 | `-w PROFILE` | `LLMDBENCH_WORKLOAD` | Workload profile YAML |
@@ -517,7 +514,6 @@ llmdbenchmark --spec gpu smoketest -p my-namespace -s 2   # config validation on
 | `-s STEPS` | | Step filter (e.g., `0,1,2` or `0-2`) |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deployment methods (standalone, modelservice, fma) |
-| `--gateway-class CLASS` | `LLMDBENCH_GATEWAY_CLASS` | Override the scenario's `gateway.className` if the smoketest re-renders templates. See [Plan Options](#plan-options) for accepted values. |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `--parallel N` | `LLMDBENCH_PARALLEL` | Max parallel stacks (default: 4). Smoketest pins this to 1 regardless - parallel probes across stacks are confusing. |
 | `--stack NAME[,NAME...]` | `LLMDBENCH_STACK` | Restrict smoketest to the named subset of stacks. |

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -155,11 +155,17 @@ Gateway class options (set via `gateway.className` in the scenario YAML):
 
 ### Overriding `gateway.className` from the CLI
 
-Every subcommand that renders templates (`plan`, `standup`, `experiment`,
-and the `run`/`smoketest`/`teardown` paths that re-render for setup
-overrides) accepts a `--gateway-class` flag that overrides the
-scenario's `gateway.className` for that invocation. The same value can
-be supplied via the `LLMDBENCH_GATEWAY_CLASS` environment variable.
+The `standup` and `teardown` subcommands accept a `--gateway-class`
+flag that overrides the scenario's `gateway.className` for that
+invocation. The same value can be supplied via the
+`LLMDBENCH_GATEWAY_CLASS` environment variable.
+
+The flag is intentionally scoped to those two phases: `standup` needs
+it to pick the right GAIE chart / Gateway provider / HTTPRoute layout,
+and `teardown` needs the matching value so it deletes the same set of
+resources. The other subcommands (`plan`, `experiment`, `run`,
+`smoketest`) consume the rendered config produced by `standup` and do
+not re-pick the gateway topology, so they don't expose the flag.
 
 ```bash
 # Scenario default is epponly -- flip to istio without editing YAML

--- a/llmdbenchmark/interface/experiment.py
+++ b/llmdbenchmark/interface/experiment.py
@@ -43,15 +43,6 @@ def add_subcommands(
         help="Deploy method (standalone, modelservice, fma).",
     )
     exp_parser.add_argument(
-        "--gateway-class",
-        default=env("LLMDBENCH_GATEWAY_CLASS"),
-        help=(
-            "Override the scenario's gateway.className. Supported values: "
-            "epponly, istio, agentgateway, gke, data-science-gateway-class. "
-            "Only takes effect on the modelservice deploy path."
-        ),
-    )
-    exp_parser.add_argument(
         "-m",
         "--models",
         default=env("LLMDBENCH_MODELS"),

--- a/llmdbenchmark/interface/plan.py
+++ b/llmdbenchmark/interface/plan.py
@@ -45,15 +45,6 @@ def add_subcommands(
         help="Deployment method (standalone, modelservice, fma).",
     )
     plan_parser.add_argument(
-        "--gateway-class",
-        default=env("LLMDBENCH_GATEWAY_CLASS"),
-        help=(
-            "Override the scenario's gateway.className. Supported values: "
-            "epponly, istio, agentgateway, gke, data-science-gateway-class. "
-            "Only takes effect on the modelservice deploy path."
-        ),
-    )
-    plan_parser.add_argument(
         "-f",
         "--monitoring",
         action="store_true",

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -39,15 +39,6 @@ def add_subcommands(
         help="Deploy method used during standup (standalone, modelservice, or custom resource name).",
     )
     run_parser.add_argument(
-        "--gateway-class",
-        default=env("LLMDBENCH_GATEWAY_CLASS"),
-        help=(
-            "Override the scenario's gateway.className when the run phase "
-            "re-renders templates for setup overrides. Supported values: "
-            "epponly, istio, agentgateway, gke, data-science-gateway-class."
-        ),
-    )
-    run_parser.add_argument(
         "--kubeconfig",
         "-k",
         default=env("LLMDBENCH_KUBECONFIG") or env("KUBECONFIG"),

--- a/llmdbenchmark/interface/smoketest.py
+++ b/llmdbenchmark/interface/smoketest.py
@@ -37,14 +37,6 @@ def add_subcommands(
         help="Deployment methods (standalone, modelservice, fma).",
     )
     smoketest_parser.add_argument(
-        "--gateway-class",
-        default=env("LLMDBENCH_GATEWAY_CLASS"),
-        help=(
-            "Override the scenario's gateway.className (only meaningful "
-            "if the smoketest re-renders templates)."
-        ),
-    )
-    smoketest_parser.add_argument(
         "--parallel",
         type=int,
         default=env_int("LLMDBENCH_PARALLEL", 4),


### PR DESCRIPTION
# Summary

- Only allow `gateway` knob for `teardown` and `standup`