### PR TITLE
Add tolerations and affinity support for inferenceExtension (EPP) pod

### DIFF
--- a/config/templates/jinja/12_gaie-values.yaml.j2
+++ b/config/templates/jinja/12_gaie-values.yaml.j2
@@ -51,6 +51,33 @@ inferenceExtension:
   resources:
 {{ inferenceExtension.resources | toyaml | indent(4, true) }}
 {% endif %}
+{% if inferenceExtension.tolerations is defined and inferenceExtension.tolerations %}
+  tolerations:
+{{ inferenceExtension.tolerations | toyaml | indent(4, true) }}
+{% endif %}
+{% if affinity is defined and affinity.enabled %}
+  affinity:
+{% if affinity.nodeSelector is defined and affinity.nodeSelector %}
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+{% for key, value in affinity.nodeSelector.items() %}
+          - key: {{ key }}
+            operator: In
+            values:
+            - "{{ value }}"
+{% endfor %}
+{% endif %}
+{% if affinity.podAffinity is defined and affinity.podAffinity %}
+    podAffinity:
+{{ affinity.podAffinity | toyaml | indent(6, true) }}
+{% endif %}
+{% if affinity.podAntiAffinity is defined and affinity.podAntiAffinity %}
+    podAntiAffinity:
+{{ affinity.podAntiAffinity | toyaml | indent(6, true) }}
+{% endif %}
+{% endif %}
 {% if inferenceExtension.pluginsCustomConfig is defined and inferenceExtension.pluginsCustomConfig %}
   pluginsCustomConfig:
 {% for filename, content in inferenceExtension.pluginsCustomConfig.items() %}

