### PR TITLE
Add lm-eval accuracy harness

### DIFF
--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -411,6 +411,7 @@ COPY llmdbenchmark/analysis/scripts/nop-analyze_results.py /usr/local/bin/nop-an
 COPY llmdbenchmark/analysis/scripts/vllm-benchmark-analyze_results.sh /usr/local/bin/vllm-benchmark-analyze_results.sh
 COPY llmdbenchmark/analysis/scripts/guidellm-analyze_results.sh /usr/local/bin/guidellm-analyze_results.sh
 COPY llmdbenchmark/analysis/scripts/inferencemax-analyze_results.sh /usr/local/bin/inferencemax-analyze_results.sh
+COPY llmdbenchmark/analysis/scripts/lm-eval-analyze_results.sh /usr/local/bin/lm-eval-analyze_results.sh
 COPY llmdbenchmark/analysis/visualize_metrics.py /usr/local/bin/visualize_metrics.py
 COPY llmdbenchmark/analysis/benchmark_report/ /opt/benchmark_report/
 RUN mv /opt/benchmark_report/_pyproject.toml /opt/pyproject.toml

--- a/config/templates/jinja/20_harness_pod.yaml.j2
+++ b/config/templates/jinja/20_harness_pod.yaml.j2
@@ -21,8 +21,8 @@ spec:
     command: ["sh", "-c"]
     args:
     - >-
-      for script in /workspace/harnesses/*.sh; do
-        [ -e "$script" ] || continue;
+      for script in /workspace/harnesses/*; do
+        [ -f "$script" ] || continue;
         cp "$script" /usr/local/bin/;
         chmod +x "/usr/local/bin/$(basename "$script")";
       done;

--- a/llmdbenchmark/analysis/scripts/lm-eval-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/lm-eval-analyze_results.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Analyze results for the lm-eval harness.
+#
+# The llm-d-benchmark launcher (build/llm-d-benchmark.sh) runs
+# "{harness}-analyze_results.sh" after the main harness. lm-evaluation-harness
+# already writes its own structured JSON (via --output_path), so this analyzer
+# is intentionally light: it locates the lm_eval results JSON, prints a compact
+# per-task accuracy summary, and copies the canonical results file to a
+# predictable name for downstream tooling.
+#
+# Contract: consumes LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR, exits 0 on success.
+
+set -uo pipefail
+
+RESULTS_DIR="${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR:-}"
+if [[ -z "${RESULTS_DIR}" || ! -d "${RESULTS_DIR}" ]]; then
+  echo "ERROR: LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR not set or missing: '${RESULTS_DIR}'" >&2
+  exit 1
+fi
+
+echo "Analyzing lm-eval results in: ${RESULTS_DIR}"
+
+# lm_eval writes results to {output_path}/**/results_*.json (or results.json).
+RESULTS_JSON="$(find "${RESULTS_DIR}" -type f \( -name 'results_*.json' -o -name 'results.json' \) 2>/dev/null \
+  | sort | tail -1)"
+
+if [[ -z "${RESULTS_JSON}" ]]; then
+  echo "WARNING: no lm_eval results JSON found under ${RESULTS_DIR}." >&2
+  echo "         Check stdout.log / stderr.log for the harness run." >&2
+  # Do not hard-fail the pipeline: the harness RC already reflects the run.
+  exit 0
+fi
+
+echo "Found results file: ${RESULTS_JSON}"
+# Expose a stable filename alongside the timestamped one.
+cp -f "${RESULTS_JSON}" "${RESULTS_DIR}/lm-eval-results.json" 2>/dev/null || true
+
+# Print a compact accuracy summary. Prefer python3 (present in the image).
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "${RESULTS_JSON}" <<'PYEOF'
+import json, sys
+
+path = sys.argv[1]
+try:
+    with open(path) as fh:
+        data = json.load(fh)
+except Exception as exc:  # pragma: no cover
+    print(f"WARNING: could not parse {path}: {exc}", file=sys.stderr)
+    sys.exit(0)
+
+results = data.get("results", {})
+if not results:
+    print("No 'results' section in lm_eval JSON.")
+    sys.exit(0)
+
+print("")
+print("lm-eval accuracy summary")
+print("-" * 48)
+print(f"{'task':<24}{'metric':<14}{'value':>10}")
+print("-" * 48)
+for task, metrics in sorted(results.items()):
+    for metric, value in metrics.items():
+        metric_name = metric.split(",", 1)[0]
+        if (
+            metric_name in {"alias", "name", "sample_len", "sample_count"}
+            or metric_name.endswith("_stderr")
+            or not isinstance(value, (int, float))
+        ):
+            continue
+        print(f"{task:<24}{metric:<14}{value:>10.4f}")
+print("-" * 48)
+PYEOF
+fi
+
+echo "lm-eval analysis complete."
+exit 0

