### PR TITLE
fix: Kustomize Option to Dynamically Create or Use Secret + Smoketest Wait Knob

### DIFF
--- a/config/scenarios/guides/flow-control.yaml
+++ b/config/scenarios/guides/flow-control.yaml
@@ -54,34 +54,11 @@ scenario:
       # Inline kustomize strategic merge patches applied on top of the
       # guide's modelserver base.  For gated models, add an HF_TOKEN
       # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
-      #patches:
-      #  - patch: |
-      #      apiVersion: apps/v1
-      #      kind: Deployment
-      #      metadata:
-      #        name: decode
-      #      spec:
-      #        replicas: 2
-      #        template:
-      #          spec:
-      #            priorityClassName: nightly-gpu-critical
+      # Default is empty -- upstream guide already injects HF_TOKEN from
+      # the `llm-d-hf-token` Secret (auto-created by standup). Add entries
+      # here only for non-token overrides (e.g. bump replicas, pin a
+      # priorityClassName) -- see optimized-baseline.yaml for an example.
+      patches: []
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods

--- a/config/scenarios/guides/optimized-baseline.yaml
+++ b/config/scenarios/guides/optimized-baseline.yaml
@@ -52,36 +52,26 @@ scenario:
       guideVariableOverrides: {}   # override/fill the guide README's ${VAR}
 
       # Inline kustomize strategic merge patches applied on top of the
-      # guide's modelserver base.  For gated models, add an HF_TOKEN
-      # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
-      #patches:
-      #  - patch: |
-      #      apiVersion: apps/v1
-      #      kind: Deployment
-      #      metadata:
-      #        name: decode
-      #      spec:
-      #        replicas: 2
-      #        template:
-      #          spec:
-      #            priorityClassName: nightly-gpu-critical
+      # guide's modelserver base. Default is empty -- the upstream guide
+      # already injects HF_TOKEN from the `llm-d-hf-token` Secret (which
+      # the benchmark's standup auto-creates from the HF_TOKEN env var),
+      # so no patch is needed for gated-model access.
+      #
+      # Use this list to override anything else upstream sets -- e.g.
+      # bump replicas or pin a priorityClassName:
+      #
+      #   patches:
+      #     - patch: |
+      #         apiVersion: apps/v1
+      #         kind: Deployment
+      #         metadata:
+      #           name: decode
+      #         spec:
+      #           replicas: 2
+      #           template:
+      #             spec:
+      #               priorityClassName: nightly-gpu-critical
+      patches: []
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods

--- a/config/scenarios/guides/pd-disaggregation.yaml
+++ b/config/scenarios/guides/pd-disaggregation.yaml
@@ -60,39 +60,11 @@ scenario:
       # Inline kustomize strategic merge patches applied on top of the
       # guide's modelserver base.  For gated models, add an HF_TOKEN
       # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: prefill
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
+      # Default is empty -- upstream guide already injects HF_TOKEN from
+      # the `llm-d-hf-token` Secret (auto-created by standup) into both
+      # decode and prefill Deployments. Add entries here only for
+      # non-token overrides -- see optimized-baseline.yaml for an example.
+      patches: []
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods

--- a/config/scenarios/guides/precise-prefix-cache-routing.yaml
+++ b/config/scenarios/guides/precise-prefix-cache-routing.yaml
@@ -58,34 +58,11 @@ scenario:
       # Inline kustomize strategic merge patches applied on top of the
       # guide's modelserver base.  For gated models, add an HF_TOKEN
       # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
-      #patches:
-      #  - patch: |
-      #      apiVersion: apps/v1
-      #      kind: Deployment
-      #      metadata:
-      #        name: decode
-      #      spec:
-      #        replicas: 2
-      #        template:
-      #          spec:
-      #            priorityClassName: nightly-gpu-critical
+      # Default is empty -- upstream guide already injects HF_TOKEN from
+      # the `llm-d-hf-token` Secret (auto-created by standup). Add entries
+      # here only for non-token overrides (e.g. bump replicas, pin a
+      # priorityClassName) -- see optimized-baseline.yaml for an example.
+      patches: []
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods

--- a/config/scenarios/guides/predicted-latency-routing.yaml
+++ b/config/scenarios/guides/predicted-latency-routing.yaml
@@ -59,34 +59,11 @@ scenario:
       # Inline kustomize strategic merge patches applied on top of the
       # guide's modelserver base.  For gated models, add an HF_TOKEN
       # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
-      #patches:
-      #  - patch: |
-      #      apiVersion: apps/v1
-      #      kind: Deployment
-      #      metadata:
-      #        name: decode
-      #      spec:
-      #        replicas: 2
-      #        template:
-      #          spec:
-      #            priorityClassName: nightly-gpu-critical
+      # Default is empty -- upstream guide already injects HF_TOKEN from
+      # the `llm-d-hf-token` Secret (auto-created by standup). Add entries
+      # here only for non-token overrides (e.g. bump replicas, pin a
+      # priorityClassName) -- see optimized-baseline.yaml for an example.
+      patches: []
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods

--- a/config/scenarios/guides/tiered-prefix-cache.yaml
+++ b/config/scenarios/guides/tiered-prefix-cache.yaml
@@ -59,23 +59,11 @@ scenario:
       # Inline kustomize strategic merge patches applied on top of the
       # guide's modelserver base.  For gated models, add an HF_TOKEN
       # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
+      # Default is empty -- upstream guide already injects HF_TOKEN from
+      # the `llm-d-hf-token` Secret (auto-created by standup). Add entries
+      # here only for non-token overrides (e.g. bump replicas, pin a
+      # priorityClassName) -- see optimized-baseline.yaml for an example.
+      patches: []
 
     # =========================================================================
     # COMMON -- Applies to all deployment methods

--- a/config/scenarios/guides/wide-ep-lws.yaml
+++ b/config/scenarios/guides/wide-ep-lws.yaml
@@ -561,3 +561,7 @@ scenario:
     harness:
       name: vllm-benchmark
       experimentProfile: random_concurrent.yaml
+
+      smoketest:
+        modelReadyTimeout: 3600     # 1 hour
+        modelReadyPollInterval: 30  # poll every 30s

--- a/config/scenarios/guides/workload-autoscaling.yaml
+++ b/config/scenarios/guides/workload-autoscaling.yaml
@@ -95,34 +95,11 @@ scenario:
       # Inline kustomize strategic merge patches applied on top of the
       # guide's modelserver base.  For gated models, add an HF_TOKEN
       # env var patch (the secret is auto-created from HF_TOKEN env):
-      patches:
-         - patch: |
-             apiVersion: apps/v1
-             kind: Deployment
-             metadata:
-               name: decode
-             spec:
-               template:
-                 spec:
-                   containers:
-                     - name: modelserver
-                       env:
-                         - name: HF_TOKEN
-                           valueFrom:
-                             secretKeyRef:
-                               name: llm-d-hf-token
-                               key: HF_TOKEN
-      #patches:
-      #  - patch: |
-      #      apiVersion: apps/v1
-      #      kind: Deployment
-      #      metadata:
-      #        name: decode
-      #      spec:
-      #        replicas: 2
-      #        template:
-      #          spec:
-      #            priorityClassName: nightly-gpu-critical
+      # Default is empty -- upstream guide already injects HF_TOKEN from
+      # the `llm-d-hf-token` Secret (auto-created by standup). Add entries
+      # here only for non-token overrides (e.g. bump replicas, pin a
+      # priorityClassName) -- see optimized-baseline.yaml for an example.
+      patches: []
 
     # =========================================================================
     # MODEL CONFIGURATION

--- a/docs/kustomize.md
+++ b/docs/kustomize.md
@@ -69,27 +69,15 @@ kustomize:
 
   # patches → modelserver. Strategic-merge, matched by
   # apiVersion + kind + metadata.name against the guide's base.
+  # NB: HF_TOKEN env injection is NOT needed here -- the upstream
+  # guides ship it (since llm-d/llm-d#1684) and step 06 creates the
+  # Secret automatically. See `## HF_TOKEN handling` below.
   patches:
     - patch: |                       # override the guide's replica count
         apiVersion: apps/v1
         kind: Deployment
         metadata: { name: decode }
         spec: { replicas: 4 }
-    - patch: |                       # gated models: inject HF token env
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata: { name: decode }
-        spec:
-          template:
-            spec:
-              containers:
-                - name: modelserver
-                  env:
-                    - name: HF_TOKEN
-                      valueFrom:
-                        secretKeyRef:
-                          name: llm-d-hf-token
-                          key: HF_TOKEN
 
   # overlayPath → modelserver. If the dir contains kustomization.yaml it
   # is added as a kustomize component; otherwise every *.yaml in it is
