### PR TITLE
Allow run workloads to use a local profile file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ llmdbenchmark --version
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` / `KUBECONFIG` | Kubeconfig path |
 | `-l HARNESS` | `LLMDBENCH_HARNESS` | Harness name (inference-perf, guidellm, vllm-benchmark) |
 | `-w PROFILE` | `LLMDBENCH_WORKLOAD` | Workload profile YAML |
+| `--workload-file-path FILE` | `LLMDBENCH_WORKLOAD_FILE_PATH` | Local workload profile file path |
 | `-e FILE` | `LLMDBENCH_EXPERIMENTS` | Experiment treatments YAML for parameter sweeping |
 | `-o OVERRIDES` | `LLMDBENCH_OVERRIDES` | Workload parameter overrides (param=value,...) |
 | `-r DEST` | `LLMDBENCH_OUTPUT` | Results destination (local, gs://, s3://) |

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -830,6 +830,7 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
             or (plan_info.get("harness", {}) or {}).get("name")
         ),
         harness_profile=getattr(args, "workload", None),
+        workload_file_path=getattr(args, "workload_file_path", None),
         experiment_treatments_file=experiments_file,
         profile_overrides=getattr(args, "overrides", None),
         harness_output=getattr(args, "output", "local") or "local",
@@ -1498,6 +1499,10 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_MODEL": ("model", "--model"),
         "LLMDBENCH_HARNESS": ("harness", "--harness"),
         "LLMDBENCH_WORKLOAD": ("workload", "--workload"),
+        "LLMDBENCH_WORKLOAD_FILE_PATH": (
+            "workload_file_path",
+            "--workload-file-path",
+        ),
         "LLMDBENCH_EXPERIMENTS": ("experiments", "--experiments"),
         "LLMDBENCH_OVERRIDES": ("overrides", "--overrides"),
         "LLMDBENCH_OUTPUT": ("output", "--output"),
@@ -1596,6 +1601,7 @@ def _all_flag_forms(flag: str) -> list[str]:
         "--model": ["--model", "-m"],
         "--harness": ["--harness", "-l"],
         "--workload": ["--workload", "-w"],
+        "--workload-file-path": ["--workload-file-path"],
         "--experiments": ["--experiments", "-e"],
         "--overrides": ["--overrides", "-o"],
         "--output": ["--output", "-r"],

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -85,6 +85,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # Run-phase configuration (set by _execute_run)
     harness_name: str | None = None
     harness_profile: str | None = None
+    workload_file_path: str | None = None
     experiment_treatments_file: str | None = None
     profile_overrides: str | None = None
     harness_output: str = "local"

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -107,6 +107,7 @@ Executes benchmark experiments against deployed infrastructure.
 | `-m` / `--model` | `LLMDBENCH_MODEL` | Model name override |
 | `-l` / `--harness` | `LLMDBENCH_HARNESS` | Harness name |
 | `-w` / `--workload` | `LLMDBENCH_WORKLOAD` | Workload profile name |
+| `--workload-file-path` | `LLMDBENCH_WORKLOAD_FILE_PATH` | Local workload profile file path |
 | `-e` / `--experiments` | `LLMDBENCH_EXPERIMENTS` | Experiment treatments YAML |
 | `-o` / `--overrides` | `LLMDBENCH_OVERRIDES` | Profile parameter overrides (param=value,...) |
 | `-r` / `--output` | `LLMDBENCH_OUTPUT` | Results destination (local, gs://, s3://) |

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -75,6 +75,14 @@ def add_subcommands(
         help="Workload profile name (e.g., sanity_random.yaml).",
     )
     run_parser.add_argument(
+        "--workload-file-path",
+        default=env("LLMDBENCH_WORKLOAD_FILE_PATH"),
+        help=(
+            "Path to a local workload profile file. When set, this file is used "
+            "instead of resolving --workload under workload/profiles/<harness>."
+        ),
+    )
+    run_parser.add_argument(
         "-e",
         "--experiments",
         default=env("LLMDBENCH_EXPERIMENTS"),

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -104,6 +104,7 @@ llmdbenchmark --spec guides/inference-scheduling run -p <NS> -z
 |------|---------|-------------|
 | `-l HARNESS` | `LLMDBENCH_HARNESS` | Harness name: `inference-perf`, `guidellm`, `vllm-benchmark`, `inferencemax`, `nop` |
 | `-w WORKLOAD` | `LLMDBENCH_WORKLOAD` | Workload profile name (e.g., `sanity_random.yaml`, `chatbot_synthetic.yaml`) |
+| `--workload-file-path FILE` | `LLMDBENCH_WORKLOAD_FILE_PATH` | Local workload profile file path |
 | `-p NS` | `LLMDBENCH_NAMESPACE` | Namespace(s) -- `deploy_ns,harness_ns` or single namespace for both |
 | `-m MODEL` | `LLMDBENCH_MODEL` | Model name override (e.g., `Qwen/Qwen3-32B`) |
 | `-t METHODS` | `LLMDBENCH_METHODS` | Deploy method used during standup (`standalone`, `modelservice`) |

--- a/llmdbenchmark/run/steps/step_05_render_profiles.py
+++ b/llmdbenchmark/run/steps/step_05_render_profiles.py
@@ -63,17 +63,36 @@ class RenderProfilesStep(Step):
 
         # Locate source profiles directory
         base_dir = context.base_dir or Path(__file__).resolve().parents[3]
-        profiles_source = base_dir / "workload" / "profiles" / harness_name
-        if not profiles_source.is_dir():
-            errors.append(f"Profiles directory not found: {profiles_source}")
-            return StepResult(
-                step_number=self.number,
-                step_name=self.name,
-                success=False,
-                message="Profile source directory not found",
-                errors=errors,
-                stack_name=stack_name,
-            )
+        workload_file_path = getattr(context, "workload_file_path", None)
+        source_profile_file: Path | None = None
+        profiles_source: Path | None = None
+        if workload_file_path:
+            source_profile_file = Path(workload_file_path).expanduser()
+            if not source_profile_file.is_absolute():
+                source_profile_file = Path.cwd() / source_profile_file
+            if not source_profile_file.is_file():
+                errors.append(f"Workload profile file not found: {source_profile_file}")
+                return StepResult(
+                    step_number=self.number,
+                    step_name=self.name,
+                    success=False,
+                    message="Workload profile file not found",
+                    errors=errors,
+                    stack_name=stack_name,
+                )
+            profile_name = source_profile_file.name
+        else:
+            profiles_source = base_dir / "workload" / "profiles" / harness_name
+            if not profiles_source.is_dir():
+                errors.append(f"Profiles directory not found: {profiles_source}")
+                return StepResult(
+                    step_number=self.number,
+                    step_name=self.name,
+                    success=False,
+                    message="Profile source directory not found",
+                    errors=errors,
+                    stack_name=stack_name,
+                )
 
         # CLI flags and runtime values override plan_config defaults
         runtime_values: dict[str, str] = {
@@ -126,25 +145,27 @@ class RenderProfilesStep(Step):
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Copy all profiles to output first (non-.yaml.in files are copied as-is)
-        for src_file in profiles_source.iterdir():
-            if src_file.is_file() and not src_file.name.endswith(".yaml.in"):
-                shutil.copy2(src_file, output_dir / src_file.name)
+        if profiles_source is not None:
+            for src_file in profiles_source.iterdir():
+                if src_file.is_file() and not src_file.name.endswith(".yaml.in"):
+                    shutil.copy2(src_file, output_dir / src_file.name)
 
         # Determine treatments
         treatments = self._resolve_treatments(context, plan_config)
 
         if not treatments:
             # Single default treatment -- render the profile as-is
-            source_file = profiles_source / profile_name
-            if not source_file.exists():
-                # Try with .in extension
-                source_file = profiles_source / f"{profile_name}.in"
-            if source_file.exists():
+            source_file = self._resolve_source_file(
+                profile_name, profiles_source, source_profile_file
+            )
+            if source_file is not None:
                 # Determine output name (strip .in if present)
                 out_name = profile_name
                 if out_name.endswith(".in"):
                     out_name = out_name[:-3]
                 dest_file = output_dir / out_name
+                if source_profile_file is not None:
+                    context.harness_profile = out_name
 
                 if context.dry_run:
                     context.logger.log_info(
@@ -163,11 +184,10 @@ class RenderProfilesStep(Step):
                 treatment_name = treatment.get("name", f"treatment-{i}")
                 treatment_overrides = treatment.get("overrides", {})
 
-                source_file = profiles_source / profile_name
-                if not source_file.exists():
-                    source_file = profiles_source / f"{profile_name}.in"
-
-                if not source_file.exists():
+                source_file = self._resolve_source_file(
+                    profile_name, profiles_source, source_profile_file
+                )
+                if source_file is None:
                     errors.append(
                         f"Profile '{profile_name}' not found for treatment "
                         f"'{treatment_name}'"
@@ -177,6 +197,8 @@ class RenderProfilesStep(Step):
                 out_name = profile_name
                 if out_name.endswith(".in"):
                     out_name = out_name[:-3]
+                if source_profile_file is not None:
+                    context.harness_profile = out_name
                 # Append treatment name to output file
                 stem = Path(out_name).stem
                 suffix = Path(out_name).suffix
@@ -234,6 +256,28 @@ class RenderProfilesStep(Step):
             message=f"Profiles rendered for {stack_name}",
             stack_name=stack_name,
         )
+
+    def _resolve_source_file(
+        self,
+        profile_name: str,
+        profiles_source: Path | None,
+        source_profile_file: Path | None,
+    ) -> Path | None:
+        if source_profile_file is not None:
+            return source_profile_file
+
+        if profiles_source is None:
+            return None
+
+        source_file = profiles_source / profile_name
+        if source_file.exists():
+            return source_file
+
+        source_file = profiles_source / f"{profile_name}.in"
+        if source_file.exists():
+            return source_file
+
+        return None
 
     def _resolve_treatments(
         self, context: ExecutionContext, plan_config: dict | None

--- a/tests/test_render_profiles_workload_file_path.py
+++ b/tests/test_render_profiles_workload_file_path.py
@@ -1,0 +1,149 @@
+"""Tests for local workload profile path rendering."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_STEP_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "llmdbenchmark"
+    / "run"
+    / "steps"
+    / "step_05_render_profiles.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "step_05_render_profiles_isolated", _STEP_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+sys.modules["step_05_render_profiles_isolated"] = _module
+_spec.loader.exec_module(_module)
+RenderProfilesStep = _module.RenderProfilesStep
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def log_info(self, msg: str, **_: Any) -> None:
+        self.messages.append(msg)
+
+    def log_warning(self, msg: str, **_: Any) -> None:
+        self.messages.append(f"WARN: {msg}")
+
+
+@dataclass
+class _Context:
+    workspace: Path
+    base_dir: Path
+    workload_file_path: str | None = None
+    harness_name: str | None = "inference-perf"
+    harness_profile: str | None = None
+    deployed_endpoints: dict[str, str] = field(default_factory=dict)
+    model_name: str | None = None
+    dataset_url: str | None = None
+    dry_run: bool = False
+    experiment_treatments_file: str | None = None
+    profile_overrides: str | None = None
+    experiment_treatments: list[dict] | None = None
+    logger: _Logger = field(default_factory=_Logger)
+
+    def workload_profiles_dir(self) -> Path:
+        path = self.workspace / "workload" / "profiles"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+def _write_stack(tmp_path: Path) -> Path:
+    stack_path = tmp_path / "stack"
+    stack_path.mkdir()
+    (stack_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "harness": {"name": "inference-perf"},
+                "namespace": {"name": "bench"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return stack_path
+
+
+def test_render_profiles_uses_local_workload_file_path(tmp_path: Path) -> None:
+    workload_file = tmp_path / "custom" / "local_profile.yaml.in"
+    workload_file.parent.mkdir()
+    workload_file.write_text("target: local\n", encoding="utf-8")
+    context = _Context(
+        workspace=tmp_path / "workspace",
+        base_dir=tmp_path / "base",
+        workload_file_path=str(workload_file),
+    )
+
+    result = RenderProfilesStep().execute(context, _write_stack(tmp_path))
+
+    assert result.success
+    rendered = context.workload_profiles_dir() / "inference-perf" / "local_profile.yaml"
+    assert rendered.read_text(encoding="utf-8") == "target: local\n"
+    assert context.harness_profile == "local_profile.yaml"
+
+
+def test_render_profiles_resolves_relative_workload_file_path(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    workload_file = tmp_path / "custom" / "relative_profile.yaml.in"
+    workload_file.parent.mkdir()
+    workload_file.write_text("target: relative\n", encoding="utf-8")
+    context = _Context(
+        workspace=tmp_path / "workspace",
+        base_dir=tmp_path / "base",
+        workload_file_path="custom/relative_profile.yaml.in",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = RenderProfilesStep().execute(context, _write_stack(tmp_path))
+
+    assert result.success
+    rendered = (
+        context.workload_profiles_dir() / "inference-perf" / "relative_profile.yaml"
+    )
+    assert rendered.read_text(encoding="utf-8") == "target: relative\n"
+    assert context.harness_profile == "relative_profile.yaml"
+
+
+def test_render_profiles_falls_back_to_workload_directory(tmp_path: Path) -> None:
+    base_dir = tmp_path / "base"
+    profiles_dir = base_dir / "workload" / "profiles" / "inference-perf"
+    profiles_dir.mkdir(parents=True)
+    (profiles_dir / "sanity_random.yaml.in").write_text(
+        "target: default\n", encoding="utf-8"
+    )
+    context = _Context(workspace=tmp_path / "workspace", base_dir=base_dir)
+
+    result = RenderProfilesStep().execute(context, _write_stack(tmp_path))
+
+    assert result.success
+    rendered = context.workload_profiles_dir() / "inference-perf" / "sanity_random.yaml"
+    assert rendered.read_text(encoding="utf-8") == "target: default\n"
+    assert context.harness_profile is None
+
+
+def test_render_profiles_returns_error_for_missing_local_workload_file(
+    tmp_path: Path,
+) -> None:
+    missing_file = tmp_path / "missing.yaml"
+    context = _Context(
+        workspace=tmp_path / "workspace",
+        base_dir=tmp_path / "base",
+        workload_file_path=str(missing_file),
+    )
+
+    result = RenderProfilesStep().execute(context, _write_stack(tmp_path))
+
+    assert not result.success
+    assert result.message == "Workload profile file not found"
+    assert result.errors == [f"Workload profile file not found: {missing_file}"]


### PR DESCRIPTION
## Summary

  Adds `--workload-file-path` / `LLMDBENCH_WORKLOAD_FILE_PATH` so a run can render a workload profile from a local file path instead of requiring the profile to live under
  `workload/profiles/<harness>`.

  ## Motivation

  Fixes #1563.

  Some workflows generate or keep workload profiles outside the repository's built-in workload directory. The existing run path only resolves profiles from the hardcoded harness
  workload directory, which makes local profile iteration awkward.

  ## What changed

  - Added a run CLI option: `--workload-file-path`.
  - Added `LLMDBENCH_WORKLOAD_FILE_PATH` env var support.
  - Passed the value through `ExecutionContext`.
  - Updated render_profiles to:
    - use the local file when provided,
    - resolve relative paths from the current working directory,
    - preserve the existing `--workload` lookup behavior when not provided.
  - Added regression tests for local absolute paths, local relative paths, fallback behavior, and missing file errors.
  - Updated CLI documentation tables.

  ## Testing

  - `python -m pytest tests -q`
    - `580 passed, 31 skipped`
  - `python -m py_compile llmdbenchmark/executor/context.py llmdbenchmark/interface/run.py llmdbenchmark/cli.py llmdbenchmark/run/steps/step_05_render_profiles.py tests/
  test_render_profiles_workload_file_path.py`
  - `git diff --check`

  ## Backward compatibility

  Existing `--workload` behavior is unchanged when `--workload-file-path` is not provided.