### PR TITLE
fix: skip non-active gateway helm repos in _add_helm_repos()

### DIFF
--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -206,12 +206,22 @@ class AdminPrerequisitesStep(Step):
             return result.stdout.strip().split()
         return []
 
+    _GATEWAY_REPO_KEYS = frozenset({"istio", "agentgateway"})
+
     def _add_helm_repos(self, cmd: CommandExecutor, plan_config: dict, errors: list):
         """Add configured Helm repositories."""
         helm_repos = plan_config.get("helmRepositories", {})
+        gateway_class = plan_config.get("gateway", {}).get("className", "")
         added_classic_repo = False
 
         for repo_key, repo_info in helm_repos.items():
+            if repo_key in self._GATEWAY_REPO_KEYS and repo_key != gateway_class:
+                cmd.logger.log_info(
+                    f"Skipping {repo_key} helm repo "
+                    f"(active gateway: {gateway_class})"
+                )
+                continue
+
             repo_name = repo_info.get("name", repo_key)
             repo_url = repo_info.get("url", "").strip()
             if not repo_url:


### PR DESCRIPTION
## Summary

`_add_helm_repos()` iterates over all `helmRepositories` entries without checking `gateway.className`, so the Istio Helm repo is always added even when the active gateway is `agentgateway` (or any other non-Istio gateway).

This adds a gateway-class filter for known gateway-specific repo keys (`istio`, `agentgateway`), matching the pattern already used by `_install_gateway_provider()` which correctly gates on `gateway.className`.

Fixes #1394

## Changes

- Add `_GATEWAY_REPO_KEYS` class-level constant with the set of gateway-specific repo keys
- Read `gateway.className` from `plan_config` at the start of `_add_helm_repos()`
- Skip any repo whose key is in `_GATEWAY_REPO_KEYS` but does not match the active gateway class
- Log a message when a repo is skipped so operators can see the filtering in action

## Test plan

- [ ] Run `llmdbenchmark standup` with `gateway.className: agentgateway` and verify Istio repo is not added
- [ ] Run with `gateway.className: istio` and verify Istio repo is added normally
- [ ] Run with `gateway.className: epponly` and verify both gateway repos are skipped