--- a/llmdbenchmark/run/steps/step_06_create_profile_configmap.py
+++ b/llmdbenchmark/run/steps/step_06_create_profile_configmap.py
@@ -166,6 +166,7 @@ class CreateProfileConfigmapStep(Step):
         """Create the llmdbench-harness-scripts ConfigMap from workload/harnesses/."""
         base_dir = context.base_dir or Path(__file__).resolve().parents[3]
         harnesses_dir = base_dir / "workload" / "harnesses"
+        analyzers_dir = base_dir / "llmdbenchmark" / "analysis" / "scripts"
 
         if not harnesses_dir.is_dir():
             return False, (f"Harness scripts directory not found: {harnesses_dir}")
@@ -178,6 +179,22 @@ class CreateProfileConfigmapStep(Step):
                     f"--from-file={script_file.name}={script_file}",
                 )
                 script_count += 1
+
+        # Harness scripts are intentionally supplied from the checked-out
+        # repository so a run can use a new/updated harness with an older
+        # benchmark image. Keep its matching analyzers on the same update path;
+        # otherwise the launcher finds the new harness but fails when the
+        # analyzer is absent from the image (for example, lm-eval on v0.7.0).
+        if analyzers_dir.is_dir():
+            for analyzer_file in sorted(analyzers_dir.iterdir()):
+                if analyzer_file.is_file() and (
+                    analyzer_file.name.endswith("-analyze_results.sh")
+                    or analyzer_file.name.endswith("-analyze_results.py")
+                ):
+                    from_file_args.append(
+                        f"--from-file={analyzer_file.name}={analyzer_file}",
+                    )
+                    script_count += 1
 
         if script_count == 0:
             return False, f"No harness scripts found in {harnesses_dir}"

--- a/tests/test_create_profile_configmap.py
+++ b/tests/test_create_profile_configmap.py
@@ -49,6 +49,18 @@ class _StubContext:
         return self._run_dir
 
 
