### PR TITLE
fix: update broken experiment link in kubecon tutorial

### DIFF
--- a/docs/tutorials/kubecon/README.md
+++ b/docs/tutorials/kubecon/README.md
@@ -200,7 +200,7 @@ And see results in the output directory `~/data/shared-prefix-cache-aware`
 ## PD Disaggregation with vllm-benchmark
 
 - Scenario: [pd-disaggregation.sh](./scenarios/pd-disaggregation.sh)
-- Experiment: [pd-disaggregation.yaml](https://raw.githubusercontent.com/llm-d/llm-d-benchmark/refs/heads/main/workload/experiments/pd-disaggregation.yaml)
+- Experiment: [pd-disaggregation.yaml](https://raw.githubusercontent.com/llm-d/llm-d-benchmark/refs/heads/main/experiments/pd-disaggregation.yaml)
 
 Command (from `llm-d-benchmark` root directory):
 


### PR DESCRIPTION
  ## Summary
  - Fix broken markdown link in `docs/tutorials/kubecon/README.md`
  - `pd-disaggregation.yaml` moved from `workload/experiments/` to `experiments/` in #1499 but this link was not updated
  - This broken link blocks the `lint-and-test` CI check on all open PRs

  ## Test plan
  - [ ] `lint-and-test` CI passes