### PR TITLE
feat: Require secret based on recent llm-d requirement for Kustomize

### DIFF
--- a/config/scenarios/guides/optimized-baseline.yaml
+++ b/config/scenarios/guides/optimized-baseline.yaml
@@ -52,25 +52,15 @@ scenario:
       guideVariableOverrides: {}   # override/fill the guide README's ${VAR}
 
       # Inline kustomize strategic merge patches applied on top of the
-      # guide's modelserver base.  For gated models, add an HF_TOKEN
-      # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
+      # guide's modelserver base.  HF_TOKEN is NOT something you need to
+      # patch in here -- the upstream guide manifests (since
+      # llm-d/llm-d#1684) already reference secret/llm-d-hf-token, and
+      # step_06_kustomize_deploy._ensure_hf_token_secret creates that
+      # Secret from your $HF_TOKEN (or LLMDBENCH_HF_TOKEN /
+      # HUGGING_FACE_HUB_TOKEN) before the modelserver apply. See
+      # docs/kustomize.md "HF_TOKEN handling".
+      #
+      # Use `patches:` for other modelserver tweaks, e.g.:
       #patches:
       #  - patch: |
       #      apiVersion: apps/v1
@@ -82,6 +72,7 @@ scenario:
       #        template:
       #          spec:
       #            priorityClassName: nightly-gpu-critical
+      patches: []
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods

--- a/config/scenarios/guides/precise-prefix-cache-routing.yaml
+++ b/config/scenarios/guides/precise-prefix-cache-routing.yaml
@@ -59,25 +59,13 @@ scenario:
       extraHelmSets: {}
 
       # Inline kustomize strategic merge patches applied on top of the
-      # guide's modelserver base.  For gated models, add an HF_TOKEN
-      # env var patch (the secret is auto-created from HF_TOKEN env):
-      #
-      #   - patch: |
-      #       apiVersion: apps/v1
-      #       kind: Deployment
-      #       metadata:
-      #         name: decode
-      #       spec:
-      #         template:
-      #           spec:
-      #             containers:
-      #               - name: modelserver
-      #                 env:
-      #                   - name: HF_TOKEN
-      #                     valueFrom:
-      #                       secretKeyRef:
-      #                         name: llm-d-hf-token
-      #                         key: HF_TOKEN
+      # guide's modelserver base.  HF_TOKEN is NOT something you need to
+      # patch in here -- the upstream guide manifests (since
+      # llm-d/llm-d#1684) already reference secret/llm-d-hf-token, and
+      # step_06_kustomize_deploy._ensure_hf_token_secret creates that
+      # Secret from your $HF_TOKEN (or LLMDBENCH_HF_TOKEN /
+      # HUGGING_FACE_HUB_TOKEN) before the modelserver apply. See
+      # docs/kustomize.md "HF_TOKEN handling".
       patches:
         - patch: |
             apiVersion: apps/v1

--- a/docs/kustomize.md
+++ b/docs/kustomize.md
@@ -69,27 +69,15 @@ kustomize:
 
   # patches → modelserver. Strategic-merge, matched by
   # apiVersion + kind + metadata.name against the guide's base.
+  # NB: HF_TOKEN env injection is NOT needed here -- the upstream
+  # guides ship it (since llm-d/llm-d#1684) and step 06 creates the
+  # Secret automatically. See `## HF_TOKEN handling` below.
   patches:
     - patch: |                       # override the guide's replica count
         apiVersion: apps/v1
         kind: Deployment
         metadata: { name: decode }
         spec: { replicas: 4 }
-    - patch: |                       # gated models: inject HF token env
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata: { name: decode }
-        spec:
-          template:
-            spec:
-              containers:
-                - name: modelserver
-                  env:
-                    - name: HF_TOKEN
-                      valueFrom:
-                        secretKeyRef:
-                          name: llm-d-hf-token
-                          key: HF_TOKEN
 
   # overlayPath → modelserver. If the dir contains kustomization.yaml it
   # is added as a kustomize component; otherwise every *.yaml in it is
