### PR TITLE
docs(readme): fix stale spec names (inference-scheduling -> guides/optimized-baseline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Every command takes a `--spec` that selects the configuration for your cluster a
 
 ```bash
 --spec gpu                              # NVIDIA GPU setup (config/specification/examples/gpu.yaml.j2)
---spec inference-scheduling             # inference scheduling guide
---spec inference-scheduling-wva         # inference scheduling + WVA autoscaling
+--spec guides/optimized-baseline        # optimized baseline guide (formerly inference-scheduling)
+--spec guides/workload-autoscaling      # optimized baseline + WVA autoscaling
 --spec multi-model-wva                  # multi-model WVA: N pools, 1 gateway, 1 shared HTTPRoute
 --spec pd-disaggregation               # prefill-decode disaggregation guide
 ...
@@ -536,7 +536,7 @@ This is useful for CI/CD pipelines, `.bashrc` configuration, or migrating from t
 
 ```bash
 # Example: set common defaults via env vars, override per-run via CLI
-export LLMDBENCH_SPEC=inference-scheduling
+export LLMDBENCH_SPEC=guides/optimized-baseline
 export LLMDBENCH_NAMESPACE=my-team-ns
 export LLMDBENCH_KUBECONFIG=~/.kube/my-cluster
 
@@ -705,7 +705,7 @@ See module-level READMEs for detailed documentation:
 `llm-d-benchmark` supports all available [Well-Lit Path Guides](https://github.com/llm-d/llm-d/blob/main/guides/README.md). Each guide has a corresponding specification:
 
 ```bash
-llmdbenchmark --spec inference-scheduling standup       # Inference scheduling
+llmdbenchmark --spec guides/optimized-baseline standup  # Optimized baseline (formerly inference-scheduling)
 llmdbenchmark --spec pd-disaggregation standup          # Prefill-decode disaggregation
 llmdbenchmark --spec tiered-prefix-cache standup        # Tiered prefix cache
 llmdbenchmark --spec precise-prefix-cache-aware standup # Precise prefix cache-aware routing


### PR DESCRIPTION
## Summary

The README points users at three `--spec` names that no longer exist, so the very first `llmdbenchmark` command in the Quick Start fails with `Specification 'inference-scheduling' not found`.

The specs were renamed:
- `inference-scheduling` → `guides/optimized-baseline`
- `inference-scheduling-wva` → `guides/workload-autoscaling`

This PR updates the four stale references in `README.md` (lines 103, 104, 539, 708) to the current names. Each user-facing example also notes the prior name in a comment so existing bookmarks/notes are easy to reconcile.

Out of scope (separate follow-ups):
- `docs/lifecycle.md`, `docs/quickstart.md`, `docs/workload-variant-autoscaler.md` still mention the old names
- `README.md` line 711 references `precise-prefix-cache-aware`, but the spec is `precise-prefix-cache-routing` — different bug

## Test plan
- [x] `grep "inference-scheduling" README.md` shows only the intentional "(formerly ...)" annotations
- [x] `llmdbenchmark --spec guides/optimized-baseline --dry-run standup -p test-ns` resolves the spec (verified locally — this is how the bug was found)
- [ ] CI passes