### PR TITLE
fix: Handle missing per-path timing fields in FMA analysis

### DIFF
--- a/llmdbenchmark/analysis/scripts/nop-analyze_results.py
+++ b/llmdbenchmark/analysis/scripts/nop-analyze_results.py
@@ -325,12 +325,24 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
             elif actuation_condition == "T_cold_launcher":
                 cold_starts += 1
 
-            t_hot = launcher_info.get("t_wake", {})
-            t_hot_val = float(t_hot["value"]) if isinstance(t_hot, dict) else None
-            t_warm = launcher_info.get("t_instance_create", {})
-            t_warm_val = float(t_warm["value"]) if isinstance(t_warm, dict) else None
-            t_cold = launcher_info.get("t_cold_launcher", {})
-            t_cold_val = float(t_cold["value"]) if isinstance(t_cold, dict) else None
+            t_hot = launcher_info.get("t_wake")
+            t_hot_val = (
+                float(t_hot["value"])
+                if isinstance(t_hot, dict) and "value" in t_hot
+                else None
+            )
+            t_warm = launcher_info.get("t_instance_create")
+            t_warm_val = (
+                float(t_warm["value"])
+                if isinstance(t_warm, dict) and "value" in t_warm
+                else None
+            )
+            t_cold = launcher_info.get("t_cold_launcher")
+            t_cold_val = (
+                float(t_cold["value"])
+                if isinstance(t_cold, dict) and "value" in t_cold
+                else None
+            )
             node = launcher_info.get("launcher_node", "")
 
             pandas_datas.append(


### PR DESCRIPTION
## Summary

Fixes #1496

When an FMA per-path timing field (e.g. `t_wake`, `t_instance_create`, `t_cold_launcher`) is absent from the launcher info, `.get("t_wake", {})` returns an empty dict. Since `isinstance({}, dict)` is `True`, the code proceeds to access `{}["value"]`, raising a `KeyError`.

The fix changes the `.get()` default from `{}` to `None` and adds a `"value" in` guard on the dict access, so missing fields gracefully resolve to `None` instead of crashing.

This unblocks #1465.

## Test plan

- Pre-commit hooks pass (pytest, ruff-format, ruff lint, detect-secrets)
- Run analysis on a results file that has iterations missing one or more of the timing fields and confirm no KeyError is raised

Assisted by Claude Code