### PR TITLE
fix: use priority-based GPU label selection for deterministic affinity

### DIFF
--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -102,6 +102,18 @@ class ClusterResourceResolver:
         }
     )
 
+    # Priority order for GPU label attribute selection when multiple labels
+    # are available. Labels are matched by their final attribute name (after
+    # the last `/` or `.`). Cloud provider labels (no attribute suffix) are
+    # treated as highest priority. Earlier items are preferred.
+    GPU_LABEL_PRIORITY = [
+        None,  # Cloud provider labels (cloud.google.com/gke-accelerator)
+        "product",  # Most specific SKU identifier
+        "product-name",  # AMD's variant of product
+        "family",  # GPU family (less specific than product)
+        "class",  # GPU class (least specific)
+    ]
+
     # Cloud-managed accelerator labels that don't follow the vendor-prefix
     # convention (the node operator sets them on accelerator-enabled nodes).
     CLOUD_PROVIDER_GPU_LABEL_KEYS = ("cloud.google.com/gke-accelerator",)
@@ -385,6 +397,36 @@ class ClusterResourceResolver:
         attribute = label_key.rsplit("/", 1)[-1].rsplit(".", 1)[-1]
         return attribute in cls.GPU_SKU_LABEL_ATTRIBUTES
 
+    @classmethod
+    def _select_best_gpu_label_key(cls, gpu_labels: dict[str, list[str]]) -> str:
+        """Select the most appropriate GPU label key from available options.
+
+        Uses GPU_LABEL_PRIORITY to prefer more specific labels (e.g., product)
+        over less specific ones (e.g., family, class). Cloud provider labels
+        (no attribute suffix) are highest priority.
+
+        Returns the first key in priority order, or the first key in sorted
+        order if none match the priority list (should not happen in practice).
+        """
+        if not gpu_labels:
+            raise ValueError("gpu_labels is empty")
+
+        # Try each priority level in order
+        for priority_attr in cls.GPU_LABEL_PRIORITY:
+            for label_key in gpu_labels:
+                if priority_attr is None:
+                    # Cloud provider labels have no attribute suffix
+                    if label_key in cls.CLOUD_PROVIDER_GPU_LABEL_KEYS:
+                        return label_key
+                else:
+                    # Extract attribute from label key
+                    attr = label_key.rsplit("/", 1)[-1].rsplit(".", 1)[-1]
+                    if attr == priority_attr:
+                        return label_key
+
+        # Fallback: return first key in sorted order (for determinism)
+        return sorted(gpu_labels.keys())[0]
+
     def _resolve_accelerator_resource(
         self,
         values: dict,
@@ -474,7 +516,7 @@ class ClusterResourceResolver:
         resources = self._node_resources or NodeResources()
 
         if resources.gpu_labels:
-            label_key = next(iter(resources.gpu_labels))
+            label_key = self._select_best_gpu_label_key(resources.gpu_labels)
             label_value = resources.gpu_labels[label_key][0]
 
             affinity["nodeSelector"] = {label_key: label_value}
@@ -536,7 +578,7 @@ class ClusterResourceResolver:
                 continue
 
             if resources.gpu_labels:
-                label_key = next(iter(resources.gpu_labels))
+                label_key = self._select_best_gpu_label_key(resources.gpu_labels)
                 label_value = resources.gpu_labels[label_key][0]
 
                 accel_type["labelKey"] = label_key

--- a/tests/test_cluster_resource_resolver.py
+++ b/tests/test_cluster_resource_resolver.py
@@ -432,3 +432,117 @@ class TestScanIntegratesHeuristicForIntel:
         assert unresolved == []
         assert values["decode"]["acceleratorType"]["labelKey"] == "gpu.intel.com/family"
         assert values["decode"]["acceleratorType"]["labelValue"] == "dg2"
+
+
+class TestGpuLabelPrioritySelection:
+    """Tests for _select_best_gpu_label_key priority-based selection."""
+
+    def test_prefers_product_over_family(self):
+        gpu_labels = {
+            "nvidia.com/gpu.family": ["Hopper"],
+            "nvidia.com/gpu.product": ["NVIDIA-H100-80GB-HBM3"],
+        }
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "nvidia.com/gpu.product"
+        )
+
+    def test_prefers_product_over_class(self):
+        gpu_labels = {
+            "gpu.nvidia.com/class": ["H100"],
+            "nvidia.com/gpu.product": ["NVIDIA-H100-80GB-HBM3"],
+        }
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "nvidia.com/gpu.product"
+        )
+
+    def test_prefers_product_name_over_family(self):
+        gpu_labels = {
+            "amd.com/gpu.family": ["CDNA3"],
+            "amd.com/gpu.product-name": ["AMD-Instinct-MI300X"],
+        }
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "amd.com/gpu.product-name"
+        )
+
+    def test_prefers_family_over_class(self):
+        gpu_labels = {
+            "gpu.nvidia.com/class": ["H100"],
+            "nvidia.com/gpu.family": ["Hopper"],
+        }
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "nvidia.com/gpu.family"
+        )
+
+    def test_cloud_provider_label_highest_priority(self):
+        gpu_labels = {
+            "nvidia.com/gpu.product": ["NVIDIA-H100-80GB-HBM3"],
+            "nvidia.com/gpu.family": ["Hopper"],
+            "cloud.google.com/gke-accelerator": ["nvidia-tesla-h100"],
+        }
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "cloud.google.com/gke-accelerator"
+        )
+
+    def test_single_label_returns_that_label(self):
+        gpu_labels = {"gpu.intel.com/family": ["dg2"]}
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "gpu.intel.com/family"
+        )
+
+    def test_empty_raises_value_error(self):
+        with pytest.raises(ValueError, match="gpu_labels is empty"):
+            ClusterResourceResolver._select_best_gpu_label_key({})
+
+    def test_unknown_label_falls_back_to_sorted_order(self):
+        """When none of the labels match known priorities, use sorted order."""
+        gpu_labels = {
+            "vendor.com/gpu.unknown-b": ["value1"],
+            "vendor.com/gpu.unknown-a": ["value2"],
+        }
+        # Falls back to sorted order
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "vendor.com/gpu.unknown-a"
+        )
+
+    def test_product_priority_with_multiple_vendors(self):
+        """When multiple vendors present, still prefer product attribute."""
+        gpu_labels = {
+            "amd.com/gpu.family": ["CDNA3"],
+            "nvidia.com/gpu.product": ["NVIDIA-H100-80GB-HBM3"],
+            "intel.com/gpu.family": ["dg2"],
+        }
+        # NVIDIA product should win over Intel/AMD family
+        assert (
+            ClusterResourceResolver._select_best_gpu_label_key(gpu_labels)
+            == "nvidia.com/gpu.product"
+        )
+
+
+class TestAffinityNodeSelectorUsesLabelPriority:
+    """Verify that affinity.nodeSelector resolution uses priority selection."""
+
+    def test_affinity_prefers_product_over_family(self):
+        resolver = ClusterResourceResolver(logger=MagicMock(), dry_run=False)
+        resolver._node_resources = NodeResources(
+            accelerator_resources=["nvidia.com/gpu"],
+            gpu_labels={
+                "nvidia.com/gpu.family": ["Hopper"],
+                "nvidia.com/gpu.product": ["NVIDIA-H100-80GB-HBM3"],
+            },
+        )
+        values = {"affinity": {"nodeSelector": "auto"}}
+        unresolved: list[str] = []
+        resolver._resolve_affinity_node_selector(values, unresolved)
+
+        assert unresolved == []
+        assert values["affinity"]["nodeSelector"] == {
+            "nvidia.com/gpu.product": "NVIDIA-H100-80GB-HBM3"
+        }
+        assert values["affinity"]["enabled"] is True


### PR DESCRIPTION
## Summary

  - Implement priority-based GPU label selection to prefer more specific labels (e.g., product) over generic ones (e.g., family, class)
  - Add deterministic fallback when multiple GPU labels are available on nodes
  - Fix non-deterministic GPU label selection that previously used next(iter())

## Changes

  - Added GPU_LABEL_PRIORITY class constant defining preference order: cloud provider labels ? product ? product-name (AMD) ? family ? class
  - Implemented _select_best_gpu_label_key() method to select the most appropriate label based on priority ordering
  - Updated _resolve_affinity_node_selector() and _resolve_accelerator_type() to use the new priority-based selection

## Motivation

  Previously, when multiple GPU labels were present on a node (e.g., nvidia.com/gpu.product and nvidia.com/gpu.family), the code used next(iter()) to select one arbitrarily. This was non-deterministic and could result in less
  specific labels (like family) being chosen over more specific ones (like product), leading to incorrect or overly broad node affinity rules. This affected the WVA tests, still relying on the VariantAutoscaling object's annotation `acceleratorName`.

