### PR TITLE
Extend WVA+FMA nightly with a hot-start scenario

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-ocp-fma-wva.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-fma-wva.yaml
@@ -9,9 +9,14 @@ name: CI - Nightly Run Benchmark on OCP ("WVA+FMA" autoscaling path)
 # exercises autoscaling and FMA pays its steady-state overhead with no
 # scaling benefit to amortize it. Override via inputs.workload if needed.
 #
-# This workflow runs TWO benchmark passes for direct comparison:
-#   1. baseline (WVA without FMA) — `cicd/ocp-wva`
-#   2. WVA with FMA               — `cicd/ocp-wva-fma-warmstart`
+# This workflow runs THREE benchmark passes for direct comparison:
+#   1. baseline (WVA without FMA)        — `cicd/ocp-wva`
+#   2. WVA with FMA (warm-start)         — `cicd/ocp-wva-fma-warmstart`
+#   3. WVA with FMA (hot-start)          — `cicd/ocp-wva-fma-hotstart`
+#
+# The hot-start variant pre-loads all models during standup, then scales down
+# to 1 before the benchmark. This isolates scaling algorithm performance from
+# model loading latency, providing a cleaner measurement of HPA/WVA behavior.
 #
 
 on:
@@ -27,10 +32,15 @@ on:
         type: 'string'
         default: 'ocp-wva'
       standup_scenario:
-        description: 'WVA with FMA scenario'
+        description: 'WVA with FMA scenario (warm-start)'
         required: false
         type: 'string'
         default: 'ocp-wva-fma-warmstart'
+      hotstart_scenario:
+        description: 'WVA with FMA scenario (hot-start)'
+        required: false
+        type: 'string'
+        default: 'ocp-wva-fma-hotstart'
       decode_pods:
         description: 'Number of decode pods (FMA path keeps decode at 0; baseline uses 1)'
         required: false
@@ -149,14 +159,15 @@ jobs:
     secrets: inherit
 
   # =========================================================================
-  # Pass 2: WVA with FMA
+  # Pass 2: WVA with FMA (Warm-Start)
   #
   # Same load against the same gateway/EPP path, but with FMA layered on:
   # decode.replicas: 0, FMA's launcher pods serve traffic, requester
-  # Deployment is the WVA scale target.
+  # Deployment is the WVA scale target. Warm-start deploys 1 replica initially,
+  # model loads during warmup, then benchmark scales 1->N.
   # =========================================================================
   nightly:
-    name: WVA with FMA (modelservice gateway)
+    name: WVA with FMA (Warm-Start)
     needs: [baseline]
     uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
@@ -189,19 +200,57 @@ jobs:
     secrets: inherit
 
   # =========================================================================