--- a/tests/test_gaie_values_render.py
+++ b/tests/test_gaie_values_render.py
@@ -1,0 +1,134 @@
+"""Tests for the 12_gaie-values.yaml.j2 inferenceExtension (EPP) value rendering.
+
+Covers propagation of optional scheduling fields into the inferencepool
+chart's `inferenceExtension` values. The chart's EPP pod spec honours
+`tolerations` and `affinity`, so the template must emit each block when the
+scenario sets one and omit it entirely when unset -- an empty block would
+otherwise override the chart defaults while adding noise to the output.
+
+`affinity` reuses the scenario-wide `affinity` convenience wrapper (the same
+one decode/prefill/standalone consume): a flat `affinity.nodeSelector` map is
+expanded into a required `nodeAffinity` term, gated on `affinity.enabled`.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_PATH = _REPO_ROOT / "config" / "templates" / "jinja" / "12_gaie-values.yaml.j2"
+DEFAULTS_PATH = _REPO_ROOT / "config" / "templates" / "values" / "defaults.yaml"
+
+# Base values on the canonical defaults the template is rendered against in
+# production. This keeps the test resilient to unrelated template churn (new
+# keys gated behind defaults) -- we only overlay the fields under test.
+_DEFAULTS = yaml.safe_load(DEFAULTS_PATH.read_text())
+
+
+@pytest.fixture
+def renderer():
+    """Bare RenderPlans instance -- only the Jinja env/render path is exercised."""
+    r = RenderPlans.__new__(RenderPlans)
+    r._jinja_env = None
+    return r
+
+
+def _values(tolerations=None, affinity=None) -> dict:
+    """Defaults overlaid with the scheduling fields under test."""
+    values = copy.deepcopy(_DEFAULTS)
+    # model_id_label is injected by the render pipeline, not defaults.yaml.
+    values["model_id_label"] = "my-model"
+    if tolerations is not None:
+        values["inferenceExtension"]["tolerations"] = tolerations
+    if affinity is not None:
+        values["affinity"] = affinity
+    return values
+
+
+def _render(renderer, values: dict) -> dict:
+    rendered = renderer._render_template(TEMPLATE_PATH.read_text(), values)
+    return yaml.safe_load(rendered)
+
+
+def test_tolerations_are_propagated(renderer):
+    """A scenario-provided tolerations list reaches inferenceExtension.tolerations."""
+    tolerations = [
+        {
+            "key": "nvidia.com/gpu",
+            "operator": "Exists",
+            "effect": "NoSchedule",
+        }
+    ]
+    doc = _render(renderer, _values(tolerations=tolerations))
+    assert doc["inferenceExtension"]["tolerations"] == tolerations
+
+
+def test_tolerations_omitted_when_unset(renderer):
+    """No tolerations key -> no tolerations block (chart default applies)."""
+    doc = _render(renderer, _values(tolerations=None))
+    assert "tolerations" not in doc["inferenceExtension"]
+
+
+def test_empty_tolerations_omitted(renderer):
+    """An explicit empty list is falsy and must not emit an empty block."""
+    doc = _render(renderer, _values(tolerations=[]))
+    assert "tolerations" not in doc["inferenceExtension"]
+
+
+def test_affinity_nodeselector_expands_to_nodeaffinity(renderer):
+    """The shared affinity wrapper expands a nodeSelector map into nodeAffinity."""
+    affinity = {
+        "enabled": True,
+        "nodeSelector": {"nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3"},
+    }
+    doc = _render(renderer, _values(affinity=affinity))
+    term = doc["inferenceExtension"]["affinity"]["nodeAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]["nodeSelectorTerms"][0]["matchExpressions"][0]
+    assert term == {
+        "key": "nvidia.com/gpu.product",
+        "operator": "In",
+        "values": ["NVIDIA-H100-80GB-HBM3"],
+    }
+
+
+def test_affinity_passthrough_blocks_render_valid_yaml(renderer):
+    """podAffinity/podAntiAffinity are passed through and stay valid YAML.
+
+    Guards the first-line indentation of the toyaml passthrough -- an
+    un-indented first line silently corrupts the inferenceExtension mapping.
+    """
+    pod_anti = {
+        "preferredDuringSchedulingIgnoredDuringExecution": [
+            {
+                "weight": 100,
+                "podAffinityTerm": {"topologyKey": "kubernetes.io/hostname"},
+            }
+        ]
+    }
+    affinity = {
+        "enabled": True,
+        "nodeSelector": {"disktype": "ssd"},
+        "podAntiAffinity": pod_anti,
+    }
+    doc = _render(renderer, _values(affinity=affinity))
+    assert doc["inferenceExtension"]["affinity"]["podAntiAffinity"] == pod_anti
+
+
+def test_affinity_omitted_when_disabled(renderer):
+    """A present-but-disabled affinity wrapper must not emit a block."""
+    affinity = {"enabled": False, "nodeSelector": {"foo": "bar"}}
+    doc = _render(renderer, _values(affinity=affinity))
+    assert "affinity" not in doc["inferenceExtension"]
+
+
+def test_affinity_omitted_when_unset(renderer):
+    """No affinity wrapper -> no affinity block."""
+    doc = _render(renderer, _values(affinity=None))
+    assert "affinity" not in doc["inferenceExtension"]


### PR DESCRIPTION
## What

Propagate optional scheduling fields for the EndpointPicker (EPP) pod into the inferencepool chart values (`config/templates/jinja/12_gaie-values.yaml.j2`):

- **`inferenceExtension.tolerations`** — emitted only when a scenario sets a non-empty list, leaving the chart's `tolerations: []` default untouched otherwise.
- **`affinity`** — reuses the scenario-wide `affinity` convenience wrapper already consumed by `decode`/`prefill`/`standalone`: a flat `affinity.nodeSelector` map is expanded into a required `nodeAffinity` term, with `podAffinity`/`podAntiAffinity` passed through. Gated on `affinity.enabled`.

This lets the EPP pod be scheduled onto tainted nodes (e.g. GPU nodes) and steered toward specific nodes.

## Why these fields

Scoped to what the inferencepool/epplib chart (v1.4.0 and v1.5.0) actually consumes in its EPP pod spec — it honours `tolerations` and `affinity` but has **no `nodeSelector`** field, so propagating a top-level `inferenceExtension.nodeSelector` would be a silent no-op.

Note: the pod(anti)affinity passthrough uses `indent(_, true)` so the first rendered line is indented; the unparametrised `indent(6)` used by the modelservice template would leave the first line at column 0 (only hidden there because those keys default to `{}`).

## Testing

- New `tests/test_gaie_values_render.py` — renders the template with and without each field, including a pod-anti-affinity case that locks the first-line indentation. Values are based on `defaults.yaml` so the test stays resilient to unrelated template churn.
- Full suite: `pytest tests/` → 279 passed, 4 skipped.
- `cicd/kind` canary renders cleanly (29 files, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)