### PR TITLE
feat(scenarios): multi-variant WVA benchmark

### DIFF
--- a/config/scenarios/guides/two-variant-wva-v2-config.yaml
+++ b/config/scenarios/guides/two-variant-wva-v2-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workload-variant-autoscaler-wva-saturation-scaling-config
+  labels:
+    app.kubernetes.io/instance: workload-variant-autoscaler
+    app.kubernetes.io/name: workload-variant-autoscaler
+    app.kubernetes.io/managed-by: Helm
+data:
+  default: |
+    analyzerName: saturation
+    scaleUpThreshold: 0.85
+    scaleDownBoundary: 0.70
+    kvCacheThreshold: 0.80
+    queueLengthThreshold: 5
+    kvSpareTrigger: 0.1
+    queueSpareTrigger: 3

--- a/config/scenarios/guides/two-variant-wva.yaml
+++ b/config/scenarios/guides/two-variant-wva.yaml
@@ -1,4 +1,4 @@
-# TWO-VARIANT WVA SCENARIO (Topology B — one shared EPP)
+# TWO-VARIANT WVA SCENARIO — one shared InferencePool/EPP, two Deployments
 #
 # Deploys the primary variant (cost 10.0) of unsloth/Meta-Llama-3.1-8B as a
 # standard single-stack benchmark. A second variant at a lower cost (default

