### PR TITLE
Restore vLLM (launcher) name that was accidentally removed.

### DIFF
--- a/llmdbenchmark/analysis/scripts/nop-analyze_results.py
+++ b/llmdbenchmark/analysis/scripts/nop-analyze_results.py
@@ -348,6 +348,7 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
             pandas_datas.append(
                 {
                     "Iteration": iteration["iteration"]["value"],
+                    "vLLM Name": launcher_info["name"],
                     "Node": node,
                     "Actuation Condition": actuation_condition,
                     "T_actuation(s)": ttrr,


### PR DESCRIPTION
This minor PR restores the launcher name (vLLM Name in the report) that was accidentally removed when the node name was being added as one of the columns.

Having the launcher name makes it easier to correlate where requesters land on the cluster and launcher re-use between requesters.