### PR TITLE
executor: print detailed step errors in summary

### DIFF
--- a/llmdbenchmark/executor/step.py
+++ b/llmdbenchmark/executor/step.py
@@ -99,12 +99,18 @@ class ExecutionResult:
             lines.append(f"Failed global steps: {len(failed_global)}")
             for r in failed_global:
                 lines.append(f"  - {r}")
+                if r.errors:
+                    for err in r.errors:
+                        lines.append(f"    * Error: {err}")
 
         for sr in self.stack_results:
             if sr.has_errors:
                 lines.append(f"Stack '{sr.stack_name}' failures:")
                 for r in sr.failed_steps:
                     lines.append(f"  - {r}")
+                    if r.errors:
+                        for err in r.errors:
+                            lines.append(f"    * Error: {err}")
 
         if not self.has_errors:
             total = len(self.global_results) + sum(


### PR DESCRIPTION
Currently, when a step fails, the final summary output only logs the step status and its top-level message (via StepResult.__str__). Any detailed errors stored inside the StepResult.errors list (e.g., specific missing templates during render_profiles) are discarded.

This PR updates ExecutionResult.summary() to format and print the individual errors under each failed step.