### PR TITLE
 plan: validate inline kustomize patches

### DIFF
--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1294,6 +1294,48 @@ class RenderPlans:
                 errors.append(f"{yaml_file.name}: {str(e)[:100]}")
         return errors
 
+    @staticmethod
+    def _validate_kustomize_patches(values: dict, stack_name: str) -> list[str]:
+        """Validate inline kustomize patches during plan rendering."""
+        kustomize_config = values.get("kustomize") or {}
+        if not kustomize_config.get("enabled"):
+            return []
+
+        errors: list[str] = []
+        patches = kustomize_config.get("patches") or []
+        for index, entry in enumerate(patches):
+            if not isinstance(entry, dict):
+                errors.append(
+                    f"[{stack_name}] kustomize.patches[{index}] must be a mapping"
+                )
+                continue
+
+            patch = entry.get("patch", "")
+            if not patch:
+                continue
+
+            try:
+                documents = list(yaml.safe_load_all(patch))
+            except yaml.YAMLError as exc:
+                errors.append(
+                    f"[{stack_name}] kustomize.patches[{index}].patch is invalid "
+                    f"YAML: {str(exc)[:100]}"
+                )
+                continue
+
+            for doc_index, document in enumerate(documents):
+                if document is None:
+                    continue
+                if not isinstance(document, dict):
+                    doc_label = "" if len(documents) == 1 else f" document {doc_index}"
+                    errors.append(
+                        f"[{stack_name}] kustomize.patches[{index}].patch"
+                        f"{doc_label} expected YAML mapping, got "
+                        f"{type(document).__name__}"
+                    )
+
+        return errors
+
     def _build_sibling_stacks(
         self,
         stacks: list[dict],
@@ -1465,6 +1507,14 @@ class RenderPlans:
             stack_name=stack_name,
         )
         for msg in epponly_errors:
+            self.logger.log_error(msg)
+            stack_errors.render_errors.append(msg)
+
+        kustomize_errors = self._validate_kustomize_patches(
+            merged_values,
+            stack_name=stack_name,
+        )
+        for msg in kustomize_errors:
             self.logger.log_error(msg)
             stack_errors.render_errors.append(msg)
 

--- a/tests/test_kustomize_plan_validation.py
+++ b/tests/test_kustomize_plan_validation.py
@@ -1,0 +1,75 @@
+"""Tests for kustomize validation during plan rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+
+class _Logger:
+    def log_info(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_warning(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_error(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_debug(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def line_break(self) -> None:
+        pass
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def test_plan_reports_scalar_kustomize_patch(tmp_path: Path) -> None:
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    (template_dir / "00_dummy.yaml.j2").write_text(
+        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: dummy\n",
+        encoding="utf-8",
+    )
+    defaults_file = tmp_path / "defaults.yaml"
+    _write_yaml(defaults_file, {})
+    scenario_file = tmp_path / "scenario.yaml"
+    _write_yaml(
+        scenario_file,
+        {
+            "scenario": [
+                {
+                    "name": "optimized-baseline",
+                    "kustomize": {
+                        "guideName": "optimized-baseline",
+                        "patches": [
+                            {
+                                "patch": ('priorityClassName="nightly-gpu-critical"'),
+                            }
+                        ],
+                    },
+                }
+            ]
+        },
+    )
+
+    result = RenderPlans(
+        template_dir=template_dir,
+        defaults_file=defaults_file,
+        scenarios_file=scenario_file,
+        output_dir=tmp_path / "plan",
+        logger=_Logger(),
+        cli_methods="kustomize",
+    ).eval()
+
+    errors = result.stacks["optimized-baseline"].render_errors
+    assert result.has_errors
+    assert any("kustomize.patches[0].patch" in error for error in errors)
+    assert any("expected YAML mapping" in error for error in errors)


### PR DESCRIPTION
## Summary

  Validate inline kustomize patches during `plan -t kustomize` so malformed patches are reported during planning instead of only failing later during `standup`.

  ## Motivation

  Fixes #1404.

  `plan -t kustomize` was expected to catch invalid kustomize patch configuration, but malformed inline patches could pass plan rendering and only fail later when
  `kubectl apply -k` was executed.

  For example, this patch is parsed as a YAML scalar instead of the mapping expected by kustomize:

  ```yaml
  patch: priorityClassName="nightly-gpu-critical"

  ## What changed

  - Added validation for kustomize.patches[*].patch when kustomize rendering is enabled.
  - Reports invalid YAML and non-mapping patch documents as render errors.
  - Added a regression test covering the scalar patch shape from #1404.

  ## Testing

  - python -m pytest tests/test_kustomize_plan_validation.py -q
  - python -m pytest tests -q
  - python -m py_compile llmdbenchmark/parser/render_plans.py tests/test_kustomize_plan_validation.py
  - git diff --check

  ## Backward compatibility

  Existing non-kustomize plan behavior is unchanged. Valid kustomize patches continue to render as before.