### PR TITLE
feat: pass routing.proxy.resources through to modelservice values

### DIFF
--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -181,6 +181,10 @@ routing:
 {% if routing.proxy.zapTimeEncoding is defined %}
     zapTimeEncoding: {{ routing.proxy.zapTimeEncoding }}
 {% endif %}
+{% if routing.proxy.resources is defined %}
+    resources:
+{{ routing.proxy.resources | toyaml | indent(6) }}
+{% endif %}
 {% endif %}
 {% if routing.debugLevel is defined %}
     debugLevel: {{ routing.debugLevel }}


### PR DESCRIPTION
The llm-d-modelservice helm chart now supports resource requests/limits on the routing-proxy initContainer. Wire the field through the Jinja template so scenario authors can set CPU/memory for the sidecar.