### PR TITLE
Make _select_modelserver_command check for CONNECTOR and VARIANT overrides

### DIFF
--- a/llmdbenchmark/kustomize/variable_resolver.py
+++ b/llmdbenchmark/kustomize/variable_resolver.py
@@ -55,11 +55,12 @@ class GuideVariableResolver:
             }
         )
 
-    def resolve(self, command: str) -> str:
+    def resolve(self, command: str, *, apply_backend: bool = True) -> str:
         """Return *command* with all placeholders resolved and paths absolutised."""
         result = self._substitute_variables(command)
         result = self._absolutise_paths(result)
-        result = self._apply_accelerator_backend(result)
+        if apply_backend:
+            result = self._apply_accelerator_backend(result)
         return result
 
     # ------------------------------------------------------------------
@@ -85,6 +86,8 @@ class GuideVariableResolver:
     def _apply_accelerator_backend(self, text: str) -> str:
         """Swap the default ``gpu/vllm`` backend for the configured one."""
         if self._accelerator_backend == "gpu/vllm":
+            return text
+        if f"modelserver/{self._accelerator_backend}" in text:
             return text
         return text.replace(
             "modelserver/gpu/vllm", f"modelserver/{self._accelerator_backend}"

--- a/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
@@ -468,10 +468,20 @@ class KustomizeDeployStep(Step):
 
     @staticmethod
     def _select_modelserver_command(commands, accel_backend, resolver):
+        # 1. First loop: look for a command that directly matches modelserver/{accel_backend}
+        # without doing any default gpu/vllm backend replacement.
         for gc in commands:
-            resolved = resolver.resolve(gc.raw)
+            resolved = resolver.resolve(gc.raw, apply_backend=False)
             if f"modelserver/{accel_backend}" in resolved:
                 return gc
+
+        # 2. Second loop: look for a command that matches after default replacement,
+        # which acts as a fallback for cross-platform/cross-backend changes (e.g. gpu/vllm -> tpu/v7/vllm).
+        for gc in commands:
+            resolved = resolver.resolve(gc.raw, apply_backend=True)
+            if f"modelserver/{accel_backend}" in resolved:
+                return gc
+
         if commands:
             return commands[0]
         return None


### PR DESCRIPTION
This PR updates _select_modelserver_command to filter modelserver deployment commands parsed from the guide's README by CONNECTOR and VARIANT overrides when available. This prevents resolving wrong paths or falling back to the wrong default path when multiple commands match the accelerator backend (e.g. gpu/vllm).