-  # Display: combine both result sets in the GH Step Summary
+  # Pass 3: WVA with FMA (Hot-Start)
+  #
+  # Hot-start variant: deploys all maxReplicas initially so all models load
+  # in parallel during standup. After loading, scales down to 1 (vLLM sleeps).
+  # Benchmark then scales 1->N, measuring pure HPA/WVA behavior without model
+  # loading latency confounding the results.
+  # =========================================================================
+  hotstart:
+    name: WVA with FMA (Hot-Start)
+    needs: [baseline]
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: 'modelservice,fma'
+      standup_scenario: ${{ inputs.hotstart_scenario || 'ocp-wva-fma-hotstart' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'ocp' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: 'llmdbenchcicdhsns-ocp'
+      helm_release: 'lmdbenchcicdhsr-ocp'
+      workspace_dir: '/tmp/llmdbenchcicdhs-ocp'
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
+      wait_timeout: ${{ inputs.wait_timeout || '7200' }}
+    secrets: inherit
+
+  # =========================================================================
+  # Display: combine all three result sets in the GH Step Summary
   # =========================================================================
   display-results:
-    name: Display Results (Baseline + WVA with FMA)
-    needs: [baseline, nightly]
+    name: Display Results (Baseline + WVA with FMA Warm-Start + Hot-Start)
+    needs: [baseline, nightly, hotstart]
     if: always()
     runs-on: ubuntu-latest
     env:
       GCS_PATH: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
       GCP_PROJECT_ID: ${{ inputs.bucket_project || 'llm-d-scale' }}
-      LLMDBENCH_CICD_TARGET: ${{ inputs.cluster_provider || 'ocp' }}
+      LLMDBENCH_CICD_TARGET: ${{ inputs.infra_provider || 'ocp' }}
       BASELINE_SCENARIO: ${{ inputs.baseline_scenario || 'ocp-wva' }}
-      FMA_WVA_SCENARIO: ${{ inputs.standup_scenario || 'ocp-wva-fma-warmstart' }}
+      FMA_WVA_WARMSTART_SCENARIO: ${{ inputs.standup_scenario || 'ocp-wva-fma-warmstart' }}
+      FMA_WVA_HOTSTART_SCENARIO: ${{ inputs.hotstart_scenario || 'ocp-wva-fma-hotstart' }}
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
@@ -217,8 +266,9 @@ jobs:
         run: |
           set +e
           BASELINE_DIR="/tmp/baseline-results"
-          FMA_WVA_DIR="/tmp/fma-wva-results"
-          mkdir -p "$BASELINE_DIR" "$FMA_WVA_DIR"
+          FMA_WVA_WARMSTART_DIR="/tmp/fma-wva-warmstart-results"
+          FMA_WVA_HOTSTART_DIR="/tmp/fma-wva-hotstart-results"
+          mkdir -p "$BASELINE_DIR" "$FMA_WVA_WARMSTART_DIR" "$FMA_WVA_HOTSTART_DIR"
 
           # Pick the most recent <date> subdir that actually has data
           latest_date_under() {
@@ -229,14 +279,18 @@ jobs:
               | sort | tail -1
           }
           BL_PREFIX="gs://${GCS_PATH}/${BASELINE_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice/"
-          FW_PREFIX="gs://${GCS_PATH}/${FMA_WVA_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
+          FW_WARMSTART_PREFIX="gs://${GCS_PATH}/${FMA_WVA_WARMSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
+          FW_HOTSTART_PREFIX="gs://${GCS_PATH}/${FMA_WVA_HOTSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
           BL_DATE=$(latest_date_under "$BL_PREFIX")
-          FW_DATE=$(latest_date_under "$FW_PREFIX")
-          echo "Baseline data date: ${BL_DATE:-none found}"
-          echo "FMA+WVA data date:  ${FW_DATE:-none found}"
+          FW_WARMSTART_DATE=$(latest_date_under "$FW_WARMSTART_PREFIX")
+          FW_HOTSTART_DATE=$(latest_date_under "$FW_HOTSTART_PREFIX")
+          echo "Baseline data date:           ${BL_DATE:-none found}"
+          echo "FMA+WVA Warm-Start data date: ${FW_WARMSTART_DATE:-none found}"
+          echo "FMA+WVA Hot-Start data date:  ${FW_HOTSTART_DATE:-none found}"
 
           [ -n "$BL_DATE" ] && gcloud storage cp -r "${BL_PREFIX}${BL_DATE}" "$BASELINE_DIR/" || true
-          [ -n "$FW_DATE" ] && gcloud storage cp -r "${FW_PREFIX}${FW_DATE}" "$FMA_WVA_DIR/" || true
+          [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_WVA_WARMSTART_DIR/" || true
+          [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_WVA_HOTSTART_DIR/" || true
 
           # PyYAML for cluster-state parsing in the timing-row computation
           # below; ubuntu-latest doesn't have it pre-installed in the user
@@ -251,14 +305,17 @@ jobs:
             # $1 = pass dir, $2 = filename
             find "$1" -path "*/results/*" -name "$2" 2>/dev/null | sort | tail -1
           }
-          BL_SUM=$(find_in_results "$BASELINE_DIR" "summary_lifecycle_metrics.json")
-          FW_SUM=$(find_in_results "$FMA_WVA_DIR"  "summary_lifecycle_metrics.json")
-          BL_WVA=$(find_in_results "$BASELINE_DIR" "wva-controller.log")
-          FW_WVA=$(find_in_results "$FMA_WVA_DIR"  "wva-controller.log")
-          BL_RES=$(find_in_results "$BASELINE_DIR" "resources.yaml")
-          FW_RES=$(find_in_results "$FMA_WVA_DIR"  "resources.yaml")
+          BL_SUM=$(find_in_results "$BASELINE_DIR"            "summary_lifecycle_metrics.json")
+          FW_WARMSTART_SUM=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "summary_lifecycle_metrics.json")
+          FW_HOTSTART_SUM=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "summary_lifecycle_metrics.json")
+          BL_WVA=$(find_in_results "$BASELINE_DIR"            "wva-controller.log")
+          FW_WARMSTART_WVA=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "wva-controller.log")
+          FW_HOTSTART_WVA=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "wva-controller.log")
+          BL_RES=$(find_in_results "$BASELINE_DIR"            "resources.yaml")
+          FW_WARMSTART_RES=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "resources.yaml")
+          FW_HOTSTART_RES=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "resources.yaml")
 
-          python3 - "$BL_SUM" "$FW_SUM" "$BL_WVA" "$FW_WVA" "$BL_RES" "$FW_RES" \
+          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_WVA" "$FW_WARMSTART_WVA" "$FW_HOTSTART_WVA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" \
             >> "$GITHUB_STEP_SUMMARY" <<'PY'
           import json, sys, os, re, datetime
           try:
@@ -267,7 +324,9 @@ jobs:
           except ImportError:
               HAVE_YAML = False
 
-          bl_sum, fw_sum, bl_wva, fw_wva, bl_res, fw_res = sys.argv[1:7]
+          (bl_sum, fw_ws_sum, fw_hs_sum,
+           bl_wva, fw_ws_wva, fw_hs_wva,
+           bl_res, fw_ws_res, fw_hs_res) = sys.argv[1:10]
 
           def load_json(p):
               if not p or not os.path.isfile(p):
@@ -279,7 +338,8 @@ jobs:
                   return None
 
           bl = load_json(bl_sum)
-          fw = load_json(fw_sum)
+          fw_ws = load_json(fw_ws_sum)   # WVA with FMA — warm start
+          fw_hs = load_json(fw_hs_sum)   # WVA with FMA — hot start
 
           def get(d, *keys, scale=1.0):
               if d is None: return None
@@ -338,7 +398,8 @@ jobs:
               return sum(deltas) / len(deltas) if deltas else None
 
           bl_cold_start = cold_start_mean(bl_wva)
-          fw_cold_start = cold_start_mean(fw_wva)
+          fw_ws_cold_start = cold_start_mean(fw_ws_wva)
+          fw_hs_cold_start = cold_start_mean(fw_hs_wva)
 
           # T_actuation: mean wall-clock from each requester pod's creation to
           # its Ready transition. Comes from kube API (resources.yaml) — no DPC
@@ -382,11 +443,12 @@ jobs:
               return sum(durs)/len(durs) if durs else None
 
           bl_actuation = actuation_mean(bl_res)
-          fw_actuation = actuation_mean(fw_res)
+          fw_ws_actuation = actuation_mean(fw_ws_res)
+          fw_hs_actuation = actuation_mean(fw_hs_res)
 
           # ----- Render the table --------------------------------------------