@@ -111,206 +99,42 @@ kustomize:
     SOME_README_VAR: "value"
 ```
 
-## Using `HF_TOKEN` with kustomize
+## HF_TOKEN handling
 
-Most llm-d guides serve gated models (Llama, Qwen, etc.) and need a
-HuggingFace token to pull weights. Under kustomize the wiring has two
-halves — the **Secret** and the **patch that mounts it into the pod**.
+Upstream llm-d guides (since
+[llm-d/llm-d#1684](https://github.com/llm-d/llm-d/pull/1684)) reference
+`secret/llm-d-hf-token` directly in their modelserver manifests
+without `optional: true`. **Kustomize standup hard-requires the Secret
+to be available** — if the Pod can't resolve the `secretKeyRef` it
+hangs in `CreateContainerConfigError` until the deploy timeout
+elapses.
 
-### 1. Provide the token before standup
+`step_06_kustomize_deploy` enforces this in
+[`_ensure_hf_token_secret`](../llmdbenchmark/standup/steps/step_06_kustomize_deploy.py).
+Three branches:
 
-Export the token in the shell that runs `llmdbenchmark`:
-
-```bash
-export HF_TOKEN=hf_XXXXXXXXXXXXXXXXXXXX
-```
-
-Equivalent fallback env vars (checked in order, first one wins) — see
-[`_ensure_hf_token_secret` in `step_06_kustomize_deploy.py`](../llmdbenchmark/standup/steps/step_06_kustomize_deploy.py):
-
-| Variable | Notes |
+| Condition | Behaviour |
 |---|---|
-| `HF_TOKEN` | Plain HuggingFace convention. Recommended. |
-| `LLMDBENCH_HF_TOKEN` | Project-prefixed; useful in CI where many vars are namespaced. |
-| `HUGGING_FACE_HUB_TOKEN` | Alternative HF convention. |
+| Secret `llm-d-hf-token` already exists in the namespace | Leave it alone, log "already exists" (supports externally managed Secrets via ESO / Vault / hand-create). No env token required. |
+| Secret absent, env token set (`HF_TOKEN`, `LLMDBENCH_HF_TOKEN`, or `HUGGING_FACE_HUB_TOKEN`, in that order) | Create the Secret. |
+| **Secret absent AND no env token** | **Standup fails fast** before applying any modelserver manifests, with a message naming the namespace and the two fix paths (export the env var or `kubectl create secret …` by hand). |
 
-If none of those is set, step 06 logs `No HF_TOKEN in environment — skipping
-secret creation (gated models will fail)` and moves on. The standup will
-still complete, but the modelserver pod will crash on first download with
-a 401 from HuggingFace.
+The token value is never written to a `kubectl` command line.  The
+manifest is built in-process, base64-encoded, written to a temp file
+(mode 0600), `kubectl apply -f`'d, and the temp file is unlinked
+afterwards — so `CommandExecutor`'s command log only ever sees
+`kubectl apply -f /tmp/llm-d-hf-token-XXXX.yaml`.  If `kubectl`
+somehow echoes the token in stderr, the surfaced error string is
+scrubbed before propagation.
 
-### 2. What the benchmark does for you
+When a scenario sets a separate `harness_namespace`, the Secret is
+ensured in **both** namespaces — the same fail-fast rule applies to
+each.
 
-During the kustomize standup, after the guide's prerequisites run but
-before the router/modelserver kustomize applies, step 06 calls
-`_ensure_hf_token_secret`. It:
-
-1. Checks whether a Secret named `llm-d-hf-token` already exists in the
-   target namespace.
-2. If not, creates it with a single key `HF_TOKEN` whose value is the
-   token you exported:
-   ```bash
-   kubectl create secret generic llm-d-hf-token \
-     --from-literal=HF_TOKEN=$HF_TOKEN \
-     --namespace <NAMESPACE>
-   ```
-
-This is **idempotent** — re-running standup against a namespace that
-already has the secret is a no-op. It does **not** rotate the value.
-If you want to rotate, delete the Secret first:
-
-```bash
-kubectl delete secret llm-d-hf-token -n <NAMESPACE>
-```
-
-### 3. Wire the Secret into the modelserver pod
-
-A Secret in the namespace doesn't do anything on its own — the container
-serving vLLM has to *mount* it as an env var. Most upstream guides do
-**not** include that env in their modelserver manifests (they expect the
-user to add it), so you supply it via `kustomize.patches`:
-
-```yaml
-kustomize:
-  enabled: true
-  guideName: "optimized-baseline"
-
-  patches:
-    - patch: |
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: decode                 # ← guide-specific; some guides
-                                       #   call this `prefill` or other
-        spec:
-          template:
-            spec:
-              containers:
-                - name: modelserver    # ← guide-specific container name
-                  env:
-                    - name: HF_TOKEN
-                      valueFrom:
-                        secretKeyRef:
-                          name: llm-d-hf-token
-                          key: HF_TOKEN
-```
-
-The patch above is exactly what
-[`config/scenarios/guides/optimized-baseline.yaml`](../config/scenarios/guides/optimized-baseline.yaml)
-ships with, and is what makes Qwen3-32B pull successfully under
-kustomize mode.
-
-**For disaggregated guides (prefill + decode):** add a second `patch:`
-entry with `metadata.name: prefill`. Both pods need the env var; a
-single strategic-merge patch only matches one Deployment name.
-
-### 4. Putting it all together — full standup command
-
-```bash
-export HF_TOKEN=hf_XXXXXXXXXXXXXXXXXXXX
-
-llmdbenchmark \
-  --spec config/scenarios/guides/optimized-baseline.yaml \
-  standup -t kustomize -p my-llm-d-ns
-```
-
-What happens, in order:
-
-1. Step 06 parses `guides/optimized-baseline/README.md` from the cloned
-   `llm-d` repo.
-2. Runs the guide's prereq commands (namespace creation, gateway provider).
-3. Creates `llm-d-hf-token` in `my-llm-d-ns` from `$HF_TOKEN`.
-4. Runs the guide's router helm install (the EPP / gateway).
-5. Builds the overlay wrapper that takes the guide's modelserver
-   kustomize dir as `resources:` and adds your `patches:` (including
-   the HF-token env injection) as `patches:`.
-6. `kubectl apply -k <wrapper-dir>` — the decode pod comes up with
-   `HF_TOKEN` set, downloads weights, starts vLLM.
-
-### Troubleshooting
-
-- **Pod logs show `401 Client Error: Unauthorized`** — the Secret was
-  not mounted into the container. Check:
-  - `kubectl get secret llm-d-hf-token -n <ns>` exists.
-  - `kubectl get deploy decode -n <ns> -o yaml | grep -A4 env:` shows
-    the `HF_TOKEN` env entry. If not, your `patches[].patch` didn't
-    apply — verify `metadata.name` matches the guide's Deployment name
-    (it's `decode` for optimized-baseline; check
-    `guides/<guideName>/modelserver/<backend>/` in the llm-d repo for
-    others).
-- **Standup log says `No HF_TOKEN in environment`** — you forgot to
-  export the variable in the shell that ran `llmdbenchmark`. CI users
-  typically wire this through `LLMDBENCH_HF_TOKEN` so the project
-  namespace prefix groups it with the other settings.
-- **The upstream guide README *also* tries to create the Secret** and
-  the parser explodes substituting `<your HuggingFace token>` into the
-  command — see the next section on skip markers; that block should be
-  wrapped on the upstream guide.
-
-## Skipping a block in the upstream guide
-
-Sometimes the upstream guide README adds a setup step that the
-benchmark already handles itself, or one that hard-codes a placeholder
-the parser will mangle. The classic example is the HuggingFace token: 
-`step_06_kustomize_deploy` creates it from `$HF_TOKEN` in
-[`_ensure_hf_token_secret`](../llmdbenchmark/standup/steps/step_06_kustomize_deploy.py),
-so if a guide also writes a `kubectl create secret generic llm-d-hf-token …`
-block in its Prerequisites we end up either duplicating the work or —
-worse — substituting an unresolved placeholder like `<your HuggingFace token>`
-into a shell command and getting a `your: No such file or directory`
-error at runtime.
-
-To opt a block out, wrap it on the **upstream guide README** with our
-HTML-comment markers:
-
-```` markdown
-- [Create the `llm-d-hf-token` secret in your target namespace …](../../helpers/hf-token.md) to pull models.
-
-<!-- llm-d-cicd:skip start -->
-  ```bash
-  export HF_TOKEN=<your HuggingFace token>
-  kubectl create secret generic llm-d-hf-token \
-    --from-literal="HF_TOKEN=${HF_TOKEN}" \
-    --namespace "${NAMESPACE}" \
-    --dry-run=client -o yaml | kubectl apply -f -
-  ```
-<!-- llm-d-cicd:skip end -->
-````
-
-Effect:
-
-- GitHub renders the README unchanged — HTML comments are invisible, so
-  a human walking through the guide still sees the bash block and can
-  copy-paste it.
-- The benchmark's parser
-  ([`llmdbenchmark/kustomize/readme_parser.py`](../llmdbenchmark/kustomize/readme_parser.py))
-  drops every fenced block between the markers: **no `GuideCommand` is
-  emitted and no `export VAR=…` is harvested into the variable table**.
-  The block becomes invisible to `step_06_kustomize_deploy` — no
-  duplicate secret, no broken substitution.
-
-Notes:
-
-- Markers are matched case-insensitively and tolerate inner whitespace
-  (`<!--LLM-D-CICD:Skip Start-->`, `<!--  llm-d-cicd : skip  start  -->`
-  both work).
-- They must sit **outside** a fenced code block — a `<!-- llm-d-cicd:skip start -->`
-  line that appears between `` ```bash `` and `` ``` `` is treated as
-  literal bash, not as a directive. The natural placement is on its own
-  markdown line immediately before / after the fence.
-- A skip region can span multiple fenced blocks and intervening prose;
-  every fenced block inside it is dropped.
-- Heading and `<details>` tracking continue to update inside a skip
-  region, so blocks that follow the region still land in the correct
-  phase (e.g. opening a region under `## Prerequisites` and closing it
-  under `## Deploy the Model Server` works as expected).
-- If the closing marker is missing, the parser skips to end-of-file.
-  Treat that as a bug in the guide, not a feature.
-
-When **not** to use a skip marker — if the block is wrong for *everyone*
-(humans included), fix it upstream instead. Skip markers are for blocks
-that are correct for a human reader but redundant or harmful for our
-automation.
+This fail-fast behaviour is **kustomize-only**.  The `modelservice` and
+`standalone` paths remain tolerant of missing tokens (auto-disabling
+`huggingface.enabled` when no token is found and gating later steps),
+because their generated manifests don't have the hard requirement.
 
 ## Caveats
 
@@ -333,7 +157,3 @@ automation.
   would collide on the same guide resources. Use the `modelservice` method
   (e.g. the `multi-model-wva` scenario) for multi-model; keep kustomize
   scenarios single-stack.
-- The parser obeys `<!-- llm-d-cicd:skip start -->` / `<!-- llm-d-cicd:skip end -->`
-  markers in the upstream guide README — wrapped bash blocks are
-  dropped entirely (no commands, no harvested variables). See
-  [Skipping a block in the upstream guide](#skipping-a-block-in-the-upstream-guide).

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -1846,9 +1846,18 @@ class BaseSmoketest:
                 if _is_retryable(stdout) and attempt < max_retries:
                     time.sleep(retry_interval)
                     continue
+                # Empty body usually means the server doesn't speak this
+                # endpoint -- legacy /v1/completions is a common gap on
+                # chat-only model servers and the llm-d simulator. The
+                # caller of _try_completions checks `should_fallback`
+                # and routes to /v1/chat/completions; chat-completions
+                # has no further fallback target, so its should_fallback
+                # is a no-op (kept for symmetric error shape).
+                body_preview = stdout[:200].strip() or "(empty body)"
                 return {
                     "success": False,
-                    "error": f"Non-JSON response from {url}: {stdout[:200]}",
+                    "error": f"Non-JSON response from {url}: {body_preview}",
+                    "should_fallback": True,
                 }
 
             if _is_non_transient_error(resp):
@@ -1931,9 +1940,18 @@ class BaseSmoketest:
                 if _is_retryable(stdout) and attempt < max_retries:
                     time.sleep(retry_interval)
                     continue
+                # Empty body usually means the server doesn't speak this
+                # endpoint -- legacy /v1/completions is a common gap on
+                # chat-only model servers and the llm-d simulator. The
+                # caller of _try_completions checks `should_fallback`
+                # and routes to /v1/chat/completions; chat-completions
+                # has no further fallback target, so its should_fallback
+                # is a no-op (kept for symmetric error shape).
+                body_preview = stdout[:200].strip() or "(empty body)"
                 return {
                     "success": False,
-                    "error": f"Non-JSON response from {url}: {stdout[:200]}",
+                    "error": f"Non-JSON response from {url}: {body_preview}",
+                    "should_fallback": True,
                 }
 
             if "error" in resp:
@@ -1978,9 +1996,14 @@ class BaseSmoketest:
         payload_json = json.dumps(payload)
         payload_b64 = base64.b64encode(payload_json.encode()).decode()
 
+        # `-w '\n%{http_code}'` appends a trailing line with the HTTP
+        # status so an empty body is still diagnosable (empty + 404 vs
+        # empty + 502 vs empty + 200 look identical to `-s` alone).
+        # We split the status off in Python before returning the body.
         curl_cmd = (
             f"'echo {payload_b64} | base64 -d | "
             f"curl -sk --max-time {timeout_seconds} "
+            f"-w \"\\n%{{http_code}}\" "
             f"-X POST {url} "
             f'-H "Content-Type: application/json" '
             f"-d @- 2>&1'"
@@ -2012,7 +2035,22 @@ class BaseSmoketest:
             detail = result.stderr[:300] or result.stdout[:300]
             return "", f"Curl to {url} failed: {detail}"
 
-        return result.stdout.strip(), None
+        # Split the trailing HTTP status off from the body. Curl writes
+        # the body followed by "\n<status>". A non-2xx status with an
+        # empty body becomes a meaningful error string instead of
+        # disappearing into "Non-JSON response: (empty body)".
+        stdout = result.stdout
+        body, _, status_part = stdout.rpartition("\n")
+        status = status_part.strip()
+        body = body.strip()
+        if status and not status.startswith("2"):
+            # Body of error responses (when the server bothered to send
+            # one) is more useful than the status alone, so include both.
+            body_preview = body[:200] or "(empty body)"
+            return body, (
+                f"Curl POST {url} returned HTTP {status}: {body_preview}"
+            )
+        return body, None
 
     def _print_demo_command(
         self,

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -1801,6 +1801,30 @@ class BaseSmoketest:
                 f"Unable to fetch OpenShift route '{route_name}'"
             )
 
+    # Inference retry budget. Sequence with default values:
+    #   attempt 1 -> wait 15s -> attempt 2 -> wait 30s -> attempt 3
+    #   -> wait 60s -> attempt 4 -> wait 120s -> attempt 5 -> fallback
+    # Total wait budget: ~225s (~3.75 min) covering most warmup races.
+    # Tunable per-scenario via:
+    #   harness.smoketest.inferenceMaxRetries
+    #   harness.smoketest.inferenceRetryBaseInterval
+    #   harness.smoketest.inferenceRetryMaxInterval
+    _DEFAULT_INFERENCE_MAX_RETRIES = 5
+    _DEFAULT_INFERENCE_RETRY_BASE = 15
+    _DEFAULT_INFERENCE_RETRY_MAX = 120
+
+    @staticmethod
+    def _compute_backoff(attempt: int, base: int, cap: int) -> int:
+        """Exponential backoff: ``base * 2 ** (attempt - 1)``, capped.
+
+        Attempt is 1-indexed (so attempt 1 -> base, attempt 2 -> 2*base,
+        etc). The cap prevents the wait from running unbounded if a
+        future scenario sets a high max_retries.
+        """
+        if attempt < 1:
+            return base
+        return min(cap, base * (2 ** (attempt - 1)))
+
     def _try_completions(
         self,
         cmd: CommandExecutor,
@@ -1809,8 +1833,9 @@ class BaseSmoketest:
         base_url: str,
         model_name: str,
         plan_config: dict | None,
-        max_retries: int = 3,
-        retry_interval: int = 15,
+        max_retries: int | None = None,
+        retry_interval: int | None = None,
+        retry_max_interval: int | None = None,
     ) -> dict:
         url = f"{base_url}/v1/completions"
         payload = {
@@ -1819,6 +1844,21 @@ class BaseSmoketest:
             "max_tokens": 5,
             "temperature": 0,
         }
+
+        # Resolve retry budget from plan config (scenarios can tune)
+        # falling back to the class defaults.
+        max_retries = self._resolve_wait_setting(
+            plan_config, "inferenceMaxRetries", max_retries,
+            self._DEFAULT_INFERENCE_MAX_RETRIES,
+        )
+        retry_interval = self._resolve_wait_setting(
+            plan_config, "inferenceRetryBaseInterval", retry_interval,
+            self._DEFAULT_INFERENCE_RETRY_BASE,
+        )
+        retry_max_interval = self._resolve_wait_setting(
+            plan_config, "inferenceRetryMaxInterval", retry_max_interval,
+            self._DEFAULT_INFERENCE_RETRY_MAX,
+        )
 
         for attempt in range(1, max_retries + 1):
             stdout, err = self._curl_post(cmd, namespace, url, payload, plan_config)
@@ -1834,9 +1874,9 @@ class BaseSmoketest:
                 if _is_retryable(err) and attempt < max_retries:
                     context.logger.log_info(
                         f"Attempt {attempt}/{max_retries}: {err[:80]}, "
-                        f"retrying in {retry_interval}s..."
+                        f"retrying in {self._compute_backoff(attempt, retry_interval, retry_max_interval)}s..."
                     )
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {"success": False, "error": err}
 
@@ -1863,7 +1903,7 @@ class BaseSmoketest:
                         f"Attempt {attempt}/{max_retries}: non-JSON body "
                         f"({body_preview[:60]}), retrying in {retry_interval}s..."
                     )
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 # Out of retries -- fall back to /v1/chat/completions.
                 # Modern chat-only model servers and the llm-d
@@ -1893,13 +1933,13 @@ class BaseSmoketest:
                 if isinstance(error_msg, dict):
                     error_msg = error_msg.get("message", str(error_msg))
                 if attempt < max_retries:
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {"success": False, "error": str(error_msg)}
 
             if "choices" not in resp or not resp["choices"]:
                 if attempt < max_retries:
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {
                     "success": False,
@@ -1909,7 +1949,7 @@ class BaseSmoketest:
             first = resp["choices"][0]
             if not first.get("text") and not first.get("message"):
                 if attempt < max_retries:
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {"success": False, "error": f"No generated text from {url}"}
 
@@ -1926,8 +1966,9 @@ class BaseSmoketest:
         base_url: str,
         model_name: str,
         plan_config: dict | None,
-        max_retries: int = 3,
-        retry_interval: int = 15,
+        max_retries: int | None = None,
+        retry_interval: int | None = None,
+        retry_max_interval: int | None = None,
     ) -> dict:
         url = f"{base_url}/v1/chat/completions"
         payload = {
@@ -1939,6 +1980,21 @@ class BaseSmoketest:
             "temperature": 0,
         }
 
+        # Same retry budget as /v1/completions -- the chat fallback also
+        # benefits from giving the server time to warm up.
+        max_retries = self._resolve_wait_setting(
+            plan_config, "inferenceMaxRetries", max_retries,
+            self._DEFAULT_INFERENCE_MAX_RETRIES,
+        )
+        retry_interval = self._resolve_wait_setting(
+            plan_config, "inferenceRetryBaseInterval", retry_interval,
+            self._DEFAULT_INFERENCE_RETRY_BASE,
+        )
+        retry_max_interval = self._resolve_wait_setting(
+            plan_config, "inferenceRetryMaxInterval", retry_max_interval,
+            self._DEFAULT_INFERENCE_RETRY_MAX,
+        )
+
         for attempt in range(1, max_retries + 1):
             stdout, err = self._curl_post(cmd, namespace, url, payload, plan_config)
 
@@ -1946,9 +2002,9 @@ class BaseSmoketest:
                 if _is_retryable(err) and attempt < max_retries:
                     context.logger.log_info(
                         f"Chat attempt {attempt}/{max_retries}: {err[:80]}, "
-                        f"retrying in {retry_interval}s..."
+                        f"retrying in {self._compute_backoff(attempt, retry_interval, retry_max_interval)}s..."
                     )
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {"success": False, "error": err}
 
@@ -1975,7 +2031,7 @@ class BaseSmoketest:
                         f"Attempt {attempt}/{max_retries}: non-JSON body "
                         f"({body_preview[:60]}), retrying in {retry_interval}s..."
                     )
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 # Out of retries -- fall back to /v1/chat/completions.
                 # Modern chat-only model servers and the llm-d
