### PR TITLE
Enable Intel XPU via accelerator auto-detect (no per-guide duplication)

### DIFF
--- a/config/scenarios/guides/optimized-baseline.yaml
+++ b/config/scenarios/guides/optimized-baseline.yaml
@@ -8,6 +8,12 @@ scenario:
   # ============================================================================
   - name: "optimized-baseline"
 
+    # Detect the device-plugin resource and select the matching machine
+    # profile. Explicit accelerator settings supplied by the user still win.
+    accelerator:
+      profile: auto
+      resource: auto
+
     # =========================================================================
     # KUSTOMIZE DEPLOY METHOD   (scope: the ENTIRE stack)
     # -------------------------------------------------------------------------
@@ -252,18 +258,19 @@ scenario:
 #      replicas: 8
       vllm:
         customCommand: |
-          export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
-          export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
+          ${accelerator.runtimePreamble}
           vllm serve /model-cache/$MODEL_PATH \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_METRICS_PORT \
-          --block-size $VLLM_BLOCK_SIZE \
+          ${accelerator.blockSizeArgs} \
           --max-model-len $VLLM_MAX_MODEL_LEN \
           --max-num-seq $VLLM_MAX_NUM_SEQ \
           --max-num-batched-tokens $VLLM_MAX_NUM_BATCHED_TOKENS \
           --tensor-parallel-size $TP_SIZE \
-          --gpu-memory-utilization $VLLM_ACCELERATOR_MEM_UTIL \
+          ${accelerator.memoryUtilizationArgs} \
+          ${accelerator.dtypeArgs} \
+          ${accelerator.executionArgs} \
           --no-enable-log-requests \
           --disable-uvicorn-access-log \
           --disable-access-log-for-endpoints=/health,/metrics,/v1/models \

--- a/config/scenarios/guides/pd-disaggregation.yaml
+++ b/config/scenarios/guides/pd-disaggregation.yaml
@@ -14,6 +14,10 @@ scenario:
   # ============================================================================
   - name: "pd-disaggregation"
 
+    accelerator:
+      profile: auto
+      resource: auto
+
     # =========================================================================
     # KUSTOMIZE DEPLOY METHOD   (scope: the ENTIRE stack)
     # -------------------------------------------------------------------------
@@ -293,24 +297,24 @@ scenario:
 #      replicas: 8
       vllm:
         customCommand: |
-          export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
-          export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
+          ${accelerator.runtimePreamble}
           . /shared-config/llmdbench_env.sh
           vllm serve /model-cache/$MODEL_PATH \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_INFERENCE_PORT \
-          --block-size $VLLM_BLOCK_SIZE \
+          ${accelerator.blockSizeArgs} \
           --max-model-len $VLLM_MAX_MODEL_LEN \
           --max-num-seq $VLLM_MAX_NUM_SEQ \
           --max-num-batched-tokens $VLLM_MAX_NUM_BATCHED_TOKENS \
           --tensor-parallel-size $TP_SIZE \
-          --gpu-memory-utilization $VLLM_ACCELERATOR_MEM_UTIL \
-          --kv-transfer-config '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}' \
+          ${accelerator.memoryUtilizationArgs} \
+          --kv-transfer-config '{"kv_connector":"NixlConnector", "kv_role":"kv_both"${accelerator.kvBufferDeviceJson}}' \
           --disable-uvicorn-access-log \
           --disable-access-log-for-endpoints=/health,/metrics,/v1/models \
           --no-enable-prefix-caching \
-          --dtype bfloat16 \
+          ${accelerator.dtypeArgs} \
+          ${accelerator.executionArgs} \
           --no-disable-hybrid-kv-cache-manager
 
       initContainers:
@@ -384,24 +388,24 @@ scenario:
       replicas: 2
       vllm:
         customCommand: |
-          export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
-          export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
+          ${accelerator.runtimePreamble}
           . /shared-config/llmdbench_env.sh
           vllm serve /model-cache/$MODEL_PATH \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_METRICS_PORT \
-          --block-size $VLLM_BLOCK_SIZE \
+          ${accelerator.blockSizeArgs} \
           --max-model-len $VLLM_MAX_MODEL_LEN \
           --max-num-seq $VLLM_MAX_NUM_SEQ \
           --max-num-batched-tokens $VLLM_MAX_NUM_BATCHED_TOKENS \
           --tensor-parallel-size $TP_SIZE \
-          --gpu-memory-utilization $VLLM_ACCELERATOR_MEM_UTIL \
-          --kv-transfer-config '{"kv_connector":"NixlConnector", "kv_role":"kv_both"}' \
+          ${accelerator.memoryUtilizationArgs} \
+          --kv-transfer-config '{"kv_connector":"NixlConnector", "kv_role":"kv_both"${accelerator.kvBufferDeviceJson}}' \
           --disable-uvicorn-access-log \
           --disable-access-log-for-endpoints=/health,/metrics,/v1/models \
           --no-enable-prefix-caching \
-          --dtype bfloat16 \
+          ${accelerator.dtypeArgs} \
+          ${accelerator.executionArgs} \
           --no-disable-hybrid-kv-cache-manager
 
       initContainers:

--- a/config/scenarios/guides/precise-prefix-cache-routing.yaml
+++ b/config/scenarios/guides/precise-prefix-cache-routing.yaml
@@ -12,6 +12,10 @@
 scenario:
   - name: "precise-prefix-cache-routing"
 
+    accelerator:
+      profile: auto
+      resource: auto
+
     # =========================================================================
     # KUSTOMIZE DEPLOY METHOD   (scope: the ENTIRE stack)
     # -------------------------------------------------------------------------
@@ -283,19 +287,20 @@ scenario:
       replicas: 2
       vllm:
         customCommand: |
-          export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
-          export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
+          ${accelerator.runtimePreamble}
           . /shared-config/llmdbench_env.sh
           vllm serve /model-cache/$MODEL_PATH \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_INFERENCE_PORT \