+class _StubLogger:
+    def log_info(self, _message: str) -> None:
+        pass
+
+
+class _ScriptContext(_StubContext):
+    def __init__(self, run_dir: Path, base_dir: Path) -> None:
+        super().__init__(run_dir)
+        self.base_dir = base_dir
+        self.logger = _StubLogger()
+
+
 def test_kubectl_create_configmap_uses_server_side_apply(tmp_path: Path) -> None:
     cmd = _StubCmd(
         [
@@ -140,3 +152,36 @@ def test_kubectl_create_configmap_returns_apply_error(tmp_path: Path) -> None:
     assert not ok
     assert msg == "Failed to apply ConfigMap 'profiles': annotation too long"
     assert len(cmd.kube_calls) == 2
+
+
+def test_harness_configmap_includes_repository_analyzers(tmp_path: Path) -> None:
+    base_dir = tmp_path / "repo"
+    harnesses_dir = base_dir / "workload" / "harnesses"
+    analyzers_dir = base_dir / "llmdbenchmark" / "analysis" / "scripts"
+    harnesses_dir.mkdir(parents=True)
+    analyzers_dir.mkdir(parents=True)
+    harness = harnesses_dir / "lm-eval-llm-d-benchmark.sh"
+    analyzer = analyzers_dir / "lm-eval-analyze_results.sh"
+    ignored = analyzers_dir / "helper.py"
+    harness.write_text("#!/bin/sh\n", encoding="utf-8")
+    analyzer.write_text("#!/bin/sh\n", encoding="utf-8")
+    ignored.write_text("", encoding="utf-8")
+
+    cmd = _StubCmd(
+        [
+            _Result(success=True, stdout="apiVersion: v1\nkind: ConfigMap\n"),
+            _Result(success=True),
+        ]
+    )
+    context = _ScriptContext(tmp_path / "run", base_dir)
+    context.run_dir().mkdir()
+
+    ok, _ = CreateProfileConfigmapStep()._create_harness_scripts_configmap(
+        context, cmd, "bench"
+    )
+
+    assert ok
+    create_args = cmd.kube_calls[0][0]
+    assert f"--from-file={harness.name}={harness}" in create_args
+    assert f"--from-file={analyzer.name}={analyzer}" in create_args
+    assert not any(str(ignored) in arg for arg in create_args)

--- a/tests/test_harness_pod_template_scripts.py
+++ b/tests/test_harness_pod_template_scripts.py
@@ -82,6 +82,8 @@ def test_harness_pod_copies_configmap_scripts_before_launch() -> None:
     launch_script = pod["spec"]["containers"][0]["args"][0]
 
     assert "/workspace/harnesses" in launch_script
+    assert "for script in /workspace/harnesses/*" in launch_script
+    assert '[ -f "$script" ]' in launch_script
     assert 'cp "$script" /usr/local/bin/' in launch_script
     assert 'chmod +x "/usr/local/bin/$(basename "$script")"' in launch_script
     assert "/usr/local/bin" in launch_script

--- a/workload/README.md
+++ b/workload/README.md
@@ -56,6 +56,7 @@ workload/
     guidellm-llm-d-benchmark.sh             # guidellm harness wrapper
     inference-perf-llm-d-benchmark.sh       # inference-perf harness wrapper
     inferencemax-llm-d-benchmark.sh         # inferencemax harness wrapper
+    lm-eval-llm-d-benchmark.sh              # lm-eval (accuracy) harness wrapper
     nop-llm-d-benchmark.py                  # No-op harness (testing/validation)
     vllm-benchmark-llm-d-benchmark.sh       # vllm-benchmark harness wrapper
   profiles/                                 # Workload profile templates
@@ -77,6 +78,8 @@ workload/
       summarization_synthetic.yaml.in
     inferencemax/                            # Profiles for inferencemax
       random_concurrent.yaml.in
+    lm-eval/                                 # Profiles for the lm-eval (accuracy) harness
+      accuracy_default.yaml.in
     nop/                                     # Profiles for the no-op harness
       nop.yaml.in
     vllm-benchmark/                          # Profiles for vllm-benchmark
@@ -160,7 +163,10 @@ The harness script runs inside the **benchmark container image** as a Kubernetes
 | `guidellm` | `guidellm-llm-d-benchmark.sh` | `guidellm benchmark` | Load testing with configurable request patterns |
 | `vllm-benchmark` | `vllm-benchmark-llm-d-benchmark.sh` | `vllm bench serve` | vLLM-native benchmarking with latency percentiles |
 | `inferencemax` | `inferencemax-llm-d-benchmark.sh` | Custom Python script | Benchmarking with warmup and random seed control |
+| `lm-eval` | `lm-eval-llm-d-benchmark.sh` | `lm_eval` (lm-evaluation-harness) | Accuracy/quality evaluation against standard tasks (hellaswag, mmlu, piqa, ...) |
 | `nop` | `nop-llm-d-benchmark.py` | No-op | Testing and validation without running real benchmarks |
+
+> **lm-eval smoke test:** the `accuracy_default` profile runs the full task set. For a quick pipeline check, cap samples per task and propagate the override into the harness pod, e.g. `LIMIT=10 llmdbenchmark ... -l lm-eval -w accuracy_default.yaml -g LIMIT ...`.
 
 ### Harness Script Contract
 
@@ -282,6 +288,42 @@ Unknown tokens (not in the substitution map) are left unchanged.
 | Profile | Load Pattern | Data Type | Description |
 |---------|-------------|-----------|-------------|
 | `random_concurrent.yaml.in` | Concurrent | Random | Concurrent random workload |
+
+#### lm-eval (1 profile)
+
+Unlike the load-generation harnesses, `lm-eval` measures **accuracy** rather than throughput/latency. Profiles configure the evaluation tasks instead of a load pattern.
+
+| Profile | Tasks | Sample Cap | Description |
+|---------|-------|-----------|-------------|
+| `accuracy_default.yaml.in` | hellaswag, mmlu, piqa | none (full run) | Full-accuracy evaluation; override with `LIMIT=<n>` env for a quick smoke test |
+
+Profile keys live under an `evaluation:` block (`tasks`, `num_fewshot`, `limit`, `num_concurrent`, `max_gen_toks`). Any key can be overridden at runtime via the matching env var (`TASKS`, `NUM_FEWSHOT`, `LIMIT`, `NUM_CONCURRENT`, `MAX_GEN_TOKS`); `LM_EVAL_BASE_URL` optionally overrides the detected endpoint.
+
+```bash
+# Quick pipeline smoke test: cap samples per task
+LIMIT=10 llmdbenchmark --spec <your-spec> run \
+  -p llmd-bench -l lm-eval -w accuracy_default.yaml -g LIMIT
+
+# Full accuracy run (hellaswag, mmlu, piqa)
+llmdbenchmark --spec <your-spec> run \
+  -p llmd-bench -l lm-eval -w accuracy_default.yaml
+
+# Override tasks / few-shot at runtime via env vars
+TASKS=hellaswag NUM_FEWSHOT=5 llmdbenchmark --spec <your-spec> run \
+  -p llmd-bench -l lm-eval -w accuracy_default.yaml
+```
+
+The PD disaggregation router is intended for generation and currently cannot
+return prompt logprobs required by lm-eval multiple-choice tasks. Run lm-eval
+against a ready decode pod while retaining the same PD deployment:
+
+```bash
+DECODE_IP=$(kubectl get pod -n llmd-pd-disaggregation \
+  -l llm-d.ai/role=decode -o jsonpath='{.items[0].status.podIP}')
+llmdbenchmark --spec guides/pd-disaggregation run \
+  -p llmd-pd-disaggregation -l lm-eval -w accuracy_default.yaml \
+  -U "http://${DECODE_IP}:8000"
+```
 
 #### nop (1 profile)
 

--- a/workload/harnesses/lm-eval-llm-d-benchmark.sh
+++ b/workload/harnesses/lm-eval-llm-d-benchmark.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Run lm-evaluation-harness against a deployed llm-d endpoint.
+#
+# Ported from llm-d/llm-d#1683 (helpers/accuracy/run-lm-eval.sh).
+# Port-forward / kubectl service-discovery removed: the llm-d-benchmark
+# framework already detects the endpoint and injects
+# LLMDBENCH_HARNESS_STACK_ENDPOINT_URL before invoking this script.
+#
+# Profile keys (read via yq from the mounted .yaml.in-rendered profile):
+#   evaluation.tasks        – comma-separated lm-eval tasks (required)
+#   evaluation.num_fewshot  – few-shot examples per task (default: 0)
+#   evaluation.limit        – per-task sample cap; absent/null = full run
+#   evaluation.num_concurrent – lm-eval client concurrency (default: 4)
+#   evaluation.max_gen_toks – max generated tokens per request (optional)
+#
+# Environment overrides (take precedence over the profile file; pass their
+# names to llmdbenchmark with `-g`, for example `-g TASKS,LIMIT`):
+#   TASKS, NUM_FEWSHOT, LIMIT, NUM_CONCURRENT, MAX_GEN_TOKS, LM_EVAL_BASE_URL
+#   (standard harness vars: LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR,
+#    LLMDBENCH_RUN_WORKSPACE_DIR, LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME,
+#    LLMDBENCH_DEPLOY_CURRENT_MODEL, LLMDBENCH_HARNESS_STACK_ENDPOINT_URL)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 1. Set up results directory
+# ---------------------------------------------------------------------------
+echo "Using experiment result dir: ${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}"
+mkdir -p "${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}"
+
+# ---------------------------------------------------------------------------
+# 2. Dependency checks
+# ---------------------------------------------------------------------------
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: 'yq' (v4+) not found. Install it before running this harness." >&2
+  exit 1
+fi
+
+if ! command -v lm_eval >/dev/null 2>&1; then
+  echo "'lm_eval' not found -- installing lm-eval[api] at runtime..." >&2
+  pip install --root-user-action=ignore "lm-eval[api]==0.4.12" >&2 || {
+    echo "ERROR: failed to install lm-eval. Install with: pip install 'lm-eval[api]' transformers" >&2
+    exit 1
+  }
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Load profile config (YAML rendered by the framework from the .yaml.in)
+# ---------------------------------------------------------------------------
+PROFILE_FILE="${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/lm-eval/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}"
+if [[ ! -f "${PROFILE_FILE}" ]]; then
+  echo "ERROR: profile not found: ${PROFILE_FILE}" >&2
+  exit 1
+fi
+
+cfg_get() {
+  # Read a scalar from the profile; treat yq "null" (missing key) as empty.
+  local v
+  v="$(yq "$1" "${PROFILE_FILE}" 2>/dev/null)"
+  [[ "${v}" == "null" ]] && v=""
+  printf '%s' "${v}"
+}
+
+# Config keys -> shell vars; environment values override profile values.
+MODEL="${MODEL:-${LLMDBENCH_DEPLOY_CURRENT_MODEL:-}}"
+TASKS="${TASKS:-$(yq '.evaluation.tasks // [] | join(",")' "${PROFILE_FILE}" 2>/dev/null)}"
+NUM_FEWSHOT="${NUM_FEWSHOT:-$(cfg_get '.evaluation.num_fewshot')}"
+NUM_FEWSHOT="${NUM_FEWSHOT:-0}"
+MAX_GEN_TOKS="${MAX_GEN_TOKS:-$(cfg_get '.evaluation.max_gen_toks')}"
+NUM_CONCURRENT="${NUM_CONCURRENT:-$(cfg_get '.evaluation.num_concurrent')}"
+NUM_CONCURRENT="${NUM_CONCURRENT:-4}"
+
+# LIMIT is special: an explicit empty LIMIT means "full run";
+# distinguish "set (even if empty)" from "unset".
+if [[ -n "${LIMIT+x}" ]]; then
+  LIMIT="${LIMIT}"
+else
+  LIMIT="$(cfg_get '.evaluation.limit')"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Validate required values
+# ---------------------------------------------------------------------------
+if [[ -z "${MODEL}" ]]; then
+  echo "ERROR: model not set in LLMDBENCH_DEPLOY_CURRENT_MODEL or MODEL env" >&2
+  exit 1
+fi
+if [[ -z "${TASKS}" ]]; then
+  echo "ERROR: tasks not set in profile (.evaluation.tasks) or TASKS env" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Build lm_eval arguments
+# ---------------------------------------------------------------------------
+BASE_URL="${LM_EVAL_BASE_URL:-${LLMDBENCH_HARNESS_STACK_ENDPOINT_URL:-}}"
+# Ensure the URL ends with /v1/completions (lm-eval local-completions needs the full path)
+if [[ -n "${BASE_URL}" && "${BASE_URL}" != */v1/completions ]]; then
+  BASE_URL="${BASE_URL%/}/v1/completions"
+fi
+
+if [[ -z "${BASE_URL}" ]]; then
+  echo "ERROR: LLMDBENCH_HARNESS_STACK_ENDPOINT_URL is not set" >&2
+  exit 1
+fi
+
+MODEL_ARGS="base_url=${BASE_URL},model=${MODEL},tokenizer_backend=huggingface,tokenized_requests=False,num_concurrent=${NUM_CONCURRENT},max_retries=3"
+if [[ -n "${MAX_GEN_TOKS}" ]]; then
+  MODEL_ARGS="${MODEL_ARGS},max_gen_toks=${MAX_GEN_TOKS}"
+fi
+
+LIMIT_ARG=()
+if [[ -n "${LIMIT}" ]]; then
+  LIMIT_ARG=(--limit "${LIMIT}")
+fi
+
+HARNESS_ARGS=(
+  --model local-completions
+  --model_args "${MODEL_ARGS}"
+  --tasks "${TASKS}"
+  --num_fewshot "${NUM_FEWSHOT}"
+  --batch_size 1
+  "${LIMIT_ARG[@]}"
+  --output_path "${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}"
+)
+export LLMDBENCH_HARNESS_ARGS="${HARNESS_ARGS[*]}"
+
+# ---------------------------------------------------------------------------
+# 6. Log run parameters
+# ---------------------------------------------------------------------------
+echo "Running lm_eval:"
+echo "  base_url:    ${BASE_URL}"
+echo "  model:       ${MODEL}"
+echo "  tasks:       ${TASKS}"
+echo "  num_fewshot: ${NUM_FEWSHOT}"
+echo "  limit:       ${LIMIT:-<full>}"
+echo "  max_gen_toks:${MAX_GEN_TOKS:-<default>}"
+echo "  concurrency: ${NUM_CONCURRENT}"
+echo "  output:      ${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}"
+echo
+
+# ---------------------------------------------------------------------------
+# 7. Execute lm_eval – capture stdout/stderr, record timing
+# ---------------------------------------------------------------------------
+start=$(date +%s.%N)
+set +e
+lm_eval "${HARNESS_ARGS[@]}" \
+  > >(tee -a "${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}/stdout.log") \
+  2> >(tee -a "${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}/stderr.log" >&2)
+export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
+set -e
+stop=$(date +%s.%N)
+
+export LLMDBENCH_HARNESS_START=$(date -d "@${start}" --iso-8601=seconds)
+export LLMDBENCH_HARNESS_STOP=$(date -d "@${stop}" --iso-8601=seconds)
+export LLMDBENCH_HARNESS_DELTA=PT$(echo "$stop - $start" | bc)S
+export LLMDBENCH_HARNESS_VERSION=$(pip show lm-eval 2>/dev/null | awk '/^Version:/{print $2}' || echo 'unknown')
+
+# ---------------------------------------------------------------------------
+# 8. Write run metadata (same schema as other harnesses)
+# ---------------------------------------------------------------------------
+cat > "${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}/run_metadata.yaml" <<METADATA
+harness_start: "${LLMDBENCH_HARNESS_START}"
+harness_stop: "${LLMDBENCH_HARNESS_STOP}"
+harness_delta: "${LLMDBENCH_HARNESS_DELTA}"
+harness_args: "${LLMDBENCH_HARNESS_ARGS}"
+harness_version: "${LLMDBENCH_HARNESS_VERSION}"
+harness_name: "lm-eval"
+harness_workload: "${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME:-}"
+harness_rc: "${LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC}"
+model: "${MODEL}"
+endpoint_url: "${LLMDBENCH_HARNESS_STACK_ENDPOINT_URL:-}"
+tasks: "${TASKS}"
+num_fewshot: "${NUM_FEWSHOT}"
+limit: "${LIMIT:-}"
+num_concurrent: "${NUM_CONCURRENT}"
+METADATA
+echo "Run metadata written to ${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}/run_metadata.yaml"
+
+# ---------------------------------------------------------------------------
+# 9. Exit with harness return code
+# ---------------------------------------------------------------------------
+if [[ ${LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC} -ne 0 ]]; then
+  echo "Harness returned with error ${LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC}"
+  exit ${LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC}
+fi
+
+echo "Done. Results: ${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}"
+exit ${LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC}

--- a/workload/profiles/lm-eval/accuracy_default.yaml.in
+++ b/workload/profiles/lm-eval/accuracy_default.yaml.in
@@ -1,0 +1,20 @@
+# Full-accuracy profile for common lm-evaluation-harness tasks.
+#
+# Usage (run-only against an existing endpoint):
+#   llmdbenchmark --spec guides/optimized-baseline run \
+#     --endpoint-url http://<gateway>:80 \
+#     --model Qwen/Qwen3-0.6B \
+#     -l lm-eval -w accuracy_default.yaml -p <namespace>
+#
+# Override individual values via env without editing this file, e.g.:
+#   TASKS=gsm8k NUM_FEWSHOT=8 LIMIT=20 llmdbenchmark ... run -l lm-eval \
+#     -g TASKS,NUM_FEWSHOT,LIMIT ...
+
+evaluation:
+  tasks:
+    - hellaswag
+    - mmlu
+    - piqa
+  num_fewshot: 0
+  limit: null       # null = full run; use LIMIT=<n> plus `-g LIMIT` for a smoke test
+  num_concurrent: 4


### PR DESCRIPTION
## Description

Add `lm-eval`  as an accuracy/quality evaluation harness alongside the existing load-generation harnesses. 
- `workload/harnesses/lm-eval-llm-d-benchmark.sh` — harness wrapper.
- `workload/profiles/lm-eval/accuracy_default.yaml.in` — default profile (hellaswag, mmlu, piqa). Every key under the `evaluation:` block (`tasks`, `num_fewshot`, `limit`, `num_concurrent`, `max_gen_toks`) can be overridden at runtime via the matching env var (`TASKS`, `NUM_FEWSHOT`,  `LIMIT`, `NUM_CONCURRENT`, `MAX_GEN_TOKS`).
- `llmdbenchmark/analysis/scripts/lm-eval-analyze_results.sh` — results analysis.
- `build/Dockerfile.s390x` — install the analysis script into the benchmark image.
- `workload/README.md` — document the harness and profile.

## How Has This Been Tested?

Local `pre-commit run` passes (pytest, changed-scenario render validation,
detect-secrets, ruff lint/format).

```bash
# Quick pipeline smoke test: cap samples per task
LIMIT=10 llmdbenchmark --spec <your-spec> run \
  -p llmd-bench -l lm-eval -w accuracy_default.yaml

# Full accuracy run (hellaswag, mmlu, piqa)
llmdbenchmark --spec <your-spec> run \
  -p llmd-bench -l lm-eval -w accuracy_default.yaml

# Override tasks / few-shot at runtime via env vars
TASKS=hellaswag NUM_FEWSHOT=5 llmdbenchmark --spec <your-spec> run \
  -p llmd-bench -l lm-eval -w accuracy_default.yaml