-          print("| Metric | Baseline (WVA without FMA) | WVA with FMA |")
-          print("|---|---:|---:|")
+          print("| Metric | Baseline (WVA without FMA) | WVA with FMA Warm Start | WVA with FMA Hot Start |")
+          print("|---|---:|---:|---:|")
 
           rows = [
               ("Duration (s)",    "benchmark_time_seconds", None, 0, ""),
@@ -414,19 +476,22 @@ jobs:
               unit = row[-1]
               prec = 0 if any(s in label for s in ("Total", "Successes", "Failures", "Duration", "tok/s")) else 1
               bl_v = get(bl, *keys, scale=scale)
-              fw_v = get(fw, *keys, scale=scale)
-              print(f"| {label} | {fmt(bl_v, unit, prec)} | {fmt(fw_v, unit, prec)} |")
+              fw_ws_v = get(fw_ws, *keys, scale=scale)
+              fw_hs_v = get(fw_hs, *keys, scale=scale)
+              print(f"| {label} | {fmt(bl_v, unit, prec)} | {fmt(fw_ws_v, unit, prec)} | {fmt(fw_hs_v, unit, prec)} |")
 
-          print(f"| Cold-start mean (s) — wva log | {fmt(bl_cold_start, '', 1)} | {fmt(fw_cold_start, '', 1)} |")
+          print(f"| Cold-start mean (s) — wva log | {fmt(bl_cold_start, '', 1)} | {fmt(fw_ws_cold_start, '', 1)} | {fmt(fw_hs_cold_start, '', 1)} |")
 
           # Mean pod create→Ready (kube-perspective). Captures the whole
-          # cold-start wall-clock for both passes.
-          print(f"| T_actuation mean (s) — pod create→ready | {fmt(bl_actuation, '', 1)} | {fmt(fw_actuation, '', 1)} |")
+          # cold-start wall-clock for all three passes.
+          print(f"| T_actuation mean (s) — pod create→ready | {fmt(bl_actuation, '', 1)} | {fmt(fw_ws_actuation, '', 1)} | {fmt(fw_hs_actuation, '', 1)} |")
 
           if bl is None:
               print("\n_No baseline results found._")
-          if fw is None:
-              print("\n_No WVA+FMA results found._")
+          if fw_ws is None:
+              print("\n_No WVA+FMA warm-start results found._")
+          if fw_hs is None:
+              print("\n_No WVA+FMA hot-start results found._")
           if not HAVE_YAML:
               print("\n_Note: PyYAML unavailable; scale-event timing rows skipped._")
           PY
@@ -446,10 +511,11 @@ jobs:
         id: cs
         run: |
           set +e
-          for label in baseline fma_wva; do
+          for label in baseline fma_wva_warmstart fma_wva_hotstart; do
             case $label in
-              baseline) base=/tmp/baseline-results ;;
-              fma_wva)  base=/tmp/fma-wva-results ;;
+              baseline)          base=/tmp/baseline-results ;;
+              fma_wva_warmstart) base=/tmp/fma-wva-warmstart-results ;;
+              fma_wva_hotstart)  base=/tmp/fma-wva-hotstart-results ;;
             esac
             latest=$(find "$base" -type d -name "runner-*" 2>/dev/null | sort | tail -1)
             exp=""
@@ -496,40 +562,78 @@ jobs:
           f="${{ steps.cs.outputs.baseline_exp }}/pods.txt"
           [ -f "$f" ] && cat "$f" || echo "no pods.txt for baseline"
 
-      # ---------------- WVA with FMA dumps ---------------------------------
+      # ---------------- WVA with FMA (Warm-Start) dumps --------------------
 
-      - name: Dump HPA — WVA with FMA
+      - name: Dump HPA — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_exp }}/hpa.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa.txt"
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for warm-start"
 
-      - name: Dump HPA describe — WVA with FMA
+      - name: Dump HPA describe — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_exp }}/hpa-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt"
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for warm-start"
 
-      - name: Dump WVA controller log tail — WVA with FMA
+      - name: Dump WVA controller log tail — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_exp }}/wva-controller.log"
-          [ -f "$f" ] && tail -200 "$f" || echo "no wva-controller.log"
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/wva-controller.log"
+          [ -f "$f" ] && tail -200 "$f" || echo "no wva-controller.log for warm-start"
 
-      - name: Dump FMA launcher-populator log tail — WVA with FMA
+      - name: Dump FMA launcher-populator log tail — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f=$(find "${{ steps.cs.outputs.fma_wva_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
-          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log"
+          f=$(find "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
+          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for warm-start"
 
-      - name: Dump events — WVA with FMA
+      - name: Dump events — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_exp }}/events.log"
-          [ -f "$f" ] && cat "$f" || echo "no events.log"
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/events.log"
+          [ -f "$f" ] && cat "$f" || echo "no events.log for warm-start"
 