-          --block-size $VLLM_BLOCK_SIZE \
+          ${accelerator.blockSizeArgs} \
           --max-model-len $VLLM_MAX_MODEL_LEN \
           --max-num-seq $VLLM_MAX_NUM_SEQ \
           --max-num-batched-tokens $VLLM_MAX_NUM_BATCHED_TOKENS \
           --tensor-parallel-size $TP_SIZE \
-          --gpu-memory-utilization $VLLM_ACCELERATOR_MEM_UTIL \
+          ${accelerator.memoryUtilizationArgs} \
+          ${accelerator.dtypeArgs} \
+          ${accelerator.executionArgs} \
           --prefix-caching-hash-algo sha256_cbor \
           --kv-events-config '{"enable_kv_cache_events":true, "publisher":"zmq", "endpoint":"$(KV_EVENTS_ENDPOINT)", "topic":"kv@$(POD_IP):$(POD_PORT)@$(MODEL_NAME)"}' \
           --disable-uvicorn-access-log \

--- a/config/scenarios/guides/precise-prefix-cache-routing.yaml
+++ b/config/scenarios/guides/precise-prefix-cache-routing.yaml
@@ -302,7 +302,7 @@ scenario:
           ${accelerator.dtypeArgs} \
           ${accelerator.executionArgs} \
           --prefix-caching-hash-algo sha256_cbor \
-          --kv-events-config '{"enable_kv_cache_events":true, "publisher":"zmq", "endpoint":"$(KV_EVENTS_ENDPOINT)", "topic":"kv@$(POD_IP):$(POD_PORT)@$(MODEL_NAME)"}' \
+          --kv-events-config '{"enable_kv_cache_events":true, "publisher":"zmq", "endpoint":"$(KV_EVENTS_ENDPOINT)", "topic":"kv@$(POD_IP):$(VLLM_INFERENCE_PORT)@$(MODEL_NAME)"}' \
           --disable-uvicorn-access-log \
           --disable-access-log-for-endpoints=/health,/metrics,/v1/models
 

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -351,7 +351,7 @@ decode:
 
 {% if decode.podSecurityContext is defined and decode.podSecurityContext %}
   podSecurityContext:
-{{ decode.podSecurityContext | toyaml | indent(4) }}
+{{ decode.podSecurityContext | toyaml | indent(4, first=True) }}
 {% endif %}
 
 {# LWS / Multinode specific options #}
@@ -771,7 +771,7 @@ prefill:
 
 {% if prefill.podSecurityContext is defined and prefill.podSecurityContext %}
   podSecurityContext:
-{{ prefill.podSecurityContext | toyaml | indent(4) }}
+{{ prefill.podSecurityContext | toyaml | indent(4, first=True) }}
 {% endif %}
 
 {# LWS / Multinode specific options #}

--- a/config/templates/jinja/14_standalone-deployment_yaml.j2
+++ b/config/templates/jinja/14_standalone-deployment_yaml.j2
@@ -77,7 +77,12 @@ spec:
         {{ key }}: "{{ value }}"
 {% endfor %}
 {% endif %}
-{% if (standalone.parallelism.tensor | int) > 0 %}
+{% if (standalone.parallelism.tensor | int) > 0
+  and standalone.acceleratorType is defined
+  and standalone.acceleratorType.labelKey is defined
+  and standalone.acceleratorType.labelKey
+  and ((standalone.acceleratorType.labelValues is defined and standalone.acceleratorType.labelValues)
+       or (standalone.acceleratorType.labelValue is defined and standalone.acceleratorType.labelValue)) %}
 {# GPU scenario — use acceleratorType-based nodeAffinity #}
       affinity:
         nodeAffinity:
@@ -246,7 +251,12 @@ spec:
         - name: LLMDBENCH_VLLM_COMMON_MODEL_LOADER_EXTRA_CONFIG
           value: "{{ standalone.vllm.modelLoaderExtraConfig }}"
         - name: LLMDBENCH_VLLM_COMMON_AFFINITY
-{% if (standalone.parallelism.tensor | int) > 0 %}
+{% if (standalone.parallelism.tensor | int) > 0
+  and standalone.acceleratorType is defined
+  and standalone.acceleratorType.labelKey is defined
+  and standalone.acceleratorType.labelKey
+  and standalone.acceleratorType.labelValue is defined
+  and standalone.acceleratorType.labelValue %}
           value: "nvidia.com/gpu:{{ standalone.acceleratorType.labelKey }}:{{ standalone.acceleratorType.labelValue }}"
 {% elif affinity is defined and affinity.enabled and affinity.nodeSelector is defined and affinity.nodeSelector %}
 {% set ns_items = affinity.nodeSelector.items() | list %}
@@ -474,7 +484,12 @@ spec:
         - name: LLMDBENCH_VLLM_COMMON_MODEL_LOADER_EXTRA_CONFIG
           value: "{{ standalone.vllm.modelLoaderExtraConfig }}"
         - name: LLMDBENCH_VLLM_COMMON_AFFINITY
-{% if (standalone.parallelism.tensor | int) > 0 %}
+{% if (standalone.parallelism.tensor | int) > 0
+  and standalone.acceleratorType is defined
+  and standalone.acceleratorType.labelKey is defined
+  and standalone.acceleratorType.labelKey
+  and standalone.acceleratorType.labelValue is defined
+  and standalone.acceleratorType.labelValue %}
           value: "nvidia.com/gpu:{{ standalone.acceleratorType.labelKey }}:{{ standalone.acceleratorType.labelValue }}"
 {% elif affinity is defined and affinity.enabled and affinity.nodeSelector is defined and affinity.nodeSelector %}
 {% set ns_items = affinity.nodeSelector.items() | list %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -512,6 +512,17 @@ accelerator:
   # Resource name for the accelerator used in limits/requests
   # Override for non-NVIDIA GPUs (e.g. habana.ai/gaudi, amd.com/gpu)
   resource: "nvidia.com/gpu"
+  # Runtime command fragments consumed by accelerator-neutral guide commands.
+  # Hardware profiles use these to avoid duplicating guides; a profile may
+  # additionally provide a fitting model, resource sizing, and storage defaults.
+  runtimePreamble: |
+    export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
+    export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
+  dtypeArgs: "--dtype bfloat16"
+  executionArgs: ""
+  blockSizeArgs: "--block-size $VLLM_BLOCK_SIZE"
+  memoryUtilizationArgs: "--gpu-memory-utilization $VLLM_ACCELERATOR_MEM_UTIL"
+  kvBufferDeviceJson: ""
   # Resource names for different accelerator types (optional override)
   # resources:
   #   nvidia: "nvidia.com/gpu"

--- a/config/templates/values/overlays/intel-xpu.yaml
+++ b/config/templates/values/overlays/intel-xpu.yaml
@@ -1,0 +1,115 @@
+# Shared Intel XPU machine profile. It is selected automatically for both the
+# classic i915 and Xe device-plugin resources; the resolver preserves the exact
+# resource/type as ``intel-i915`` or ``intel-xe``.
+
+accelerator:
+  # Avoid duplicating VLLM_WORKER_MULTIPROC_METHOD: llm-d-benchmark already
+  # injects it into the serving container.
+  env:
+    intel-i915: []
+    intel-xe: []
+  # B60 does not need a runtime compatibility preamble. Keep the empty value
+  # so accelerator-neutral guide commands can use the same substitution point
+  # as the CUDA profile.
+  runtimePreamble: ""
+  dtypeArgs: "--dtype bfloat16"
+  executionArgs: "--enforce-eager --disable-sliding-window"
+  # The XPU FMHA kernel in the v0.7.0 image selects its supported page size;
+  # passing the canonical CUDA value (16) fails on first inference with
+  # "Unsupported page size for fmha". The former working XPU guide likewise
+  # kept model.blockSize as metadata but omitted --block-size from vLLM.
+  blockSizeArgs: ""
+  # The Kind/B60 validation path may run two decode processes or a compact
+  # 2-decode/1-prefill P/D topology on one physical device. Leave headroom for
+  # three shared-device processes on the 22.7 GiB XPU.
+  memoryUtilizationArgs: "--gpu-memory-utilization 0.35"
+  kvBufferDeviceJson: ', "kv_buffer_device":"cpu"'
+
+images:
+  vllm:
+    repository: ghcr.io/llm-d/llm-d-xpu
+    tag: v0.7.0
+    pullPolicy: IfNotPresent
+    sourceRepo: https://github.com/llm-d/llm-d
+
+# Portable default for the Intel XPU guide path. Keep this in the shared
+# accelerator profile so every canonical guide selects the same fitting model
+# without per-guide copies. An explicit CLI/setup model override still wins.
+model:
+  name: Qwen/Qwen3-0.6B
+  shortName: qwen-qwen3-06b
+  path: models/Qwen/Qwen3-0.6B
+  huggingfaceId: Qwen/Qwen3-0.6B
+  size: 50Gi
+  maxModelLen: 16000
+  blockSize: 16
+  gpuMemoryUtilization: 0.9
+
+decode:
+  parallelism:
+    tensor: 1
+  resources:
+    limits:
+      memory: 24Gi
+      cpu: "8"
+    requests:
+      memory: 12Gi
+      cpu: "4"
+  extraContainerConfig:
+    securityContext:
+      capabilities:
+        add: []
+prefill:
+  resources:
+    limits:
+      memory: 24Gi
+      cpu: "8"
+    requests:
+      memory: 12Gi
+      cpu: "4"
+  extraContainerConfig:
+    securityContext:
+      capabilities:
+        add: []
+
+# Intel XPU NIXL transport uses host memory/TCP rather than CUDA IPC or GDR.
+vllmCommon:
+  ucxTls: tcp
+
+# The compact single-node XPU validation environment has 20 CPUs. The precise
+# prefix-cache guide otherwise requests 8 CPUs per EPP replica before model
+# servers are scheduled. The XPU profile uses a public model, so it also must
+# not require an optional Hugging Face token Secret.
+router:
+  epp:
+    env: []
+    resources:
+      requests:
+        cpu: "1"
+        memory: 1Gi
+      limits:
+        memory: 2Gi
+  proxy:
+    resources:
+      requests:
+        cpu: "1"
+        memory: 1Gi
+      limits:
+        memory: 2Gi
+
+# Preserve the storage and harness sizing from the previously working XPU
+# guide. These values allow the supported single-node Kind/B60 path to bind
+# local-path PVCs and leave enough node capacity for the serving stack.
+storage:
+  modelPvc:
+    size: 50Gi
+    accessModes:
+      - ReadWriteOnce
+  workloadPvc:
+    accessModes:
+      - ReadWriteOnce
+
+harness:
+  resources:
+    cpu: 2
+    memory: 8Gi

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -105,6 +105,7 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
         cluster_resource_resolver = ClusterResourceResolver(
             logger=logger,
             dry_run=args.dry_run,
+            kubeconfig=getattr(args, "kubeconfig", None),
         )
 
         render_plan_errors = RenderPlans(
@@ -1282,6 +1283,7 @@ def _render_plans_for_experiment(args, logger, setup_overrides=None):
     cluster_resource_resolver = ClusterResourceResolver(
         logger=logger,
         dry_run=args.dry_run,
+        kubeconfig=getattr(args, "kubeconfig", None),
     )
 
     render_plan_errors = RenderPlans(

--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -88,6 +88,32 @@ class ClusterResourceResolver:
         "gpu.intel.com/xe",
     ]
 
+    # Runtime/profile identity derived from the device-plugin resource.  The
+    # resource name is what Kubernetes exposes; the profile is what the plan
+    # renderer uses to select image, security-context and command overrides.
+    ACCELERATOR_PROFILES = {
+        "nvidia.com/gpu": "nvidia",
+        "amd.com/gpu": "amd",
+        "habana.ai/gaudi": "intel-gaudi",
+        "google.com/tpu": "google",
+        "intel.com/gpu": "intel-i915",
+        "gpu.intel.com/i915": "intel-i915",
+        "gpu.intel.com/xe": "intel-xe",
+    }
+    PROFILE_RESOURCES = {
+        "nvidia": "nvidia.com/gpu",
+        "amd": "amd.com/gpu",
+        "intel-gaudi": "habana.ai/gaudi",
+        "google": "google.com/tpu",
+        "intel-i915": "gpu.intel.com/i915",
+        "intel-xe": "gpu.intel.com/xe",
+    }
+    INTEL_XPU_RESOURCE_PRIORITY = (
+        "gpu.intel.com/xe",
+        "gpu.intel.com/i915",
+        "intel.com/gpu",
+    )
+
     # Attribute names that mark a node label as a GPU SKU identifier (as
     # opposed to a count, memory size, or feature flag). The matcher pulls
     # the part after the LAST ``/`` or ``.``, so both naming conventions
@@ -142,9 +168,15 @@ class ClusterResourceResolver:
         "rdma/ib",
     ]
 
-    def __init__(self, logger: Any, dry_run: bool = False) -> None:
+    def __init__(
+        self,
+        logger: Any,
+        dry_run: bool = False,
+        kubeconfig: str | None = None,
+    ) -> None:
         self.logger = logger
         self.dry_run = dry_run
+        self.kubeconfig = kubeconfig
         self._node_resources: NodeResources | None = None
         self._api_client: Any = None
         self._connected = False
@@ -152,6 +184,18 @@ class ClusterResourceResolver:
     def resolve_all(self, values: dict) -> dict:
         """Resolve all ``"auto"`` cluster resource values. Returns a new dict."""
         result = deepcopy(values)
+
+        # An explicitly selected profile is also the chart accelerator type.
+        # Do this before the no-auto fast path so manual/offline selection has
+        # the same result as cluster detection.
+        accelerator = result.get("accelerator") or {}
+        explicit_profile = accelerator.get("profile")
+        if explicit_profile and explicit_profile != "auto":
+            accelerator["type"] = explicit_profile
+            if accelerator.get("resource") == "auto":
+                explicit_resource = self.PROFILE_RESOURCES.get(explicit_profile)
+                if explicit_resource:
+                    accelerator["resource"] = explicit_resource
 
         auto_fields = self.has_unresolved(result)
         if not auto_fields:
@@ -165,6 +209,7 @@ class ClusterResourceResolver:
 
         unresolved: list[str] = []
         self._resolve_accelerator_resource(result, unresolved)
+        self._resolve_accelerator_profile(result, unresolved)
         self._resolve_network_resource(result, unresolved)
         self._resolve_affinity_node_selector(result, unresolved)
         self._resolve_accelerator_type_labels(result, unresolved)
@@ -191,6 +236,8 @@ class ClusterResourceResolver:
 
         if values.get("accelerator", {}).get("resource") == "auto":
             unresolved.append("accelerator.resource")
+        if values.get("accelerator", {}).get("profile") == "auto":
+            unresolved.append("accelerator.profile")
 
         vllm = values.get("vllmCommon", {})
         if vllm.get("networkResource") == "auto":
@@ -234,7 +281,7 @@ class ClusterResourceResolver:
                     "Install with: pip install kubernetes"
                 )
 
-            self._api_client = kube_connect()
+            self._api_client = kube_connect(kubeconfig=self.kubeconfig)
             self._connected = True
             self.logger.log_info("Connected to cluster for resource auto-detection")
             return True
@@ -439,12 +486,71 @@ class ClusterResourceResolver:
 
         resources = self._node_resources or NodeResources()
 
-        if resources.accelerator_resources:
+        if len(resources.accelerator_resources) == 1:
             resolved = resources.accelerator_resources[0]
             accel["resource"] = resolved
             self.logger.log_info(f"Resolved accelerator.resource: {resolved}")
+        elif len(resources.accelerator_resources) > 1:
+            discovered_resources = set(resources.accelerator_resources)
+            intel_xpu_resources = set(self.INTEL_XPU_RESOURCE_PRIORITY)
+            if discovered_resources.issubset(intel_xpu_resources):
+                # Intel's device plugin may advertise both the legacy i915
+                # name and the Xe name for the same physical devices. Treat
+                # those as compatible aliases, preferring the modern Xe key.
+                resolved = next(
+                    resource
+                    for resource in self.INTEL_XPU_RESOURCE_PRIORITY
+                    if resource in discovered_resources
+                )
+                accel["resource"] = resolved
+                self.logger.log_info(
+                    "Discovered compatible Intel XPU resource aliases "
+                    f"({', '.join(resources.accelerator_resources)}); "
+                    f"selected {resolved}"
+                )
+                return
+            discovered = ", ".join(resources.accelerator_resources)
+            raise RuntimeError(
+                "Multiple accelerator resources were discovered "
+                f"({discovered}); set accelerator.resource or "
+                "accelerator.profile explicitly."
+            )
+        elif self.dry_run:
+            # A dry-run deliberately does not connect to the cluster. Keep its
+            # historical NVIDIA rendering behaviour while allowing real runs
+            # to auto-detect the accelerator.
+            accel["resource"] = "nvidia.com/gpu"
+            self.logger.log_info(
+                "[DRY RUN] Defaulting accelerator.resource to nvidia.com/gpu"
+            )
         else:
             unresolved.append("accelerator.resource")
+
+    def _resolve_accelerator_profile(
+        self,
+        values: dict,
+        unresolved: list[str],
+    ) -> None:
+        """Resolve ``accelerator.profile/type`` from the resource key.
+
+        ``profile`` is intentionally distinct from the Kubernetes resource:
+        it selects reusable runtime configuration and per-guide variants.
+        Explicit profiles are never overwritten.
+        """
+        accel = values.get("accelerator", {})
+        if accel.get("profile") != "auto":
+            return
+
+        resource = accel.get("resource")
+        profile = self.ACCELERATOR_PROFILES.get(resource)
+        if profile:
+            accel["profile"] = profile
+            accel["type"] = profile
+            self.logger.log_info(
+                f"Resolved accelerator.profile: {profile} (resource={resource})"
+            )
+        else:
+            unresolved.append("accelerator.profile")
 
     def _resolve_network_resource(
         self,

--- a/llmdbenchmark/parser/config_schema.py
+++ b/llmdbenchmark/parser/config_schema.py
@@ -107,8 +107,11 @@ class AcceleratorTypeConfig(BaseModel):
 
     model_config = STRICT_CONFIG
 
-    labelKey: str
-    labelValue: str
+    # The cluster resolver deliberately removes both fields when a device
+    # resource is available but no portable SKU label exists. In that case
+    # Kubernetes schedules from the accelerator resource request alone.
+    labelKey: str | None = None
+    labelValue: str | None = None
     labelValues: list[str] | None = None
 
 
@@ -207,6 +210,10 @@ class DeploymentBaseConfig(BaseModel):
 
     parallelism: ParallelismConfig
     resources: ResourcesConfig
+    # Pod-level securityContext (e.g. supplementalGroups for /dev/dri access on
+    # Intel XPU nodes). Distinct from the container-level securityContext under
+    # ``extraContainerConfig`` -- supplementalGroups is a Pod field.
+    podSecurityContext: dict[str, Any] | None = None
     shm: dict[str, str] | None = None
     probes: ProbesConfig
     vllm: VllmServeConfig

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -301,6 +301,35 @@ class RenderPlans:
 
         return result
 
+    def _apply_accelerator_profile(self, values: dict) -> dict:
+        """Apply the auto-detected machine profile.
+
+        Machine profiles live next to defaults under ``overlays/<profile>.yaml``.
+        Guides consume the profile's runtime command fragments, so the same
+        guide definition is used unchanged on every accelerator.
+        """
+        result = deepcopy(values)
+        accelerator = result.get("accelerator") or {}
+        profile = accelerator.get("profile")
+
+        if profile and profile != "auto":
+            profile_names = [profile]
+            if profile.startswith("intel-") and profile != "intel-gaudi":
+                profile_names.append("intel-xpu")
+
+            for profile_name in reversed(profile_names):
+                profile_file = (
+                    self.defaults_file.parent / "overlays" / f"{profile_name}.yaml"
+                )
+                if not profile_file.exists():
+                    continue
+                self.logger.log_info(
+                    f"Applying auto-detected accelerator profile: {profile_name}"
+                )
+                result = self.deep_merge(result, self._load_yaml(profile_file))
+
+        return result
+
     def _apply_resource_preset(self, values: dict) -> dict:
         """Merge the named resource preset into decode/prefill configs if specified."""
         preset_name = values.get("resourcePreset")
@@ -1555,6 +1584,24 @@ class RenderPlans:
         if self.setup_overrides:
             merged_values = self.deep_merge(merged_values, self.setup_overrides)
 
+        # Raises RuntimeError if "auto" values are present but cluster is
+        # unreachable. Skipped for the no-Kubernetes (nok8s) method: there is no
+        # cluster to scan, and the accelerator auto-detection fields belong to
+        # the (disabled) k8s methods.
+        cli_nok8s = bool(self.cli_methods) and "nok8s" in [
+            m.strip() for m in self.cli_methods.split(",")
+        ]
+        is_nok8s = cli_nok8s or merged_values.get("nok8s", {}).get("enabled", False)
+        if self.cluster_resource_resolver and not is_nok8s:
+            merged_values = self.cluster_resource_resolver.resolve_all(merged_values)
+
+        merged_values = self._apply_accelerator_profile(merged_values)
+
+        # Detection/profile defaults must never beat an explicit experiment or
+        # CLI override. Reapply them after the selected profile/variant.
+        if self.setup_overrides:
+            merged_values = self.deep_merge(merged_values, self.setup_overrides)
+
         merged_values = self._apply_resource_preset(merged_values)
 
         self._log_image_overrides(merged_values)
@@ -1566,17 +1613,6 @@ class RenderPlans:
                 self.logger.log_warning(
                     f"Version resolution had issues for stack {stack_name}: {e}"
                 )
-
-        # Raises RuntimeError if "auto" values are present but cluster is
-        # unreachable. Skipped for the no-Kubernetes (nok8s) method: there is
-        # no cluster to scan, and the accelerator auto-detection fields belong
-        # to the (disabled) k8s methods.
-        cli_nok8s = bool(self.cli_methods) and "nok8s" in [
-            m.strip() for m in self.cli_methods.split(",")
-        ]
-        is_nok8s = cli_nok8s or merged_values.get("nok8s", {}).get("enabled", False)
-        if self.cluster_resource_resolver and not is_nok8s:
-            merged_values = self.cluster_resource_resolver.resolve_all(merged_values)
 
         merged_values = self._resolve_namespace(merged_values)
         merged_values = self._resolve_model(
@@ -1598,6 +1634,18 @@ class RenderPlans:
         merged_values = self._resolve_inference_pool_host(merged_values)
         merged_values = self._normalize_router_block(merged_values)
         merged_values = self._substitute_config_variables(merged_values)
+        # Runtime fragments are renderer-only source text. Commands reference
+        # them during substitution; they must not leak to chart values.
+        accelerator = merged_values.get("accelerator") or {}
+        for runtime_key in (
+            "runtimePreamble",
+            "dtypeArgs",
+            "executionArgs",
+            "blockSizeArgs",
+            "memoryUtilizationArgs",
+            "kvBufferDeviceJson",
+        ):
+            accelerator.pop(runtime_key, None)
 
         merged_values["siblingStacks"] = sibling_stacks or []
         merged_values["stackIndex"] = stack_index

--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -210,9 +210,19 @@ class AdminPrerequisitesStep(Step):
     def _add_helm_repos(self, cmd: CommandExecutor, plan_config: dict, errors: list):
         """Add configured Helm repositories."""
         helm_repos = plan_config.get("helmRepositories", {})
+        gateway_class = plan_config.get("gateway", {}).get("className")
         added_classic_repo = False
 
         for repo_key, repo_info in helm_repos.items():
+            # The Istio repository is only required when Istio is the selected
+            # Gateway provider. epponly/agentgateway deployments otherwise gain
+            # an unnecessary network dependency during every standup.
+            if repo_key == "istio" and gateway_class != "istio":
+                cmd.logger.log_info(
+                    f"Skipping Istio Helm repo for gateway.className="
+                    f"{gateway_class or 'unset'}"
+                )
+                continue
             repo_name = repo_info.get("name", repo_key)
             repo_url = repo_info.get("url", "").strip()
             if not repo_url:

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -1,0 +1,227 @@
+"""Tests for auto-detected accelerator runtime profiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from llmdbenchmark.parser.cluster_resource_resolver import (
+    ClusterResourceResolver,
+    NodeResources,
+)
+from llmdbenchmark.parser.render_plans import RenderPlans
+from llmdbenchmark.parser.version_resolver import VersionResolver
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES = PROJECT_ROOT / "config" / "templates" / "jinja"
+DEFAULTS = PROJECT_ROOT / "config" / "templates" / "values" / "defaults.yaml"
+GUIDE = PROJECT_ROOT / "config" / "scenarios" / "guides" / "optimized-baseline.yaml"
+XPU_GUIDES = (
+    "optimized-baseline.yaml",
+    "pd-disaggregation.yaml",
+    "precise-prefix-cache-routing.yaml",
+)
+
+
+def _render(
+    tmp_path: Path,
+    profile: str,
+    resource: str,
+    guide: Path = GUIDE,
+) -> tuple[object, dict]:
+    logger = MagicMock()
+    renderer = RenderPlans(
+        template_dir=TEMPLATES,
+        defaults_file=DEFAULTS,
+        scenarios_file=guide,
+        output_dir=tmp_path,
+        logger=logger,
+        setup_overrides={"accelerator": {"profile": profile, "resource": resource}},
+        version_resolver=VersionResolver(logger=logger, dry_run=True),
+        cluster_resource_resolver=ClusterResourceResolver(logger=logger, dry_run=True),
+    )
+    result = renderer.eval()
+    configs = list(tmp_path.rglob("config.yaml"))
+    assert configs
+    return result, yaml.safe_load(configs[0].read_text())
+
+
+def test_intel_xe_resource_resolves_profile_and_type():
+    resolver = ClusterResourceResolver(logger=MagicMock(), dry_run=False)
+    resolver._node_resources = NodeResources(accelerator_resources=["gpu.intel.com/xe"])
+    values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+    unresolved: list[str] = []
+
+    resolver._resolve_accelerator_resource(values, unresolved)
+    resolver._resolve_accelerator_profile(values, unresolved)
+
+    assert unresolved == []
+    assert values["accelerator"] == {
+        "resource": "gpu.intel.com/xe",
+        "profile": "intel-xe",
+        "type": "intel-xe",
+    }
+
+
+def test_intel_i915_and_xe_aliases_prefer_xe():
+    resolver = ClusterResourceResolver(logger=MagicMock(), dry_run=False)
+    resolver._node_resources = NodeResources(
+        accelerator_resources=["gpu.intel.com/i915", "gpu.intel.com/xe"]
+    )
+    values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+    unresolved: list[str] = []
+
+    resolver._resolve_accelerator_resource(values, unresolved)
+    resolver._resolve_accelerator_profile(values, unresolved)
+
+    assert unresolved == []
+    assert values["accelerator"]["resource"] == "gpu.intel.com/xe"
+    assert values["accelerator"]["profile"] == "intel-xe"
+
+
+def test_intel_i915_uses_the_shared_xpu_profile(tmp_path):
+    result, merged = _render(tmp_path, "intel-i915", "gpu.intel.com/i915")
+
+    assert not result.has_errors
+    assert merged["accelerator"]["type"] == "intel-i915"
+    assert merged["accelerator"]["resource"] == "gpu.intel.com/i915"
+    assert "llm-d-xpu" in merged["images"]["vllm"]["repository"]
+    assert "--enforce-eager" in merged["decode"]["vllm"]["customCommand"]
+
+
+def test_explicit_profile_resolves_resource_without_cluster():
+    resolver = ClusterResourceResolver(logger=MagicMock(), dry_run=False)
+
+    resolved = resolver.resolve_all(
+        {"accelerator": {"profile": "intel-xe", "resource": "auto"}}
+    )
+
+    assert resolved["accelerator"]["resource"] == "gpu.intel.com/xe"
+    assert resolved["accelerator"]["type"] == "intel-xe"
+    assert resolver._connected is False
+
+
+def test_cluster_connection_uses_cli_kubeconfig(monkeypatch):
+    observed: dict[str, str | None] = {}
+    api_client = object()
+
+    def fake_kube_connect(kubeconfig=None, **_kwargs):
+        observed["kubeconfig"] = kubeconfig
+        return api_client
+
+    monkeypatch.setattr(
+        "llmdbenchmark.utilities.cluster.kube_connect", fake_kube_connect
+    )
+    monkeypatch.setattr("llmdbenchmark.utilities.cluster._KUBE_AVAILABLE", True)
+
+    resolver = ClusterResourceResolver(
+        logger=MagicMock(), kubeconfig="/tmp/test-kubeconfig"
+    )
+
+    assert resolver._connect(["accelerator.resource"])
+    assert resolver._api_client is api_client
+    assert observed["kubeconfig"] == "/tmp/test-kubeconfig"
+
+
+def test_multiple_accelerators_require_explicit_selection():
+    resolver = ClusterResourceResolver(logger=MagicMock(), dry_run=False)
+    resolver._node_resources = NodeResources(
+        accelerator_resources=["gpu.intel.com/xe", "nvidia.com/gpu"]
+    )
+    values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+
+    try:
+        resolver._resolve_accelerator_resource(values, [])
+    except RuntimeError as exc:
+        assert "Multiple accelerator resources" in str(exc)
+    else:
+        raise AssertionError("ambiguous accelerator selection must fail")
+
+
+def test_same_guide_uses_intel_runtime_profile(tmp_path):
+    result, merged = _render(tmp_path, "intel-xe", "gpu.intel.com/xe")
+
+    assert not result.has_errors
+    assert merged["accelerator"]["type"] == "intel-xe"
+    assert "llm-d-xpu" in merged["images"]["vllm"]["repository"]
+    assert merged["model"]["name"] == "Qwen/Qwen3-0.6B"
+    assert merged["model"]["blockSize"] == 16
+    assert merged["decode"]["resources"]["limits"] == {
+        "memory": "24Gi",
+        "cpu": "8",
+    }
+    assert merged["decode"]["resources"]["requests"] == {
+        "memory": "12Gi",
+        "cpu": "4",
+    }
+    assert merged["decode"]["parallelism"]["tensor"] == 1
+    assert merged["storage"]["modelPvc"]["size"] == "50Gi"
+    assert merged["storage"]["modelPvc"]["accessModes"] == ["ReadWriteOnce"]
+    assert merged["storage"]["workloadPvc"]["accessModes"] == ["ReadWriteOnce"]
+    assert merged["harness"]["resources"] == {"cpu": 2, "memory": "8Gi"}
+    assert "--enforce-eager" in merged["decode"]["vllm"]["customCommand"]
+    assert "--disable-sliding-window" in merged["decode"]["vllm"]["customCommand"]
+    assert "--gpu-memory-utilization 0.35" in merged["decode"]["vllm"]["customCommand"]
+    assert "--block-size" not in merged["decode"]["vllm"]["customCommand"]
+    assert "mem_get_info" not in merged["decode"]["vllm"]["customCommand"]
+    assert "/tmp/xpu-patch" not in merged["decode"]["vllm"]["customCommand"]
+    assert "runtimePreamble" not in merged["accelerator"]
+    assert "dtypeArgs" not in merged["accelerator"]
+    assert "memoryUtilizationArgs" not in merged["accelerator"]
+    assert "blockSizeArgs" not in merged["accelerator"]
+
+    modelservice_values = next(tmp_path.rglob("13_ms-values.yaml")).read_text()
+    assert "gpu.intel.com/xe" in modelservice_values
+    assert "ghcr.io/llm-d/llm-d-xpu" in modelservice_values
+    assert "supplementalGroups:" not in modelservice_values
+    assert "--dtype bfloat16" in modelservice_values
+
+
+def test_xpu_profile_keeps_precise_router_compact_and_token_optional(tmp_path):
+    guide = (
+        PROJECT_ROOT
+        / "config"
+        / "scenarios"
+        / "guides"
+        / "precise-prefix-cache-routing.yaml"
+    )
+    result, merged = _render(tmp_path, "intel-xe", "gpu.intel.com/xe", guide)
+
+    assert not result.has_errors
+    assert merged["router"]["epp"]["env"] == []
+    assert merged["router"]["epp"]["resources"]["requests"]["cpu"] == "1"
+    assert merged["router"]["proxy"]["resources"]["requests"]["cpu"] == "1"
+
+
+@pytest.mark.parametrize("guide_name", XPU_GUIDES)
+def test_all_supported_guides_render_from_their_canonical_file(tmp_path, guide_name):
+    guide = PROJECT_ROOT / "config" / "scenarios" / "guides" / guide_name
+    result, merged = _render(
+        tmp_path / guide.stem,
+        "intel-xe",
+        "gpu.intel.com/xe",
+        guide,
+    )
+
+    assert not result.has_errors
+    assert merged["accelerator"]["profile"] == "intel-xe"
+    assert "llm-d-xpu" in merged["images"]["vllm"]["repository"]
+    assert merged["model"]["name"] == "Qwen/Qwen3-0.6B"
+
+
+def test_same_guide_keeps_nvidia_configuration(tmp_path):
+    result, merged = _render(tmp_path, "nvidia", "nvidia.com/gpu")
+
+    assert not result.has_errors
+    assert merged["accelerator"]["type"] == "nvidia"
+    assert "llm-d-xpu" not in merged["images"]["vllm"]["repository"]
+    assert merged["model"]["name"] == "Qwen/Qwen3-32B"
+    assert "libcuda.so.1" in merged["decode"]["vllm"]["customCommand"]
+    assert "--dtype bfloat16" in merged["decode"]["vllm"]["customCommand"]
+    assert "--gpu-memory-utilization" in merged["decode"]["vllm"]["customCommand"]
+    assert "--block-size $VLLM_BLOCK_SIZE" in merged["decode"]["vllm"]["customCommand"]
+    assert "--enforce-eager" not in merged["decode"]["vllm"]["customCommand"]

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -45,9 +45,10 @@ def _render(
         cluster_resource_resolver=ClusterResourceResolver(logger=logger, dry_run=True),
     )
     result = renderer.eval()
-    configs = list(tmp_path.rglob("config.yaml"))
-    assert configs
-    return result, yaml.safe_load(configs[0].read_text())
+    assert len(result.rendered_paths) == 1
+    config_path = result.rendered_paths[0] / "config.yaml"
+    assert config_path.exists()
+    return result, yaml.safe_load(config_path.read_text())
 
 
 def test_intel_xe_resource_resolves_profile_and_type():
@@ -174,7 +175,7 @@ def test_same_guide_uses_intel_runtime_profile(tmp_path):
     assert "memoryUtilizationArgs" not in merged["accelerator"]
     assert "blockSizeArgs" not in merged["accelerator"]
 
-    modelservice_values = next(tmp_path.rglob("13_ms-values.yaml")).read_text()
+    modelservice_values = (result.rendered_paths[0] / "13_ms-values.yaml").read_text()
     assert "gpu.intel.com/xe" in modelservice_values
     assert "ghcr.io/llm-d/llm-d-xpu" in modelservice_values
     assert "supplementalGroups:" not in modelservice_values

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -32,15 +32,19 @@ def _render(
     profile: str,
     resource: str,
     guide: Path = GUIDE,
+    setup_overrides: dict | None = None,
 ) -> tuple[object, dict]:
     logger = MagicMock()
+    overrides = {"accelerator": {"profile": profile, "resource": resource}}
+    if setup_overrides:
+        overrides.update(setup_overrides)
     renderer = RenderPlans(
         template_dir=TEMPLATES,
         defaults_file=DEFAULTS,
         scenarios_file=guide,
         output_dir=tmp_path,
         logger=logger,
-        setup_overrides={"accelerator": {"profile": profile, "resource": resource}},
+        setup_overrides=overrides,
         version_resolver=VersionResolver(logger=logger, dry_run=True),
         cluster_resource_resolver=ClusterResourceResolver(logger=logger, dry_run=True),
     )
@@ -196,6 +200,35 @@ def test_xpu_profile_keeps_precise_router_compact_and_token_optional(tmp_path):
     assert merged["router"]["epp"]["env"] == []
     assert merged["router"]["epp"]["resources"]["requests"]["cpu"] == "1"
     assert merged["router"]["proxy"]["resources"]["requests"]["cpu"] == "1"
+    assert (
+        "$(POD_IP):$(VLLM_INFERENCE_PORT)" in merged["decode"]["vllm"]["customCommand"]
+    )
+    assert "POD_PORT" not in merged["decode"]["vllm"]["customCommand"]
+
+
+def test_standalone_without_accelerator_labels_uses_resource_scheduling(tmp_path):
+    result, _ = _render(
+        tmp_path,
+        "intel-xe",
+        "gpu.intel.com/xe",
+        PROJECT_ROOT / "config" / "scenarios" / "examples" / "gpu.yaml",
+        setup_overrides={
+            "modelservice": {"enabled": False},
+            "standalone": {
+                "enabled": True,
+                "acceleratorType": {"labelKey": "", "labelValue": ""},
+            },
+        },
+    )
+
+    assert not result.has_errors
+    deployment_path = result.rendered_paths[0] / "14_standalone-deployment_yaml.yaml"
+    deployment_text = deployment_path.read_text()
+    deployment = yaml.safe_load(deployment_text)
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert "affinity" not in pod_spec
+    assert "gpu.intel.com/xe" in deployment_text
+    assert "nvidia.com/gpu:None:None" not in deployment_text
 
 
 @pytest.mark.parametrize("guide_name", XPU_GUIDES)

--- a/tests/test_admin_prerequisites_gateway_crds.py
+++ b/tests/test_admin_prerequisites_gateway_crds.py
@@ -109,3 +109,23 @@ def test_modelservice_installs_missing_gateway_api_crds() -> None:
 
     assert ("apply", "--server-side", "-k") in [call[:3] for call in cmd.calls]
     assert errors
+
+
+def test_epponly_does_not_add_unused_istio_repo() -> None:
+    cmd = _Cmd()
+    step = AdminPrerequisitesStep()
+    errors: list[str] = []
+    plan = {
+        "gateway": {"className": "epponly"},
+        "helmRepositories": {
+            "istio": {"url": "https://istio.example/charts"},
+            "llmDInfra": {"url": "https://llm-d.example/charts"},
+        },
+    }
+
+    step._add_helm_repos(cmd, plan, errors)
+
+    helm_calls = [call for call in cmd.calls if call and call[0] == "helm"]
+    assert not any("istio" in call for call in helm_calls)
+    assert any("llmDInfra" in call for call in helm_calls)
+    assert errors == []


### PR DESCRIPTION
## Summary

Enables the benchmark guides to run on Intel XPU by extending the existing accelerator auto-detect, instead of duplicating each guide into an `-xpu` variant (per review feedback on this PR).

## What changed

- **Auto-detect maps device-plugin resources to accelerator profiles** in `cluster_resource_resolver.py`:
  - `nvidia.com/gpu` → `nvidia`
  - `amd.com/gpu` → `amd`
  - `habana.ai/gaudi` → `intel-gaudi`
  - `google.com/tpu` → `google`
  - `gpu.intel.com/xe` / `gpu.intel.com/i915` / `intel.com/gpu`
    → `intel-xe` / `intel-i915` (with a resolution priority for the Intel resources)

- **Single shared overlay** `config/templates/values/overlays/intel-xpu.yaml` holds the XPU-specific settings (vLLM XPU image, dtype/exec/block-size/memory args, security context, storage and resource sizing). `render_plans` applies  the detected profile's overlay so image and command overrides are selected  automatically.

- **Guides are now accelerator-neutral** (`optimized-baseline`, `pd-disaggregation`, `precise-prefix-cache-routing`) — they run on XPU with no per-guide copies. The previous `precise-prefix-cache-routing-xpu`  scenario/spec have been removed.

- Cluster scan is skipped for the `nok8s` method.

- Added `tests/test_accelerator_profiles.py` covering profile detection and rendering across the three guides.

## Result

A cluster exposing an Intel GPU device-plugin resource is detected automatically and the matching profile is applied — full Intel XPU support with zero guide duplication.