### PR TITLE
Fix WVA autoscaling for the FMA benchmark scenarios

### DIFF
--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -157,6 +157,11 @@ scenario:
         minReplicas: 1
         variantCost: "10.0"
 
+      # Autoscaling — feeds the KEDA ScaledObject (28_wva-scaledobject.yaml.j2):
+      # min/maxReplicas -> min/maxReplicaCount, targetAvgValue -> the Prometheus
+      # trigger threshold on wva_desired_replicas, behavior -> the ScaledObject's
+      # advanced.horizontalPodAutoscalerConfig.behavior. KEDA owns the generated
+      # HPA. (`hpa:` key name retained as the ScaledObject's config surface.)
       hpa:
         enabled: true
         minReplicas: 1

--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -148,14 +148,14 @@ scenario:
         baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
         port: 9091
 
+      # WVA's annotation-based path (28_wva-hpa.yaml.j2) replaced the
+      # VariantAutoscaling CR; only variantCost (→ llm-d.ai/variant-cost
+      # annotation) and minReplicas (hot-start scale-down floor fallback) are
+      # still read. enabled/maxReplicas/slo drove the deprecated VA CR and are
+      # dropped — the HPA block below is the source of truth for min/max.
       variantAutoscaling:
-        enabled: true
         minReplicas: 1
-        maxReplicas: 10
         variantCost: "10.0"
-        slo:
-          tpot: 10
-          ttft: 1000
 
       hpa:
         enabled: true

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -216,24 +216,18 @@ scenario:
       # -----------------------------------------------------------------------
       # VariantAutoscaling — per-model scaling intent
       #
-      # Should match the HPA min/max below; the VA caps what the controller
-      # is willing to compute, the HPA caps what actually gets applied.
+      # WVA's annotation-based path (28_wva-hpa.yaml.j2) replaced the
+      # VariantAutoscaling CR, so only variantCost is still read (emitted as the
+      # llm-d.ai/variant-cost annotation on the HPA). The former enabled /
+      # minReplicas / maxReplicas / slo keys drove the deprecated VA CR and are
+      # dropped — min/max live in the HPA block below.
       # -----------------------------------------------------------------------
       variantAutoscaling:
-        enabled: true                # required for the VA to render at all
-        minReplicas: 1               # controller floor — never compute below this
-        maxReplicas: 10              # controller ceiling — never compute above this
         # Relative GPU cost weight used by WVA's saturation solver to decide
         # WHICH model to scale when several share GPU capacity. Higher =
         # more expensive to scale up. Common tiering: H100=10, A100=8,
         # L40S=5, MI300X=10. Tweak per stack to express your business priority.
         variantCost: "10.0"
-        # SLO targets the controller tries to keep the variant within when
-        # computing desiredReplicas. Lower numbers = more aggressive scale-up
-        # under load.
-        slo:
-          tpot: 10                   # Time-Per-Output-Token target (ms)
-          ttft: 1000                 # Time-To-First-Token target (ms)
 
       # -----------------------------------------------------------------------
       # HorizontalPodAutoscaler — what actually changes the replica count

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -230,31 +230,33 @@ scenario:
         variantCost: "10.0"
 
       # -----------------------------------------------------------------------
-      # HorizontalPodAutoscaler — what actually changes the replica count
+      # Autoscaling — what actually changes the replica count
       #
-      # The HPA reads `wva_desired_replicas` (emitted by the WVA controller
-      # via prometheus-adapter) and scales the decode Deployment between
-      # min/max.
+      # These keys feed the KEDA ScaledObject (28_wva-scaledobject.yaml.j2):
+      # minReplicas/maxReplicas -> minReplicaCount/maxReplicaCount, targetAvgValue
+      # -> the Prometheus trigger threshold on wva_desired_replicas, and behavior
+      # -> advanced.horizontalPodAutoscalerConfig.behavior. KEDA queries WVA's
+      # metric and generates/owns the underlying HPA that scales the Deployment.
+      # (The `hpa:` key name is retained as the config surface the ScaledObject
+      # template reads.)
       # -----------------------------------------------------------------------
       hpa:
-        enabled: true                # set false to render the VA only, no HPA
-        minReplicas: 1               # never scale below this — must be >= 1
-                                     # (HPA refuses to manage targets at 0)
-                                     # Keep aligned with variantAutoscaling.minReplicas above.
-        maxReplicas: 10              # safety ceiling — scale-up cap regardless
-                                     # of what the controller computes
-                                     # Keep aligned with variantAutoscaling.maxReplicas above.
-        targetAvgValue: 1            # target value the HPA tries to reach for
+        enabled: true                # set false to skip rendering the ScaledObject
+        minReplicas: 1               # ScaledObject minReplicaCount — must be >= 1
+                                     # (KEDA's generated HPA won't manage a 0 floor)
+        maxReplicas: 10              # ScaledObject maxReplicaCount — scale-up ceiling
+        targetAvgValue: 1            # Prometheus trigger threshold for
                                      # `wva_desired_replicas` per pod.
                                      # 1 = "match controller's desiredReplicas
                                      # exactly". Don't change unless you
