### PR TITLE
Improving FMA + WVA benchmarking 

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-ocp-fma-wva.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-fma-wva.yaml
@@ -1,9 +1,13 @@
 name: CI - Nightly Run Benchmark on OCP ("WVA+FMA" autoscaling path)
 
 # Mirrors ci-nightly-benchmark-ocp-fma.yaml but targets the WVA(modelservice)+FMA scenario
-# under inference-perf load. Default harness
-# is inference-perf + shared_prefix_synthetic.yaml (same as running
-# guides/workload-autoscaling.yaml manually).
+# under inference-perf load. Default harness is inference-perf +
+# shared_prefix_synthetic_heavy.yaml — calibrated to drive WVA's saturation
+# gauges past the optimizer's threshold so HPA actually scales out during
+# the run. The light shared_prefix_synthetic.yaml profile peaks at 20 RPS,
+# which doesn't saturate even one Qwen3-32B replica, so neither path
+# exercises autoscaling and FMA pays its steady-state overhead with no
+# scaling benefit to amortize it. Override via inputs.workload if needed.
 #
 # This workflow runs TWO benchmark passes for direct comparison:
 #   1. baseline (WVA without FMA) — `cicd/ocp-nofma-wva`
@@ -95,7 +99,10 @@ on:
       workload:
         description: 'Workload profile (under workload/profiles/<harness>/)'
         required: false
-        default: 'shared_prefix_synthetic.yaml'
+        # Default to the heavy variant (calibrated to drive WVA saturation
+        # past the scale-up threshold). Override to shared_prefix_synthetic.yaml
+        # for a light-load smoke test of the deployment chain itself.
+        default: 'shared_prefix_synthetic_heavy.yaml'
         type: 'string'
       wait_timeout:
         # The reusable workflow's default is 3600s, but CI runs of the
@@ -137,7 +144,7 @@ jobs:
       dry_run: ${{ inputs.dry_run || 'false' }}
       verbose: ${{ inputs.verbose || 'false' }}
       harness: ${{ inputs.harness || 'inference-perf' }}
-      workload: ${{ inputs.workload || 'shared_prefix_synthetic.yaml' }}
+      workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '5400' }}
     secrets: inherit
 
@@ -177,7 +184,7 @@ jobs:
       dry_run: ${{ inputs.dry_run || 'false' }}
       verbose: ${{ inputs.verbose || 'false' }}
       harness: ${{ inputs.harness || 'inference-perf' }}
-      workload: ${{ inputs.workload || 'shared_prefix_synthetic.yaml' }}
+      workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '5400' }}
     secrets: inherit
 

--- a/config/scenarios/cicd/ocp-nofma-wva.yaml
+++ b/config/scenarios/cicd/ocp-nofma-wva.yaml
@@ -271,6 +271,22 @@ scenario:
       additionalVolumes: []
 
       # -----------------------------------------------------------------------
+      # vLLM args
+      #
+      # `--no-enable-prefix-caching` is set here so the decode pod's vLLM
+      # configuration matches the FMA launcher's (which hard-codes
+      # `--no-enable-prefix-caching` in config/templates/jinja/24_fma-
+      # deployment.yaml.j2). Without this, baseline gets a massive unfair
+      # advantage on shared-prefix workloads (heavy profile = 4000-token
+      # shared prefix × 32 reuses per group → ~16× fewer prefill tokens
+      # with caching on). Keeping both sides apples-to-apples means we're
+      # benchmarking the scaling/scheduling path, not vLLM's prefix cache.
+      # -----------------------------------------------------------------------
+      vllm:
+        additionalFlags:
+          - "--no-enable-prefix-caching"
+
+      # -----------------------------------------------------------------------
       # Probes
       #
       # HTTP probes aligned with the upstream WVA well-lit-path guide
@@ -332,7 +348,14 @@ scenario:
         role: kv_both
 
       flags:
-        enforceEager: true
+        # enforceEager: false (overrides the defaults.yaml default of true).
+        # CUDA graphs improve decode throughput ~10-30% on H100 by eliminating
+        # per-kernel launch overhead. Symmetric with FMA's launcher, which has
+        # never run with --enforce-eager (its options string in
+        # 24_fma-deployment.yaml.j2 doesn't include it). With this set to true,
+        # baseline got an unfair perf handicap that masked real architectural
+        # comparisons.
+        enforceEager: false
         disableLogRequests: true
         disableUvicornAccessLog: true
         allowLongMaxModelLen: "1"

--- a/config/scenarios/guides/workload-autoscaling.yaml
+++ b/config/scenarios/guides/workload-autoscaling.yaml
@@ -377,7 +377,12 @@ scenario:
         role: kv_both
 
       flags:
-        enforceEager: true
+        # enforceEager: false (overrides the defaults.yaml default of true).
+        # Cosmetic for the FMA path itself — FMA's launcher options are
+        # hard-coded in 24_fma-deployment.yaml.j2 and don't read this flag —
+        # but kept here to mirror the baseline scenario and to document intent
+        # if FMA's template ever starts honoring vllmCommon.flags.
+        enforceEager: false
         disableLogRequests: true
         disableUvicornAccessLog: true
         allowLongMaxModelLen: "1"

--- a/config/templates/jinja/24_fma-deployment.yaml.j2
+++ b/config/templates/jinja/24_fma-deployment.yaml.j2
@@ -187,13 +187,27 @@ spec:
         dual-pods.llm-d.ai/admin-port: "8081"
         dual-pods.llm-d.ai/inference-server-config: fma-{{ model_id_label }}
     spec:
+      {# Pick a resolved accelerator type from decode/prefill/standalone
+         (cluster_resource_resolver.py rewrites `labelValue: auto` into the
+         concrete value, e.g. NVIDIA-H100-80GB-HBM3, before this template
+         runs). Using `operator: In` with a concrete value is required for
+         WVA's resolver to extract the accelerator name from nodeAffinity;
+         `operator: Exists` finds the key but returns no value, and WVA falls
+         back to "unresolved" — which silences its saturation engine
+         (OptimizationFailed: No saturation metrics available for model). #}
+      {% set _fma_accel = (decode.acceleratorType if decode is defined and decode.acceleratorType is defined and decode.acceleratorType.labelValue is defined
+                           else (prefill.acceleratorType if prefill is defined and prefill.acceleratorType is defined and prefill.acceleratorType.labelValue is defined
+                                 else (standalone.acceleratorType if standalone is defined and standalone.acceleratorType is defined and standalone.acceleratorType.labelValue is defined
+                                       else None))) %}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: nvidia.com/gpu.product
-                    operator: Exists
+                  - key: {{ _fma_accel.labelKey if _fma_accel else 'nvidia.com/gpu.product' }}
+                    operator: In
+                    values:
+                      - "{{ _fma_accel.labelValue if _fma_accel else 'NVIDIA-H100-80GB-HBM3' }}"
       containers:
         - name: inference-server
           image: {{ fma.requester.image.repository }}:{{ fma.requester.image.tag }}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1278,23 +1278,23 @@ fma:
     stood-up-via: "fma"
 
   crds:
-    inferenceServerConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.0-alpha.13/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
-    launcherConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.0-alpha.13/config/crd/fma.llm-d.ai_launcherconfigs.yaml
-    launcherPopulatorConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.0-alpha.13/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml
+    inferenceServerConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.0/config/crd/fma.llm-d.ai_inferenceserverconfigs.yaml
+    launcherConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.0/config/crd/fma.llm-d.ai_launcherconfigs.yaml
+    launcherPopulatorConfig: https://raw.githubusercontent.com/llm-d-incubation/llm-d-fast-model-actuation/v0.6.0/config/crd/fma.llm-d.ai_launcherpopulationpolicies.yaml
 
   chart:
     url: oci://ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/charts/fma-controllers
-    version: 0.6.0-alpha.13
+    version: 0.6.0
 
   image:
     repository: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation
-    tag: v0.6.0-alpha.13
+    tag: v0.6.0
     pullPolicy: IfNotPresent
 
   requester:
     image:
       repository: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/requester
-      tag: v0.6.0-alpha.13
+      tag: v0.6.0
       pullPolicy: IfNotPresent
     probePort: 8080
     spiPort: 8081
@@ -1308,7 +1308,7 @@ fma:
     maxInstances: 4
     image:
       repository: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher
-      tag: v0.6.0-alpha.13
+      tag: v0.6.0
       pullPolicy: IfNotPresent
     runtimeClassName: nvidia-legacy
     podTemplate:


### PR DESCRIPTION
 This PR provides some fixes that improve the results computed by FMA + WVA benchmarking. 

  **Proposed Changes**

  - :gift: Default the WVA+FMA nightly workflow to `shared_prefix_synthetic_heavy.yaml` (was shared_prefix_synthetic.yaml). The heavy profile is calibrated to exceed 1-replica capacity so WVA's saturation engine actually triggers scaling — the light profile didn't exercise the autoscaling path under test.
  - :broom: Bump FMA pin to `v0.6.0` (was `v0.6.0-alpha.13`) across CRDs, chart version, and the three image tags (image.tag, requester.image.tag, launcher.image.tag) in config/templates/values/defaults.yaml. v0.6.0 is the stable release that promoted v0.6.0-alpha.14.
  - :bug: Fix the FMA requester Deployment's nodeAffinity in `config/templates/jinja/24_fma-deployment.yaml.j2` to use operator: In with a resolved value (was operator: Exists). WVA's accelerator resolver extracts the value from `matchExpressions[*].values[0]` for In operators, but returns empty for Exists. The empty value caused WVA's saturation engine to emit AcceleratorNotResolved + OptimizationFailed: No saturation metrics available for model for the entire run, leaving FMA scaling purely reactive (and too late). The template now reads the resolved value from `decode.acceleratorType.labelValue` (auto-resolved by`cluster_resource_resolver.py`), with prefill/standalone fallbacks and a `NVIDIA-H100-80GB-HBM3` final fallback.
  - :bug: Align vLLM configuration across baseline decode and FMA launcher so the benchmark measures scaling/serving differences, not vLLM-flag asymmetry:
    - Add `--no-enable-prefix-caching` to baseline decode.vllm.additionalFlags (FMA's launcher hard-codes this; baseline was getting ~16× free prefill on the shared-prefix workload because of 32-way prefix reuse per group).
    - Set `enforceEager: false` on both scenarios (was true in vllmCommon.flags). Baseline was running without CUDA graphs while FMA's launcher (whose options don't read this flag) had them enabled — measurable ~10-30% throughput bias against baseline. Both now use CUDA graphs.

  **Files changed**
  
-   `.github/workflows/ci-nightly-benchmark-ocp-fma-wva.yaml`         ← heavy workload as default
-   `config/scenarios/cicd/ocp-nofma-wva.yaml`                          ← --no-enable-prefix-caching, enforceEager: false
-   `config/scenarios/guides/workload-autoscaling.yaml`                 ← enforceEager: false
-   `config/templates/jinja/24_fma-deployment.yaml.j2`                  ← nodeAffinity operator: Exists → In
-   `config/templates/values/defaults.yaml`                             ← FMA v0.6.0-alpha.13 → v0.6.0
  
**Improved Results:**
<img width="753" height="815" alt="Screenshot 2026-06-26 at 3 10 22 PM" src="https://github.com/user-attachments/assets/16d2b705-7a96-4750-ae2c-ed3e575d9aba" />