-      - name: Dump pods — WVA with FMA
+      - name: Dump pods — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_exp }}/pods.txt"
-          [ -f "$f" ] && cat "$f" || echo "no pods.txt"
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/pods.txt"
+          [ -f "$f" ] && cat "$f" || echo "no pods.txt for warm-start"
+
+      # ---------------- WVA with FMA (Hot-Start) dumps ---------------------
+
+      - name: Dump HPA — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for hot-start"
+
+      - name: Dump HPA describe — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for hot-start"
+
+      - name: Dump WVA controller log tail — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/wva-controller.log"
+          [ -f "$f" ] && tail -200 "$f" || echo "no wva-controller.log for hot-start"
+
+      - name: Dump FMA launcher-populator log tail — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f=$(find "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
+          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for hot-start"
+
+      - name: Dump events — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/events.log"
+          [ -f "$f" ] && cat "$f" || echo "no events.log for hot-start"
+
+      - name: Dump pods — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/pods.txt"
+          [ -f "$f" ] && cat "$f" || echo "no pods.txt for hot-start"

--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -1,0 +1,301 @@
+# CI/CD WVA + FMA HOT-START benchmark scenario (OpenShift).
+#
+# Hot-start variant of ocp-wva-fma-warmstart.yaml. Measures WVA scaling behavior
+# isolated from model loading latency. Goal: identical 1->N scaling as warm-start
+# but without model load time confounding the results.
+#
+# Standup Phase:
+#   1. Deploy all 10 requester pods immediately (vs. 1 in warm-start)
+#   2. All launcher pods simultaneously load Qwen3-32B (~10-20 min total)
+#   3. After all pods ready, scale requester pods down to 1 (vLLM sleeps)
+#   4. Confirm all launcher pods have sleeping vLLM instance
+#
+# Benchmark Phase:
+#   - HPA scales 1->10 as load arrives (IDENTICAL to warm-start)
+#   - Difference: No model load latency; scaling measures ONLY HPA/WVA behavior
+#   - All models pre-loaded in memory, so scale-up is instantaneous
+#
+# The WVA+FMA arm of the FMA-vs-WVA comparison nightly. Its no-FMA baseline is
+# cicd/ocp-wva; the two are kept apples-to-apples (same model, WVA config,
+# and heavy workload profile, both with vLLM prefix caching off) so the
+# comparison measures the scaling path, not the prefix cache. For the
+# user-facing WVA well-lit path that the WVA make targets consume, use
+# guides/workload-autoscaling (WVA-only).
+#
+# All HPA / VariantAutoscaling knobs are listed below even when they match
+# defaults.yaml, so the full surface area is visible in one place.
+#
+# Note: FMA owns the elastic vLLM tier here, so the modelservice decode and
+# prefill Deployments are explicitly disabled below (decode.enabled: false,
+# prefill.enabled: false). modelservice still renders the gateway / EPP /
+# InferencePool that route to the FMA launcher pods.
+#
+# WVA scales an FMA-served model deployment. Topology:
+#
+#   modelservice (decode.enabled: false) provides gateway / EPP / InferencePool
+#     / PodMonitor; its decode Deployment is disabled — FMA owns the
+#     elastic vLLM tier instead.
+#
+#   FMA (fma.enabled: true)           launcher pods host vLLM and serve
+#     inference traffic; the requester Deployment holds the GPU lease
+#     that FMA scales.
+#
+#   WVA (wva.enabled: true)           scales the FMA requester Deployment;
+#     FMA's launcher-populator reconciles launcher pods to match.
+#
+# How EPP reaches FMA: 12_router-values.yaml.j2 emits a router.modelServers
+# selector matching `llm-d.ai/inferenceServing=true, llm-d.ai/model=<id>`.
+# 24_fma-deployment.yaml.j2 puts those labels on the InferenceServerConfig's
+# `modelServerConfig.labels` (NOT on the LauncherConfig pod template) — the
+# dual-pods controller propagates them to the launcher pod at BIND time, so
+# only launchers actually serving traffic show up in the InferencePool.
+#
+# How WVA tracks FMA: launcher pods carry `llm-d.ai/variant=<id>-fma` (also
+# applied at bind time via the ISC; label-based variant identification per
+# WVA repo PR #1145). Templates 27/28 retarget the VariantAutoscaling + HPA
+# at the FMA requester Deployment (`fma-requester-<id>`) when fma.enabled.
+#
+# Based on:
+#   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+#
+# Running:
+#
+#   llmdbenchmark --spec cicd/ocp-wva-fma-hotstart standup -p <namespace>
+#
+# `wva.enabled: true` and `fma.enabled: true` are already set below, so no CLI
+# flag is needed to enable them for this scenario.
+
+scenario:
+  # ============================================================================
+  # CI/CD WVA + FMA HOT-START - Qwen3-32B served by FMA launchers, autoscaled by WVA
+  # ============================================================================
+  - name: "ocp-wva-fma-hotstart-cicd"
+
+    kustomize:
+      enabled: false
+
+    # =========================================================================
+    # MODEL CONFIGURATION
+    # =========================================================================
+    model:
+      name: Qwen/Qwen3-32B
+      shortName: qwen-qwen3-32b
+      path: models/Qwen/Qwen3-32B
+      huggingfaceId: Qwen/Qwen3-32B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+
+    # =========================================================================
+    # DEPLOYMENT METHOD
+    # =========================================================================
+    modelservice:
+      enabled: true
+
+    standalone:
+      enabled: false
+
+    gateway:
+      className: epponly
+
+    fma:
+      enabled: true
+      iterations: 1
+
+      # HOT-START CHANGE #1: Deploy all replicas at standup for parallel model loading
+      # Initially set to maxReplicas so all launcher pods load models simultaneously
+      # during standup. After model loading completes, the warmup step scales this
+      # down to 1 to put vLLM servers into sleep state while keeping models in memory.
+      # Benchmark then scales 1->N, measuring pure HPA/WVA behavior (identical to
+      # warm-start) without model load latency.
+      requester:
+        replicas: 10  # ← Match maxReplicas; will be scaled down after warmup
+
+      # HOT-START CHANGE #2: Extended warmup for parallel model loading + scale-down
+      # Warmup sequence:
+      #   1. Wait for Deployment to be Available (all 10 pods Ready)
+      #   2. No additional buffer (models already loaded on all pods)
+      #   3. Scale requester Deployment down to 1 (vLLM sleeps on 9 pods)
+      #   4. Confirm sleeping vLLM instances are present
+      warmupTimeout: 1200  # ← Increased: 10-20 min model load + scale-down verification
+      warmupBufferSeconds: 0  # ← No buffer needed
+
+    # =========================================================================
+    # WVA CONFIGURATION
+    # =========================================================================
+    wva:
+      enabled: true
+      wellLitPath: optimized-baseline-hotstart
+
+      namespace: ""
+
+      image:
+        repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
+        tag: v0.8.0
+
+      replicaCount: 1
+      controller:
+        enabled: true
+      namespaceScoped: true
+
+      metrics:
+        enabled: true
+        port: 8443
+        secure: true
+
+      prometheus:
+        baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+        port: 9091
+
+      variantAutoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        variantCost: "10.0"
+        slo:
+          tpot: 10
+          ttft: 1000
+
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetAvgValue: 1
+
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 30
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+          scaleDown:
+            stabilizationWindowSeconds: 120
+            policies:
+              - type: Percent
+                value: 100
+                periodSeconds: 15
+
+      vllmService:
+        enabled: false
+
+    # =========================================================================
+    # WVA-RELATED CHART VERSIONS
+    # =========================================================================
+    chartVersions:
+      wva: 0.6.0
+      prometheusAdapter: 5.2.0
+
+    # =========================================================================
+    # ROUTING / GAIE CONFIGURATION
+    # =========================================================================
+    router:
+      epp:
+        pluginsConfigFile: "wva-plugins.yaml"
+        pluginsCustomConfig:
+          wva-plugins.yaml: |
+            apiVersion: llm-d.ai/v1alpha1
+            kind: EndpointPickerConfig
+            featureGates:
+              - flowControl
+            plugins:
+              - type: queue-scorer
+              - type: kv-cache-utilization-scorer
+              - type: prefix-cache-scorer
+            schedulingProfiles:
+              - name: default
+                plugins:
+                  - pluginRef: queue-scorer
+                    weight: 2
+                  - pluginRef: kv-cache-utilization-scorer
+                    weight: 2
+                  - pluginRef: prefix-cache-scorer
+                    weight: 3
+
+    # =========================================================================
+    # PREFILL / DECODE CONFIGURATION
+    # =========================================================================
+    prefill:
+      enabled: false
+
+    decode:
+      enabled: false
+      replicas: 0
+      # The FMA requester's nodeAffinity borrows decode.acceleratorType.labelValue
+      # (24_fma-deployment.yaml.j2), and WVA's saturation engine reads it back off
+      # the requester. The cluster resolver skips auto-detection for disabled
+      # sections, so pin the product explicitly here (pokprod = H100) — otherwise
+      # the requester's affinity stays "auto" and it never schedules. Non-"auto"
+      # values are left untouched by the resolver.
+      acceleratorType:
+        labelKey: nvidia.com/gpu.product
+        labelValue: NVIDIA-H100-80GB-HBM3
+
+    # =========================================================================
+    # VLLM COMMON CONFIGURATION
+    # =========================================================================
+    vllmCommon:
+      kvTransfer:
+        enabled: true
+        connector: NixlConnector
+        role: kv_both
+
+      flags:
+        enforceEager: false
+        disableLogRequests: true
+        disableUvicornAccessLog: true
+        allowLongMaxModelLen: "1"
+        serverDevMode: "1"
+
+      volumes:
+        - name: shared-config
+          type: emptyDir
+          emptyDir: {}
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: shared-config
+          mountPath: /shared-config
+
+    # =========================================================================
+    # STORAGE
+    # =========================================================================
+    storage:
+      modelPvc:
+        size: 1Ti
+
+    # =========================================================================
+    # WORKLOAD / HARNESS
+    # =========================================================================
+    workDir: "/tmp/llmdbenchcicd-ocp-wva-fma-hotstart/"
+
+    # Custom run-phase warmup step for hot-start scenario.
+    # Specifies step_02a_fma_warmup_hotstart instead of the default
+    # step_02a_fma_warmup. Hot-start warmup:
+    #   1. Waits for all N replicas to load (all launchers hot)
+    #   2. Scales down to minReplicas (puts vLLM to sleep, keeps models in memory)
+    #   3. Verifies launcher pods exist with sleeping vLLM instances
+    # Benchmark then scales 1->N (same as warm-start) but without load latency.
+    fmaWarmupStep: step_02a_fma_warmup_hotstart
+
+    harness:
+      name: inference-perf
+      experimentProfile: shared_prefix_synthetic_heavy.yaml
+      # The heavy profile drives high RPS against Qwen3-32B; the infra
+      # reusable does not pass --wait-timeout on the CLI so the CLI falls
+      # back to this field (see cli.py harness_wait_timeout resolution).
+      # Hot-start uses a larger value than warm-start/baseline (5400): its
+      # standup loads all 10 launchers in parallel (~10-20 min) before the
+      # run even begins, matching the hot-start job's wait_timeout: 7200.
+      waitTimeout: 7200
+
+    images:
+      benchmark:
+        tag: nightly

--- a/config/specification/cicd/ocp-wva-fma-hotstart.yaml.j2
+++ b/config/specification/cicd/ocp-wva-fma-hotstart.yaml.j2
@@ -1,0 +1,17 @@
+# OpenShift Container Platform CI/CD Specification - WVA + FMA (hot-start)
+
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml

--- a/llmdbenchmark/run/steps/step_02a_fma_warmup.py
+++ b/llmdbenchmark/run/steps/step_02a_fma_warmup.py
@@ -16,6 +16,11 @@ benchmark".
 
 Skipped when ``fma.enabled`` is false or no requester deployment was
 rendered (``fma.requester.replicas == 0``).
+
+A scenario may select an alternate warmup by setting the top-level
+``fmaWarmupStep`` key; ``step_02a_fma_warmup_hotstart`` delegates to
+:class:`FMAWarmupHotStartStep` (load all launchers, scale down to a sleeping
+vLLM, then benchmark scales back up).
 """
 
 import time
@@ -54,6 +59,24 @@ class FMAWarmupStep(Step):
 
         plan_config = self._load_stack_config(stack_path)
         stack_name = stack_path.name
+
+        # Per-stack warmup-variant dispatch. A scenario can opt into an
+        # alternate warmup by setting the top-level `fmaWarmupStep` key (it
+        # survives rendering into config.yaml via the plain deep-merge in
+        # render_plans.py, and the root config schema is extra="allow").
+        # `get_run_steps()` registers a single step-02a for the whole run, so
+        # the selection has to happen here at execute time where we have the
+        # per-stack config in hand. Hot-start loads all launchers, then scales
+        # the requester Deployment down to minReplicas so the extra launchers
+        # hold a sleeping vLLM (model in memory) before the benchmark drives
+        # scale-up 1->N.
+        warmup_step = self._resolve(plan_config, "fmaWarmupStep", default="")
+        if warmup_step == "step_02a_fma_warmup_hotstart":
+            from llmdbenchmark.run.steps.step_02a_fma_warmup_hotstart import (
+                FMAWarmupHotStartStep,
+            )
+
+            return FMAWarmupHotStartStep().execute(context, stack_path)
 
         if not self._resolve(plan_config, "fma.enabled", default=False):
             return StepResult(

--- a/llmdbenchmark/run/steps/step_02a_fma_warmup_hotstart.py
+++ b/llmdbenchmark/run/steps/step_02a_fma_warmup_hotstart.py
@@ -1,0 +1,388 @@
+"""Step 02a-hotstart -- FMA hot-start warmup: load all models, then scale down.
+
+Hot-start variant of step_02a_fma_warmup.py. Instead of just waiting for one
+replica to load and then running the benchmark, this step:
+
+  1. Waits for the FULL rollout — all N requester replicas available (all
+     launchers loaded), via `kubectl rollout status` (not the weaker Available
+     condition, which only needs the minAvailable threshold)
+  2. Scales requester Deployment down to minReplicas, then waits for the
+     scale-down to settle (rollout status), which unbinds N-1 launchers so the
+     controller puts each unbound launcher's vLLM to sleep (model retained)
+  3. STRICT gate (polled until convergence or timeout): fails unless
+     <= minReplicas launchers are awake and the whole scaled-down surplus is
+     sleeping AND Running+Ready (controller-owned label
+     dual-pods.llm-d.ai/sleeping=true) — hot-start requires sleeping instances
+  4. Benchmark then scales back up (1->N), measuring pure HPA/WVA behavior
+
+Goal: Measure the same 1->N scaling as warm-start but without model load
+latency confounding the results. All replicas have pre-loaded models in memory,
+so scale-up is instantaneous.
+
+Used by workload-autoscaling-hotstart scenario.
+"""
+
+import time
+from pathlib import Path
+
+from llmdbenchmark.executor.step import Step, StepResult, Phase
+from llmdbenchmark.executor.context import ExecutionContext
+
+
+class FMAWarmupHotStartStep(Step):
+    """Hot-start warmup: load all models, scale down to 1, verify sleeping vLLM."""
+
+    def __init__(self):
+        super().__init__(
+            number=2,
+            name="fma_warmup_hotstart",
+            description="Hot-start: load all models, scale down, verify sleeping vLLM",
+            phase=Phase.RUN,
+            per_stack=True,
+        )
+
+    def should_skip(self, context: ExecutionContext) -> bool:
+        return context.harness_skip_run
+
+    def execute(
+        self, context: ExecutionContext, stack_path: Path | None = None
+    ) -> StepResult:
+        if stack_path is None:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="No stack path provided for per-stack step",
+                errors=["stack_path is required"],
+            )
+
+        plan_config = self._load_stack_config(stack_path)
+        stack_name = stack_path.name
+
+        if not self._resolve(plan_config, "fma.enabled", default=False):
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=True,
+                message="fma.enabled is false; skipping hotstart warmup",
+                stack_name=stack_name,
+            )
+
+        replicas = int(
+            self._resolve(plan_config, "fma.requester.replicas", default=0) or 0
+        )
+        if replicas == 0:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=True,
+                message=(
+                    "fma.requester.replicas=0 (no requester deployment "
+                    "rendered); skipping hotstart warmup"
+                ),
+                stack_name=stack_name,
+            )
+
+        cmd = context.require_cmd()
+        namespace = context.require_namespace()
+        model_id_label = plan_config.get("model_id_label", "")
+        if not model_id_label:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="model_id_label missing from plan_config",
+                errors=["model_id_label is required for FMA hotstart warmup"],
+                stack_name=stack_name,
+            )
+
+        # Model name for user-facing log messages only. Derived from config so
+        # this step stays reusable across scenarios/models; falls back to a
+        # generic label if unset.
+        model_name = self._resolve(plan_config, "model.name", default="the model")
+        deploy_name = f"fma-requester-{model_id_label}"
+        timeout = int(self._resolve(plan_config, "fma.warmupTimeout", default=1200))
+        # Scale-down floor: read the HPA's minReplicas, since the HPA is what
+        # actually enforces the requester Deployment's replica count during the
+        # benchmark. Scaling below it would just get bounced back up on the next
+        # HPA sync, defeating the "sleep until the benchmark scales up" intent.
+        # variantAutoscaling.minReplicas only bounds what the WVA controller
+        # *computes*; fall back to it (then 1) when the HPA floor is unset.
+        min_replicas = int(
+            self._resolve(
+                plan_config,
+                "wva.hpa.minReplicas",
+                "wva.variantAutoscaling.minReplicas",
+                default=1,
+            )
+        )
+
+        # Stage 1: Wait for the FULL rollout — ALL N requester replicas must be
+        # available, i.e. all N launchers are bound and vLLM has finished
+        # loading the model.
+        #
+        # We use `kubectl rollout status`, NOT `wait --for=condition=Available`:
+        # a Deployment's Available condition only requires the minimum-
+        # availability threshold (readyReplicas >= replicas - maxUnavailable),
+        # so with replicas=10 it can flip to Available at 8/10. That would let
+        # hot-start proceed before every launcher has loaded the model,
+        # invalidating the "all models pre-loaded" precondition. `rollout status`
+        # returns success only once updatedReplicas == readyReplicas ==
+        # availableReplicas == desired, i.e. the complete 10/10 rollout.
+        context.logger.log_info(
+            f"⏳ Hot-start warmup Stage 1: waiting up to {timeout}s for the full "
+            f"rollout of Deployment/{deploy_name} (all {replicas} launchers "
+            f"loaded) in ns/{namespace}"
+        )
+        result = cmd.kube(
+            "rollout",
+            "status",
+            f"deployment/{deploy_name}",
+            f"--timeout={timeout}s",
+            namespace=namespace,
+            check=False,
+        )
+        if not result.success:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message=(
+                    f"Hot-start warmup Stage 1: Deployment/{deploy_name} rollout "
+                    f"did not complete ({replicas}/{replicas} available) within "
+                    f"{timeout}s (some launchers failed to load the model)"
+                ),
+                errors=[
+                    result.stderr.strip()[:400]
+                    or result.stdout.strip()[:400]
+                    or "rollout status timed out"
+                ],
+                stack_name=stack_name,
+            )
+
+        context.logger.log_info(
+            f"✓ Hot-start warmup Stage 1 complete: full rollout done — all "
+            f"{replicas} launchers have {model_name} loaded"
+        )
+
+        # Stage 2: Scale requester Deployment down to minReplicas.
+        # This unbinds N-1 requesters, putting their launcher's vLLM in sleep
+        # state while keeping the model in memory. Benchmark will then scale
+        # back up (1->N), measuring pure HPA/WVA behavior.
+        context.logger.log_info(
+            f"⏳ Hot-start warmup Stage 2: scaling Deployment/{deploy_name} "
+            f"from {replicas} -> {min_replicas} to put vLLM in sleep state"
+        )
+        result = cmd.kube(
+            "scale",
+            f"deployment/{deploy_name}",
+            f"--replicas={min_replicas}",
+            "--namespace",
+            namespace,
+            check=False,
+        )
+        if not result.success:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message=(
+                    f"Hot-start warmup Stage 2: failed to scale "
+                    f"Deployment/{deploy_name} to {min_replicas} replicas"
+                ),
+                errors=[result.stderr.strip()[:400] or "scale failed"],
+                stack_name=stack_name,
+            )
+
+        # Wait for the scale-DOWN to settle before gating on sleep state, rather
+        # than sleeping a brittle fixed interval: pod termination + unbinding +
+        # the controller flipping the sleeping label can take well over a few
+        # seconds, so a fixed sleep makes Stage 3 flake on a cluster that would
+        # otherwise converge. `rollout status` on the down-scaled Deployment
+        # returns once available == desired == min_replicas (surplus requester
+        # pods fully terminated), the deterministic settle point after which the
+        # controller unbinds their launchers. Stage 3 then polls for the sleep
+        # label so the remaining async (label flip) is waited on, not raced.
+        context.logger.log_info(
+            f"⏳ Hot-start warmup Stage 2b: waiting up to {timeout}s for "
+            f"Deployment/{deploy_name} to settle at {min_replicas} replica(s) "
+            f"after scale-down"
+        )
+        result = cmd.kube(
+            "rollout",
+            "status",
+            f"deployment/{deploy_name}",
+            f"--timeout={timeout}s",
+            namespace=namespace,
+            check=False,
+        )
+        if not result.success:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message=(
+                    f"Hot-start warmup Stage 2b: Deployment/{deploy_name} did not "
+                    f"settle at {min_replicas} replica(s) within {timeout}s after "
+                    f"scale-down"
+                ),
+                errors=[
+                    result.stderr.strip()[:400]
+                    or result.stdout.strip()[:400]
+                    or "rollout status timed out"
+                ],
+                stack_name=stack_name,
+            )
+
+        # Stage 3: STRICT gate on the hot-start precondition — the pool must be
+        # mostly ASLEEP, with the sleeping instances actually resident.
+        #
+        # The dual-pods controller stamps each launcher pod with
+        # `dual-pods.llm-d.ai/sleeping=<true|false>`: after our scale-down it
+        # unbinds the surplus requesters and flips their launchers to
+        # `sleeping=true` (model tensors retained in CPU memory, vLLM level-1
+        # sleep), while the launcher(s) still bound to the remaining requester(s)
+        # stay `sleeping=false`. That label is the authoritative, controller-
+        # owned signal, so we gate on it directly.
+        #
+        # Hot-start REQUIRES resident sleeping instances, so we FAIL the run
+        # unless (see the three gates below):
+        #   1. every sleeping launcher we need is Running AND Ready (a Pending /
+        #      not-Ready pod is not a resident vLLM),
+        #   2. at most min_replicas launchers are awake (sleeping=false) — more
+        #      than that means the surplus never went to sleep, so there is no
+        #      hot-start to measure, and
+        #   3. at least (replicas - min_replicas) launchers are sleeping AND
+        #      Running+Ready — the whole surplus we scaled down is asleep.
+        expected_sleeping = max(replicas - min_replicas, 0)
+        context.logger.log_info(
+            f"⏳ Hot-start warmup Stage 3: polling sleeping launcher pool "
+            f"(require <= {min_replicas} awake and >= {expected_sleeping} "
+            f"Running+Ready sleeping launchers) up to {timeout}s before benchmark"
+        )
+
+        # One custom-columns query gives, per launcher pod and aligned by row,
+        # the sleeping label, phase, and Ready-condition status. cmd.kube()
+        # shell-joins its args (and runs under shell=True), so the whole
+        # custom-columns spec is passed as ONE single-quoted token — otherwise
+        # the shell glob-expands the `[?(@.type=="Ready")]` filter and strips
+        # the quotes ("no matches found").
+        pool_selector = (
+            f"stood-up-via=fma,"
+            f"dual-pods.llm-d.ai/launcher-config-name=fma-{model_id_label}"
+        )
+        columns = (
+            "'custom-columns="
+            "SLEEP:.metadata.labels.dual-pods\\.llm-d\\.ai/sleeping,"
+            "PHASE:.status.phase,"
+            'READY:.status.conditions[?(@.type=="Ready")].status\''
+        )
+
+        def _sleep(cols):
+            return cols[0] if cols else ""
+
+        def _running_ready(cols):
+            # cols == [sleeping, phase, ready]; ready is "True"/"False"/"<none>"
+            return len(cols) >= 3 and cols[1] == "Running" and cols[2] == "True"
+
+        # Poll the sleep gate rather than checking once: the controller flips the
+        # sleeping label asynchronously after the surplus requesters terminate,
+        # so the pool may still be settling when Stage 2b returns. We re-query
+        # until both gates pass or the timeout elapses, and only then fail —
+        # with the last-observed counts — so we never flake on a cluster that
+        # would have converged given a little more time.
+        poll_interval = 10
+        deadline = timeout
+        elapsed = 0
+        awake = 0
+        sleeping_ready = 0
+        gate_error = "launcher pool never converged to the sleeping precondition"
+        while True:
+            result = cmd.kube(
+                "get",
+                "pods",
+                "-l",
+                pool_selector,
+                "-o",
+                columns,
+                "--no-headers",
+                namespace=namespace,
+                check=False,
+            )
+            if not result.success:
+                return StepResult(
+                    step_number=self.number,
+                    step_name=self.name,
+                    success=False,
+                    message="Hot-start warmup Stage 3: failed to query launcher pool",
+                    errors=[result.stderr.strip()[:400] or "get pods failed"],
+                    stack_name=stack_name,
+                )
+
+            # Each row: "<sleeping> <phase> <ready>" (e.g. "true Running True").
+            pool = [row.split() for row in result.stdout.splitlines() if row.split()]
+            awake = sum(1 for c in pool if _sleep(c) == "false")
+            sleeping_ready = sum(
+                1 for c in pool if _sleep(c) == "true" and _running_ready(c)
+            )
+
+            # Gate 2 (awake) + Gate 3 (sleeping surplus resident). Both must hold.
+            if not pool:
+                gate_error = f"no launcher pods found for fma-{model_id_label}"
+            elif awake > min_replicas:
+                gate_error = (
+                    f"{awake} awake launcher(s) (sleeping=false) exceeds "
+                    f"min_replicas={min_replicas} — surplus not put to sleep"
+                )
+            elif sleeping_ready < expected_sleeping:
+                gate_error = (
+                    f"{sleeping_ready} of {expected_sleeping} surplus launchers "
+                    "sleeping AND Running+Ready — still converging"
+                )
+            else:
+                break  # both gates satisfied
+
+            if elapsed >= deadline:
+                return StepResult(
+                    step_number=self.number,
+                    step_name=self.name,
+                    success=False,
+                    message=(
+                        f"Hot-start warmup Stage 3: launcher pool did not reach "
+                        f"the sleeping precondition within {timeout}s "
+                        f"(observed {awake} awake, {sleeping_ready}/"
+                        f"{expected_sleeping} sleeping+Running+Ready) — "
+                        "hot-start requires the scaled-down surplus to be "
+                        "resident sleeping instances"
+                    ),
+                    errors=[gate_error],
+                    stack_name=stack_name,
+                )
+
+            context.logger.log_info(
+                f"    | Stage 3: not converged yet ({awake} awake, "
+                f"{sleeping_ready}/{expected_sleeping} sleeping+ready); "
+                f"re-checking in {poll_interval}s"
+            )
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+
+        context.logger.log_info(
+            f"✓ Hot-start warmup Stage 3 complete: {sleeping_ready} launcher(s) "
+            f"sleeping and Running+Ready (>= {expected_sleeping}), {awake} awake "
+            f"(<= {min_replicas}). Ready for benchmark scale-up (1->{replicas})"
+        )
+
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=True,
+            message=(
+                f"Hot-start warmup complete: {replicas} launchers pre-loaded "
+                f"{model_name}, requester scaled down to {min_replicas}; "
+                f"{sleeping_ready} launcher(s) sleeping and Running+Ready, "
+                f"{awake} awake (model resident). Benchmark will scale up "
+                f"(1->{replicas}) measuring pure HPA/WVA behavior"
+            ),
+            stack_name=stack_name,
+        )


### PR DESCRIPTION
This PR adds a hot-start benchmark scenario to the WVA+FMA autoscaling nightly, alongside the existing baseline (WVA-only) and warm-start passes. Hot-start measures WVA scale-up (1→N) with models pre-lo

**What's included**

Hot-start scenario — config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
Mirrors ocp-wva-fma-warmstart.yaml (same model, WVA config, heavy workload profile) with hot-start deltas:
- `fma.requester.replicas: 10` — all requester pods deployed immediately so all launchers load in parallel
- `warmupTimeout: 1200`, `warmupBufferSeconds: 0`
- `fmaWarmupStep`: `step_02a_fma_warmup_hotstart` — selects the custom warmup

Hot-start warmup step — llmdbenchmark/run/steps/step_02a_fma_warmup_hotstart.py
Three stages: (1) wait for the requester Deployment to be Available (all 10 launchers loaded), (2) scale down to minReplicas so the extra launchers' vLLM goes to sleep with the model in memory, (3) verify launcher pods are still present. Benchmark then scales 1→N with no load latency.

Warmup dispatch wiring — `llmdbenchmark/run/steps/step_02a_fma_warmup.py`
FMAWarmupStep.execute now delegates to FMAWarmupHotStartStep when the stack's config sets `fmaWarmupStep: step_02a_fma_warmup_hotstart`. This is per-stack correct and requires no change to the run-step registry or step ordering — warm-start stacks stay on the default path untouched.

**Workflow results** — `.github/workflows/ci-nightly-benchmark-ocp-fma-wva.yaml`
- Extends the GH Step Summary to a 4-column comparison table:
`| Metric | Baseline (WVA without FMA) | WVA with FMA Warm Start | WVA with FMA Hot Start |`
- Wires the hot-start data path through the GCS download and per-resource dump steps (HPA, WVA controller log, launcher-populator, events, pods) for all three passes.