### PR TITLE
fix: add first=True to routing.proxy.resources indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ The analysis pipeline generates per-request distribution plots, cross-treatment 
 ## Dependencies
 
 - [llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra.git)
-- [llm-d-modelservice](https://github.com/llm-d/llm-d-model-service.git)
+- [llm-d-modelservice v0.4.14](https://github.com/llm-d/llm-d-model-service.git)
 - [inference-perf](https://github.com/kubernetes-sigs/inference-perf)
 - [guidellm](https://github.com/vllm-project/guidellm.git)
 - [vllm](https://github.com/vllm-project/vllm.git)

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -183,7 +183,7 @@ routing:
 {% endif %}
 {% if routing.proxy.resources is defined %}
     resources:
-{{ routing.proxy.resources | toyaml | indent(6) }}
+{{ routing.proxy.resources | toyaml | indent(6, first=True) }}
 {% endif %}
 {% endif %}
 {% if routing.debugLevel is defined %}


### PR DESCRIPTION
## Summary
- Fixes YAML rendering error introduced in #1493
- Without first=True, Jinja indent filter skips the first line, producing invalid YAML where the first key under resources: has no indentation
