### PR TITLE
Remove dead VariantAutoscaling object references

### DIFF
--- a/config/templates/jinja/27_wva-variantautoscaling.yaml.j2
+++ b/config/templates/jinja/27_wva-variantautoscaling.yaml.j2
@@ -1,7 +1,0 @@
-{# ============================================================================
-   27_wva-variantautoscaling.yaml.j2
-
-   DEPRECATED. WVA's modern path discovers managed HPAs via the
-   `llm-d.ai/managed: "true"` annotation; the VariantAutoscaling CR is no
-   longer required. See 28_wva-hpa.yaml.j2 for the annotation-based HPA.
-   ============================================================================ #}

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -359,10 +359,9 @@ class DeployModelserviceStep(Step):
                     f"service/{route_service}:80"
                 )
 
-        # WVA controller + prometheus-adapter are installed up-front by
-        # step_02 (admin prerequisites). Here we only apply this stack's
-        # VariantAutoscaling + HPA resources so the (already-running)
-        # controller can manage THIS model's decode deployment.
+        # WVA controller is installed up-front by step_03 (admin prerequisites).
+        # Here we only apply this stack's KEDA ScaledObject so the (already-running)
+        # controller can manage THIS model's decode deployment via KEDA autoscaling.
         wva_config = plan_config.get("wva", {})
         if wva_config.get("enabled", False) and context.is_openshift:
             self._apply_wva_stack_resources(cmd, stack_path, errors)
@@ -644,14 +643,14 @@ class DeployModelserviceStep(Step):
         stack_path: Path,
         errors: list,
     ) -> None:
-        """Apply this stack's VariantAutoscaling + ScaledObject to the WVA namespace.
+        """Apply this stack's KEDA ScaledObject to the WVA namespace.
 
         The WVA controller was already installed by step_03 once per unique
-        wva.namespace. Here we only kubectl apply the per-stack resources so
+        wva.namespace. Here we only kubectl apply the per-stack ScaledObject so
         a single controller can manage multiple models. KEDA generates and
         manages the HPA automatically when the ScaledObject is applied.
         """
-        for stem in ("27_wva-variantautoscaling", "28_wva-scaledobject"):
+        for stem in ("28_wva-scaledobject",):
             yaml_path = self._find_yaml(stack_path, stem)
             if not (yaml_path and self._has_yaml_content(yaml_path)):
                 continue
@@ -665,10 +664,10 @@ class DeployModelserviceStep(Step):
         context: ExecutionContext,
         plan_config: dict,
     ) -> None:
-        """Log the current state of this stack's VariantAutoscaling + ScaledObject + HPA.
+        """Log the current state of this stack's KEDA ScaledObject + HPA.
 
-        Lets the standup output show what got created (VA OPTIMIZED, ScaledObject
-        status, HPA TARGETS/REPLICAS, etc.) without needing follow-up ``oc get``.
+        Lets the standup output show what got created (ScaledObject status,
+        HPA TARGETS/REPLICAS, etc.) without needing follow-up ``oc get``.
         Best-effort - failures here don't fail step_09. KEDA's generated HPA
         carries the same name as the ScaledObject.
         """
@@ -683,7 +682,6 @@ class DeployModelserviceStep(Step):
         resource_name = f"{model_id_label}-decode"
 
         for kind, label in (
-            ("variantautoscaling.llmd.ai", "VariantAutoscaling"),
             ("scaledobject.keda.sh", "ScaledObject"),
             ("hpa", "HorizontalPodAutoscaler"),
         ):

--- a/llmdbenchmark/standup/wva.py
+++ b/llmdbenchmark/standup/wva.py
@@ -5,9 +5,8 @@ Secret, thanos-querier ClusterRole) are cluster/admin-scoped and must be
 provisioned *before* any per-stack work runs. KEDA itself is pre-installed by
 cluster admins and not managed by this harness. These helpers are called from
 ``step_03_workload_monitoring`` once per unique ``wva.namespace`` across all