@@ -1995,13 +2051,13 @@ class BaseSmoketest:
                 if isinstance(error_msg, dict):
                     error_msg = error_msg.get("message", str(error_msg))
                 if _is_retryable(str(error_msg)) and attempt < max_retries:
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {"success": False, "error": str(error_msg)}
 
             if "choices" not in resp or not resp["choices"]:
                 if attempt < max_retries:
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {"success": False, "error": f"Missing choices from {url}"}
 
@@ -2009,7 +2065,7 @@ class BaseSmoketest:
             text = message.get("content", "").strip()
             if not text:
                 if attempt < max_retries:
-                    time.sleep(retry_interval)
+                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
                     continue
                 return {"success": False, "error": f"No content in response from {url}"}
 

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -413,9 +413,7 @@ class BaseSmoketest:
                 url_path_prefix=url_path_prefix,
             )
             if wait_err:
-                report.add(
-                    CheckResult("model_ready", False, message=wait_err)
-                )
+                report.add(CheckResult("model_ready", False, message=wait_err))
 
         # 4. Test service/gateway. Skipped when model_ready already
         # timed out -- the assertion would fail with a cryptic Envoy
@@ -1637,11 +1635,15 @@ class BaseSmoketest:
         over the class defaults.
         """
         timeout = self._resolve_wait_setting(
-            plan_config, "modelReadyTimeout", timeout,
+            plan_config,
+            "modelReadyTimeout",
+            timeout,
             self._DEFAULT_MODEL_READY_TIMEOUT,
         )
         poll_interval = self._resolve_wait_setting(
-            plan_config, "modelReadyPollInterval", poll_interval,
+            plan_config,
+            "modelReadyPollInterval",
+            poll_interval,
             self._DEFAULT_MODEL_READY_POLL_INTERVAL,
         )
 
@@ -1848,15 +1850,21 @@ class BaseSmoketest:
         # Resolve retry budget from plan config (scenarios can tune)
         # falling back to the class defaults.
         max_retries = self._resolve_wait_setting(
-            plan_config, "inferenceMaxRetries", max_retries,
+            plan_config,
+            "inferenceMaxRetries",
+            max_retries,
             self._DEFAULT_INFERENCE_MAX_RETRIES,
         )
         retry_interval = self._resolve_wait_setting(
-            plan_config, "inferenceRetryBaseInterval", retry_interval,
+            plan_config,
+            "inferenceRetryBaseInterval",
+            retry_interval,
             self._DEFAULT_INFERENCE_RETRY_BASE,
         )
         retry_max_interval = self._resolve_wait_setting(
-            plan_config, "inferenceRetryMaxInterval", retry_max_interval,
+            plan_config,
+            "inferenceRetryMaxInterval",
+            retry_max_interval,
             self._DEFAULT_INFERENCE_RETRY_MAX,
         )
 
@@ -1876,7 +1884,11 @@ class BaseSmoketest:
                         f"Attempt {attempt}/{max_retries}: {err[:80]}, "
                         f"retrying in {self._compute_backoff(attempt, retry_interval, retry_max_interval)}s..."
                     )
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {"success": False, "error": err}
 
@@ -1903,7 +1915,11 @@ class BaseSmoketest:
                         f"Attempt {attempt}/{max_retries}: non-JSON body "
                         f"({body_preview[:60]}), retrying in {retry_interval}s..."
                     )
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 # Out of retries -- fall back to /v1/chat/completions.
                 # Modern chat-only model servers and the llm-d
@@ -1933,13 +1949,21 @@ class BaseSmoketest:
                 if isinstance(error_msg, dict):
                     error_msg = error_msg.get("message", str(error_msg))
                 if attempt < max_retries:
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {"success": False, "error": str(error_msg)}
 
             if "choices" not in resp or not resp["choices"]:
                 if attempt < max_retries:
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {
                     "success": False,
@@ -1949,7 +1973,11 @@ class BaseSmoketest:
             first = resp["choices"][0]
             if not first.get("text") and not first.get("message"):
                 if attempt < max_retries:
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {"success": False, "error": f"No generated text from {url}"}
 
@@ -1983,15 +2011,21 @@ class BaseSmoketest:
         # Same retry budget as /v1/completions -- the chat fallback also
         # benefits from giving the server time to warm up.
         max_retries = self._resolve_wait_setting(
-            plan_config, "inferenceMaxRetries", max_retries,
+            plan_config,
+            "inferenceMaxRetries",
+            max_retries,
             self._DEFAULT_INFERENCE_MAX_RETRIES,
         )
         retry_interval = self._resolve_wait_setting(
-            plan_config, "inferenceRetryBaseInterval", retry_interval,
+            plan_config,
+            "inferenceRetryBaseInterval",
+            retry_interval,
             self._DEFAULT_INFERENCE_RETRY_BASE,
         )
         retry_max_interval = self._resolve_wait_setting(
-            plan_config, "inferenceRetryMaxInterval", retry_max_interval,
+            plan_config,
+            "inferenceRetryMaxInterval",
+            retry_max_interval,
             self._DEFAULT_INFERENCE_RETRY_MAX,
         )
 
@@ -2004,7 +2038,11 @@ class BaseSmoketest:
                         f"Chat attempt {attempt}/{max_retries}: {err[:80]}, "
                         f"retrying in {self._compute_backoff(attempt, retry_interval, retry_max_interval)}s..."
                     )
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {"success": False, "error": err}
 
@@ -2031,7 +2069,11 @@ class BaseSmoketest:
                         f"Attempt {attempt}/{max_retries}: non-JSON body "
                         f"({body_preview[:60]}), retrying in {retry_interval}s..."
                     )
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 # Out of retries -- fall back to /v1/chat/completions.
                 # Modern chat-only model servers and the llm-d
@@ -2051,13 +2093,21 @@ class BaseSmoketest:
                 if isinstance(error_msg, dict):
                     error_msg = error_msg.get("message", str(error_msg))
                 if _is_retryable(str(error_msg)) and attempt < max_retries:
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {"success": False, "error": str(error_msg)}
 
             if "choices" not in resp or not resp["choices"]:
                 if attempt < max_retries:
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {"success": False, "error": f"Missing choices from {url}"}
 
@@ -2065,7 +2115,11 @@ class BaseSmoketest:
             text = message.get("content", "").strip()
             if not text:
                 if attempt < max_retries:
-                    time.sleep(self._compute_backoff(attempt, retry_interval, retry_max_interval))
+                    time.sleep(
+                        self._compute_backoff(
+                            attempt, retry_interval, retry_max_interval
+                        )
+                    )
                     continue
                 return {"success": False, "error": f"No content in response from {url}"}
 
@@ -2095,7 +2149,7 @@ class BaseSmoketest:
         curl_cmd = (
             f"'echo {payload_b64} | base64 -d | "
             f"curl -sk --max-time {timeout_seconds} "
-            f"-w \"\\n%{{http_code}}\" "
+            f'-w "\\n%{{http_code}}" '
             f"-X POST {url} "
             f'-H "Content-Type: application/json" '
             f"-d @- 2>&1'"
@@ -2139,9 +2193,7 @@ class BaseSmoketest:
             # Body of error responses (when the server bothered to send
             # one) is more useful than the status alone, so include both.
             body_preview = body[:200] or "(empty body)"
-            return body, (
-                f"Curl POST {url} returned HTTP {status}: {body_preview}"
-            )
+            return body, (f"Curl POST {url} returned HTTP {status}: {body_preview}")
         return body, None
 
     def _print_demo_command(

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -400,8 +400,9 @@ class BaseSmoketest:
                 )
 
         # 3. Wait for model ready (/v1/models)
+        wait_err: str | None = None
         if report.passed:
-            self._wait_for_model_ready(
+            wait_err = self._wait_for_model_ready(
                 cmd,
                 context,
                 namespace,
@@ -411,9 +412,22 @@ class BaseSmoketest:
                 plan_config,
                 url_path_prefix=url_path_prefix,
             )
+            if wait_err:
+                report.add(
+                    CheckResult("model_ready", False, message=wait_err)
+                )
 
-        # 4. Test service/gateway
+        # 4. Test service/gateway. Skipped when model_ready already
+        # timed out -- the assertion would fail with a cryptic Envoy
+        # "upstream connection refused" that buries the real cause
+        # (model still loading) under transport-layer noise.
         service_test_passed = False
+        if wait_err:
+            context.logger.log_info(
+                "Skipping service/gateway assertion -- model_ready check "
+                "already reported the underlying failure"
+            )
+            return report
         context.logger.log_info(
             f'Testing service/gateway "{service_ip}" (port {gateway_port})'
             f"{' [prefix=' + url_path_prefix + ']' if url_path_prefix else ''}..."
@@ -1587,6 +1601,13 @@ class BaseSmoketest:
             )
             time.sleep(poll_interval)
 
+    # Default 30 minutes -- accommodates large models (DeepSeek-R1,
+    # Llama-3.1-405B, Qwen3-235B etc.) where weight download + load
+    # across N workers can take 15+ minutes. Small models finish in
+    # seconds and exit immediately; the larger ceiling is upside-free.
+    _DEFAULT_MODEL_READY_TIMEOUT = 1800
+    _DEFAULT_MODEL_READY_POLL_INTERVAL = 15
+
     def _wait_for_model_ready(
         self,
         cmd: CommandExecutor,
@@ -1596,24 +1617,61 @@ class BaseSmoketest:
         port: str | int,
         expected_model: str,
         plan_config: dict | None = None,
-        timeout: int = 300,
-        poll_interval: int = 15,
+        timeout: int | None = None,
+        poll_interval: int | None = None,
         url_path_prefix: str = "",
-    ):
+    ) -> str | None:
+        """Poll ``/v1/models`` until the expected model is served.
+
+        Returns ``None`` on success, or a human-readable error message
+        on timeout (caller is expected to surface it as a check failure
+        -- the historical "log warning and silently proceed" was wrong
+        because the subsequent assertion would then fail with the
+        cryptic Envoy "upstream connection refused" instead of the
+        actual cause).
+
+        Timeout / poll interval can be overridden per-scenario via
+        ``harness.smoketest.modelReadyTimeout`` and
+        ``harness.smoketest.modelReadyPollInterval`` in the plan
+        config; explicit kwargs win over plan-config values which win
+        over the class defaults.
+        """
+        timeout = self._resolve_wait_setting(
+            plan_config, "modelReadyTimeout", timeout,
+            self._DEFAULT_MODEL_READY_TIMEOUT,
+        )
+        poll_interval = self._resolve_wait_setting(
+            plan_config, "modelReadyPollInterval", poll_interval,
+            self._DEFAULT_MODEL_READY_POLL_INTERVAL,
+        )
+
         context.logger.log_info(
-            f"Waiting for model to be ready at {host}:{port} (timeout {timeout}s)..."
+            f"Waiting for model '{expected_model}' at {host}:{port} "
+            f"(timeout {timeout}s, poll every {poll_interval}s)..."
         )
         start = time.time()
         attempt = 0
+        last_progress_log = 0.0
+        # Log first 3 polls verbosely, then once per ~60s. A 30-minute
+        # wait at 15s polls would otherwise produce 120 "not ready yet"
+        # lines -- noise that obscures the surrounding standup output.
+        verbose_attempts = 3
+        progress_interval = 60.0
 
         while True:
             elapsed = time.time() - start
             if elapsed > timeout:
-                context.logger.log_warning(
-                    f"Model readiness wait timed out after {timeout}s -- "
-                    f"proceeding with smoketest assertions"
+                err = (
+                    f"Model '{expected_model}' did not become ready at "
+                    f"{host}:{port} within {timeout}s. For large models "
+                    f"(DeepSeek-R1, Llama-3.1-405B, etc.) increase the "
+                    f"wait via `harness.smoketest.modelReadyTimeout: 3600` "
+                    f"in your scenario, or check the model-server logs:\n"
+                    f"  kubectl logs -n {namespace} "
+                    f"-l llm-d.ai/role=decode -c vllm --tail=100"
                 )
-                return
+                context.logger.log_error(err)
+                return err
 
             attempt += 1
             result = test_model_serving(
@@ -1628,19 +1686,52 @@ class BaseSmoketest:
             )
 
             if cmd.dry_run:
-                return
+                return None
 
             if result is None:
                 context.logger.log_info(
-                    f"Model ready at {host}:{port} (ok) ({int(elapsed)}s elapsed)"
+                    f"Model '{expected_model}' ready at {host}:{port} "
+                    f"({int(elapsed)}s, attempt {attempt})"
                 )
-                return
+                return None
 
             remaining = int(timeout - elapsed)
-            context.logger.log_info(
-                f"Model not ready yet (attempt {attempt}, {remaining}s remaining)..."
-            )
+            if attempt <= verbose_attempts or (
+                elapsed - last_progress_log >= progress_interval
+            ):
+                context.logger.log_info(
+                    f"Model not ready yet (attempt {attempt}, "
+                    f"{int(elapsed)}s elapsed, {remaining}s remaining)..."
+                )
+                last_progress_log = elapsed
             time.sleep(poll_interval)
+
+    @staticmethod
+    def _resolve_wait_setting(
+        plan_config: dict | None,
+        key: str,
+        explicit: int | None,
+        default: int,
+    ) -> int:
+        """Pick a wait timeout / poll interval.
+
+        Priority: explicit kwarg > plan_config.harness.smoketest.<key> >
+        class default. Plan-config values that aren't a positive int are
+        ignored (with no log -- scenario authors typo'ing this is rare
+        enough that we'd rather not fire false-positive warnings).
+        """
+        if explicit is not None:
+            return explicit
+        if plan_config:
+            cfg = ((plan_config.get("harness") or {}).get("smoketest") or {}).get(key)
+            if cfg is not None:
+                try:
+                    cfg_int = int(cfg)
+                    if cfg_int > 0:
+                        return cfg_int
+                except (TypeError, ValueError):
+                    pass
+        return default
 
     def _test_openshift_route(
         self,

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -1843,17 +1843,35 @@ class BaseSmoketest:
             try:
                 resp = json.loads(stdout)
             except json.JSONDecodeError:
-                if _is_retryable(stdout) and attempt < max_retries:
+                # JSON decode failed -- empty body, partial body, or
+                # garbage. All three are dominated by transient
+                # warmup races (model server still loading after
+                # /v1/models began responding, gateway flapping
+                # mid-request, sim's request handler not yet bound).
+                # We have no negative signal -- the HTTP status was
+                # already vetted as 2xx by _curl_post -- so retry
+                # unconditionally up to max_retries before falling
+                # back to /v1/chat/completions. Don't gate on
+                # _is_retryable here: that function looks for known
+                # error strings (502/503/504/...) but for "no body"
+                # there's nothing to match, and the historical
+                # `_is_retryable("") -> False` made every transient
+                # warmup race a hard smoketest failure.
+                body_preview = stdout[:200].strip() or "(empty body)"
+                if attempt < max_retries:
+                    context.logger.log_info(
+                        f"Attempt {attempt}/{max_retries}: non-JSON body "
+                        f"({body_preview[:60]}), retrying in {retry_interval}s..."
+                    )
                     time.sleep(retry_interval)
                     continue
-                # Empty body usually means the server doesn't speak this
-                # endpoint -- legacy /v1/completions is a common gap on
-                # chat-only model servers and the llm-d simulator. The
-                # caller of _try_completions checks `should_fallback`
-                # and routes to /v1/chat/completions; chat-completions
-                # has no further fallback target, so its should_fallback
-                # is a no-op (kept for symmetric error shape).
-                body_preview = stdout[:200].strip() or "(empty body)"
+                # Out of retries -- fall back to /v1/chat/completions.
+                # Modern chat-only model servers and the llm-d
+                # simulator both produce empty /v1/completions
+                # responses; the chat endpoint usually works.
+                # Chat-completions has no further fallback target so
+                # its should_fallback is a no-op (kept for symmetric
+                # error shape).
                 return {
                     "success": False,
                     "error": f"Non-JSON response from {url}: {body_preview}",
@@ -1937,17 +1955,35 @@ class BaseSmoketest:
             try:
                 resp = json.loads(stdout)
             except json.JSONDecodeError:
-                if _is_retryable(stdout) and attempt < max_retries:
+                # JSON decode failed -- empty body, partial body, or
+                # garbage. All three are dominated by transient
+                # warmup races (model server still loading after
+                # /v1/models began responding, gateway flapping
+                # mid-request, sim's request handler not yet bound).
+                # We have no negative signal -- the HTTP status was
+                # already vetted as 2xx by _curl_post -- so retry
+                # unconditionally up to max_retries before falling
+                # back to /v1/chat/completions. Don't gate on
+                # _is_retryable here: that function looks for known
+                # error strings (502/503/504/...) but for "no body"
+                # there's nothing to match, and the historical
+                # `_is_retryable("") -> False` made every transient
+                # warmup race a hard smoketest failure.
+                body_preview = stdout[:200].strip() or "(empty body)"
+                if attempt < max_retries:
+                    context.logger.log_info(
+                        f"Attempt {attempt}/{max_retries}: non-JSON body "
+                        f"({body_preview[:60]}), retrying in {retry_interval}s..."
+                    )
                     time.sleep(retry_interval)
                     continue
-                # Empty body usually means the server doesn't speak this
-                # endpoint -- legacy /v1/completions is a common gap on
-                # chat-only model servers and the llm-d simulator. The
-                # caller of _try_completions checks `should_fallback`
-                # and routes to /v1/chat/completions; chat-completions
-                # has no further fallback target, so its should_fallback
-                # is a no-op (kept for symmetric error shape).
-                body_preview = stdout[:200].strip() or "(empty body)"
+                # Out of retries -- fall back to /v1/chat/completions.
+                # Modern chat-only model servers and the llm-d
+                # simulator both produce empty /v1/completions
+                # responses; the chat endpoint usually works.
+                # Chat-completions has no further fallback target so
+                # its should_fallback is a no-op (kept for symmetric
+                # error shape).
                 return {
                     "success": False,
                     "error": f"Non-JSON response from {url}: {body_preview}",

--- a/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import shlex
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -164,7 +166,26 @@ class KustomizeDeployStep(Step):
             )
 
         # --- 1b. HF token secret ---
-        self._ensure_hf_token_secret(cmd, context, namespace)
+        # Upstream guide manifests (since llm-d/llm-d#1684) reference
+        # `secret/llm-d-hf-token` without `optional: true`, so missing
+        # the Secret hangs every Pod in CreateContainerConfigError.
+        # Ensure it exists (or fail fast) in both the deploy namespace
+        # and the harness namespace when they differ.
+        hf_error = self._ensure_hf_token_secret(cmd, context, namespace)
+        if hf_error:
+            return self._fail(
+                [hf_error], stack_path, "HF token setup failed", context=context
+            )
+        harness_ns = getattr(context, "harness_namespace", None)
+        if harness_ns and harness_ns != namespace:
+            hf_error = self._ensure_hf_token_secret(cmd, context, harness_ns)
+            if hf_error:
+                return self._fail(
+                    [hf_error],
+                    stack_path,
+                    "HF token setup failed in harness namespace",
+                    context=context,
+                )
 
         # --- 2. Router ---
         router_cmds = parsed.get_commands(CommandPhase.ROUTER, DeployMode.STANDALONE)
@@ -352,13 +373,41 @@ class KustomizeDeployStep(Step):
         return str(repo_dir)
 
     _HF_SECRET_NAME = "llm-d-hf-token"
+    _HF_SECRET_KEY = "HF_TOKEN"
 
     @staticmethod
     def _ensure_hf_token_secret(
         cmd: CommandExecutor,
         context: ExecutionContext,
         namespace: str,
-    ) -> None:
+    ) -> str | None:
+        """Ensure the HF token Secret exists in ``namespace``.
+
+        Kustomize-mode-only.  Upstream llm-d guide manifests (since PR
+        llm-d/llm-d#1684) reference ``secret/llm-d-hf-token`` directly
+        with no ``optional: true`` -- without it every Pod hangs in
+        ``CreateContainerConfigError``.  This helper enforces presence:
+
+        - If a Secret named ``llm-d-hf-token`` already exists in the
+          namespace, succeed and leave it alone (supports externally
+          managed Secrets via ESO / Vault / manual create).
+        - If no Secret exists and ``HF_TOKEN`` /
+          ``LLMDBENCH_HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` is set in
+          the process env, create it from that value.
+        - If no Secret AND no env token, return a descriptive error
+          string so the caller can fail the step fast.
+
+        Returns ``None`` on success, or an error message string on
+        failure (caller is expected to surface via ``self._fail``).
+
+        Security: the token value is never passed on a command line
+        (which would be logged by ``CommandExecutor``).  Instead we
+        build the Secret manifest in-process, base64-encode the token,
+        write to a ``NamedTemporaryFile`` (Python defaults to mode
+        0600 on Unix), ``kubectl apply -f`` that file, then unlink it.
+        Any ``kubectl`` stderr we surface is also scrubbed of the
+        literal token value as a belt-and-braces precaution.
+        """
         import os
 
         hf_token = (
@@ -366,14 +415,13 @@ class KustomizeDeployStep(Step):
             or os.environ.get("LLMDBENCH_HF_TOKEN")
             or os.environ.get("HUGGING_FACE_HUB_TOKEN")
         )
-        if not hf_token:
-            context.logger.log_info(
-                "No HF_TOKEN in environment -- skipping secret creation "
-                "(gated models will fail)"
-            )
-            return
 
         secret_name = KustomizeDeployStep._HF_SECRET_NAME
+        secret_key = KustomizeDeployStep._HF_SECRET_KEY
+
+        # 1. Already in the cluster? Leave it alone -- supports ESO /
+        #    Vault / hand-created Secret workflows where the operator
+        #    owns rotation.  No env token required in that case.
         check = cmd.kube(
             "get",
             "secret",
@@ -386,26 +434,87 @@ class KustomizeDeployStep(Step):
             context.logger.log_info(
                 f"HF token secret '{secret_name}' already exists in {namespace}"
             )
-            return
+            return None
 
-        result = cmd.kube(
-            "create",
-            "secret",
-            "generic",
-            secret_name,
-            f"--from-literal=HF_TOKEN={hf_token}",
-            "--namespace",
-            namespace,
-            check=False,
-        )
+        # 2. No Secret AND no env token -- fail fast with actionable
+        #    instructions.  We do this *only* in the kustomize path
+        #    because upstream guide manifests now hard-require the
+        #    Secret; modelservice/standalone keep their tolerant
+        #    behaviour.
+        if not hf_token:
+            return (
+                f"HF_TOKEN is not set and Secret '{secret_name}' does not "
+                f"exist in namespace {namespace}.  A HF_TOKEN is now "
+                f"required for well-lit-path guides.\n"
+                f"\n"
+                f"Either:\n"
+                f"  1. Export HF_TOKEN (or LLMDBENCH_HF_TOKEN, "
+                f"HUGGING_FACE_HUB_TOKEN) before running standup, or\n"
+                f"  2. Pre-create the Secret:\n"
+                f"     kubectl create secret generic {secret_name} \\\n"
+                f"       --from-literal={secret_key}=<your-token> "
+                f"-n {namespace}"
+            )
+
+        # 3. Have a token, no Secret -- create it without ever putting
+        #    the token on a command line.  We build the manifest in
+        #    Python, base64-encode the token, write to a temp file
+        #    (NamedTemporaryFile is mode 0600 by default on Unix),
+        #    apply, and unlink.  The logged kubectl invocation is just
+        #    ``kubectl apply -f /tmp/xxx.yaml``.
+        token_b64 = base64.b64encode(hf_token.encode("utf-8")).decode("ascii")
+        secret_manifest = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "metadata": {
+                "name": secret_name,
+                "namespace": namespace,
+            },
+            "data": {
+                secret_key: token_b64,
+            },
+        }
+
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".yaml",
+                delete=False,
+                prefix="llm-d-hf-token-",
+            ) as tmp:
+                yaml.safe_dump(secret_manifest, tmp)
+                tmp_path = tmp.name
+
+            result = cmd.kube(
+                "apply",
+                "-f",
+                tmp_path,
+                "--namespace",
+                namespace,
+                check=False,
+            )
+        finally:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
+
         if result.success:
             context.logger.log_info(
                 f"Created HF token secret '{secret_name}' in {namespace}"
             )
-        else:
-            context.logger.log_warning(
-                f"Failed to create HF token secret: {result.stderr[:200]}"
-            )
+            return None
+
+        # Scrub any accidental token echo from kubectl stderr before
+        # surfacing it -- not expected for ``apply -f`` failures but
+        # cheap insurance.
+        stderr = (result.stderr or "")[:300]
+        if hf_token and hf_token in stderr:
+            stderr = stderr.replace(hf_token, "<redacted>")
+        return (
+            f"Failed to create HF token secret '{secret_name}' in "
+            f"namespace {namespace}: {stderr}"
+        )
 
     def _fail(
         self,

--- a/llmdbenchmark/standup/steps/step_10_smoketest.py
+++ b/llmdbenchmark/standup/steps/step_10_smoketest.py
@@ -390,11 +390,15 @@ class SmoketestStep(Step):
         class defaults.
         """
         timeout = self._resolve_wait_setting(
-            plan_config, "modelReadyTimeout", timeout,
+            plan_config,
+            "modelReadyTimeout",
+            timeout,
             self._DEFAULT_MODEL_READY_TIMEOUT,
         )
         poll_interval = self._resolve_wait_setting(
-            plan_config, "modelReadyPollInterval", poll_interval,
+            plan_config,
+            "modelReadyPollInterval",
+            poll_interval,
             self._DEFAULT_MODEL_READY_POLL_INTERVAL,
         )
 

--- a/llmdbenchmark/standup/steps/step_10_smoketest.py
+++ b/llmdbenchmark/standup/steps/step_10_smoketest.py
@@ -135,8 +135,12 @@ class SmoketestStep(Step):
         # Pods can be Running/Ready per K8s but still loading the model
         # or warming up the P/D topology.  Poll the service endpoint
         # until it actually serves the model before running assertions.
+        # If the wait itself times out, surface that as the error rather
+        # than letting the subsequent assertion fail with a cryptic
+        # Envoy "upstream connection refused".
+        wait_err: str | None = None
         if service_ip and not errors:
-            self._wait_for_model_ready(
+            wait_err = self._wait_for_model_ready(
                 cmd,
                 context,
                 namespace,
@@ -145,6 +149,8 @@ class SmoketestStep(Step):
                 model_name,
                 plan_config,
             )
+            if wait_err:
+                errors.append(wait_err)
 
         service_test_passed = False
         if service_ip:
@@ -346,6 +352,13 @@ class SmoketestStep(Step):
             )
             time.sleep(poll_interval)
 
+    # Default 30 minutes -- accommodates large models (DeepSeek-R1,
+    # Llama-3.1-405B, Qwen3-235B etc.) where weight download + load
+    # across N workers can take 15+ minutes. Small models finish in
+    # seconds and exit the poll loop immediately.
+    _DEFAULT_MODEL_READY_TIMEOUT = 1800
+    _DEFAULT_MODEL_READY_POLL_INTERVAL = 15
+
     def _wait_for_model_ready(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         cmd: CommandExecutor,
@@ -355,29 +368,60 @@ class SmoketestStep(Step):
         port: str | int,
         expected_model: str,
         plan_config: dict | None = None,
-        timeout: int = 300,
-        poll_interval: int = 15,
-    ):
+        timeout: int | None = None,
+        poll_interval: int | None = None,
+    ) -> str | None:
         """Poll the service endpoint until the model is actually serving.
 
         Kubernetes may report pods as Ready before the model is fully loaded
         or the P/D topology has finished warming up.  This blocks until
-        ``/v1/models`` returns the expected model name, up to *timeout* seconds.
+        ``/v1/models`` returns the expected model name.
+
+        Returns ``None`` on success, or a human-readable error message on
+        timeout (caller is expected to surface it as a check failure --
+        the historical "log warning and silently proceed" was wrong
+        because the subsequent assertion would then fail with the cryptic
+        Envoy "upstream connection refused" instead of the actual cause).
+
+        Timeout / poll interval can be overridden per-scenario via
+        ``harness.smoketest.modelReadyTimeout`` and
+        ``harness.smoketest.modelReadyPollInterval`` in the plan config;
+        explicit kwargs win over plan-config values which win over the
+        class defaults.
         """
+        timeout = self._resolve_wait_setting(
+            plan_config, "modelReadyTimeout", timeout,
+            self._DEFAULT_MODEL_READY_TIMEOUT,
+        )
+        poll_interval = self._resolve_wait_setting(
+            plan_config, "modelReadyPollInterval", poll_interval,
+            self._DEFAULT_MODEL_READY_POLL_INTERVAL,
+        )
+
         context.logger.log_info(
-            f"Waiting for model to be ready at {host}:{port} (timeout {timeout}s)..."
+            f"Waiting for model '{expected_model}' at {host}:{port} "
+            f"(timeout {timeout}s, poll every {poll_interval}s)..."
         )
         start = time.time()
         attempt = 0
+        last_progress_log = 0.0
+        verbose_attempts = 3
+        progress_interval = 60.0
 
         while True:
             elapsed = time.time() - start
             if elapsed > timeout:
-                context.logger.log_warning(
-                    f"Model readiness wait timed out after {timeout}s -- "
-                    f"proceeding with smoketest assertions"
+                err = (
+                    f"Model '{expected_model}' did not become ready at "
+                    f"{host}:{port} within {timeout}s. For large models "
+                    f"(DeepSeek-R1, Llama-3.1-405B, etc.) increase the "
+                    f"wait via `harness.smoketest.modelReadyTimeout: 3600` "
+                    f"in your scenario, or check the model-server logs:\n"
+                    f"  kubectl logs -n {namespace} "
+                    f"-l llm-d.ai/role=decode -c vllm --tail=100"
                 )
-                return
+                context.logger.log_error(err)
+                return err
 
             attempt += 1
             result = test_model_serving(
@@ -391,19 +435,51 @@ class SmoketestStep(Step):
             )
 
             if cmd.dry_run:
-                return  # Command logged, skip polling
+                return None
 
             if result is None:
                 context.logger.log_info(
-                    f"Model ready at {host}:{port} ✓ ({int(elapsed)}s elapsed)"
+                    f"Model '{expected_model}' ready at {host}:{port} "
+                    f"({int(elapsed)}s, attempt {attempt})"
                 )
-                return
+                return None
 
             remaining = int(timeout - elapsed)
-            context.logger.log_info(
-                f"Model not ready yet (attempt {attempt}, {remaining}s remaining)..."
-            )
+            if attempt <= verbose_attempts or (
+                elapsed - last_progress_log >= progress_interval
+            ):
+                context.logger.log_info(
+                    f"Model not ready yet (attempt {attempt}, "
+                    f"{int(elapsed)}s elapsed, {remaining}s remaining)..."
+                )
+                last_progress_log = elapsed
             time.sleep(poll_interval)
+
+    @staticmethod
+    def _resolve_wait_setting(
+        plan_config: dict | None,
+        key: str,
+        explicit: int | None,
+        default: int,
+    ) -> int:
+        """Pick a wait timeout / poll interval.
+
+        Priority: explicit kwarg > plan_config.harness.smoketest.<key> >
+        class default. Plan-config values that aren't a positive int
+        are silently ignored.
+        """
+        if explicit is not None:
+            return explicit
+        if plan_config:
+            cfg = ((plan_config.get("harness") or {}).get("smoketest") or {}).get(key)
+            if cfg is not None:
+                try:
+                    cfg_int = int(cfg)
+                    if cfg_int > 0:
+                        return cfg_int
+                except (TypeError, ValueError):
+                    pass
+        return default
 
     def _test_openshift_route(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,

--- a/tests/test_kustomize_hf_token.py
+++ b/tests/test_kustomize_hf_token.py
@@ -1,0 +1,304 @@
+"""Tests for the HF-token fail-fast logic in step_06_kustomize_deploy.
+
+Three behaviours are covered:
+
+1. Pre-existing Secret short-circuits without requiring an env token.
+2. No Secret + no env token returns the exact, user-facing error.
+3. No Secret + env token set creates the Secret via a temp manifest
+   file -- never via ``--from-literal=`` on the kubectl command line
+   (the token must not appear in any captured kubectl args).
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+# ``llmdbenchmark.standup.steps.__init__`` eagerly imports a sibling
+# (``step_03_workload_monitoring``) that transitively depends on a
+# ``planner`` package not installed in this test environment.  Stub it
+# permissively (any attribute resolves to a no-op callable) so the
+# import chain reaches ``step_06_kustomize_deploy``.
+if "planner.capacity_planner" not in sys.modules:
+
+    class _PermissiveModule(types.ModuleType):
+        def __getattr__(self, name: str):  # type: ignore[override]
+            return type(name, (), {})
+
+    sys.modules.setdefault("planner", _PermissiveModule("planner"))
+    sys.modules["planner.capacity_planner"] = _PermissiveModule(
+        "planner.capacity_planner"
+    )
+
+from llmdbenchmark.standup.steps.step_06_kustomize_deploy import (  # noqa: E402
+    KustomizeDeployStep,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeResult:
+    """Stand-in for ``CommandResult`` covering only the fields we use."""
+
+    success: bool = True
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class FakeCommandExecutor:
+    """Capture every ``kube(*args)`` invocation and dispatch by verb.
+
+    ``get_handler`` is invoked for ``("get", "secret", …)`` calls and
+    must return a ``FakeResult``.  ``apply_handler`` is invoked for
+    ``("apply", "-f", <tmpfile>, …)`` calls.  Both default to success
+    so individual tests only override the bit they care about.
+    """
+
+    get_handler: Any = field(default_factory=lambda: lambda *a, **k: FakeResult(True))
+    apply_handler: Any = field(default_factory=lambda: lambda *a, **k: FakeResult(True))
+    calls: list[tuple[tuple[str, ...], dict[str, Any]]] = field(default_factory=list)
+    apply_manifests: list[dict] = field(default_factory=list)
+
+    def kube(self, *args: str, **kwargs: Any) -> FakeResult:
+        self.calls.append((tuple(args), dict(kwargs)))
+        if args and args[0] == "get":
+            return self.get_handler(*args, **kwargs)
+        if args and args[0] == "apply":
+            # Capture the rendered manifest so tests can verify the
+            # token was base64-encoded into Secret.data correctly.
+            for i, tok in enumerate(args):
+                if tok == "-f" and i + 1 < len(args):
+                    path = Path(args[i + 1])
+                    if path.exists():
+                        self.apply_manifests.append(
+                            yaml.safe_load(path.read_text(encoding="utf-8"))
+                        )
+                    break
+            return self.apply_handler(*args, **kwargs)
+        return FakeResult(True)
+
+
+def _fake_context() -> Any:
+    """Minimal stand-in for ``ExecutionContext`` with a mocked logger."""
+    ctx = MagicMock()
+    ctx.logger = MagicMock()
+    return ctx
+
+
+def _flatten_call_args(cmd: FakeCommandExecutor) -> str:
+    """All kubectl args ever captured, joined for token-leak scanning."""
+    return " ".join(str(a) for args, _ in cmd.calls for a in args)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _clear_hf_env(monkeypatch):
+    """Strip every HF-token env var so each test starts clean."""
+    for var in ("HF_TOKEN", "LLMDBENCH_HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestEnsureHfTokenSecret:
+    """Cover the three branches of ``_ensure_hf_token_secret``."""
+
+    def test_pre_existing_secret_succeeds_without_env_token(self, monkeypatch):
+        """Externally managed Secret -- no env token required."""
+        _clear_hf_env(monkeypatch)
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "my-ns")
+
+        assert result is None, (
+            "Pre-existing Secret should make the helper succeed without an env token."
+        )
+        # No `apply` was attempted -- only the single get.
+        verbs = [args[0] for args, _ in cmd.calls]
+        assert verbs == ["get"], verbs
+
+    def test_missing_secret_and_no_token_returns_error_with_namespace(
+        self, monkeypatch
+    ):
+        """The exact user-facing error message."""
+        _clear_hf_env(monkeypatch)
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "my-cool-ns")
+
+        assert result is not None
+        # The opening line, with the namespace populated.
+        assert (
+            "HF_TOKEN is not set and Secret 'llm-d-hf-token' does not exist "
+            "in namespace my-cool-ns" in result
+        )
+        assert "A HF_TOKEN is now required for well-lit-path guides" in result
+        # Both remediation paths are spelled out.
+        assert "Export HF_TOKEN" in result
+        assert "LLMDBENCH_HF_TOKEN" in result
+        assert "HUGGING_FACE_HUB_TOKEN" in result
+        assert "kubectl create secret generic llm-d-hf-token" in result
+        assert "-n my-cool-ns" in result
+        # No apply was attempted -- we bailed before creating.
+        verbs = [args[0] for args, _ in cmd.calls]
+        assert verbs == ["get"], verbs
+
+    def test_env_token_creates_secret_via_temp_manifest(self, monkeypatch):
+        """Token comes from env, Secret applied from a temp file."""
+        token = "hf_unique_test_value_DO_NOT_LOG_ME"
+        monkeypatch.setenv("HF_TOKEN", token)
+        monkeypatch.delenv("LLMDBENCH_HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert result is None, "Creation should succeed."
+        # An apply was attempted with -f <tmp> and the right namespace.
+        verbs = [args[0] for args, _ in cmd.calls]
+        assert verbs == ["get", "apply"], verbs
+
+        apply_args = cmd.calls[1][0]
+        assert apply_args[0] == "apply"
+        assert "-f" in apply_args
+        assert "--namespace" in apply_args
+        assert "ns42" in apply_args
+
+        # The rendered Secret manifest was correct: base64(token) under
+        # data.HF_TOKEN, type Opaque, named llm-d-hf-token.
+        assert len(cmd.apply_manifests) == 1
+        manifest = cmd.apply_manifests[0]
+        assert manifest["kind"] == "Secret"
+        assert manifest["type"] == "Opaque"
+        assert manifest["metadata"]["name"] == "llm-d-hf-token"
+        assert manifest["metadata"]["namespace"] == "ns42"
+        expected_b64 = base64.b64encode(token.encode("utf-8")).decode("ascii")
+        assert manifest["data"]["HF_TOKEN"] == expected_b64
+
+    def test_token_never_appears_in_any_captured_command_arg(self, monkeypatch, capsys):
+        """The HF token value must never reach the kubectl argv (which
+        ``CommandExecutor._run_once`` logs to disk).  Belt-and-braces:
+        also assert it never reaches stdout/stderr captured by pytest."""
+        token = "hf_unique_canary_value_zzz_DO_NOT_LEAK"
+        monkeypatch.setenv("HF_TOKEN", token)
+        monkeypatch.delenv("LLMDBENCH_HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        joined = _flatten_call_args(cmd)
+        assert token not in joined, (
+            f"HF token leaked into captured kubectl args: {joined!r}"
+        )
+        # And not into anything pytest captured from stdout/stderr.
+        captured = capsys.readouterr()
+        assert token not in captured.out
+        assert token not in captured.err
+        # And not into anything sent to the (mocked) logger.
+        for call in ctx.logger.method_calls:
+            args_str = " ".join(str(a) for a in call.args)
+            assert token not in args_str, (
+                f"HF token leaked into a logger call: {call!r}"
+            )
+
+    def test_apply_failure_returns_error_redacted_of_token(self, monkeypatch):
+        """If kubectl somehow echoes the token in stderr, we scrub it."""
+        token = "hf_canary_token_for_redaction"
+        monkeypatch.setenv("HF_TOKEN", token)
+
+        # Synthesise a stderr that contains the token to exercise the
+        # belt-and-braces redaction.
+        fake_stderr = f"the server rejected token {token}: 401 Unauthorized"
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=False, stderr=fake_stderr),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert result is not None
+        assert token not in result, f"Token leaked into the surfaced error: {result!r}"
+        assert "<redacted>" in result
+        assert "Failed to create HF token secret" in result
+
+    def test_env_token_fallback_order(self, monkeypatch):
+        """LLMDBENCH_HF_TOKEN is honoured when HF_TOKEN is unset."""
+        token = "hf_from_llmdbench_var"
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setenv("LLMDBENCH_HF_TOKEN", token)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=lambda *a, **k: FakeResult(success=True),
+        )
+        ctx = _fake_context()
+
+        result = KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert result is None
+        expected_b64 = base64.b64encode(token.encode("utf-8")).decode("ascii")
+        assert cmd.apply_manifests[0]["data"]["HF_TOKEN"] == expected_b64
+
+    def test_temp_manifest_file_is_deleted_after_apply(self, monkeypatch):
+        """No stale temp file with a base64 token left on disk."""
+        monkeypatch.setenv("HF_TOKEN", "hf_temp_file_cleanup_test")
+
+        captured_path: list[str] = []
+
+        def apply_handler(*args, **kwargs):
+            for i, tok in enumerate(args):
+                if tok == "-f" and i + 1 < len(args):
+                    captured_path.append(args[i + 1])
+                    break
+            return FakeResult(success=True)
+
+        cmd = FakeCommandExecutor(
+            get_handler=lambda *a, **k: FakeResult(success=False),
+            apply_handler=apply_handler,
+        )
+        ctx = _fake_context()
+
+        KustomizeDeployStep._ensure_hf_token_secret(cmd, ctx, "ns42")
+
+        assert captured_path, "Apply was not invoked with -f <path>"
+        assert not Path(captured_path[0]).exists(), (
+            "Temp manifest file was not unlinked after apply -- the "
+            "base64 token would persist on disk."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_smoketest_inference.py
+++ b/tests/test_smoketest_inference.py
@@ -69,6 +69,23 @@ class TestNonJsonTriggersFallback:
             staticmethod(lambda *a, **kw: (body_returned, None)),
         )
 
+    def _patch_curl_sequence(self, monkeypatch, bodies):
+        """Patch _curl_post to return a different body each call.
+        Use this to simulate "transient empty -> retry succeeds"."""
+        bodies_iter = iter(bodies)
+        monkeypatch.setattr(
+            BaseSmoketest,
+            "_curl_post",
+            staticmethod(lambda *a, **kw: (next(bodies_iter), None)),
+        )
+
+    def _patch_sleep(self, monkeypatch):
+        """Skip the retry_interval sleeps in tests."""
+        monkeypatch.setattr(
+            "llmdbenchmark.smoketests.base.time.sleep",
+            lambda _: None,
+        )
+
     def test_empty_body_returns_should_fallback(self, monkeypatch):
         """Empty body (chat-only server) -> should_fallback=True so the
         caller routes to /v1/chat/completions."""
@@ -116,6 +133,67 @@ class TestNonJsonTriggersFallback:
         # fixture is gone in the result).
         assert result["generated_text"] == "Washington, D.C."
         assert "should_fallback" not in result
+
+    def test_transient_empty_then_valid_succeeds(self, monkeypatch):
+        """The kind-sim warmup race: first request returns empty
+        body (sim's request handler not yet bound), second request
+        returns valid JSON. We MUST retry rather than fall back, so
+        the smoketest reports success at /v1/completions and the
+        common case stays in the primary code path."""
+        cmd, ctx = self._mocks()
+        self._patch_sleep(monkeypatch)
+        good = (
+            '{"choices": [{"text": "ok"}],'
+            '"model": "model-name", "id": "x"}'
+        )
+        self._patch_curl_sequence(monkeypatch, ["", good])
+        inst = self._build()
+        result = inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "model-name",
+            plan_config=None, max_retries=3, retry_interval=0,
+        )
+        assert result["success"] is True
+        assert result["generated_text"] == "ok"
+        assert "should_fallback" not in result
+        # The "retrying in ..." log line fired on attempt 1
+        assert any(
+            "retrying" in str(c) for c in ctx.logger.log_info.call_args_list
+        )
+
+    def test_exhausted_retries_then_fallback(self, monkeypatch):
+        """All retries return empty (server genuinely doesn't speak
+        /v1/completions). After max_retries, return
+        should_fallback=True so chat fallback kicks in."""
+        cmd, ctx = self._mocks()
+        self._patch_sleep(monkeypatch)
+        self._patch_curl_sequence(monkeypatch, ["", "", ""])
+        inst = self._build()
+        result = inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "model-name",
+            plan_config=None, max_retries=3, retry_interval=0,
+        )
+        assert result["success"] is False
+        assert result.get("should_fallback") is True
+        assert "(empty body)" in result["error"]
+
+    def test_transient_partial_then_valid_succeeds(self, monkeypatch):
+        """Connection cut mid-stream gives partial JSON. Same handling
+        as empty: retry, succeed on next attempt."""
+        cmd, ctx = self._mocks()
+        self._patch_sleep(monkeypatch)
+        good = (
+            '{"choices": [{"text": "ok"}],'
+            '"model": "model-name", "id": "x"}'
+        )
+        self._patch_curl_sequence(
+            monkeypatch, ['{"choices": [{"text', good],
+        )
+        inst = self._build()
+        result = inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "model-name",
+            plan_config=None, max_retries=3, retry_interval=0,
+        )
+        assert result["success"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoketest_inference.py
+++ b/tests/test_smoketest_inference.py
@@ -197,6 +197,112 @@ class TestNonJsonTriggersFallback:
 
 
 # ---------------------------------------------------------------------------
+# Exponential backoff between retries
+# ---------------------------------------------------------------------------
+
+
+class TestExponentialBackoff:
+    """Waits between retries should grow so a slow-to-warm server gets
+    more time on later attempts. With base=15s, cap=120s:
+        attempt 1 -> 15s, 2 -> 30s, 3 -> 60s, 4 -> 120s, 5 -> 120s (capped)
+    Total budget over 5 attempts: ~225s (3.75 min)."""
+
+    @pytest.mark.parametrize(
+        "attempt,expected",
+        [
+            (1, 15),    # base
+            (2, 30),    # 2x
+            (3, 60),    # 4x
+            (4, 120),   # 8x, hits cap
+            (5, 120),   # cap
+            (6, 120),   # cap (defensive)
+        ],
+    )
+    def test_compute_backoff_sequence(self, attempt, expected):
+        assert BaseSmoketest._compute_backoff(attempt, 15, 120) == expected
+
+    def test_compute_backoff_below_attempt_1_returns_base(self):
+        """Defensive: garbage input falls back to the base interval."""
+        assert BaseSmoketest._compute_backoff(0, 15, 120) == 15
+        assert BaseSmoketest._compute_backoff(-3, 15, 120) == 15
+
+    def test_compute_backoff_respects_cap(self):
+        """Cap below base is honored even when 2^0 * base would exceed it
+        (edge case, but pins the cap-wins-on-tie semantic)."""
+        assert BaseSmoketest._compute_backoff(1, 100, 50) == 50
+
+    def test_default_retry_budget_pinned(self):
+        """If someone reverts to the old 3-attempt / 15s-flat budget we
+        want a loud failure. Old default gave only 30s of total wait,
+        too short for warmup races on slower clusters."""
+        assert BaseSmoketest._DEFAULT_INFERENCE_MAX_RETRIES == 5
+        assert BaseSmoketest._DEFAULT_INFERENCE_RETRY_BASE == 15
+        assert BaseSmoketest._DEFAULT_INFERENCE_RETRY_MAX == 120
+
+    def test_actual_backoff_used_in_completions_loop(self, monkeypatch):
+        """The sleep durations called during a real retry sequence
+        match the backoff schedule, not the flat retry_interval."""
+        cmd = MagicMock()
+        cmd.dry_run = False
+        ctx = MagicMock()
+        # Always-empty stdout, no err -> drives JSON-decode-failure
+        # branch on every attempt and exhausts retries.
+        monkeypatch.setattr(
+            BaseSmoketest,
+            "_curl_post",
+            staticmethod(lambda *a, **kw: ("", None)),
+        )
+        sleeps: list[int] = []
+        monkeypatch.setattr(
+            "llmdbenchmark.smoketests.base.time.sleep",
+            lambda s: sleeps.append(s),
+        )
+        inst = BaseSmoketest.__new__(BaseSmoketest)
+        inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "m",
+            plan_config=None,
+            max_retries=4,
+            retry_interval=15,
+            retry_max_interval=120,
+        )
+        # 4 attempts -> 3 sleeps in between (no sleep after final attempt)
+        assert sleeps == [15, 30, 60]
+
+    def test_plan_config_can_lengthen_retry_budget(self, monkeypatch):
+        """A scenario shipping a slow-to-warm model can crank the budget
+        without touching code."""
+        cmd = MagicMock()
+        cmd.dry_run = False
+        ctx = MagicMock()
+        monkeypatch.setattr(
+            BaseSmoketest,
+            "_curl_post",
+            staticmethod(lambda *a, **kw: ("", None)),
+        )
+        sleeps: list[int] = []
+        monkeypatch.setattr(
+            "llmdbenchmark.smoketests.base.time.sleep",
+            lambda s: sleeps.append(s),
+        )
+        plan_config = {
+            "harness": {
+                "smoketest": {
+                    "inferenceMaxRetries": 3,
+                    "inferenceRetryBaseInterval": 30,
+                    "inferenceRetryMaxInterval": 60,
+                },
+            },
+        }
+        inst = BaseSmoketest.__new__(BaseSmoketest)
+        inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "m",
+            plan_config=plan_config,
+        )
+        # 3 attempts -> 2 sleeps: 30s, 60s (2x base hits the 60s cap)
+        assert sleeps == [30, 60]
+
+
+# ---------------------------------------------------------------------------
 # _curl_post: HTTP status code parsing
 # ---------------------------------------------------------------------------
 

--- a/tests/test_smoketest_inference.py
+++ b/tests/test_smoketest_inference.py
@@ -1,0 +1,225 @@
+"""Tests for the smoketest inference path's resilience to non-JSON
+responses and its handling of HTTP status codes.
+
+Pins two correctness contracts that were missing and caused a
+hard-to-diagnose failure on the kind-sim CICD job:
+
+1. **Non-JSON / empty body on /v1/completions triggers chat fallback.**
+   The llm-d simulator and modern chat-only model servers respond
+   empty (or non-JSON) to legacy /v1/completions. Before this fix,
+   _try_completions would fail the smoketest entirely instead of
+   trying /v1/chat/completions. The fallback was previously gated on
+   `should_fallback: True` which was only set on non-transient JSON
+   errors, leaving the most common server-incompatibility case
+   uncovered.
+
+2. **HTTP status code is captured by _curl_post.** The previous
+   ``curl -sk`` invocation swallowed the response status entirely, so
+   an empty 404 / empty 502 / empty 200 all collapsed to "Non-JSON
+   response: (empty body)" with no way to distinguish them. We now
+   pass ``-w '\\n%{http_code}'`` and split the trailing status off
+   in Python; non-2xx returns a meaningful error.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub planner so we can import smoketest modules (see
+# test_smoketest_wait_for_model.py for the same pattern + rationale).
+if "planner" not in sys.modules:
+    planner_stub = types.ModuleType("planner")
+    capacity_stub = types.ModuleType("planner.capacity_planner")
+    capacity_stub.__getattr__ = lambda name: lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules["planner"] = planner_stub
+    sys.modules["planner.capacity_planner"] = capacity_stub
+
+from llmdbenchmark.smoketests.base import BaseSmoketest  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _try_completions: non-JSON / empty body triggers chat fallback
+# ---------------------------------------------------------------------------
+
+
+class TestNonJsonTriggersFallback:
+    """Before this fix, an empty body from /v1/completions was a
+    terminal smoketest failure. Modern chat-only servers and the
+    llm-d simulator both produce this exact pattern, so the fallback
+    to /v1/chat/completions has to fire."""
+
+    def _build(self):
+        return BaseSmoketest.__new__(BaseSmoketest)
+
+    def _mocks(self):
+        cmd = MagicMock()
+        cmd.dry_run = False
+        ctx = MagicMock()
+        return cmd, ctx
+
+    def _patch_curl(self, monkeypatch, body_returned: str):
+        """Patch _curl_post to return a fixed body, no error."""
+        monkeypatch.setattr(
+            BaseSmoketest,
+            "_curl_post",
+            staticmethod(lambda *a, **kw: (body_returned, None)),
+        )
+
+    def test_empty_body_returns_should_fallback(self, monkeypatch):
+        """Empty body (chat-only server) -> should_fallback=True so the
+        caller routes to /v1/chat/completions."""
+        cmd, ctx = self._mocks()
+        self._patch_curl(monkeypatch, "")
+        inst = self._build()
+        result = inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "model-name",
+            plan_config=None, max_retries=1,
+        )
+        assert result["success"] is False
+        assert result.get("should_fallback") is True, (
+            "Empty body must trigger fallback so chat-only servers pass smoketest"
+        )
+        assert "(empty body)" in result["error"]
+
+    def test_non_json_html_response_returns_should_fallback(self, monkeypatch):
+        """E.g. a misconfigured gateway returning an HTML 404 page."""
+        cmd, ctx = self._mocks()
+        self._patch_curl(monkeypatch, "<html><body>404 Not Found</body></html>")
+        inst = self._build()
+        result = inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "model-name",
+            plan_config=None, max_retries=1,
+        )
+        assert result.get("should_fallback") is True
+        # Body preview is included for debugging
+        assert "404 Not Found" in result["error"]
+
+    def test_valid_json_completion_returns_success(self, monkeypatch):
+        cmd, ctx = self._mocks()
+        body = (
+            '{"choices": [{"text": " Washington, D.C."}],'
+            '"model": "model-name", "id": "x"}'
+        )
+        self._patch_curl(monkeypatch, body)
+        inst = self._build()
+        result = inst._try_completions(
+            cmd, ctx, "ns", "http://svc:80", "model-name",
+            plan_config=None, max_retries=1,
+        )
+        assert result["success"] is True
+        # _try_completions strips the text before returning -- pin that
+        # we match the post-strip value (the leading space in the
+        # fixture is gone in the result).
+        assert result["generated_text"] == "Washington, D.C."
+        assert "should_fallback" not in result
+
+
+# ---------------------------------------------------------------------------
+# _curl_post: HTTP status code parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCurlPostStatusParsing:
+    """The new ``-w '\\n%{http_code}'`` flag means stdout ends with the
+    status on its own line. Tests pin the split logic."""
+
+    def _mock_kube_result(self, stdout: str, success: bool = True):
+        result = MagicMock()
+        result.success = success
+        result.stdout = stdout
+        result.stderr = ""
+        result.dry_run = False
+        return result
+
+    def _make_cmd(self, kube_result):
+        cmd = MagicMock()
+        cmd.kube = MagicMock(return_value=kube_result)
+        return cmd
+
+    def test_2xx_with_body_returns_body_no_error(self):
+        # JSON body + trailing 200
+        stdout = '{"choices":[{"text":"hi"}]}\n200'
+        cmd = self._make_cmd(self._mock_kube_result(stdout))
+        body, err = BaseSmoketest._curl_post(
+            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+        )
+        assert err is None
+        assert body == '{"choices":[{"text":"hi"}]}'
+
+    def test_2xx_empty_body_returns_empty_no_error(self):
+        # Some servers legitimately return empty 2xx; treat as success
+        # at the curl layer -- the JSON parser later flags it as
+        # non-JSON and triggers the fallback.
+        stdout = "\n200"
+        cmd = self._make_cmd(self._mock_kube_result(stdout))
+        body, err = BaseSmoketest._curl_post(
+            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+        )
+        assert err is None
+        assert body == ""
+
+    def test_404_empty_body_returns_diagnosable_error(self):
+        """An empty 404 (e.g. server doesn't speak this endpoint at all)
+        previously disappeared into 'Non-JSON: (empty body)'. Now it
+        surfaces the actual status code."""
+        stdout = "\n404"
+        cmd = self._make_cmd(self._mock_kube_result(stdout))
+        body, err = BaseSmoketest._curl_post(
+            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+        )
+        assert err is not None
+        assert "HTTP 404" in err
+        assert "/v1/completions" in err
+
+    def test_502_with_envoy_body_includes_both_status_and_body(self):
+        """Envoy returns a status + body when upstream is unreachable;
+        both should be surfaced for diagnosis."""
+        stdout = (
+            "upstream connect error or disconnect/reset before headers. "
+            "reset reason: connection refused\n502"
+        )
+        cmd = self._make_cmd(self._mock_kube_result(stdout))
+        body, err = BaseSmoketest._curl_post(
+            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+        )
+        assert err is not None
+        assert "HTTP 502" in err
+        assert "upstream connect error" in err
+
+    def test_5xx_distinct_from_4xx_in_error_text(self):
+        """Just a regression guard that we're not bucketing 5xx into 4xx."""
+        for status in ("500", "502", "503", "504"):
+            stdout = f"server error\n{status}"
+            cmd = self._make_cmd(self._mock_kube_result(stdout))
+            body, err = BaseSmoketest._curl_post(
+                cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+            )
+            assert err is not None
+            assert f"HTTP {status}" in err
+
+    def test_curl_subprocess_failure_returns_original_error_shape(self):
+        """If kubectl itself fails (network, RBAC, etc.) we still report
+        a usable error -- this path predates the status-code split."""
+        bad_result = self._mock_kube_result("", success=False)
+        bad_result.stderr = "Error from server (Forbidden): pods is forbidden"
+        cmd = self._make_cmd(bad_result)
+        body, err = BaseSmoketest._curl_post(
+            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+        )
+        assert body == ""
+        assert err is not None
+        assert "Forbidden" in err
+
+    def test_dry_run_short_circuits(self):
+        result = MagicMock()
+        result.dry_run = True
+        cmd = self._make_cmd(result)
+        body, err = BaseSmoketest._curl_post(
+            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+        )
+        assert body == ""
+        assert err is None

--- a/tests/test_smoketest_inference.py
+++ b/tests/test_smoketest_inference.py
@@ -93,8 +93,13 @@ class TestNonJsonTriggersFallback:
         self._patch_curl(monkeypatch, "")
         inst = self._build()
         result = inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "model-name",
-            plan_config=None, max_retries=1,
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "model-name",
+            plan_config=None,
+            max_retries=1,
         )
         assert result["success"] is False
         assert result.get("should_fallback") is True, (
@@ -108,8 +113,13 @@ class TestNonJsonTriggersFallback:
         self._patch_curl(monkeypatch, "<html><body>404 Not Found</body></html>")
         inst = self._build()
         result = inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "model-name",
-            plan_config=None, max_retries=1,
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "model-name",
+            plan_config=None,
+            max_retries=1,
         )
         assert result.get("should_fallback") is True
         # Body preview is included for debugging
@@ -124,8 +134,13 @@ class TestNonJsonTriggersFallback:
         self._patch_curl(monkeypatch, body)
         inst = self._build()
         result = inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "model-name",
-            plan_config=None, max_retries=1,
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "model-name",
+            plan_config=None,
+            max_retries=1,
         )
         assert result["success"] is True
         # _try_completions strips the text before returning -- pin that
@@ -142,23 +157,24 @@ class TestNonJsonTriggersFallback:
         common case stays in the primary code path."""
         cmd, ctx = self._mocks()
         self._patch_sleep(monkeypatch)
-        good = (
-            '{"choices": [{"text": "ok"}],'
-            '"model": "model-name", "id": "x"}'
-        )
+        good = '{"choices": [{"text": "ok"}],"model": "model-name", "id": "x"}'
         self._patch_curl_sequence(monkeypatch, ["", good])
         inst = self._build()
         result = inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "model-name",
-            plan_config=None, max_retries=3, retry_interval=0,
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "model-name",
+            plan_config=None,
+            max_retries=3,
+            retry_interval=0,
         )
         assert result["success"] is True
         assert result["generated_text"] == "ok"
         assert "should_fallback" not in result
         # The "retrying in ..." log line fired on attempt 1
-        assert any(
-            "retrying" in str(c) for c in ctx.logger.log_info.call_args_list
-        )
+        assert any("retrying" in str(c) for c in ctx.logger.log_info.call_args_list)
 
     def test_exhausted_retries_then_fallback(self, monkeypatch):
         """All retries return empty (server genuinely doesn't speak
@@ -169,8 +185,14 @@ class TestNonJsonTriggersFallback:
         self._patch_curl_sequence(monkeypatch, ["", "", ""])
         inst = self._build()
         result = inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "model-name",
-            plan_config=None, max_retries=3, retry_interval=0,
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "model-name",
+            plan_config=None,
+            max_retries=3,
+            retry_interval=0,
         )
         assert result["success"] is False
         assert result.get("should_fallback") is True
@@ -181,17 +203,21 @@ class TestNonJsonTriggersFallback:
         as empty: retry, succeed on next attempt."""
         cmd, ctx = self._mocks()
         self._patch_sleep(monkeypatch)
-        good = (
-            '{"choices": [{"text": "ok"}],'
-            '"model": "model-name", "id": "x"}'
-        )
+        good = '{"choices": [{"text": "ok"}],"model": "model-name", "id": "x"}'
         self._patch_curl_sequence(
-            monkeypatch, ['{"choices": [{"text', good],
+            monkeypatch,
+            ['{"choices": [{"text', good],
         )
         inst = self._build()
         result = inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "model-name",
-            plan_config=None, max_retries=3, retry_interval=0,
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "model-name",
+            plan_config=None,
+            max_retries=3,
+            retry_interval=0,
         )
         assert result["success"] is True
 
@@ -210,12 +236,12 @@ class TestExponentialBackoff:
     @pytest.mark.parametrize(
         "attempt,expected",
         [
-            (1, 15),    # base
-            (2, 30),    # 2x
-            (3, 60),    # 4x
-            (4, 120),   # 8x, hits cap
-            (5, 120),   # cap
-            (6, 120),   # cap (defensive)
+            (1, 15),  # base
+            (2, 30),  # 2x
+            (3, 60),  # 4x
+            (4, 120),  # 8x, hits cap
+            (5, 120),  # cap
+            (6, 120),  # cap (defensive)
         ],
     )
     def test_compute_backoff_sequence(self, attempt, expected):
@@ -259,7 +285,11 @@ class TestExponentialBackoff:
         )
         inst = BaseSmoketest.__new__(BaseSmoketest)
         inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "m",
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "m",
             plan_config=None,
             max_retries=4,
             retry_interval=15,
@@ -295,7 +325,11 @@ class TestExponentialBackoff:
         }
         inst = BaseSmoketest.__new__(BaseSmoketest)
         inst._try_completions(
-            cmd, ctx, "ns", "http://svc:80", "m",
+            cmd,
+            ctx,
+            "ns",
+            "http://svc:80",
+            "m",
             plan_config=plan_config,
         )
         # 3 attempts -> 2 sleeps: 30s, 60s (2x base hits the 60s cap)
@@ -329,7 +363,11 @@ class TestCurlPostStatusParsing:
         stdout = '{"choices":[{"text":"hi"}]}\n200'
         cmd = self._make_cmd(self._mock_kube_result(stdout))
         body, err = BaseSmoketest._curl_post(
-            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+            cmd,
+            "ns",
+            "http://svc/v1/completions",
+            {"x": 1},
+            plan_config=None,
         )
         assert err is None
         assert body == '{"choices":[{"text":"hi"}]}'
@@ -341,7 +379,11 @@ class TestCurlPostStatusParsing:
         stdout = "\n200"
         cmd = self._make_cmd(self._mock_kube_result(stdout))
         body, err = BaseSmoketest._curl_post(
-            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+            cmd,
+            "ns",
+            "http://svc/v1/completions",
+            {"x": 1},
+            plan_config=None,
         )
         assert err is None
         assert body == ""
@@ -353,7 +395,11 @@ class TestCurlPostStatusParsing:
         stdout = "\n404"
         cmd = self._make_cmd(self._mock_kube_result(stdout))
         body, err = BaseSmoketest._curl_post(
-            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+            cmd,
+            "ns",
+            "http://svc/v1/completions",
+            {"x": 1},
+            plan_config=None,
         )
         assert err is not None
         assert "HTTP 404" in err
@@ -368,7 +414,11 @@ class TestCurlPostStatusParsing:
         )
         cmd = self._make_cmd(self._mock_kube_result(stdout))
         body, err = BaseSmoketest._curl_post(
-            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+            cmd,
+            "ns",
+            "http://svc/v1/completions",
+            {"x": 1},
+            plan_config=None,
         )
         assert err is not None
         assert "HTTP 502" in err
@@ -380,7 +430,11 @@ class TestCurlPostStatusParsing:
             stdout = f"server error\n{status}"
             cmd = self._make_cmd(self._mock_kube_result(stdout))
             body, err = BaseSmoketest._curl_post(
-                cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+                cmd,
+                "ns",
+                "http://svc/v1/completions",
+                {"x": 1},
+                plan_config=None,
             )
             assert err is not None
             assert f"HTTP {status}" in err
@@ -392,7 +446,11 @@ class TestCurlPostStatusParsing:
         bad_result.stderr = "Error from server (Forbidden): pods is forbidden"
         cmd = self._make_cmd(bad_result)
         body, err = BaseSmoketest._curl_post(
-            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+            cmd,
+            "ns",
+            "http://svc/v1/completions",
+            {"x": 1},
+            plan_config=None,
         )
         assert body == ""
         assert err is not None
@@ -403,7 +461,11 @@ class TestCurlPostStatusParsing:
         result.dry_run = True
         cmd = self._make_cmd(result)
         body, err = BaseSmoketest._curl_post(
-            cmd, "ns", "http://svc/v1/completions", {"x": 1}, plan_config=None,
+            cmd,
+            "ns",
+            "http://svc/v1/completions",
+            {"x": 1},
+            plan_config=None,
         )
         assert body == ""
         assert err is None

--- a/tests/test_smoketest_wait_for_model.py
+++ b/tests/test_smoketest_wait_for_model.py
@@ -1,0 +1,271 @@
+"""Tests for the smoketest's ``_wait_for_model_ready`` and the priority
+chain used to pick its timeout / poll interval.
+
+Pins three behaviour contracts:
+
+1. The class default is **30 minutes**, not the historical 5 minutes
+   (which is too short for any modern large model -- DeepSeek-R1 alone
+   takes 15+ minutes to download + load).
+2. Per-scenario override via ``harness.smoketest.modelReadyTimeout`` /
+   ``modelReadyPollInterval`` in the plan config takes precedence over
+   the default but loses to an explicit kwarg.
+3. On timeout the helper **returns an error string** instead of silently
+   logging a warning and proceeding. Historically the silent-proceed
+   path let the subsequent service assertion fail with a cryptic Envoy
+   "upstream connection refused" that buried the real cause (the model
+   was still loading) under transport-layer noise.
+
+Both copies of the helper live in:
+- ``llmdbenchmark.smoketests.base.BaseSmoketest``
+- ``llmdbenchmark.standup.steps.step_10_smoketest.SmoketestStep``
+
+We test both to keep them in sync.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# `llmdbenchmark.standup.steps.__init__` eagerly imports
+# step_03_workload_monitoring, which depends on an external `planner`
+# package not installed in this test env. We don't exercise capacity
+# planning here, so stub it.
+if "planner" not in sys.modules:
+    planner_stub = types.ModuleType("planner")
+    capacity_stub = types.ModuleType("planner.capacity_planner")
+    # Module-level __getattr__ catches any name lookup (PEP 562), so we
+    # don't have to enumerate the planner exports capacity_validator.py
+    # uses -- future additions stay covered without test churn.
+    capacity_stub.__getattr__ = lambda name: (lambda *a, **kw: None)  # type: ignore[attr-defined]
+    sys.modules["planner"] = planner_stub
+    sys.modules["planner.capacity_planner"] = capacity_stub
+
+from llmdbenchmark.smoketests.base import BaseSmoketest  # noqa: E402
+from llmdbenchmark.standup.steps.step_10_smoketest import SmoketestStep  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _resolve_wait_setting -- priority chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", [BaseSmoketest, SmoketestStep])
+class TestResolveWaitSetting:
+    def test_default_when_nothing_set(self, cls):
+        assert (
+            cls._resolve_wait_setting(None, "modelReadyTimeout", None, 1800) == 1800
+        )
+
+    def test_explicit_kwarg_wins_over_everything(self, cls):
+        plan_config = {
+            "harness": {"smoketest": {"modelReadyTimeout": 9999}},
+        }
+        assert (
+            cls._resolve_wait_setting(plan_config, "modelReadyTimeout", 42, 1800) == 42
+        )
+
+    def test_plan_config_overrides_default(self, cls):
+        plan_config = {
+            "harness": {"smoketest": {"modelReadyTimeout": 3600}},
+        }
+        assert (
+            cls._resolve_wait_setting(plan_config, "modelReadyTimeout", None, 1800)
+            == 3600
+        )
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "not-an-int",
+            -1,
+            0,
+            None,
+            [],
+            {"unexpected": "shape"},
+        ],
+    )
+    def test_invalid_plan_config_value_falls_back_to_default(self, cls, bad_value):
+        """Typo'd values shouldn't crash the smoketest; just use the default."""
+        plan_config = {
+            "harness": {"smoketest": {"modelReadyTimeout": bad_value}},
+        }
+        assert (
+            cls._resolve_wait_setting(plan_config, "modelReadyTimeout", None, 1800)
+            == 1800
+        )
+
+    def test_missing_harness_block_is_safe(self, cls):
+        assert (
+            cls._resolve_wait_setting({}, "modelReadyTimeout", None, 1800) == 1800
+        )
+
+    def test_missing_smoketest_subblock_is_safe(self, cls):
+        plan_config = {"harness": {"name": "inference-perf"}}
+        assert (
+            cls._resolve_wait_setting(plan_config, "modelReadyTimeout", None, 1800)
+            == 1800
+        )
+
+    def test_string_int_value_is_coerced(self, cls):
+        """Scenarios written with YAML quoted numbers ('1800') should still work."""
+        plan_config = {
+            "harness": {"smoketest": {"modelReadyTimeout": "1800"}},
+        }
+        assert (
+            cls._resolve_wait_setting(plan_config, "modelReadyTimeout", None, 300)
+            == 1800
+        )
+
+
+# ---------------------------------------------------------------------------
+# Default-bump pin
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsPinned:
+    """If someone reverts the default to 300 we want a loud failure --
+    that value was insufficient for any modern large model and produced
+    misleading 'connection refused' smoketest failures."""
+
+    def test_base_smoketest_default_is_30min(self):
+        assert BaseSmoketest._DEFAULT_MODEL_READY_TIMEOUT == 1800
+
+    def test_step_10_smoketest_default_is_30min(self):
+        assert SmoketestStep._DEFAULT_MODEL_READY_TIMEOUT == 1800
+
+    def test_poll_interval_default_is_15s(self):
+        """15s gives ~5 polls/min, balancing responsiveness vs log noise."""
+        assert BaseSmoketest._DEFAULT_MODEL_READY_POLL_INTERVAL == 15
+        assert SmoketestStep._DEFAULT_MODEL_READY_POLL_INTERVAL == 15
+
+    def test_base_and_step_defaults_match(self):
+        """The two implementations must agree so users don't have to learn
+        two different defaults."""
+        assert (
+            BaseSmoketest._DEFAULT_MODEL_READY_TIMEOUT
+            == SmoketestStep._DEFAULT_MODEL_READY_TIMEOUT
+        )
+        assert (
+            BaseSmoketest._DEFAULT_MODEL_READY_POLL_INTERVAL
+            == SmoketestStep._DEFAULT_MODEL_READY_POLL_INTERVAL
+        )
+
+
+# ---------------------------------------------------------------------------
+# Timeout behavior -- returns error message, not silent proceed
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutReturnsError:
+    """Pin that timeout returns a human-actionable error string rather
+    than logging a warning and silently letting the caller proceed to a
+    cryptic downstream assertion failure."""
+
+    def _build(self, cls):
+        inst = cls.__new__(cls)
+        return inst
+
+    def _mocks(self):
+        logger = MagicMock()
+        cmd = MagicMock()
+        cmd.dry_run = False
+        ctx = MagicMock()
+        ctx.logger = logger
+        return cmd, ctx, logger
+
+    @pytest.mark.parametrize("cls", [BaseSmoketest, SmoketestStep])
+    def test_dry_run_returns_none(self, cls, monkeypatch):
+        """Dry-run shouldn't poll; it returns None immediately."""
+        cmd, ctx, _ = self._mocks()
+        cmd.dry_run = True
+        monkeypatch.setattr(
+            "llmdbenchmark.smoketests.base.test_model_serving",
+            lambda *a, **kw: "should not be reached",
+        )
+        monkeypatch.setattr(
+            "llmdbenchmark.standup.steps.step_10_smoketest.test_model_serving",
+            lambda *a, **kw: "should not be reached",
+        )
+        inst = self._build(cls)
+        result = inst._wait_for_model_ready(
+            cmd, ctx, "ns", "svc", 80, "m", plan_config=None, timeout=1,
+        )
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "cls,module",
+        [
+            (BaseSmoketest, "llmdbenchmark.smoketests.base"),
+            (SmoketestStep, "llmdbenchmark.standup.steps.step_10_smoketest"),
+        ],
+    )
+    def test_immediate_success_returns_none(self, cls, module, monkeypatch):
+        cmd, ctx, _ = self._mocks()
+        monkeypatch.setattr(
+            f"{module}.test_model_serving",
+            lambda *a, **kw: None,  # Success on first poll
+        )
+        inst = self._build(cls)
+        result = inst._wait_for_model_ready(
+            cmd, ctx, "ns", "svc", 80, "m", plan_config=None,
+            timeout=10, poll_interval=1,
+        )
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "cls,module",
+        [
+            (BaseSmoketest, "llmdbenchmark.smoketests.base"),
+            (SmoketestStep, "llmdbenchmark.standup.steps.step_10_smoketest"),
+        ],
+    )
+    def test_timeout_returns_actionable_error(self, cls, module, monkeypatch):
+        """The returned string must name the model, host, timeout, AND
+        the override knob -- those are the four pieces a debugging
+        user needs to fix the situation themselves."""
+        cmd, ctx, logger = self._mocks()
+        monkeypatch.setattr(
+            f"{module}.test_model_serving",
+            lambda *a, **kw: "still loading",
+        )
+        # Patch time.time to fast-forward past the timeout immediately on
+        # the second loop iteration.
+        import time as _time
+
+        clock = [0.0]
+
+        def _tick():
+            v = clock[0]
+            clock[0] += 5  # Each call advances 5s
+            return v
+
+        monkeypatch.setattr(f"{module}.time.time", _tick)
+        monkeypatch.setattr(f"{module}.time.sleep", lambda _: None)
+
+        inst = self._build(cls)
+        err = inst._wait_for_model_ready(
+            cmd, ctx, "vezio-gpu", "svc", 80,
+            "deepseek-ai/DeepSeek-R1-0528",
+            plan_config=None,
+            timeout=3,
+            poll_interval=1,
+        )
+        assert err is not None
+        # Names the model
+        assert "deepseek-ai/DeepSeek-R1-0528" in err
+        # Names the namespace (for the kubectl command)
+        assert "vezio-gpu" in err
+        # Names the timeout value
+        assert "3s" in err
+        # Names the override knob
+        assert "modelReadyTimeout" in err
+        # Suggests checking model-server logs
+        assert "kubectl logs" in err
+        assert "vllm" in err
+        # And the helper logged the error (so it's visible even if caller
+        # ignores the return value).
+        logger.log_error.assert_called_once()

--- a/tests/test_smoketest_wait_for_model.py
+++ b/tests/test_smoketest_wait_for_model.py
@@ -40,7 +40,7 @@ if "planner" not in sys.modules:
     # Module-level __getattr__ catches any name lookup (PEP 562), so we
     # don't have to enumerate the planner exports capacity_validator.py
     # uses -- future additions stay covered without test churn.
-    capacity_stub.__getattr__ = lambda name: (lambda *a, **kw: None)  # type: ignore[attr-defined]
+    capacity_stub.__getattr__ = lambda name: lambda *a, **kw: None  # type: ignore[attr-defined]
     sys.modules["planner"] = planner_stub
     sys.modules["planner.capacity_planner"] = capacity_stub
 
@@ -56,9 +56,7 @@ from llmdbenchmark.standup.steps.step_10_smoketest import SmoketestStep  # noqa:
 @pytest.mark.parametrize("cls", [BaseSmoketest, SmoketestStep])
 class TestResolveWaitSetting:
     def test_default_when_nothing_set(self, cls):
-        assert (
-            cls._resolve_wait_setting(None, "modelReadyTimeout", None, 1800) == 1800
-        )
+        assert cls._resolve_wait_setting(None, "modelReadyTimeout", None, 1800) == 1800
 
     def test_explicit_kwarg_wins_over_everything(self, cls):
         plan_config = {
@@ -99,9 +97,7 @@ class TestResolveWaitSetting:
         )
 
     def test_missing_harness_block_is_safe(self, cls):
-        assert (
-            cls._resolve_wait_setting({}, "modelReadyTimeout", None, 1800) == 1800
-        )
+        assert cls._resolve_wait_setting({}, "modelReadyTimeout", None, 1800) == 1800
 
     def test_missing_smoketest_subblock_is_safe(self, cls):
         plan_config = {"harness": {"name": "inference-perf"}}
@@ -192,7 +188,14 @@ class TestTimeoutReturnsError:
         )
         inst = self._build(cls)
         result = inst._wait_for_model_ready(
-            cmd, ctx, "ns", "svc", 80, "m", plan_config=None, timeout=1,
+            cmd,
+            ctx,
+            "ns",
+            "svc",
+            80,
+            "m",
+            plan_config=None,
+            timeout=1,
         )
         assert result is None
 
@@ -211,8 +214,15 @@ class TestTimeoutReturnsError:
         )
         inst = self._build(cls)
         result = inst._wait_for_model_ready(
-            cmd, ctx, "ns", "svc", 80, "m", plan_config=None,
-            timeout=10, poll_interval=1,
+            cmd,
+            ctx,
+            "ns",
+            "svc",
+            80,
+            "m",
+            plan_config=None,
+            timeout=10,
+            poll_interval=1,
         )
         assert result is None
 
@@ -234,8 +244,6 @@ class TestTimeoutReturnsError:
         )
         # Patch time.time to fast-forward past the timeout immediately on
         # the second loop iteration.
-        import time as _time
-
         clock = [0.0]
 
         def _tick():
@@ -248,7 +256,11 @@ class TestTimeoutReturnsError:
 
         inst = self._build(cls)
         err = inst._wait_for_model_ready(
-            cmd, ctx, "vezio-gpu", "svc", 80,
+            cmd,
+            ctx,
+            "vezio-gpu",
+            "svc",
+            80,
             "deepseek-ai/DeepSeek-R1-0528",
             plan_config=None,
             timeout=3,


### PR DESCRIPTION
# Summary

- Allows us to dynamically use the secret in ns or create on fly for kustomize
- Enables smoketests to have custom wait time for larger models