### PR TITLE
skip gateway API installation in Openshift

### DIFF
--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -117,6 +117,7 @@ class AdminPrerequisitesStep(Step):
 
         self._install_gateway_api_crds(
             cmd,
+            context,
             plan_config,
             errors,
             existing_crds,
@@ -235,6 +236,7 @@ class AdminPrerequisitesStep(Step):
     def _install_gateway_api_crds(
         self,
         cmd: CommandExecutor,
+        context: ExecutionContext,
         plan_config: dict,
         errors: list,
         existing_crds: list[str],
@@ -243,6 +245,13 @@ class AdminPrerequisitesStep(Step):
         if plan_config.get("gateway", {}).get("externallyManaged", False):
             cmd.logger.log_info(
                 "✅ Gateway is externally managed — skipping Gateway API CRD install"
+            )
+            return
+
+        if context.is_openshift:
+            cmd.logger.log_info(
+                "✅ OpenShift detected — using platform-bundled Gateway API "
+                "(skipping CRD install)"
             )
             return
 


### PR DESCRIPTION
In Openshift, the Gateway API CRDs are managed by the Ingress Operator, and a manual update as done in this repo is denied. The first commit of this PR skips the installation of the Gateway API CRD when the platform is Openshift.

~~Moreover, new versions of the Gateway API inference extension define the inference pool as v1 in the group inference.networking.k8s.io. The second commit introduces the WVA Helm Chart's value poolGroup in the related Jinja template, with a default to the group `inference.networking.k8s.io`.~~

These changes have been tested with the WVA scenario in Openshift 4.22.2.