### PR TITLE
 Support inference-perf report conversion in run-only mode

### DIFF
--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
@@ -237,11 +237,19 @@ def _populate_run(ev_dict: dict) -> dict:
     # Create cluster ID from the API server certificate
     host = os.environ.get("KUBERNETES_SERVICE_HOST")
     port = int(os.environ.get("KUBERNETES_SERVICE_PORT", 0))
-    try:
-        cert = ssl.get_server_certificate((host, port), timeout=5)
-    except (TimeoutError, OSError):
-        # As a failover, just use the service host
-        cert = host
+    cert = None
+    if host and port:
+        try:
+            cert = ssl.get_server_certificate((host, port), timeout=5)
+        except (TimeoutError, OSError):
+            # As a failover, just use the service host
+            cert = host
+    if not cert:
+        cert = (
+            ev_dict.get("harness_stack_endpoint_url")
+            or ev_dict.get("vllm_common_namespace")
+            or "run-only"
+        )
     cid = str(uuid.uuid5(uuid.NAMESPACE_DNS, cert))
 
     # Use the namespace for "user"
@@ -300,13 +308,28 @@ def _populate_load() -> dict:
             value = None
         args[key] = value
 
-    # Import config file, if it exists
-    config_file = os.environ.get("LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME", "")
-    try:
-        with open(config_file, "r", encoding="UTF-8") as file:
-            config = yaml.safe_load(file)
-    except (FileNotFoundError, IsADirectoryError):
-        config = None
+    # Import config file, if it exists. In run-only/local analysis the workload
+    # env var may be just a file name, while harness_args carries the full path.
+    config = None
+    config_candidates = [
+        os.environ.get("LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME", ""),
+        args.get("config_file", ""),
+    ]
+    run_metadata = _load_run_metadata()
+    results_dir = os.environ.get("LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR", "")
+    harness_workload = run_metadata.get("harness_workload", "")
+    if results_dir and harness_workload:
+        config_candidates.append(os.path.join(results_dir, harness_workload))
+
+    for config_file in config_candidates:
+        if not config_file:
+            continue
+        try:
+            with open(config_file, "r", encoding="UTF-8") as file:
+                config = yaml.safe_load(file)
+            break
+        except (FileNotFoundError, IsADirectoryError):
+            continue
 
     br_dict = {
         "scenario": {

--- a/tests/test_run_only_report_conversion.py
+++ b/tests/test_run_only_report_conversion.py
@@ -1,0 +1,76 @@
+"""Tests for run-only inference-perf report conversion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.analysis.benchmark_report.native_to_br0_2 import (
+    _get_harness_meta,
+    import_inference_perf,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "inference_perf_lifecycle.yaml"
+
+
+def test_run_only_conversion_uses_metadata_without_kubernetes_context(
+    tmp_path: Path, monkeypatch
+) -> None:
+    results_file = tmp_path / "stage_0_lifecycle_metrics.json"
+    results_file.write_text(FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    workload_file = tmp_path / "code_generation.yaml"
+    workload_file.write_text(
+        yaml.safe_dump(
+            {
+                "load": {"type": "concurrent"},
+                "api": {"type": "completion", "streaming": True},
+                "server": {
+                    "type": "vllm",
+                    "model_name": "Qwen/Qwen3-32B",
+                    "base_url": "http://10.128.0.22",
+                },
+                "data": {
+                    "type": "conversation_replay",
+                    "conversation_replay": {"seed": 42, "num_conversations": 20},
+                },
+                "metrics": {
+                    "type": "prometheus",
+                    "prometheus": {"google_managed": True, "scrape_interval": 15},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "run_metadata.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "harness_args": f"--config_file {workload_file}",
+                "harness_start": "2026-06-23T22:54:25+00:00",
+                "harness_stop": "2026-06-23T23:14:35+00:00",
+                "harness_delta": "PT1210S",
+                "harness_version": "test-version",
+                "harness_name": "inference-perf",
+                "harness_workload": workload_file.name,
+                "harness_rc": "0",
+                "model": "Qwen/Qwen3-32B",
+                "endpoint_url": "http://10.128.0.22",
+                "namespace": "llm-d-storage",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("LLMDBENCH_MAGIC_ENVAR", "harness_pod")
+    monkeypatch.setenv("LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR", str(tmp_path))
+    monkeypatch.delenv("LLMDBENCH_BASE64_CONTEXT_CONTENTS", raising=False)
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    monkeypatch.delenv("KUBERNETES_SERVICE_PORT", raising=False)
+    if hasattr(_get_harness_meta, "_cache"):
+        delattr(_get_harness_meta, "_cache")
+
+    report = import_inference_perf(str(results_file))
+
+    assert report.run.user == "namespace=llm-d-storage"
+    assert report.scenario.load.native.config["metrics"]["prometheus"]["google_managed"]


### PR DESCRIPTION
## Summary

  Fix inference-perf benchmark report conversion for run-only executions where no standup ConfigMap, `/standup/ev.yaml`, or Kubernetes service environment is available.

  ## Motivation

  Fixes #1477.

  In run-only mode against an existing endpoint, the harness writes `run_metadata.yaml`, but report conversion may run without Kubernetes service host/port information or standup
  environment data. Before this change, v0.2 report conversion could crash while deriving the cluster id because the Kubernetes API certificate fallback could be `None`.

  The same run-only path could also lose the workload config because `_populate_load()` only tried `LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME`, which is often just the
  workload file name. The real rendered config path is available in `--config_file` inside `harness_args`.

  ## What changed

  - Use run metadata endpoint URL or namespace as a stable cluster-id fallback when Kubernetes service certificate data is unavailable.
  - Load the workload config from the parsed `--config_file` path in `harness_args`.
  - Keep the existing env-var based config lookup as the first candidate.
  - Add a regression test for run-only inference-perf conversion without Kubernetes context.

  ## Reproduction

  The new test constructs a run-only result directory with:

  - an inference-perf lifecycle fixture,
  - `run_metadata.yaml`,
  - a workload config containing `metrics.prometheus.google_managed: true`,
  - no Kubernetes service environment,
  - no standup ConfigMap,
  - no `/standup/ev.yaml`.

  Before the fix, conversion failed with:

  ```text
  TypeError: can't concat NoneType to bytes

  After the fix, conversion succeeds and preserves the native workload config.

  ## Testing

  - python -m pytest tests/test_run_only_report_conversion.py -q
  - manual run_analysis("inference-perf", results_dir) on the run-only fixture
  - python -m pytest tests -q
  - python -m py_compile llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py tests/test_run_only_report_conversion.py
  - git diff --check

  ## Backward compatibility

  Existing in-cluster conversion still prefers Kubernetes API certificate data for the cluster id. The new fallback only applies when Kubernetes service details are unavailable.