### PR TITLE
[part-3] [dep: #1430] Declarative units validation for the v0.2.1 schema

### DIFF
--- a/llmdbenchmark/analysis/benchmark_report/base.py
+++ b/llmdbenchmark/analysis/benchmark_report/base.py
@@ -4,9 +4,9 @@ Benchmark report base class with common methods.
 
 import json
 from enum import StrEnum, auto
-from typing import Any
+from typing import Any, ClassVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 import yaml
 
 ###############################################################################
@@ -163,6 +163,46 @@ UNITS_GEN_THROUGHPUT = [Units.TOKEN_PER_S]
 UNITS_REQUEST_THROUGHPUT = [Units.QUERY_PER_S]
 UNITS_MEDIA_THROUGHPUT = [Units.IMAGE_PER_S, Units.VIDEO_PER_S, Units.AUDIO_PER_S]
 UNITS_POWER = [Units.WATTS]
+
+
+###############################################################################
+# Declarative units validation
+###############################################################################
+
+
+class UnitsValidatedModel(BaseModel):
+    """Base model that validates ``Statistics`` field units declaratively.
+
+    Instead of hand-writing a ``check_units`` method per class, a subclass sets
+    ``UNIT_RULES``, mapping a field name to the list of units allowed for that
+    field's ``Statistics.units``. A single inherited validator checks every
+    rule declared anywhere in the class's MRO, so each subclass only declares
+    the fields it introduces; ``None`` (unset Optional) fields are skipped.
+
+    The validator is named distinctly from any ``check_units`` so it co-runs
+    with, rather than shadows, a hand-written validator inherited from another
+    base under multiple inheritance.
+    """
+
+    # field name -> allowed Units. Merged across the MRO at validation time.
+    UNIT_RULES: ClassVar[dict[str, list[Units]]] = {}
+
+    @model_validator(mode="after")
+    def validate_declared_units(self):
+        merged: dict[str, list[Units]] = {}
+        # Most-derived first, so a subclass rule overrides a base rule.
+        for klass in type(self).__mro__:
+            for field, allowed in klass.__dict__.get("UNIT_RULES", {}).items():
+                merged.setdefault(field, allowed)
+        for field, allowed in merged.items():
+            stat = getattr(self, field, None)
+            if stat is not None and stat.units not in allowed:
+                raise ValueError(
+                    f'Invalid units "{stat.units}" for "{field}", must be one'
+                    f" of: {' '.join(allowed)}"
+                )
+        return self
+
 
 ###############################################################################
 # Base benchmark report class

--- a/llmdbenchmark/analysis/benchmark_report/br_v0_2_1_json_schema.json
+++ b/llmdbenchmark/analysis/benchmark_report/br_v0_2_1_json_schema.json
@@ -114,7 +114,7 @@
     },
     "AggregateRequests": {
       "additionalProperties": false,
-      "description": "v0.2 request statistics, plus multi-modal payload details.",
+      "description": "v0.2 request statistics, plus multi-modal payload details.\n\nInherits the v0.2 input/output-length unit checks and adds a declarative\nrule for the new request_size field.",
       "properties": {
         "total": {
           "description": "Total number of requests sent.",

--- a/llmdbenchmark/analysis/benchmark_report/schema_v0_2_1.py
+++ b/llmdbenchmark/analysis/benchmark_report/schema_v0_2_1.py
@@ -17,7 +17,9 @@ descriptor on LoadStandardized is deliberately left out of this revision; see
 the PR description.
 """
 
-from pydantic import BaseModel, model_validator
+from typing import ClassVar
+
+from pydantic import BaseModel
 
 from .base import (
     UNITS_MEDIA_THROUGHPUT,
@@ -25,6 +27,8 @@ from .base import (
     UNITS_QUANTITY,
     UNITS_RATIO,
     UNITS_TIME,
+    Units,
+    UnitsValidatedModel,
 )
 from .schema_v0_2 import (
     MODEL_CONFIG,
@@ -66,7 +70,7 @@ assert VERSION_V02 == "0.2", (
 ###############################################################################
 
 
-class MediaPayloadStats(BaseModel):
+class MediaPayloadStats(UnitsValidatedModel):
     """Payload statistics shared by every media modality.
 
     All fields are distributions over the individual media instances the client
@@ -75,24 +79,15 @@ class MediaPayloadStats(BaseModel):
 
     model_config = MODEL_CONFIG.copy()
 
+    UNIT_RULES: ClassVar[dict[str, list[Units]]] = {
+        "count": UNITS_QUANTITY,
+        "filesize": UNITS_MEMORY,
+    }
+
     count: Statistics | None = None
     """Number of media instances of this modality per request."""
     filesize: Statistics | None = None
     """Encoded size per media instance."""
-
-    @model_validator(mode="after")
-    def check_media_units(self):
-        if self.count and self.count.units not in UNITS_QUANTITY:
-            raise ValueError(
-                f'Invalid units "{self.count.units}", must be one of:'
-                f" {' '.join(UNITS_QUANTITY)}"
-            )
-        if self.filesize and self.filesize.units not in UNITS_MEMORY:
-            raise ValueError(
-                f'Invalid units "{self.filesize.units}", must be one of:'
-                f" {' '.join(UNITS_MEMORY)}"
-            )
-        return self
 
 
 class VisualPayloadStats(MediaPayloadStats):
@@ -100,24 +95,15 @@ class VisualPayloadStats(MediaPayloadStats):
 
     model_config = MODEL_CONFIG.copy()
 
+    UNIT_RULES: ClassVar[dict[str, list[Units]]] = {
+        "pixels": UNITS_QUANTITY,
+        "aspect_ratio": UNITS_RATIO,
+    }
+
     pixels: Statistics | None = None
     """Pixel count per media instance (height x width, summed over frames)."""
     aspect_ratio: Statistics | None = None
     """Aspect ratio (width / height) per media instance."""
-
-    @model_validator(mode="after")
-    def check_visual_units(self):
-        if self.pixels and self.pixels.units not in UNITS_QUANTITY:
-            raise ValueError(
-                f'Invalid units "{self.pixels.units}", must be one of:'
-                f" {' '.join(UNITS_QUANTITY)}"
-            )
-        if self.aspect_ratio and self.aspect_ratio.units not in UNITS_RATIO:
-            raise ValueError(
-                f'Invalid units "{self.aspect_ratio.units}", must be one of:'
-                f" {' '.join(UNITS_RATIO)}"
-            )
-        return self
 
 
 class ImagePayloadStats(VisualPayloadStats):
@@ -131,17 +117,10 @@ class VideoPayloadStats(VisualPayloadStats):
 
     model_config = MODEL_CONFIG.copy()
 
+    UNIT_RULES: ClassVar[dict[str, list[Units]]] = {"frames": UNITS_QUANTITY}
+
     frames: Statistics | None = None
     """Number of frames per video instance."""
-
-    @model_validator(mode="after")
-    def check_video_units(self):
-        if self.frames and self.frames.units not in UNITS_QUANTITY:
-            raise ValueError(
-                f'Invalid units "{self.frames.units}", must be one of:'
-                f" {' '.join(UNITS_QUANTITY)}"
-            )
-        return self
 
 
 class AudioPayloadStats(MediaPayloadStats):
@@ -149,17 +128,10 @@ class AudioPayloadStats(MediaPayloadStats):
 
     model_config = MODEL_CONFIG.copy()
 
+    UNIT_RULES: ClassVar[dict[str, list[Units]]] = {"duration": UNITS_TIME}
+
     duration: Statistics | None = None
     """Duration per audio instance."""
-
-    @model_validator(mode="after")
-    def check_audio_units(self):
-        if self.duration and self.duration.units not in UNITS_TIME:
-            raise ValueError(
-                f'Invalid units "{self.duration.units}", must be one of:'
-                f" {' '.join(UNITS_TIME)}"
-            )
-        return self
 
 
 class MultiModalRequests(BaseModel):
@@ -180,30 +152,33 @@ class MultiModalRequests(BaseModel):
 ###############################################################################
 
 
-class AggregateRequests(AggregateRequestsV02):
-    """v0.2 request statistics, plus multi-modal payload details."""
+class AggregateRequests(AggregateRequestsV02, UnitsValidatedModel):
+    """v0.2 request statistics, plus multi-modal payload details.
+
+    Inherits the v0.2 input/output-length unit checks and adds a declarative
+    rule for the new request_size field.
+    """
 
     model_config = MODEL_CONFIG.copy()
+
+    UNIT_RULES: ClassVar[dict[str, list[Units]]] = {"request_size": UNITS_MEMORY}
 
     request_size: Statistics | None = None
     """Total encoded request size, including all media payloads."""
     multimodal: MultiModalRequests | None = None
     """Per-modality payload statistics."""
 
-    @model_validator(mode="after")
-    def check_request_size_units(self):
-        if self.request_size and self.request_size.units not in UNITS_MEMORY:
-            raise ValueError(
-                f'Invalid units "{self.request_size.units}", must be one of:'
-                f" {' '.join(UNITS_MEMORY)}"
-            )
-        return self
 
-
-class AggregateThroughput(AggregateThroughputV02):
+class AggregateThroughput(AggregateThroughputV02, UnitsValidatedModel):
     """v0.2 throughput metrics, plus per-modality payload rates."""
 
     model_config = MODEL_CONFIG.copy()
+
+    UNIT_RULES: ClassVar[dict[str, list[Units]]] = {
+        "image_rate": UNITS_MEDIA_THROUGHPUT,
+        "video_rate": UNITS_MEDIA_THROUGHPUT,
+        "audio_rate": UNITS_MEDIA_THROUGHPUT,
+    }
 
     image_rate: Statistics | None = None
     """Image delivery rate."""
@@ -211,20 +186,6 @@ class AggregateThroughput(AggregateThroughputV02):
     """Video delivery rate."""
     audio_rate: Statistics | None = None
     """Audio delivery rate."""
-
-    @model_validator(mode="after")
-    def check_media_rate_units(self):
-        for name, stat in (
-            ("image_rate", self.image_rate),
-            ("video_rate", self.video_rate),
-            ("audio_rate", self.audio_rate),
-        ):
-            if stat and stat.units not in UNITS_MEDIA_THROUGHPUT:
-                raise ValueError(
-                    f'Invalid units "{stat.units}" for {name}, must be one of:'
-                    f" {' '.join(UNITS_MEDIA_THROUGHPUT)}"
-                )
-        return self
 
 
 ###############################################################################


### PR DESCRIPTION
Addresses: https://github.com/llm-d/llm-d-benchmark/issues/989

## Summary
  **Replaces the hand-written per-class `check_units` methods in v0.2.1 with a 
  declarative table.** A new `UnitsValidatedModel` base holds a `UNIT_RULES` map 
  (field name -> allowed units); one inherited validator merges the rules declared 
  across the class hierarchy and checks them. Each class now declares only the 
  fields it introduces instead of writing a validator method.

  **Pure refactor, no behavior change.** Depends on #1430 (introduces the 
  v0.2.1 classes this touches). Independent of the converter PR (no file overlap), 
  so it can review and merge in either order once #1430 lands.
