### PR TITLE
standup: probe decode vllm port

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -809,12 +809,12 @@ When no `customCommand` is set, the command is built from:
 
 Two ports are involved in the vLLM serving configuration:
 
-- **Port 8000** (`decode.vllm.servicePort` / `prefill.vllm.servicePort`) -- the inference/service port. Kubernetes probes (startup, liveness, readiness) always check this port. When routing proxy is enabled, the proxy listens on 8000. When routing proxy is disabled, vLLM binds directly to 8000.
-- **Port 8200** (`decode.vllm.port`) -- the vLLM backend port. Only used in the `--port` flag of the vLLM command when routing proxy is enabled (proxy on 8000 forwards to vLLM on 8200). Not used for probes.
+- **Port 8000** (`decode.vllm.servicePort` / `prefill.vllm.servicePort`) -- the inference/service port. When routing proxy is enabled, the proxy listens on 8000. When routing proxy is disabled, vLLM binds directly to 8000.
+- **Port 8200** (`decode.vllm.port`) -- the vLLM backend port. Used in the decode `--port` flag when routing proxy is enabled (proxy on 8000 forwards to vLLM on 8200).
 
-Probe port is overrideable via `decode.vllm.servicePort` or `prefill.vllm.servicePort` in the scenario YAML. Individual per-probe port overrides are not supported (matches the original bash implementation).
+Decode probe ports default to the vLLM bind port: `decode.vllm.port` when routing proxy is enabled, or `decode.vllm.servicePort` when routing proxy is disabled. Prefill pods do not have the routing proxy and continue to probe `prefill.vllm.servicePort`.
 
-When routing proxy is **enabled** (modelservice only), vLLM binds to `decode.vllm.port` (default 8200) and the proxy handles `servicePort` (8000) to `vllmPort` (8200) forwarding. When routing proxy is **disabled**, vLLM binds directly to `decode.vllm.servicePort` (8000). In both cases, probes target the `servicePort` (8000).
+Probe ports can be overridden with `decode.probes.startup.port`, `decode.probes.liveness.port`, `decode.probes.readiness.port`, or the corresponding `prefill.probes.*.port` fields.
 
 ### Custom command
 

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -231,11 +231,11 @@ requester:
 {# ========================================================================== #}
 {# DECODE SECTION                                                             #}
 {# ========================================================================== #}
-{# Probe port: always use servicePort (8000) to match bash behavior.
-   The inference port is what Kubernetes probes check -- whether the proxy
-   is in front (proxy on 8000, vLLM on 8200) or vLLM binds directly (8000).
-   The vllm.port (8200) is only for the --port flag in the vLLM command. #}
-{% set decode_effective_port = decode.vllm.servicePort -%}
+{# Probe port: follow the vLLM bind port. When the routing proxy is disabled,
+   vLLM binds directly to servicePort (8000). When the proxy is enabled,
+   vLLM binds to vllm.port (8200) and the sidecar handles servicePort (8000). #}
+{% set decode_proxy_disabled = (routing is defined and routing.proxy is defined and routing.proxy.enabled is defined and not routing.proxy.enabled) -%}
+{% set decode_effective_port = decode.vllm.servicePort if decode_proxy_disabled else decode.vllm.port -%}
 decode:
   create: {{ decode_create | lower }}
 {% if decode_create %}

--- a/tests/test_decode_probe_port.py
+++ b/tests/test_decode_probe_port.py
@@ -1,0 +1,61 @@
+"""Tests for decode probe port rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+
+class _Logger:
+    def log_info(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_warning(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_error(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_debug(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def line_break(self) -> None:
+        pass
+
+
+def _render_pd_disaggregation(tmp_path: Path) -> dict[str, Any]:
+    root = Path(__file__).resolve().parents[1]
+    result = RenderPlans(
+        template_dir=root / "config" / "templates" / "jinja",
+        defaults_file=root / "config" / "templates" / "values" / "defaults.yaml",
+        scenarios_file=(
+            root / "config" / "scenarios" / "guides" / "pd-disaggregation.yaml"
+        ),
+        output_dir=tmp_path / "plan",
+        logger=_Logger(),
+    ).eval()
+
+    assert not result.has_errors
+    values_path = tmp_path / "plan" / "pd-disaggregation" / "13_ms-values.yaml"
+    return yaml.safe_load(values_path.read_text(encoding="utf-8"))
+
+
+def test_decode_probes_use_vllm_port_for_pd_disaggregation(tmp_path: Path) -> None:
+    values = _render_pd_disaggregation(tmp_path)
+
+    decode_container = values["decode"]["containers"][0]
+    env = {
+        item["name"]: item["value"]
+        for item in decode_container["env"]
+        if "value" in item
+    }
+    extra_config = decode_container["extraConfig"]
+
+    assert env["VLLM_METRICS_PORT"] == "8200"
+    assert extra_config["startupProbe"]["httpGet"]["port"] == 8200
+    assert extra_config["livenessProbe"]["tcpSocket"]["port"] == 8200
+    assert extra_config["readinessProbe"]["httpGet"]["port"] == 8200


### PR DESCRIPTION
## Summary

  Fix decode pod probe ports so they target the actual vLLM bind port when routing proxy is enabled.

  ## Motivation

  Fixes #1435.

  In `pd-disaggregation`, decode vLLM is started with `--port $VLLM_METRICS_PORT`, which resolves to `8200`. However, the rendered ModelService values used
  `decode.vllm.servicePort` (`8000`) as the default decode probe port. This can cause decode pod readiness checks to fail even though vLLM is listening on 8200.

  ## What changed

  - Decode probe defaults now follow the vLLM bind port:
    - routing proxy enabled: `decode.vllm.port`
    - routing proxy disabled: `decode.vllm.servicePort`
  - Existing explicit `decode.probes.*.port` overrides are preserved.
  - Updated the port selection docs.
  - Added a regression test rendering the real `pd-disaggregation` scenario and verifying decode startup/liveness/readiness probes use `8200`.

  ## Testing

  - `python -m pytest tests/test_decode_probe_port.py -q`
  - `python -m pytest tests -q`
  - `python -m py_compile tests/test_decode_probe_port.py`
  - `git diff --check`

  ## Backward Compatibility

  Scenarios with explicit probe port overrides are unchanged. When routing proxy is disabled, decode probes continue to default to `decode.vllm.servicePort`.