-rendered stacks. Per-stack resources (VariantAutoscaling + ScaledObject) are
-rendered from ``27_wva-variantautoscaling.yaml.j2`` / ``28_wva-scaledobject.yaml.j2``
-and applied in ``step_09``.
+rendered stacks. Per-stack ScaledObject is rendered from
+``28_wva-scaledobject.yaml.j2`` and applied in ``step_09``.
 
 Helpers live in this module (rather than in a step class) so both the
 admin step and per-stack step can import them without a cyclic dependency.

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -312,7 +312,7 @@ class UninstallHelmStep(Step):
     ) -> None:
         """Tear down WVA resources.
 
-        Always deletes the per-stack VariantAutoscaling + ScaledObject so the model
+        Always deletes the per-stack KEDA ScaledObject so the model
         no longer auto-scales after teardown. Deleting the ScaledObject cascades
         to KEDA's generated HPA deletion.
 
@@ -371,13 +371,13 @@ class UninstallHelmStep(Step):
         if not wva_stacks:
             return
 
-        # 1. Per-stack VariantAutoscaling + ScaledObject: always delete. Suffix is
-        # `-fma` under FMA, `-decode` otherwise -- matches templates 27/28.
+        # 1. Per-stack ScaledObject: always delete. Suffix is
+        # `-fma` under FMA, `-decode` otherwise -- matches template 28.
         # Deleting the ScaledObject cascades to KEDA's generated HPA.
         for wva_ns, model_id_label, fma_enabled, _stack_path in wva_stacks:
             variant_suffix = "fma" if fma_enabled else "decode"
             resource_name = f"{model_id_label}-{variant_suffix}"
-            for kind in ("scaledobject.keda.sh", "variantautoscaling.llmd.ai"):
+            for kind in ("scaledobject.keda.sh",):
                 context.logger.log_info(
                     f"Deleting {kind}/{resource_name} from ns/{wva_ns}"
                 )

--- a/tests/test_teardown_wva.py
+++ b/tests/test_teardown_wva.py
@@ -4,7 +4,7 @@ Behavior under test:
 - Full-scenario teardown (no ``--stack`` filter): controller is uninstalled.
 - Partial-stack teardown (``--stack X`` filter set): controller is preserved.
 - ``--deep``: controller is uninstalled regardless of filter.
-- Per-stack VariantAutoscaling + HPA are always deleted, regardless of mode.
+- Per-stack KEDA ScaledObject is always deleted, regardless of mode.
 - Non-OpenShift platforms: WVA teardown is skipped entirely.
 """
 


### PR DESCRIPTION
## Summary
Removes dead code that still references the deprecated, permanently-empty `27_wva-variantautoscaling.yaml.j2` template. This template is a stub that never renders non-empty, so no VariantAutoscaling (VA) object is ever actually applied today. Simplifying the codebase by cleaning up misleading references makes the KEDA/ScaledObject path the only one, removing confusion about whether VA creation is a live code path.

## Changes
- Delete `config/templates/jinja/27_wva-variantautoscaling.yaml.j2` (empty template)
- Update `_apply_wva_stack_resources()`: drop VA from the template-apply loop
- Update `_log_wva_stack_state()`: remove VA from resource-state queries
- Update `_teardown_wva()`: drop VA deletion from cleanup
- Update docstrings in `wva.py`, `step_09_deploy_modelservice.py`, `step_01_uninstall_helm.py`, and `test_teardown_wva.py`

## Test Plan
- [x] `ruff format --check` — all files formatted
- [x] `ruff check` — all linting passes
- [x] `pytest tests/ -v` — 606 passed, 31 skipped (baseline maintained)
- [x] No remaining references to `variantautoscaling.llmd.ai` or `27_wva-variantautoscaling` in Python code
- [x] Commit GPG-signed ✓

## Notes
This is a follow-up to the prometheus-adapter → KEDA migration (#1601). No behavior change — VA was never created before, and still won't be. This just removes the dead code paths to reduce confusion and improve maintainability.

🤖 Generated with Claude Code