--- a/config/scenarios/guides/two-variant-wva.yaml
+++ b/config/scenarios/guides/two-variant-wva.yaml
@@ -1,0 +1,325 @@
+# TWO-VARIANT WVA SCENARIO (Topology B — one shared EPP)
+#
+# Deploys the primary variant (cost 10.0) of unsloth/Meta-Llama-3.1-8B as a
+# standard single-stack benchmark. A second variant at a lower cost (default
+# 5.0) is then layered on top via `tools/add_variant.py`.
+#
+# Both variants register their pods into the SAME InferencePool / EPP so the
+# WVA saturation solver can compare their costs under a unified queue-depth
+# signal and scale the cheaper variant first.
+#
+# Topology:
+#
+#         +--------- Gateway -------------------------+
+#         |  HTTPRoute → InferencePool (one EPP)      |
+#         +--------------------------------------------+
+#                              |
+#               +--------------+--------------+
+#               |                             |
+#     +---------+--------+       +------------+-----+
+#     | vLLM decode      |       | vLLM decode      |
+#     | primary (cost 10)|       | secondary (cost 5)|
+#     | VA + HPA         |       | VA + HPA          |
+#     +------------------+       +------------------+
+#                   ^                       ^
+#                   +------- WVA (1) -------+
+#                              controller
+#
+# How the two variants share one InferencePool
+# --------------------------------------------
+# The InferencePool EPP selects pods by two labels:
+#   llm-d.ai/inferenceServing: "true"          (camelCase)
+#   llm-d.ai/model:            <model-hash>
+#
+# The primary Deployment (managed by modelservice chart) also sets a third
+# label on its pods: llm-d.ai/inference-serving: "true" (kebab-case), which
+# is the primary's own selector discriminator.
+#
+# The secondary Deployment created by `tools/add_variant.py` intentionally
+# OMITS the kebab label but KEEPS the camelCase + model-hash labels, so:
+#   - The InferencePool picks up both Deployments' pods (two labels match).
+#   - The primary Deployment does not accidentally claim secondary pods
+#     (primary selector requires the kebab label, which secondary pods lack).
+#   - The secondary Deployment uses wva.llmd.ai/variant=v2 as a unique
+#     discriminator in its own pod selector.
+#
+# Both VAs share spec.modelID = "unsloth/Meta-Llama-3.1-8B" so the WVA
+# solver groups them and applies cost-weighted scaling.
+#
+# Running:
+#
+#   # Step 1 — stand up the primary variant (cost 10.0)
+#   llmdbenchmark --spec guides/two-variant-wva standup -p <ns>
+#
+#   # Step 2 — enable WVA's V2 saturation analyzer (the cost-aware path).
+#   #          See the chart-side note in docs/multi-variant-benchmark.md
+#   #          about why this is a separate ConfigMap apply for now.
+#   kubectl apply -n <ns> -f config/scenarios/guides/two-variant-wva-v2-config.yaml
+#
+#   # Step 3 — layer on the secondary variant
+#   python tools/add_variant.py -n <ns> \
+#       --config config/scenarios/guides/variants/v2-cost-only.yaml
+#
+#   # Step 4 — run the benchmark (both variants share one InferencePool)
+#   llmdbenchmark --spec guides/two-variant-wva run \
+#       -p <ns> -l guidellm -w prefill_heavy.yaml
+#
+#   # Step 5 — teardown
+#   llmdbenchmark --spec guides/two-variant-wva teardown -p <ns>
+#
+# See docs/multi-variant-benchmark.md for the full guide.
+
+# ============================================================================
+# SHARED — applied to the stack before per-stack overrides
+# ============================================================================
+shared:
+  # --------------------------------------------------------------------------
+  # DEPLOYMENT METHOD
+  # --------------------------------------------------------------------------
+  modelservice:
+    enabled: true
+  standalone:
+    enabled: false
+
+  # --------------------------------------------------------------------------
+  # WVA CONTROLLER — installed once per namespace; per-stack scaling intent
+  # (variantAutoscaling, hpa) lives in each stack's wva: block below.
+  # --------------------------------------------------------------------------
+  wva:
+    enabled: true
+    wellLitPath: inference-scheduling
+    namespace: ""
+    image:
+      repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+      tag: v0.7.0
+    replicaCount: 1
+    controller:
+      enabled: true
+    namespaceScoped: true
+    metrics:
+      enabled: true
+      port: 8443
+      secure: true
+    prometheus:
+      baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+      port: 9091
+    # Enable the WVA-side ServiceMonitor that propagates the `llm-d.ai/variant`
+    # pod label into scraped metrics as `llm_d_ai_variant`. Required by PR #1145
+    # for the V2 main path: without this relabeling, vllm:cache_config_info
+    # arrives in Prometheus with no variant label, the WVA collector can't map
+    # the row to a VariantAutoscaling, TotalKvCapacityTokens stays 0, and the
+    # analyzer falls into computeReplicaCapacityFallback (which uses the
+    # per-step batch budget — wrong dimension, ~50× under-states real KV).
+    vllmService:
+      enabled: true
+
+  # Per PR #1145 requirement: tag every scrape target with its VariantAutoscaling
+  # name so the WVA collector can directly map metric rows to variants.
+  # The primary VA name = `<model_id_label>-decode`. add_variant.py overrides
+  # this on the secondary Deployment to point at the v2 VA.
+  modelArtifacts:
+    extraLabels:
+      "llm-d.ai/variant": "unsloth--1409d52c-a-3-1-8b-decode"
+
+  chartVersions:
+    wva: 0.6.0
+    prometheusAdapter: 5.2.0
+
+  # --------------------------------------------------------------------------
+  # IMAGE OVERRIDES — pin vllm-openai to v0.14.0 (newer than the v0.9.2
+  # default) so the model server emits vllm:cache_config_info, allowing the
+  # WVA saturation-V2 analyzer to use real KV-memory capacity instead of
+  # the per-step batch budget fallback.
+  # --------------------------------------------------------------------------
+  images:
+    vllmOpenai:
+      repository: docker.io/vllm/vllm-openai
+      tag: v0.14.0
+
+  # --------------------------------------------------------------------------
+  # EPP PLUGIN CONFIG — flowControl feature gate required for WVA queue-depth
+  # driven scaling signal.
+  # --------------------------------------------------------------------------
+  inferenceExtension:
+    pluginsConfigFile: "wva-plugins.yaml"
+    pluginsCustomConfig:
+      wva-plugins.yaml: |
+        apiVersion: inference.networking.x-k8s.io/v1alpha1
+        kind: EndpointPickerConfig
+        featureGates:
+          - flowControl
+        plugins:
+          - type: queue-scorer
+          - type: kv-cache-utilization-scorer
+          - type: prefix-cache-scorer
+        schedulingProfiles:
+          - name: default
+            plugins:
+              - pluginRef: queue-scorer
+                weight: 2
+              - pluginRef: kv-cache-utilization-scorer
+                weight: 2
+              - pluginRef: prefix-cache-scorer
+                weight: 3
+
+  # --------------------------------------------------------------------------
+  # VLLM COMMON
+  # --------------------------------------------------------------------------
+  vllmCommon:
+    kvTransfer:
+      enabled: true
+      connector: NixlConnector
+      role: kv_both
+    flags:
+      enforceEager: true
+      disableLogRequests: true
+      disableUvicornAccessLog: true
+      allowLongMaxModelLen: "1"
+      serverDevMode: "1"
+    volumes:
+      - name: shared-config
+        type: emptyDir
+        emptyDir: {}
+      - name: dshm
+        type: emptyDir
+        emptyDir:
+          medium: Memory
+          sizeLimit: 8Gi
+    volumeMounts:
+      - name: dshm
+        mountPath: /dev/shm
+      - name: shared-config
+        mountPath: /shared-config
+
+  # --------------------------------------------------------------------------
+  # PREFILL / DECODE defaults
+  # --------------------------------------------------------------------------
+  prefill:
+    enabled: false
+    replicas: 0
+
+  decode:
+    initContainers:
+      - name: preprocess
+        imageKey: benchmark
+        imagePullPolicy: Always
+        command: ["set_llmdbench_environment.py", "-e", "/shared-config/llmdbench_env.sh", "-i"]
+        volumeMounts:
+          - name: shared-config
+            mountPath: /shared-config
+    parallelism:
+      tensor: 1
+      data: 1
+      dataLocal: 1
+      workers: 1
+    extraEnvVars: []
+    extraContainerConfig:
+      ports:
+        - containerPort: 5557
+          protocol: TCP
+        - containerPort: 8200
+          name: metrics
+          protocol: TCP
+      securityContext:
+        capabilities:
+          add:
+            - "IPC_LOCK"
+            - "SYS_RAWIO"
+        runAsGroup: 0
+        runAsUser: 0
+      imagePullPolicy: Always
+    additionalVolumeMounts: []
+    additionalVolumes: []
+    probes:
+      startup:
+        path: /v1/models
+        failureThreshold: 60
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+      liveness:
+        path: /health
+        failureThreshold: 3
+        periodSeconds: 10
+        timeoutSeconds: 5
+      readiness:
+        path: /v1/models
+        failureThreshold: 3
+        periodSeconds: 5
+        timeoutSeconds: 2
+    monitoring:
+      podmonitor:
+        enabled: true
+        portName: metrics
+        path: /metrics
+        interval: 30s
+        labels:
+          release: llmd
+
+  workDir: "~/data/two-variant-wva"
+  harness:
+    name: inference-perf
+    experimentProfile: shared_prefix_synthetic.yaml
+
+  storage:
+    modelPvc:
+      size: 32Gi
+
+
+# ============================================================================
+# SCENARIO — primary variant (high-cost, cost 10.0)
+#
+# This standup deploys the primary variant only. Run
+# `python tools/add_variant.py -n <ns> --config <variant-yaml>` afterwards
+# to layer on the secondary variant at a lower cost.
+# ============================================================================
+scenario:
+  - name: "llama-8b"
+
+    model:
+      name: unsloth/Meta-Llama-3.1-8B
+      shortName: unsloth-meta-llama-3-1-8b
+      path: models/unsloth/Meta-Llama-3.1-8B
+      huggingfaceId: unsloth/Meta-Llama-3.1-8B
+      size: 32Gi
+      maxModelLen: 8192
+      blockSize: 64
+      gpuMemoryUtilization: 0.85
+
+    wva:
+      variantAutoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        variantCost: "10.0"
+        slo:
+          tpot: 10
+          ttft: 1000
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetAvgValue: 1
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+          scaleDown:
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+
+    decode:
+      replicas: 1
+      resources:
+        limits:
+          memory: 48Gi
+          cpu: "16"
+        requests:
+          memory: 48Gi
+          cpu: "16"

