### PR TITLE
fix: gracefully handle DRA-managed accelerators in auto-detection

### DIFF
--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -63,6 +63,10 @@ class NodeResources:
     # e.g. {"nvidia.com/gpu.product": ["NVIDIA-H100-80GB-HBM3"]}
     gpu_labels: dict[str, list[str]] = field(default_factory=dict)
 
+    # DRA driver names from ResourceSlices, e.g. ["gpu.intel.com"]. These
+    # accelerators expose no node capacity resource or SKU label.
+    dra_drivers: list[str] = field(default_factory=list)
+
 
 class ClusterResourceResolver:
     """Resolve ``"auto"`` cluster resource values by querying node capacities and labels.
@@ -284,7 +288,13 @@ class ClusterResourceResolver:
             resources.accelerator_resources = sorted(accel_set)
             resources.network_resources = sorted(net_set)
             resources.gpu_labels = {k: sorted(v) for k, v in gpu_labels.items()}
+            resources.dra_drivers = self._scan_dra_drivers()
 
+            if resources.dra_drivers:
+                self.logger.log_info(
+                    f"Discovered DRA accelerator drivers: "
+                    f"{', '.join(resources.dra_drivers)}"
+                )
             if resources.accelerator_resources:
                 self.logger.log_info(
                     f"Discovered accelerator resources: "
@@ -310,6 +320,28 @@ class ClusterResourceResolver:
 
         self._node_resources = resources
         return resources
+
+    def _scan_dra_drivers(self) -> list[str]:
+        """Driver names from ResourceSlices (resource.k8s.io). Empty if none/unsupported."""
+        from kubernetes import client as k8s_client
+
+        drivers: set[str] = set()
+        for version in ("v1", "v1beta2", "v1beta1"):
+            try:
+                api = k8s_client.CustomObjectsApi(self._api_client)
+                slices = api.list_cluster_custom_object(
+                    group="resource.k8s.io",
+                    version=version,
+                    plural="resourceslices",
+                )
+            except Exception:
+                continue
+            for item in slices.get("items", []):
+                driver = (item.get("spec") or {}).get("driver")
+                if driver:
+                    drivers.add(driver)
+            break  # first served version wins
+        return sorted(drivers)
 
     @staticmethod
     def _vendor_prefixes(accelerator_resources: set[str] | list[str]) -> set[str]:
@@ -531,6 +563,20 @@ class ClusterResourceResolver:
                     "pods will schedule via resource request only. To require a "
                     f"specific SKU, set {section}.acceleratorType.labelKey and "
                     "labelValue explicitly in your scenario."
+                )
+                accel_type.pop("labelKey", None)
+                accel_type.pop("labelValue", None)
+                accel_type.pop("labelValues", None)
+            elif resources.dra_drivers:
+                # GPUs managed via DRA (e.g. gpu.intel.com): no node capacity
+                # resource or SKU label exists, pods schedule via ResourceClaim.
+                # Drop the acceleratorType constraint, same as the resource case.
+                self.logger.log_warning(
+                    f"Cluster uses DRA accelerator drivers "
+                    f"({', '.join(resources.dra_drivers)}) with no GPU SKU label. "
+                    f"Dropping {section}.acceleratorType constraint -- pods schedule "
+                    "via ResourceClaim. To require a specific SKU, set "
+                    f"{section}.acceleratorType.labelKey and labelValue explicitly."
                 )
                 accel_type.pop("labelKey", None)
                 accel_type.pop("labelValue", None)

--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -10,6 +10,8 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 
+from kubernetes import client as k8s_client
+
 
 def effective_accelerator_count(method_config: dict) -> tuple[int, str]:
     """Resolve the per-pod accelerator count for a method section.
@@ -250,8 +252,6 @@ class ClusterResourceResolver:
             return resources
 
         try:
-            from kubernetes import client as k8s_client
-
             v1 = k8s_client.CoreV1Api(self._api_client)
             nodes = v1.list_node()
 
@@ -323,8 +323,6 @@ class ClusterResourceResolver:
 
     def _scan_dra_drivers(self) -> list[str]:
         """Driver names from ResourceSlices (resource.k8s.io). Empty if none/unsupported."""
-        from kubernetes import client as k8s_client
-
         drivers: set[str] = set()
         for version in ("v1", "v1beta2", "v1beta1"):
             try:
@@ -340,7 +338,7 @@ class ClusterResourceResolver:
                 driver = (item.get("spec") or {}).get("driver")
                 if driver:
                     drivers.add(driver)
-            break  # first served version wins
+            break
         return sorted(drivers)
 
     @staticmethod

--- a/tests/test_cluster_resource_resolver.py
+++ b/tests/test_cluster_resource_resolver.py
@@ -271,6 +271,57 @@ class TestAmdRocmGracefulDegradation:
         assert unresolved == ["decode.acceleratorType.labelValue"]
 
 
+class TestDraGracefulDegradation:
+    """Intel XPU exposes GPUs via DRA: no node capacity resource, no SKU label.
+    Resolver must drop the acceleratorType constraint (pods schedule via
+    ResourceClaim) rather than raising, just like the resource-only case.
+    """
+
+    @pytest.fixture
+    def dra_resources(self):
+        return NodeResources(dra_drivers=["gpu.intel.com"])
+
+    def test_dra_only_cluster_drops_constraint_and_does_not_error(
+        self, resolver, dra_resources
+    ):
+        resolver._node_resources = dra_resources
+        values = {
+            "decode": {
+                "parallelism": {"tensor": 1},
+                "acceleratorType": {
+                    "labelKey": "nvidia.com/gpu.product",
+                    "labelValue": "auto",
+                },
+            },
+        }
+        unresolved: list[str] = []
+        resolver._resolve_accelerator_type_labels(values, unresolved)
+
+        assert unresolved == []
+        accel = values["decode"]["acceleratorType"]
+        assert "labelKey" not in accel
+        assert "labelValue" not in accel
+
+    def test_capacity_label_takes_precedence_over_dra(self, resolver):
+        """A real SKU label still wins -- DRA is only the last-resort drop."""
+        resolver._node_resources = NodeResources(
+            gpu_labels={"gpu.intel.com/family": ["Data Center Max"]},
+            dra_drivers=["gpu.intel.com"],
+        )
+        values = {
+            "decode": {
+                "parallelism": {"tensor": 1},
+                "acceleratorType": {"labelValue": "auto"},
+            },
+        }
+        unresolved: list[str] = []
+        resolver._resolve_accelerator_type_labels(values, unresolved)
+
+        assert unresolved == []
+        assert values["decode"]["acceleratorType"]["labelKey"] == "gpu.intel.com/family"
+        assert values["decode"]["acceleratorType"]["labelValue"] == "Data Center Max"
+
+
 class TestGpuSkuLabelHeuristic:
     """The vendor-prefix + SKU-suffix heuristic that lets the resolver match
     GPU SKU labels from any vendor without per-vendor maintenance.


### PR DESCRIPTION
## Problem

The nightly **Optimized Baseline E2E (Intel XPU)** job started failing after #1511 flipped the default `acceleratorType.labelValue` to `auto`. 

Root cause: Intel XPU exposes GPUs via **Dynamic Resource Allocation** (a `ResourceClaimTemplate` + `DeviceClass gpu.intel.com`), not a `node.status.capacity` extended resource or a GPU SKU label. `ClusterResourceResolver` only scans node capacity and labels, so on a DRA-only cluster `auto` cannot be resolved and the section falls into the fatal `else`. Previously the hardcoded literal default meant detection never ran, so the same cluster passed.