-                                     # understand HPA averaging math.
+                                     # understand the trigger averaging math.
 
-        # Scaling behavior — how aggressively the HPA reacts. See:
+        # Scaling behavior — passed through to the ScaledObject's
+        # advanced.horizontalPodAutoscalerConfig.behavior. See:
         #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
         behavior:
           scaleUp:
-            # 30s (down from upstream's 120) so HPA reacts quickly when WVA
+            # 30s (down from upstream's 120) so scaling reacts quickly when WVA
             # trips saturation — important for benchmark runs where the
             # configured load exceeds 1-replica capacity. Default 120s
             # leaves ~2 min of queue growth before relief, which pushes

--- a/config/scenarios/cicd/ocp-wva.yaml
+++ b/config/scenarios/cicd/ocp-wva.yaml
@@ -97,24 +97,18 @@ scenario:
       # -----------------------------------------------------------------------
       # VariantAutoscaling — per-model scaling intent
       #
-      # Should match the HPA min/max below; the VA caps what the controller
-      # is willing to compute, the HPA caps what actually gets applied.
+      # WVA's annotation-based path (28_wva-hpa.yaml.j2) replaced the
+      # VariantAutoscaling CR, so only variantCost is still read (emitted as the
+      # llm-d.ai/variant-cost annotation on the HPA). The former enabled /
+      # minReplicas / maxReplicas / slo keys drove the deprecated VA CR and are
+      # dropped — min/max live in the HPA block below.
       # -----------------------------------------------------------------------
       variantAutoscaling:
-        enabled: true                # required for the VA to render at all
-        minReplicas: 1               # controller floor — never compute below this
-        maxReplicas: 10              # controller ceiling — never compute above this
         # Relative GPU cost weight used by WVA's saturation solver to decide
         # WHICH model to scale when several share GPU capacity. Higher =
         # more expensive to scale up. Common tiering: H100=10, A100=8,
         # L40S=5, MI300X=10. Tweak per stack to express your business priority.
         variantCost: "10.0"
-        # SLO targets the controller tries to keep the variant within when
-        # computing desiredReplicas. Lower numbers = more aggressive scale-up
-        # under load.
-        slo:
-          tpot: 10                   # Time-Per-Output-Token target (ms)
-          ttft: 1000                 # Time-To-First-Token target (ms)
 
       # -----------------------------------------------------------------------
       # HorizontalPodAutoscaler — what actually changes the replica count

--- a/config/scenarios/cicd/ocp-wva.yaml
+++ b/config/scenarios/cicd/ocp-wva.yaml
@@ -111,31 +111,33 @@ scenario:
         variantCost: "10.0"
 
       # -----------------------------------------------------------------------
-      # HorizontalPodAutoscaler — what actually changes the replica count
+      # Autoscaling — what actually changes the replica count
       #
-      # The HPA reads `wva_desired_replicas` (emitted by the WVA controller
-      # via prometheus-adapter) and scales the decode Deployment between
-      # min/max.
+      # These keys feed the KEDA ScaledObject (28_wva-scaledobject.yaml.j2):
+      # minReplicas/maxReplicas -> minReplicaCount/maxReplicaCount, targetAvgValue
+      # -> the Prometheus trigger threshold on wva_desired_replicas, and behavior
+      # -> advanced.horizontalPodAutoscalerConfig.behavior. KEDA queries WVA's
+      # metric and generates/owns the underlying HPA that scales the Deployment.
+      # (The `hpa:` key name is retained as the config surface the ScaledObject
+      # template reads.)
       # -----------------------------------------------------------------------
       hpa:
-        enabled: true                # set false to render the VA only, no HPA
-        minReplicas: 1               # never scale below this — must be >= 1
-                                     # (HPA refuses to manage targets at 0)
-                                     # Keep aligned with variantAutoscaling.minReplicas above.
-        maxReplicas: 10              # safety ceiling — scale-up cap regardless
-                                     # of what the controller computes
-                                     # Keep aligned with variantAutoscaling.maxReplicas above.
-        targetAvgValue: 1            # target value the HPA tries to reach for
+        enabled: true                # set false to skip rendering the ScaledObject
+        minReplicas: 1               # ScaledObject minReplicaCount — must be >= 1
+                                     # (KEDA's generated HPA won't manage a 0 floor)
+        maxReplicas: 10              # ScaledObject maxReplicaCount — scale-up ceiling
+        targetAvgValue: 1            # Prometheus trigger threshold for
                                      # `wva_desired_replicas` per pod.
                                      # 1 = "match controller's desiredReplicas
                                      # exactly". Don't change unless you
