### PR TITLE
fix: set USER in standalone vLLM container to survive restricted-v2 SCC

### DIFF
--- a/config/templates/jinja/14_standalone-deployment_yaml.j2
+++ b/config/templates/jinja/14_standalone-deployment_yaml.j2
@@ -263,6 +263,14 @@ spec:
 {% endif %}
         - name: HOME
           value: "{{ vllmCommon.containerHome }}"
+        # Workaround for https://github.com/vllm-project/vllm/issues/44548:
+        # vLLM v0.20.0+ (torch 2.11) calls getpass.getuser() at import time,
+        # which raises KeyError under OpenShift's restricted-v2 SCC (random
+        # UID not in /etc/passwd). Setting USER bypasses the pwd lookup; the
+        # value is arbitrary. Without this the standalone pod CrashLoopBackOffs
+        # on restricted-v2 (CI) while running fine under anyuid (dev ns).
+        - name: USER
+          value: "llm-d"
         - name: HF_HOME
           value: "{{ vllmCommon.hfHome }}"
         - name: MODEL_NAME


### PR DESCRIPTION
The **OCP standalone nightly** CrashLoopBackOffs at standup. The vLLM
container's `--previous` log (captured from a `teardown: false` CI run):

```
File ".../torch/_inductor/runtime/cache_dir_utils.py", line 23, in default_cache_dir
    sanitized_username = re.sub(..., getpass.getuser())
File ".../getpass.py", line 169, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 1002700000'
```

## Why it surfaced now / why only standalone

- **Until ~Jun 22** the standalone image tag was `auto`, which the resolver
  (`crane ls`, last unsorted tag) happened to resolve to **vLLM v0.9.2** —
  old enough to predate the import-time `getpass` call, so it ran fine on
  `restricted-v2`. The `auto` bug was accidentally shielding standalone.
- Pinning standalone to `v0.23.0` (a separate, correct fix to escape the
  junk-tag resolver) brought in a new-enough vLLM to trigger getpwuid.
- **modelservice was never affected**: its decode/prefill pods set
  `USER=llm-d` via the shared `build_ms_env_vars()` macro. The standalone
  deployment uses its own hand-written env list, where the same workaround
  existed only in a dead `{% else %}` branch — the main container's env had
  `HOME` but no `USER`.
- Local dev namespaces (e.g. fma-ansu) grant `anyuid`, so the pod runs as
  root (in `/etc/passwd`) and the bug is masked — which is why prior manual
  standup tests passed while CI (`restricted-v2`) failed.

## Fix

Add `USER=llm-d` to the main standalone container's env in
`14_standalone-deployment_yaml.j2`, matching the coverage modelservice
already has. `getpass.getuser()` returns the env value and never reaches
`pwd.getpwuid`.