### PR TITLE
Update cp command to support oc

### DIFF
--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -355,11 +355,14 @@ def collect_pod_results(
     local_path = local_results_dir / pod_suffix
     local_path.mkdir(parents=True, exist_ok=True)
 
+    # oc cp does not support --retries; kubectl cp does (v1.23+). Skip flag for oc.
+    cp_args = ["cp"]
+    if not cmd.openshift:
+        cp_args.append("--retries=5")
+    cp_args.extend([remote_path, str(local_path)])
+
     cp_result = cmd.kube(
-        "cp",
-        "--retries=5",
-        remote_path,
-        str(local_path),
+        *cp_args,
         namespace=namespace,
         check=False,
     )


### PR DESCRIPTION
oc cp does not support --retries; kubectl cp does (v1.23+). Skip flag for oc