@@ -110,6 +98,43 @@ kustomize:
   guideVariableOverrides:
     SOME_README_VAR: "value"
 ```
+
+## HF_TOKEN handling
+
+Upstream llm-d guides (since
+[llm-d/llm-d#1684](https://github.com/llm-d/llm-d/pull/1684)) reference
+`secret/llm-d-hf-token` directly in their modelserver manifests
+without `optional: true`. **Kustomize standup hard-requires the Secret
+to be available** — if the Pod can't resolve the `secretKeyRef` it
+hangs in `CreateContainerConfigError` until the deploy timeout
+elapses.
+
+`step_06_kustomize_deploy` enforces this in
+[`_ensure_hf_token_secret`](../llmdbenchmark/standup/steps/step_06_kustomize_deploy.py).
+Three branches:
+
+| Condition | Behaviour |
+|---|---|
+| Secret `llm-d-hf-token` already exists in the namespace | Leave it alone, log "already exists" (supports externally managed Secrets via ESO / Vault / hand-create). No env token required. |
+| Secret absent, env token set (`HF_TOKEN`, `LLMDBENCH_HF_TOKEN`, or `HUGGING_FACE_HUB_TOKEN`, in that order) | Create the Secret. |
+| **Secret absent AND no env token** | **Standup fails fast** before applying any modelserver manifests, with a message naming the namespace and the two fix paths (export the env var or `kubectl create secret …` by hand). |
+
+The token value is never written to a `kubectl` command line.  The
+manifest is built in-process, base64-encoded, written to a temp file
+(mode 0600), `kubectl apply -f`'d, and the temp file is unlinked
+afterwards — so `CommandExecutor`'s command log only ever sees
+`kubectl apply -f /tmp/llm-d-hf-token-XXXX.yaml`.  If `kubectl`
+somehow echoes the token in stderr, the surfaced error string is
+scrubbed before propagation.
+
+When a scenario sets a separate `harness_namespace`, the Secret is
+ensured in **both** namespaces — the same fail-fast rule applies to
+each.
+
+This fail-fast behaviour is **kustomize-only**.  The `modelservice` and
+`standalone` paths remain tolerant of missing tokens (auto-disabling
+`huggingface.enabled` when no token is found and gating later steps),
+because their generated manifests don't have the hard requirement.
 
 ## Caveats
 

--- a/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import shlex
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -164,7 +166,26 @@ class KustomizeDeployStep(Step):
             )
 
         # --- 1b. HF token secret ---
-        self._ensure_hf_token_secret(cmd, context, namespace)
+        # Upstream guide manifests (since llm-d/llm-d#1684) reference
+        # `secret/llm-d-hf-token` without `optional: true`, so missing
+        # the Secret hangs every Pod in CreateContainerConfigError.
+        # Ensure it exists (or fail fast) in both the deploy namespace
+        # and the harness namespace when they differ.
+        hf_error = self._ensure_hf_token_secret(cmd, context, namespace)
+        if hf_error:
+            return self._fail(
+                [hf_error], stack_path, "HF token setup failed", context=context
+            )
+        harness_ns = getattr(context, "harness_namespace", None)
+        if harness_ns and harness_ns != namespace:
+            hf_error = self._ensure_hf_token_secret(cmd, context, harness_ns)
+            if hf_error:
+                return self._fail(
+                    [hf_error],
+                    stack_path,
+                    "HF token setup failed in harness namespace",
+                    context=context,
+                )
 
         # --- 2. Router ---
         router_cmds = parsed.get_commands(CommandPhase.ROUTER, DeployMode.STANDALONE)
@@ -352,13 +373,41 @@ class KustomizeDeployStep(Step):
         return str(repo_dir)
 
     _HF_SECRET_NAME = "llm-d-hf-token"
+    _HF_SECRET_KEY = "HF_TOKEN"
 
     @staticmethod
     def _ensure_hf_token_secret(
         cmd: CommandExecutor,
         context: ExecutionContext,
         namespace: str,
-    ) -> None:
+    ) -> str | None:
+        """Ensure the HF token Secret exists in ``namespace``.
+
+        Kustomize-mode-only.  Upstream llm-d guide manifests (since PR
+        llm-d/llm-d#1684) reference ``secret/llm-d-hf-token`` directly
+        with no ``optional: true`` -- without it every Pod hangs in
+        ``CreateContainerConfigError``.  This helper enforces presence:
+
+        - If a Secret named ``llm-d-hf-token`` already exists in the
+          namespace, succeed and leave it alone (supports externally
+          managed Secrets via ESO / Vault / manual create).
+        - If no Secret exists and ``HF_TOKEN`` /
+          ``LLMDBENCH_HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` is set in
+          the process env, create it from that value.
+        - If no Secret AND no env token, return a descriptive error
+          string so the caller can fail the step fast.
+
+        Returns ``None`` on success, or an error message string on
+        failure (caller is expected to surface via ``self._fail``).
+
+        Security: the token value is never passed on a command line
+        (which would be logged by ``CommandExecutor``).  Instead we
+        build the Secret manifest in-process, base64-encode the token,
+        write to a ``NamedTemporaryFile`` (Python defaults to mode
+        0600 on Unix), ``kubectl apply -f`` that file, then unlink it.
+        Any ``kubectl`` stderr we surface is also scrubbed of the
+        literal token value as a belt-and-braces precaution.
+        """
         import os
 
         hf_token = (
@@ -366,14 +415,13 @@ class KustomizeDeployStep(Step):
             or os.environ.get("LLMDBENCH_HF_TOKEN")
             or os.environ.get("HUGGING_FACE_HUB_TOKEN")
         )
-        if not hf_token:
-            context.logger.log_info(
-                "No HF_TOKEN in environment -- skipping secret creation "
-                "(gated models will fail)"
-            )
-            return
 
         secret_name = KustomizeDeployStep._HF_SECRET_NAME
+        secret_key = KustomizeDeployStep._HF_SECRET_KEY
+
+        # 1. Already in the cluster? Leave it alone -- supports ESO /
+        #    Vault / hand-created Secret workflows where the operator
+        #    owns rotation.  No env token required in that case.
         check = cmd.kube(
             "get",
             "secret",
@@ -386,26 +434,87 @@ class KustomizeDeployStep(Step):
             context.logger.log_info(
                 f"HF token secret '{secret_name}' already exists in {namespace}"
             )
-            return
+            return None
 
-        result = cmd.kube(
-            "create",
-            "secret",
-            "generic",
-            secret_name,
-            f"--from-literal=HF_TOKEN={hf_token}",
-            "--namespace",
-            namespace,
-            check=False,
-        )
+        # 2. No Secret AND no env token -- fail fast with actionable
+        #    instructions.  We do this *only* in the kustomize path
+        #    because upstream guide manifests now hard-require the
+        #    Secret; modelservice/standalone keep their tolerant
+        #    behaviour.
+        if not hf_token:
+            return (
+                f"HF_TOKEN is not set and Secret '{secret_name}' does not "
+                f"exist in namespace {namespace}.  A HF_TOKEN is now "
+                f"required for well-lit-path guides.\n"
+                f"\n"
+                f"Either:\n"
+                f"  1. Export HF_TOKEN (or LLMDBENCH_HF_TOKEN, "
+                f"HUGGING_FACE_HUB_TOKEN) before running standup, or\n"
+                f"  2. Pre-create the Secret:\n"
+                f"     kubectl create secret generic {secret_name} \\\n"
+                f"       --from-literal={secret_key}=<your-token> "
+                f"-n {namespace}"
+            )
+
+        # 3. Have a token, no Secret -- create it without ever putting
+        #    the token on a command line.  We build the manifest in
+        #    Python, base64-encode the token, write to a temp file
+        #    (NamedTemporaryFile is mode 0600 by default on Unix),
+        #    apply, and unlink.  The logged kubectl invocation is just
+        #    ``kubectl apply -f /tmp/xxx.yaml``.
+        token_b64 = base64.b64encode(hf_token.encode("utf-8")).decode("ascii")
+        secret_manifest = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {
+                "name": secret_name,
+                "namespace": namespace,
+            },
+            "data": {
+                secret_key: token_b64,
+            },
+        }
+
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".yaml",
+                delete=False,
+                prefix="llm-d-hf-token-",
+            ) as tmp:
+                yaml.safe_dump(secret_manifest, tmp)
+                tmp_path = tmp.name
+
+            result = cmd.kube(
+                "apply",
+                "-f",
+                tmp_path,
+                "--namespace",
+                namespace,
+                check=False,
+            )
+        finally:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
+
         if result.success:
             context.logger.log_info(
                 f"Created HF token secret '{secret_name}' in {namespace}"
             )
-        else:
-            context.logger.log_warning(
-                f"Failed to create HF token secret: {result.stderr[:200]}"
-            )
+            return None
+
+        # Scrub any accidental token echo from kubectl stderr before
+        # surfacing it -- not expected for ``apply -f`` failures but
+        # cheap insurance.
+        stderr = (result.stderr or "")[:300]
+        if hf_token and hf_token in stderr:
+            stderr = stderr.replace(hf_token, "<redacted>")
+        return (
+            f"Failed to create HF token secret '{secret_name}' in "
+            f"namespace {namespace}: {stderr}"
+        )
 
     def _fail(
         self,

--- a/tests/test_kustomize_hf_token.py
+++ b/tests/test_kustomize_hf_token.py
@@ -1,0 +1,304 @@
+"""Tests for the HF-token fail-fast logic in step_06_kustomize_deploy.
+
+Three behaviours are covered:
+
+1. Pre-existing Secret short-circuits without requiring an env token.
+2. No Secret + no env token returns the exact, user-facing error.
+3. No Secret + env token set creates the Secret via a temp manifest
+   file -- never via ``--from-literal=`` on the kubectl command line
+   (the token must not appear in any captured kubectl args).
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+# ``llmdbenchmark.standup.steps.__init__`` eagerly imports a sibling
+# (``step_03_workload_monitoring``) that transitively depends on a
+# ``planner`` package not installed in this test environment.  Stub it
+# permissively (any attribute resolves to a no-op callable) so the
+# import chain reaches ``step_06_kustomize_deploy``.
+if "planner.capacity_planner" not in sys.modules:
+
+    class _PermissiveModule(types.ModuleType):
+        def __getattr__(self, name: str):  # type: ignore[override]
+            return type(name, (), {})
+
+    sys.modules.setdefault("planner", _PermissiveModule("planner"))
+    sys.modules["planner.capacity_planner"] = _PermissiveModule(
+        "planner.capacity_planner"
+    )
+
+from llmdbenchmark.standup.steps.step_06_kustomize_deploy import (  # noqa: E402
+    KustomizeDeployStep,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeResult:
+    """Stand-in for ``CommandResult`` covering only the fields we use."""
+
+    success: bool = True
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class FakeCommandExecutor:
+    """Capture every ``kube(*args)`` invocation and dispatch by verb.
+
+    ``get_handler`` is invoked for ``("get", "secret", …)`` calls and
+    must return a ``FakeResult``.  ``apply_handler`` is invoked for
+    ``("apply", "-f", <tmpfile>, …)`` calls.  Both default to success
+    so individual tests only override the bit they care about.
+    """
+
+    get_handler: Any = field(default_factory=lambda: lambda *a, **k: FakeResult(True))
+    apply_handler: Any = field(default_factory=lambda: lambda *a, **k: FakeResult(True))
+    calls: list[tuple[tuple[str, ...], dict[str, Any]]] = field(default_factory=list)
+    apply_manifests: list[dict] = field(default_factory=list)
+
+    def kube(self, *args: str, **kwargs: Any) -> FakeResult:
+        self.calls.append((tuple(args), dict(kwargs)))
+        if args and args[0] == "get":
+            return self.get_handler(*args, **kwargs)
+        if args and args[0] == "apply":
+            # Capture the rendered manifest so tests can verify the
+            # token was base64-encoded into Secret.data correctly.
+            for i, tok in enumerate(args):
+                if tok == "-f" and i + 1 < len(args):
+                    path = Path(args[i + 1])
+                    if path.exists():
+                        self.apply_manifests.append(
+                            yaml.safe_load(path.read_text(encoding="utf-8"))
+                        )
+                    break
+            return self.apply_handler(*args, **kwargs)
+        return FakeResult(True)
+
+
+def _fake_context() -> Any:
+    """Minimal stand-in for ``ExecutionContext`` with a mocked logger."""
+    ctx = MagicMock()
+    ctx.logger = MagicMock()
+    return ctx
+
+
+def _flatten_call_args(cmd: FakeCommandExecutor) -> str:
+    """All kubectl args ever captured, joined for token-leak scanning."""
+    return " ".join(str(a) for args, _ in cmd.calls for a in args)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _clear_hf_env(monkeypatch):
+    """Strip every HF-token env var so each test starts clean."""
+    for var in ("HF_TOKEN", "LLMDBENCH_HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestEnsureHfTokenSecret:
+    """Cover the three branches of ``_ensure_hf_token_secret``."""
+
+    def test_pre_existing_secret_succeeds_without_env_token(self, monkeypatch):
+        """Externally managed Secret -- no env token required."""
+        _clear_hf_env(monkeypatch)
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "my-ns")
+
+        assert result is None, (
+            "Pre-existing Secret should make the helper succeed without an env token."
+        )
+        # No `apply` was attempted -- only the single get.
+        verbs = [args[0] for args, _ in cmd.calls]
+        assert verbs == ["get"], verbs
+
+    def test_missing_secret_and_no_token_returns_error_with_namespace(
+        self, monkeypatch
+    ):
+        """The exact user-facing error message."""
+        _clear_hf_env(monkeypatch)
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "my-cool-ns")
+
+        assert result is not None
+        # The opening line, with the namespace populated.
+        assert (
+            "HF_TOKEN is not set and Secret 'llm-d-hf-token' does not exist "
+            "in namespace my-cool-ns" in result
+        )
+        assert "A HF_TOKEN is now required for well-lit-path guides" in result
+        # Both remediation paths are spelled out.
+        assert "Export HF_TOKEN" in result
+        assert "LLMDBENCH_HF_TOKEN" in result
+        assert "HUGGING_FACE_HUB_TOKEN" in result
+        assert "kubectl create secret generic llm-d-hf-token" in result
+        assert "-n my-cool-ns" in result
+        # No apply was attempted -- we bailed before creating.
+        verbs = [args[0] for args, _ in cmd.calls]
+        assert verbs == ["get"], verbs
+
+    def test_env_token_creates_secret_via_temp_manifest(self, monkeypatch):
+        """Token comes from env, Secret applied from a temp file."""
+        token = "hf_unique_test_value_DO_NOT_LOG_ME"
+        monkeypatch.setenv("HF_TOKEN", token)
+        monkeypatch.delenv("LLMDBENCH_HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert result is None, "Creation should succeed."
+        # An apply was attempted with -f <tmp> and the right namespace.
+        verbs = [args[0] for args, _ in cmd.calls]
+        assert verbs == ["get", "apply"], verbs
+
+        apply_args = cmd.calls[1][0]
+        assert apply_args[0] == "apply"
+        assert "-f" in apply_args
+        assert "--namespace" in apply_args
+        assert "ns42" in apply_args
+
+        # The rendered Secret manifest was correct: base64(token) under
+        # data.HF_TOKEN, type Opaque, named llm-d-hf-token.
+        assert len(cmd.apply_manifests) == 1
+        manifest = cmd.apply_manifests[0]
+        assert manifest["kind"] == "Secret"
+        assert manifest["type"] == "Opaque"
+        assert manifest["metadata"]["name"] == "llm-d-hf-token"
+        assert manifest["metadata"]["namespace"] == "ns42"
+        expected_b64 = base64.b64encode(token.encode("utf-8")).decode("ascii")
+        assert manifest["data"]["HF_TOKEN"] == expected_b64
+
+    def test_token_never_appears_in_any_captured_command_arg(self, monkeypatch, capsys):
+        """The HF token value must never reach the kubectl argv (which
+        ``CommandExecutor._run_once`` logs to disk).  Belt-and-braces:
+        also assert it never reaches stdout/stderr captured by pytest."""
+        token = "hf_unique_canary_value_zzz_DO_NOT_LEAK"
+        monkeypatch.setenv("HF_TOKEN", token)
+        monkeypatch.delenv("LLMDBENCH_HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        joined = _flatten_call_args(cmd)
+        assert token not in joined, (
+            f"HF token leaked into captured kubectl args: {joined!r}"
+        )
+        # And not into anything pytest captured from stdout/stderr.
+        captured = capsys.readouterr()
+        assert token not in captured.out
+        assert token not in captured.err
+        # And not into anything sent to the (mocked) logger.
+        for call in ctx.logger.method_calls:
+            args_str = " ".join(str(a) for a in call.args)
+            assert token not in args_str, (
+                f"HF token leaked into a logger call: {call!r}"
+            )
+
+    def test_apply_failure_returns_error_redacted_of_token(self, monkeypatch):
+        """If kubectl somehow echoes the token in stderr, we scrub it."""
+        token = "hf_canary_token_for_redaction"
+        monkeypatch.setenv("HF_TOKEN", token)
+
+        # Synthesise a stderr that contains the token to exercise the
+        # belt-and-braces redaction.
+        fake_stderr = f"the server rejected token {token}: 401 Unauthorized"
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=False, stderr=fake_stderr),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert result is not None
+        assert token not in result, f"Token leaked into the surfaced error: {result!r}"
+        assert "<redacted>" in result
+        assert "Failed to create HF token secret" in result
+
+    def test_env_token_fallback_order(self, monkeypatch):
+        """LLMDBENCH_HF_TOKEN is honoured when HF_TOKEN is unset."""
+        token = "hf_from_llmdbench_var"
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setenv("LLMDBENCH_HF_TOKEN", token)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert result is None
+        expected_b64 = base64.b64encode(token.encode("utf-8")).decode("ascii")
+        assert cmd.apply_manifests[0]["data"]["HF_TOKEN"] == expected_b64
+
+    def test_temp_manifest_file_is_deleted_after_apply(self, monkeypatch):
+        """No stale temp file with a base64 token left on disk."""
+        monkeypatch.setenv("HF_TOKEN", "hf_temp_file_cleanup_test")
+
+        captured_path: list[str] = []
+
+        def apply_handler(*args, **kwargs):
+            for i, tok in enumerate(args):
+                if tok == "-f" and i + 1 < len(args):
+                    captured_path.append(args[i + 1])
+                    break
+            return FakeResult(success=True)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=apply_handler,
+        )
+        ctx = _fake_context()
+
+        KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert captured_path, "Apply was not invoked with -f <path>"
+        assert not Path(captured_path[0]).exists(), (
+            "Temp manifest file was not unlinked after apply -- the "
+            "base64 token would persist on disk."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
# Summary

# Problem

The upstream llm-d#1684 made secret/llm-d-hf-token a hard requirement (no optional: true) so any kustomize standup without the Secret hangs every Pod in CreateContainerConfigError, then dies with an opaque "pod readiness timeout"

## Solution

This issue only pertains to `kustomize`, the modelservice/standalone deployment types still tolerant of missing token for non-gated models

Here is what we now do for `kustomize`:

if the Secret already exists in the ns then we will leave it alone, 

if no Secret + no HF_TOKEN env then we will fail fast in 5s with a clear error naming the namespace + telling you to either export HF_TOKEN or kubectl create secret …

if no Secret + env token then we will create it

We also cover the  harness_namespace when it differs from the deploy ns