-                                     # understand HPA averaging math.
+                                     # understand the trigger averaging math.
 
-        # Scaling behavior — how aggressively the HPA reacts. See:
+        # Scaling behavior — passed through to the ScaledObject's
+        # advanced.horizontalPodAutoscalerConfig.behavior. See:
         #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
         behavior:
           scaleUp:
-            # 30s (down from upstream's 120) so HPA reacts quickly when WVA
+            # 30s (down from upstream's 120) so scaling reacts quickly when WVA
             # trips saturation — important for benchmark runs where the
             # configured load exceeds 1-replica capacity. Default 120s
             # leaves ~2 min of queue growth before relief, which pushes

--- a/config/templates/jinja/19_wva-kustomize.yaml.j2
+++ b/config/templates/jinja/19_wva-kustomize.yaml.j2
@@ -12,15 +12,21 @@
    ============================================================================ #}
 {% if wva is defined and wva.enabled | default(false) %}
 {% set _wva_ns = wva.namespace | default(namespace.name, true) %}
-{# ClusterRoleBindings produced by the upstream overlay. Per-tenant uniqueness
-   is added by suffixing metadata.name with the WVA namespace; roleRef.name
-   stays at the upstream default because the ClusterRole is shared. #}
-{% set _cluster_role_bindings = [
+{# ClusterRoleBindings from the upstream overlay. Renamed per-namespace to avoid
+   cross-tenant collisions. The overlay hard-codes their subject namespace to
+   `wva-system` and kustomize's `namespace:` won't rewrite an already-set CRB
+   subject, so we repoint it to {{ _wva_ns }} — otherwise the controller SA is
+   unbound (tokenreviews/variantautoscalings forbidden, HPA stuck at <unknown>).
+   Split by subject location: _crb_wva_subject (SA in the WVA namespace, repoint)
+   vs _crb_ext_subject (prometheus SA elsewhere, rename only). #}
+{% set _crb_wva_subject = [
   'wva-epp-metrics-reader-role-binding',
   'wva-manager-cluster-monitoring-view',
   'wva-manager-rolebinding',
   'wva-metrics-auth-rolebinding',
   'wva-metrics-reader-rolebinding',
+] %}
+{% set _crb_ext_subject = [
   'wva-prometheus-cluster-monitoring-view',
 ] %}
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -47,10 +53,21 @@ patches:
       path: /spec/replicas
       value: {{ wva.replicaCount | default(1) }}
 
-# Suffix each ClusterRoleBinding's metadata.name with the WVA namespace so
-# concurrent WVA installs in different namespaces don't fight over these
-# cluster-scoped binding names
-{% for _crb in _cluster_role_bindings %}
+# Rename + repoint subject namespace to {{ _wva_ns }} (SA lives in WVA namespace).
+{% for _crb in _crb_wva_subject %}
+- target:
+    kind: ClusterRoleBinding
+    name: {{ _crb }}
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: {{ _crb }}-{{ _wva_ns }}
+    - op: replace
+      path: /subjects/0/namespace
+      value: {{ _wva_ns }}
+{% endfor %}
+# Rename only — subject SA is in openshift-user-workload-monitoring, leave it.
+{% for _crb in _crb_ext_subject %}
 - target:
     kind: ClusterRoleBinding
     name: {{ _crb }}


### PR DESCRIPTION
The WVA+FMA benchmark passes (warm-start and hot-start) never autoscaled — the HPA sat at <unknown> and stayed at 1 replica, making hot-start look no faster than baseline. Root cause: the WVA controller's ServiceAccount was unbound (tokenreviews/variantautoscalings forbidden), so it never published the `wva_desired_replicas metric`.

**Changes**

- `19_wva-kustomize.yaml.j2` — the upstream overlay pins the ClusterRoleBinding subjects to wva-system, and kustomize's namespace: doesn't rewrite an already-set subject. Added a patch to repoint each WVA-SA binding's subject namespace to the deploy namespace (leaving the prometheus/user-workload-monitoring binding alone). This is the actual fix for the autoscaling failure.
- `ocp-wva.yaml, ocp-wva-fma-warmstart.yaml, ocp-wva-fma-hotstart.yaml` — trimmed dead variantAutoscaling keys (enabled, maxReplicas, slo) left over from the deprecated VariantAutoscaling CR. Kept variantCost (still emitted as the llm-d.ai/variant-cost HPA annotation) and hot-start's minReplicas fallback. Comment-only/cleanup — no behavior change.