--- a/config/scenarios/guides/variants/v2-cost-only.yaml
+++ b/config/scenarios/guides/variants/v2-cost-only.yaml
@@ -1,0 +1,6 @@
+# Secondary variant: same operational shape as primary, only cheaper.
+# Reproduces the original two-variant experiment (cost differentiation only).
+suffix: v2
+variantCost: "5.0"
+minReplicas: 1
+maxReplicas: 10

--- a/config/specification/guides/two-variant-wva.yaml.j2
+++ b/config/specification/guides/two-variant-wva.yaml.j2
@@ -1,0 +1,18 @@
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/guides/two-variant-wva.yaml
+
+# Same model (unsloth/Meta-Llama-3.1-8B) deployed as two variants with
+# different variantCost values (10.0 and 5.0) under one shared WVA controller.

--- a/docs/multi-variant-benchmark.md
+++ b/docs/multi-variant-benchmark.md
@@ -1,4 +1,4 @@
-# Multi-Variant Benchmark (WVA Topology B)
+# Multi-Variant WVA Benchmark
 
 End-to-end recipe for benchmarking the
 [Workload Variant Autoscaler (WVA)](https://github.com/llm-d/llm-d-workload-variant-autoscaler)

--- a/docs/multi-variant-benchmark.md
+++ b/docs/multi-variant-benchmark.md
@@ -1,0 +1,194 @@
+# Multi-Variant Benchmark (WVA Topology B)
+
+End-to-end recipe for benchmarking the
+[Workload Variant Autoscaler (WVA)](https://github.com/llm-d/llm-d-workload-variant-autoscaler)
+in a **two-variant** setup: one model, two `Deployment`s of differing
+`variantCost`, both registered into the same `InferencePool` / EPP.
+Exercises WVA's cost-aware optimizer, which steers scale-up toward the
+cheaper variant first when the shared pool saturates.
+
+This is the canonical recipe for [issue #1425](
+https://github.com/llm-d/llm-d-benchmark/issues/1425).
+
+---
+
+## Prerequisites
+
+- A Kubernetes / OpenShift cluster with vLLM-capable GPUs (the bundled
+  scenario targets H100 and `unsloth/Meta-Llama-3.1-8B`; both knobs are
+  in the scenario yaml).
+- `llmdbenchmark` CLI installed, plus `kubectl`, `helm`, and `python3` on
+  the workstation.
+- A namespace you have admin in; the steps below use `<ns>` as a stand-in.
+
+> **Important — WVA chart version.** This scenario demonstrates
+> cost-aware behavior correctly only with a WVA chart that includes
+> [llm-d/llm-d-workload-variant-autoscaler#1198](
+> https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/1198)
+> (drop `model_name` filter from the `cache_config_info` query).
+> Without that fix, V2's per-replica capacity reading falls back to the
+> per-step batch budget (~6.5K tokens/pod for typical vLLM defaults vs.
+> ~412K real KV memory on Llama-3.1-8B / H100), causing both variants
+> to run away to `maxReplicas` and the cost-aware demonstration to
+> collapse. The fix landed on `main` 2026-05-27 but is **not** in the
+> tagged `v0.6.0` or `v0.7.0` chart releases.
+
+---
+
+## The five steps
+
+### 1. Stand up the primary variant
+
+```bash
+llmdbenchmark --spec guides/two-variant-wva standup -p <ns>
+```
+
+This installs the four standard helm releases (`llm-d-infra`,
+`inferencepool-gaie`, `llm-d-modelservice`, `workload-variant-autoscaler`)
+with the primary variant only — `unsloth/Meta-Llama-3.1-8B` at
+`variantCost: "10.0"`, `min/maxReplicas: 1/10`.
+
+### 2. Enable WVA's V2 saturation analyzer
+
+Apply the included override ConfigMap:
+
+```bash
+kubectl apply -n <ns> -f config/scenarios/guides/two-variant-wva-v2-config.yaml
+```
+
+This sets `analyzerName: saturation` on the WVA controller's saturation
+config so it runs the V2 (token-based, cost-aware) path. The WVA chart
+template at v0.7.0 does not yet expose `analyzerName` in its values, so
+this is a separate manifest until that lands; see the [chart-side
+follow-up](#chart-side-follow-up) below.
+
+Verify V2 is active:
+
+```bash
+kubectl logs -n <ns> -l app.kubernetes.io/name=workload-variant-autoscaler \
+  --tail=50 | grep "Processing model (V2)"
+```
+
+You should see `Processing model (V2)` lines once per reconcile.
+
+### 3. Layer on the secondary variant
+
+```bash
+python tools/add_variant.py -n <ns> \
+    --config config/scenarios/guides/variants/v2-cost-only.yaml
+```
+
+`add_variant.py` reads a small variant config yaml (cost, replica
+bounds, optional shape overrides) and creates the secondary
+`Deployment`, `VariantAutoscaling`, and `HPA` from the primary's, with
+the label trick that makes both deployments register into the same
+`InferencePool`. See [Variant config schema](#variant-config-schema)
+below.
+
+The bundled `v2-cost-only.yaml` keeps the secondary's operational shape
+identical to the primary (TP=1, 1 GPU/pod), changing only the
+`variantCost` to `5.0`. The result: one model served by two
+deployments, identical capacity per pod, asymmetric cost.
+
+Verify both Deployments and VAs are present:
+
+```bash
+kubectl get va,hpa,deploy -n <ns> -l llm-d.ai/inferenceServing=true
+```
+
+### 4. Run the benchmark
+
+```bash
+llmdbenchmark --spec guides/two-variant-wva run \
+    -p <ns> -l guidellm -w prefill_heavy.yaml
+```
+
+Defaults to `prefill_heavy.yaml` (4000-token prompts, 1000-token
+outputs, Poisson at the workload's `rate`). Substitute any other
+profile you want.
+
+### 5. Teardown
+
+```bash
+llmdbenchmark --spec guides/two-variant-wva teardown -p <ns>
+```
+
+The secondary variant's `Deployment` / `VA` / `HPA` are owned by the
+modelservice helm release, so teardown removes them along with the
+primary.
+
+---
+
+## Variant config schema
+
+Each `tools/variants/*.yaml` declares only what differs from the
+primary; everything else is inherited.
+
+```yaml
+# Required
+suffix: v2                     # secondary Deployment/VA/HPA name suffix
+
+# WVA / scaling (all optional; defaults shown)
+variantCost: "5.0"             # default "5.0"
+minReplicas: 1                 # default 1
+maxReplicas: 10                # default 10
+
+# vLLM model-server overrides (all optional; omitted = inherit from primary)
+parallelism:
+  tensor: 2                    # rewrites --tensor-parallel-size
+
+# Pod-level resource overrides
+resources:
+  nvidia.com/gpu: 2            # mirrors limits + requests
+```
+
+The bundled `v2-cost-only.yaml` shows the simplest case (cost only).
+Future PRs can ship richer variants (e.g. TP=2 for "different hardware
+shape" demonstrations on a single-hardware cluster).
+
+---
+
+## What the demo shows
+
+Under sustained load, WVA's cost-aware optimizer should:
+
+- Keep **primary at minReplicas** (cost 10) until the cheaper variant
+  hits its own ceiling.
+- Scale **secondary** up to absorb the load (cost 5).
+- On scale-down, drop the **expensive variant first**.
+
+Compared to a per-Deployment HPA reading model-level signals
+independently — which would scale **both** variants symmetrically
+because each HPA observes the same gateway-side metric in isolation —
+WVA's holistic view is the differentiator.
+
+---
+
+## Chart-side follow-up
+
+The two-step workflow above (separate `kubectl apply` for the V2
+ConfigMap) exists because the WVA chart's
+`templates/manager/wva-cp-configmap.yaml` only emits the V1 fields
+(`kvCacheThreshold`, `queueLengthThreshold`, `kvSpareTrigger`,
+`queueSpareTrigger`). It does not template `analyzerName`, so V2 cannot
+be enabled via helm values today.
+
+A planned WVA-chart PR will add `analyzerName` (and V2's
+`scaleUpThreshold` / `scaleDownBoundary`) to the chart's values surface.
+Once that lands and is released, this scenario yaml can hard-code
+`analyzerName: saturation` in its `wva.capacityScaling.default` block,
+and the standalone `two-variant-wva-v2-config.yaml` manifest + Step 2
+above can be removed.
+
+---
+
+## Files in this PR
+
+| Path | What it is |
+|---|---|
+| `config/scenarios/guides/two-variant-wva.yaml` | Scenario yaml for the primary variant standup |
+| `config/specification/guides/two-variant-wva.yaml.j2` | Specification wrapper |
+| `config/scenarios/guides/two-variant-wva-v2-config.yaml` | Standalone ConfigMap that enables V2 saturation (Step 2) |
+| `config/scenarios/guides/variants/v2-cost-only.yaml` | Variant override config (cost-only secondary) |
+| `tools/add_variant.py` | Helper that creates the secondary Deployment / VA / HPA |
+| `docs/multi-variant-benchmark.md` | This file |

--- a/tools/add_variant.py
+++ b/tools/add_variant.py
@@ -2,9 +2,10 @@
 """
 add_variant.py — Add a secondary WVA variant to an existing single-stack benchmark.
 
-Implements Topology B: one shared InferencePool/EPP fed by two Deployments,
-each with its own VariantAutoscaling (VA) at a different variantCost. The WVA
-saturation solver uses variantCost to decide which variant to scale first.
+Layers a secondary Deployment into an existing single-variant standup so
+both Deployments register into the same InferencePool/EPP, each with its
+own VariantAutoscaling (VA) at a different variantCost. The WVA saturation
+solver uses variantCost to decide which variant to scale first.
 
 Label strategy
 --------------

--- a/tools/add_variant.py
+++ b/tools/add_variant.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""
+add_variant.py — Add a secondary WVA variant to an existing single-stack benchmark.
+
+Implements Topology B: one shared InferencePool/EPP fed by two Deployments,
+each with its own VariantAutoscaling (VA) at a different variantCost. The WVA
+saturation solver uses variantCost to decide which variant to scale first.
+
+Label strategy
+--------------
+The InferencePool created by the primary standup selects pods by:
+  llm-d.ai/inferenceServing: "true"   (camelCase)
+  llm-d.ai/model:            <hash>
+
+The primary Deployment selector additionally requires:
+  llm-d.ai/inference-serving: "true"  (kebab-case)
+
+The secondary Deployment this script creates:
+  - KEEPS  llm-d.ai/inferenceServing + llm-d.ai/model  → joins the pool
+  - OMITS  llm-d.ai/inference-serving (kebab)           → not claimed by primary
+  - ADDS   wva.llmd.ai/variant: <suffix>                → unique selector
+
+Both VAs share the same spec.modelID so the WVA solver groups them.
+
+Usage
+-----
+  python hack/benchmark/add_variant.py -n NAMESPACE \
+      --config hack/benchmark/scenarios/guides/variants/<name>.yaml [--dry-run]
+
+The variant config yaml declares only what differs from the primary.
+Schema:
+
+  suffix: v2                     # required; secondary name suffix
+  variantCost: "5.0"             # default "5.0"
+  minReplicas: 1                 # default 1
+  maxReplicas: 10                # default 10
+  parallelism:
+    tensor: 2                    # rewrites --tensor-parallel-size
+  resources:
+    nvidia.com/gpu: 2            # mirrors limits + requests on GPU containers
+"""
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "ERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# kubectl helpers
+# ---------------------------------------------------------------------------
+
+
+def kubectl(*args, stdin=None, check=True):
+    cmd = ["kubectl"] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True, input=stdin)
+    if check and result.returncode != 0:
+        print(f"ERROR: {' '.join(cmd)}\n{result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout
+
+
+def kubectl_apply(obj, dry_run=False):
+    payload = json.dumps(obj)
+    if dry_run:
+        print("---")
+        print(json.dumps(obj, indent=2))
+        return
+    kubectl("apply", "-f", "-", stdin=payload)
+
+
+def _strip_managed(obj):
+    """Remove server-managed fields before re-applying as a new object."""
+    meta = obj.setdefault("metadata", {})
+    for field in (
+        "resourceVersion",
+        "uid",
+        "generation",
+        "creationTimestamp",
+        "managedFields",
+        "selfLink",
+    ):
+        meta.pop(field, None)
+    ann = meta.get("annotations", {})
+    ann.pop("kubectl.kubernetes.io/last-applied-configuration", None)
+    if not ann:
+        meta.pop("annotations", None)
+    obj.pop("status", None)
+    tmpl_meta = obj.get("spec", {}).get("template", {}).get("metadata", {})
+    tmpl_meta.pop("creationTimestamp", None)
+    tmpl_meta.pop("annotations", None)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Variant config parsing
+# ---------------------------------------------------------------------------
+
+CONFIG_DEFAULTS = {
+    "variantCost": "5.0",
+    "minReplicas": 1,
+    "maxReplicas": 10,
+}
+
+
+def load_variant_config(path):
+    """Load a variant override yaml, validate, and apply defaults.
+
+    Required: `suffix`. All other keys are optional and inherit the primary's
+    value if omitted (with the defaults in CONFIG_DEFAULTS for VA fields).
+    """
+    p = Path(path)
+    if not p.is_file():
+        print(f"ERROR: variant config not found: {p}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        cfg = yaml.safe_load(p.read_text()) or {}
+    except yaml.YAMLError as e:
+        print(f"ERROR: failed to parse {p}: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(cfg, dict):
+        print(
+            f"ERROR: variant config {p} must be a yaml mapping, got "
+            f"{type(cfg).__name__}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if "suffix" not in cfg or not isinstance(cfg["suffix"], str) or not cfg["suffix"]:
+        print(f"ERROR: variant config {p} must set non-empty 'suffix'", file=sys.stderr)
+        sys.exit(1)
+    for k, v in CONFIG_DEFAULTS.items():
+        cfg.setdefault(k, v)
+    cfg["variantCost"] = str(cfg["variantCost"])
+    cfg["minReplicas"] = int(cfg["minReplicas"])
+    cfg["maxReplicas"] = int(cfg["maxReplicas"])
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Resource discovery
+# ---------------------------------------------------------------------------
+
+
+def find_primary_deployment(namespace):
+    # The llm-d.ai/* labels live on spec.selector.matchLabels (not metadata.labels),
+    # so kubectl -l filtering doesn't work — fetch all Deployments and filter here.
+    out = kubectl("get", "deployment", "-n", namespace, "-o", "json")
+    items = json.loads(out)["items"]
+
+    def _is_primary(d):
+        sel = d.get("spec", {}).get("selector", {}).get("matchLabels", {})
+        if sel.get("llm-d.ai/inference-serving") != "true":
+            return False
+        if sel.get("llm-d.ai/role") != "decode":
+            return False
+        # Exclude secondary variants created by this script
+        if "wva.llmd.ai/variant" in sel:
+            return False
+        return True
+
+    primaries = [d for d in items if _is_primary(d)]
+    if not primaries:
+        print(
+            "ERROR: No primary decode deployment found "
+            "(spec.selector: llm-d.ai/inference-serving=true,llm-d.ai/role=decode)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if len(primaries) > 1:
+        names = [d["metadata"]["name"] for d in primaries]
+        print(f"ERROR: Multiple primary deployments found: {names}.", file=sys.stderr)
+        sys.exit(1)
+    return primaries[0]
+
+
+def find_primary_va(namespace, deployment_name):
+    out = kubectl("get", "variantautoscaling", "-n", namespace, "-o", "json")
+    vas = json.loads(out)["items"]
+    for va in vas:
+        if va["spec"]["scaleTargetRef"]["name"] == deployment_name:
+            return va
+    print(
+        f"ERROR: No VariantAutoscaling found targeting deployment '{deployment_name}'",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def find_primary_hpa(namespace, deployment_name):
+    out = kubectl("get", "hpa", "-n", namespace, "-o", "json")
+    hpas = json.loads(out)["items"]
+    for hpa in hpas:
+        if hpa["spec"]["scaleTargetRef"]["name"] == deployment_name:
+            return hpa
+    print(
+        f"ERROR: No HPA found targeting deployment '{deployment_name}'", file=sys.stderr
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Container-arg overrides
+# ---------------------------------------------------------------------------
+
+
+def _override_tensor_parallel(containers, tp_value):
+    """Replace `--tensor-parallel-size N` (or append it) in every container's args.
+
+    vLLM accepts either `--tensor-parallel-size N` (two-arg) or
+    `--tensor-parallel-size=N` (one-arg). Handle both.
+    """
+    flag = "--tensor-parallel-size"
+    target = str(tp_value)
+    for c in containers:
+        args = c.get("args")
+        if not isinstance(args, list):
+            continue
+        new_args = []
+        i = 0
+        replaced = False
+        while i < len(args):
+            a = args[i]
+            if a == flag and i + 1 < len(args):
+                new_args.extend([flag, target])
+                i += 2
+                replaced = True
+            elif isinstance(a, str) and a.startswith(flag + "="):
+                new_args.append(f"{flag}={target}")
+                i += 1
+                replaced = True
+            else:
+                new_args.append(a)
+                i += 1
+        if not replaced:
+            new_args.extend([flag, target])
+        c["args"] = new_args
+
+
+def _override_gpu_resources(containers, gpu_count):
+    """Set both limits and requests of nvidia.com/gpu on every container that
+    already requests a GPU. Containers without a GPU resource are untouched
+    (init containers, sidecars).
+    """
+    target = str(gpu_count)
+    for c in containers:
+        res = c.get("resources") or {}
+        limits = res.get("limits") or {}
+        requests = res.get("requests") or {}
+        already_has_gpu = "nvidia.com/gpu" in limits or "nvidia.com/gpu" in requests
+        if not already_has_gpu:
+            continue
+        limits["nvidia.com/gpu"] = target
+        requests["nvidia.com/gpu"] = target
+        res["limits"] = limits
+        res["requests"] = requests
+        c["resources"] = res
+
+
+def _read_tensor_parallel(containers):
+    """Return the TP value seen in the first container that sets it, or None."""
+    flag = "--tensor-parallel-size"
+    for c in containers:
+        args = c.get("args") or []
+        for i, a in enumerate(args):
+            if a == flag and i + 1 < len(args):
+                return args[i + 1]
+            if isinstance(a, str) and a.startswith(flag + "="):
+                return a.split("=", 1)[1]
+    return None
+
+
+def _read_gpu_per_pod(containers):
+    """Return the GPU count from the first container with one, or None."""
+    for c in containers:
+        res = c.get("resources") or {}
+        for bucket in ("limits", "requests"):
+            v = (res.get(bucket) or {}).get("nvidia.com/gpu")
+            if v is not None:
+                return v
+    return None
+
+
+def _all_containers(deployment):
+    """All scrape-relevant containers in a Deployment template (main +
+    initContainers). Returns a list of dicts (mutable references)."""
+    spec = deployment.get("spec", {}).get("template", {}).get("spec", {})
+    return list(spec.get("containers") or []) + list(spec.get("initContainers") or [])
+
+
+# ---------------------------------------------------------------------------
+# Object builders
+# ---------------------------------------------------------------------------
+
+
+def make_secondary_deployment(primary, cfg, namespace):
+    sec = copy.deepcopy(primary)
+    _strip_managed(sec)
+
+    suffix = cfg["suffix"]
+    primary_name = primary["metadata"]["name"]
+    sec_name = f"{primary_name}-{suffix}"
+    sec["metadata"]["name"] = sec_name
+    sec["metadata"]["namespace"] = namespace
+
+    spec = sec["spec"]
+    spec["replicas"] = 1
+
+    # --- pod template labels ------------------------------------------------
+    tmpl_labels = spec["template"]["metadata"].setdefault("labels", {})
+    # Remove kebab label so primary Deployment selector won't claim these pods
+    tmpl_labels.pop("llm-d.ai/inference-serving", None)
+    # Add variant discriminator
+    tmpl_labels["wva.llmd.ai/variant"] = suffix
+    # Override the WVA variant label inherited from the primary pod template so
+    # this deployment's metrics map to the v2 VariantAutoscaling, not primary.
+    # Required by PR #1145 (Prometheus relabeling -> llm_d_ai_variant).
+    tmpl_labels["llm-d.ai/variant"] = sec_name
+
+    # --- Deployment selector ------------------------------------------------
+    # Must match the pod template labels (minus kebab, plus variant).
+    # Kubernetes selector is immutable after creation so get it right once.
+    sel = spec["selector"]["matchLabels"]
+    sel.pop("llm-d.ai/inference-serving", None)
+    sel["wva.llmd.ai/variant"] = suffix
+    # Override inherited primary's llm-d.ai/variant value so this selector
+    # matches the secondary's pod-template labels (PR #1145 alignment).
+    sel["llm-d.ai/variant"] = sec_name
+
+    # --- shape overrides ----------------------------------------------------
+    pod_spec = spec["template"]["spec"]
+    main_containers = pod_spec.setdefault("containers", [])
+
+    tp = (cfg.get("parallelism") or {}).get("tensor")
+    if tp is not None:
+        _override_tensor_parallel(main_containers, tp)
+
+    gpu = (cfg.get("resources") or {}).get("nvidia.com/gpu")
+    if gpu is not None:
+        _override_gpu_resources(main_containers, gpu)
+
+    return sec
+
+
+def make_secondary_va(primary_va, sec_dep_name, cfg, namespace):
+    primary_name = primary_va["metadata"]["name"]
+    sec = copy.deepcopy(primary_va)
+    _strip_managed(sec)
+
+    sec["metadata"]["name"] = f"{primary_name}-{cfg['suffix']}"
+    sec["metadata"]["namespace"] = namespace
+    # Inherit controller-instance label so the namespace-scoped controller sees it
+    sec["metadata"].setdefault("labels", {})
+    sec["metadata"]["labels"]["wva.llmd.ai/controller-instance"] = namespace
+
+    sec["spec"] = {
+        "scaleTargetRef": {
+            "kind": "Deployment",
+            "name": sec_dep_name,
+        },
+        "modelID": primary_va["spec"]["modelID"],
+        "variantCost": cfg["variantCost"],
+        "minReplicas": cfg["minReplicas"],
+        "maxReplicas": cfg["maxReplicas"],
+    }
+    return sec
+
+
+def make_secondary_hpa(primary_hpa, sec_dep_name, cfg, namespace):
+    primary_name = primary_hpa["metadata"]["name"]
+    sec = copy.deepcopy(primary_hpa)
+    _strip_managed(sec)
+
+    sec["metadata"]["name"] = f"{primary_name}-{cfg['suffix']}"
+    sec["metadata"]["namespace"] = namespace
+
+    sec["spec"]["scaleTargetRef"]["name"] = sec_dep_name
+    sec["spec"]["minReplicas"] = cfg["minReplicas"]
+    sec["spec"]["maxReplicas"] = cfg["maxReplicas"]
+
+    for m in sec["spec"].get("metrics", []):
+        if m.get("type") == "External":
+            sel = m["external"]["metric"]["selector"]["matchLabels"]
+            if "variant_name" in sel:
+                sel["variant_name"] = sec_dep_name
+
+    return sec
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Add a secondary WVA variant to an existing benchmark deployment."
+    )
+    ap.add_argument("-n", "--namespace", required=True, help="Kubernetes namespace")
+    ap.add_argument(
+        "--config",
+        required=True,
+        help="Path to a variant override yaml (see module docstring)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print manifests as JSON without applying",
+    )
+    args = ap.parse_args()
+
+    ns = args.namespace
+    cfg = load_variant_config(args.config)
+    suffix = cfg["suffix"]
+
+    print(f"[1/3] Finding primary decode Deployment in namespace '{ns}'...")
+    primary_dep = find_primary_deployment(ns)
+    dep_name = primary_dep["metadata"]["name"]
+    model_hash = (
+        primary_dep.get("spec", {})
+        .get("selector", {})
+        .get("matchLabels", {})
+        .get("llm-d.ai/model", "?")
+    )
+    primary_containers = _all_containers(primary_dep)
+    primary_tp = _read_tensor_parallel(primary_containers) or "1"
+    primary_gpu = _read_gpu_per_pod(primary_containers) or "1"
+    print(f"      {dep_name}  (llm-d.ai/model={model_hash})")
+
+    print("[2/3] Finding primary VariantAutoscaling...")
+    primary_va = find_primary_va(ns, dep_name)
+    model_id = primary_va["spec"]["modelID"]
+    primary_cost = primary_va["spec"].get("variantCost", "?")
+    print(
+        f"      {primary_va['metadata']['name']}  "
+        f"(modelID={model_id}, variantCost={primary_cost})"
+    )
+
+    print("[3/3] Finding primary HPA...")
+    primary_hpa = find_primary_hpa(ns, dep_name)
+    print(f"      {primary_hpa['metadata']['name']}")
+
+    sec_dep_name = f"{dep_name}-{suffix}"
+
+    print(
+        f"\nCreating secondary variant '{suffix}'  "
+        f"variantCost={cfg['variantCost']}  modelID={model_id}\n"
+    )
+
+    sec_dep = make_secondary_deployment(primary_dep, cfg, ns)
+    sec_va = make_secondary_va(primary_va, sec_dep_name, cfg, ns)
+    sec_hpa = make_secondary_hpa(primary_hpa, sec_dep_name, cfg, ns)
+
+    for kind, obj in [
+        ("Deployment", sec_dep),
+        ("VariantAutoscaling", sec_va),
+        ("HPA", sec_hpa),
+    ]:
+        name = obj["metadata"]["name"]
+        print(f"  Applying {kind}: {name}")
+        kubectl_apply(obj, dry_run=args.dry_run)
+
+    if args.dry_run:
+        return
+
+    sec_containers = _all_containers(sec_dep)
+    sec_tp = _read_tensor_parallel(sec_containers) or "1"
+    sec_gpu = _read_gpu_per_pod(sec_containers) or "1"
+
+    print()
+    print("Secondary variant created successfully.")
+    print(
+        f"  Primary   (cost {primary_cost:>5}, TP={primary_tp}, "
+        f"{primary_gpu} GPU/pod): {dep_name}"
+    )
+    print(
+        f"  Secondary (cost {cfg['variantCost']:>5}, TP={sec_tp}, "
+        f"{sec_gpu} GPU/pod): {sec_dep_name}"
+    )
+    print()
+    print("Both VAs share modelID=" + repr(model_id) + ".")
+    print("WVA will scale the cheaper variant first when both are saturated.")
+    print()
+    print("Verify:")
+    print(f"  kubectl get va,hpa -n {ns}")
+    print(
+        f"  kubectl get pods -n {ns} "
+        f"-l 'llm-d.ai/inferenceServing=true,llm-d.ai/model={model_hash}'"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a multi-variant benchmark scenario for the
[Workload Variant Autoscaler (WVA)](https://github.com/llm-d/llm-d-workload-variant-autoscaler):
one model deployed as two `Deployment`s with differing `variantCost`,
both registered into the same `InferencePool` / EPP.

Addresses #1425 — *"Add multi-variants benchmark for testing WVA behaviour."*

## Files

| Path | Role |
|---|---|
| `config/scenarios/guides/two-variant-wva.yaml` | Primary-variant standup (Llama-3.1-8B / H100, cost 10.0) with WVA + HPA per stack |
| `config/specification/guides/two-variant-wva.yaml.j2` | Spec wrapper |
| `config/scenarios/guides/two-variant-wva-v2-config.yaml` | Standalone ConfigMap that flips WVA into V2 saturation mode (the cost-aware analyzer) |
| `config/scenarios/guides/variants/v2-cost-only.yaml` | Variant override (cost-only secondary at cost 5.0) |
| `tools/add_variant.py` | Helper that builds the secondary `Deployment` / `VariantAutoscaling` / `HPA` from a variant override yaml |
| `docs/multi-variant-benchmark.md` | End-to-end recipe |

## Why draft

**Blocking dependency on a WVA chart release** that includes
[llm-d/llm-d-workload-variant-autoscaler#1198](https://github.com/llm-d/llm-d-workload-variant-autoscaler/pull/1198)
(drop `model_name` filter from the `cache_config_info` query). Without
that fix, WVA's V2 analyzer falls back to the per-step batch budget
(~6.5K tokens/pod vs ~412K real KV on Llama-3.1-8B / H100),
under-counting capacity ~50× and making the cost-aware demonstration
ineffective.

The fix landed on WVA `main` on 2026-05-27. The currently-tagged WVA
chart versions (`v0.6.0`, `v0.7.0`) **predate** it. This PR pins the
chart at `v0.7.0` to align with current upstream conventions; once a
chart release that includes #1198 is cut, the `tag:` in the scenario
yaml will be bumped and the PR converted to ready-for-review.

## Follow-ups (not in this PR)

1. **WVA chart-side change** to expose `analyzerName` /
   `scaleUpThreshold` / `scaleDownBoundary` in the chart's values
   surface. Once that lands, the standalone
   `two-variant-wva-v2-config.yaml` ConfigMap and the "Step 2 — enable
   V2" instruction in the doc become unnecessary (`analyzerName` would
   be set inline in the scenario yaml's `wva.capacityScaling.default`).
2. **HPA-EPP comparison scenario** (separate PR) that toggles the same
   topology between WVA-driven scaling and a per-Deployment HPA-EPP
   baseline, so we can quantify WVA's cost-per-successful-request
   advantage with the same workload and infra.
3. **Shape-diversity variants** (e.g. `v2-tp2.yaml` with TP=2 / 2 GPUs)
   for "different hardware shape" demonstrations on a single-hardware
   cluster.

## Testing

End-to-end on an OpenShift cluster with H100 GPUs:

```bash
NS=<your-namespace>
llmdbenchmark --spec guides/two-variant-wva standup -p $NS
kubectl apply -n $NS -f config/scenarios/guides/two-variant-wva-v2-config.yaml
python tools/add_variant.py -n $NS \
    --config config/scenarios/guides/variants/v2-cost-only.yaml
llmdbenchmark --spec guides/two-variant-wva run \
    -p $NS -l guidellm -w prefill_heavy.yaml
```

Verified end-to-end with a WVA `main`-built image (post-#1198) on
Llama-3.1-8B at rate=5: primary held at minReplicas=1 throughout, v2
absorbed the load curve up to ~5 replicas — the cost-aware behavior the
issue calls for. With the upstream `v0.6.0`/`v0.7.0` chart (without
#1198), both variants run away to `maxReplicas` instead.
