### PR TITLE
fix: query Deployment (not ReplicaSet) in find_fma_endpoint

### DIFF
--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -155,27 +155,28 @@ def find_standalone_endpoint(
 
 
 def find_fma_endpoint(cmd: CommandExecutor, namespace: str) -> str | None:
-    """Find FMA replicaset name.
+    """Find FMA requester deployment name.
 
-    Queries for replicaset labelled ``stood-up-from=llm-d-benchmark``.
+    Queries for deployments labelled ``stood-up-from=llm-d-benchmark``.
 
     Returns:
         name -- None if not found.
     """
 
-    result = cmd.kube(
-        "get",
-        "replicaset",
-        "-l",
-        "stood-up-from=llm-d-benchmark",
-        "--namespace",
-        namespace,
-        "-o",
-        "jsonpath={.items[*].metadata.name}",
-        check=False,
-    )
-    if result.success and result.stdout.strip():
-        return f"{result.stdout.strip()}.{namespace}.cluster.local"
+    for resource in ("deployment", "replicaset"):
+        result = cmd.kube(
+            "get",
+            resource,
+            "-l",
+            "stood-up-from=llm-d-benchmark",
+            "--namespace",
+            namespace,
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+            check=False,
+        )
+        if result.success and result.stdout.strip():
+            return f"{result.stdout.strip()}.{namespace}.cluster.local"
 
     return None
 


### PR DESCRIPTION
PR #1498 changed the FMA requester resource in `24_fma-deployment.yaml.j2` from `kind: ReplicaSet` to `kind: Deployment`, but `find_fma_endpoint()` in `endpoint.py` was left querying `replicaset`.  On the FMA-only nightly (`--methods fma`) the query returns nothing, `service_ip` stays None, and step_03 fails with `"Could not detect endpoint"`.

Fix: try Deployments first, then fall back to ReplicaSets for any cluster that was stood up before the change was deployed.