### PR TITLE
 run: report harness pod crash reasons

### DIFF
--- a/docs/workload-variant-autoscaler.md
+++ b/docs/workload-variant-autoscaler.md
@@ -515,11 +515,12 @@ HPA, but it's still considered cluster-hygiene rude to run cluster-scoped.
 |---|---|
 | Kustomize wrapper for the WVA controller install | [`config/templates/jinja/19_wva-kustomize.yaml.j2`](../config/templates/jinja/19_wva-kustomize.yaml.j2) |
 | WVA namespace label patch | [`config/templates/jinja/23_wva-namespace.yaml.j2`](../config/templates/jinja/23_wva-namespace.yaml.j2) |
+| KEDA trigger authentication | [`config/templates/jinja/21_keda-triggerauthentication.yaml.j2`](../config/templates/jinja/21_keda-triggerauthentication.yaml.j2) |
 | Per-stack `VariantAutoscaling` + `HorizontalPodAutoscaler` | [`config/templates/jinja/28_wva-scaledobject.yaml.j2`](../config/templates/jinja/28_wva-scaledobject.yaml.j2) |
 | `allow-thanos-querier-api-access` ClusterRole | [`config/templates/jinja/22_prometheus-rbac.yaml.j2`](../config/templates/jinja/22_prometheus-rbac.yaml.j2) |
 | Cluster-wide WVA defaults (chart version, image, monitoring URL) | [`config/templates/values/defaults.yaml`](../config/templates/values/defaults.yaml) (`wva:` and `chartVersions.wva` blocks) |
 | Standup admin install (controller + adapter) | [`llmdbenchmark/standup/steps/step_03_workload_monitoring.py`](../llmdbenchmark/standup/steps/step_03_workload_monitoring.py) |
-| Standup per-stack VA/HPA apply | [`llmdbenchmark/standup/steps/step_09_deploy_modelservice.py`](../llmdbenchmark/standup/steps/step_09_deploy_modelservice.py) |
+| Standup per-stack WVA/KEDA apply | [`llmdbenchmark/standup/steps/step_09_deploy_modelservice.py`](../llmdbenchmark/standup/steps/step_09_deploy_modelservice.py) |
 | Shared install/teardown helpers | [`llmdbenchmark/standup/wva.py`](../llmdbenchmark/standup/wva.py) |
 | Teardown logic | [`llmdbenchmark/teardown/steps/step_01_uninstall_helm.py`](../llmdbenchmark/teardown/steps/step_01_uninstall_helm.py) |
 | Smoketest WVA mixin | [`llmdbenchmark/smoketests/validators/wva.py`](../llmdbenchmark/smoketests/validators/wva.py) |

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -7,6 +7,7 @@ step_08, and step_10.
 
 from __future__ import annotations
 
+import json
 import shutil
 import time
 from pathlib import Path
@@ -27,6 +28,55 @@ CRASH_STATES = {
 }
 
 DATA_ACCESS_LABEL = "role=llm-d-benchmark-data-access"
+
+
+def _container_crash_summary(pod_name: str, container_status: dict) -> str | None:
+    """Return a concise crash summary for one container status."""
+    container_name = container_status.get("name", "?")
+
+    state = container_status.get("state", {}) or {}
+    last_state = container_status.get("lastState", {}) or {}
+
+    current_terminated = state.get("terminated") or {}
+    current_waiting = state.get("waiting") or {}
+    last_terminated = last_state.get("terminated") or {}
+
+    current_reason = current_terminated.get("reason") or current_waiting.get("reason")
+    last_reason = last_terminated.get("reason")
+
+    if current_reason not in CRASH_STATES and last_reason not in CRASH_STATES:
+        return None
+
+    details = []
+    if current_reason in CRASH_STATES:
+        details.append(current_reason)
+    if last_reason in CRASH_STATES and last_reason != current_reason:
+        details.append(f"last terminated: {last_reason}")
+
+    exit_code = current_terminated.get("exitCode")
+    if exit_code is None:
+        exit_code = last_terminated.get("exitCode")
+    if exit_code is not None:
+        details.append(f"exit_code={exit_code}")
+
+    return f"{pod_name}/{container_name} ({', '.join(details)})"
+
+
+def _summarize_pod_failures(pods_json: str) -> list[str]:
+    """Extract crash summaries from ``kubectl get pods -o json`` output."""
+    try:
+        data = json.loads(pods_json)
+    except json.JSONDecodeError:
+        return []
+
+    failures: list[str] = []
+    for item in data.get("items", []):
+        pod_name = item.get("metadata", {}).get("name", "?")
+        for container_status in item.get("status", {}).get("containerStatuses", []):
+            summary = _container_crash_summary(pod_name, container_status)
+            if summary:
+                failures.append(summary)
+    return failures
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +253,7 @@ def wait_for_pods_by_label(
         errors.append(f"Pods did not complete within timeout: {result.stderr.strip()}")
         return errors
 
-    # Check for crash states
+    # Check for crash states and surface the concrete pod/container reason.
     check_result = cmd.kube(
         "get",
         "pods",
@@ -211,18 +261,19 @@ def wait_for_pods_by_label(
         f"app={label}",
         "--namespace",
         namespace,
-        "--no-headers",
+        "-o",
+        "json",
         check=False,
     )
     if check_result.success and check_result.stdout:
-        for state in CRASH_STATES:
-            if state in check_result.stdout:
-                errors.append(
-                    f"Found pods in error state. Run: "
-                    f"kubectl --namespace {namespace} get pods "
-                    f"-l app={label}"
-                )
-                break
+        failures = _summarize_pod_failures(check_result.stdout)
+        if failures:
+            errors.append(
+                "Found pods in error state: "
+                f"{'; '.join(failures)}. Run: "
+                f"kubectl --namespace {namespace} describe pod "
+                f"-l app={label}"
+            )
 
     if not errors:
         context.logger.log_info("All pods completed successfully")

--- a/tests/test_kube_helpers_pod_failures.py
+++ b/tests/test_kube_helpers_pod_failures.py
@@ -1,0 +1,95 @@
+"""Tests for Kubernetes pod failure reporting helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from llmdbenchmark.utilities.kube_helpers import wait_for_pods_by_label
+
+
+class _Result:
+    def __init__(self, success: bool = True, stdout: str = "", stderr: str = ""):
+        self.success = success
+        self.stdout = stdout
+        self.stderr = stderr
+        self.dry_run = False
+
+
+class _Command:
+    def __init__(self, pods_json: str):
+        self.pods_json = pods_json
+        self.calls: list[tuple[str, ...]] = []
+
+    def kube(self, *args: str, **_: Any) -> _Result:
+        self.calls.append(args)
+        if args[0] == "wait":
+            return _Result()
+        if args[:2] == ("get", "pods"):
+            return _Result(stdout=self.pods_json)
+        raise AssertionError(f"unexpected kube call: {args}")
+
+
+class _Logger:
+    def log_info(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_warning(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_error(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_debug(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def line_break(self) -> None:
+        pass
+
+
+class _Context:
+    logger = _Logger()
+
+
+def test_wait_for_pods_by_label_reports_oomkilled_container() -> None:
+    pods_json = json.dumps(
+        {
+            "items": [
+                {
+                    "metadata": {"name": "inference-perf-abc"},
+                    "status": {
+                        "containerStatuses": [
+                            {
+                                "name": "harness",
+                                "state": {"waiting": {"reason": "CrashLoopBackOff"}},
+                                "lastState": {
+                                    "terminated": {
+                                        "reason": "OOMKilled",
+                                        "exitCode": 137,
+                                    }
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+    )
+    cmd = _Command(pods_json)
+
+    errors = wait_for_pods_by_label(
+        cmd,
+        label="llmdbench-harness-launcher",
+        namespace="bench",
+        timeout=60,
+        context=_Context(),
+    )
+
+    assert len(errors) == 1
+    assert "inference-perf-abc/harness" in errors[0]
+    assert "CrashLoopBackOff" in errors[0]
+    assert "OOMKilled" in errors[0]
+    assert "exit_code=137" in errors[0]
+    assert ("get", "pods", "-l", "app=llmdbench-harness-launcher") == cmd.calls[2][:4]
+    assert "-o" in cmd.calls[2]
+    assert "json" in cmd.calls[2]


### PR DESCRIPTION
## Summary

  Improve run-phase harness pod failure reporting by surfacing concrete pod/container crash reasons such as `OOMKilled`.

  ## Motivation

  Related to #1339.

  When long-running inference-perf workloads fail because the harness pod is OOMKilled, `llm-d-benchmark` can currently report only a generic run failure such as:

  ```text
  [07] deploy_harness: FAILED - Some treatments had errors

  or:

  Found pods in error state

  This makes it hard to distinguish an application-level benchmark failure from a Kubernetes container termination such as OOMKilled.

  ## What changed

  - Changed the final harness pod crash-state check in wait_for_pods_by_label() to read kubectl get pods -o json.
  - Extract pod/container crash details from:
      - containerStatuses[*].state
      - containerStatuses[*].lastState

  - Include concrete failure details in the returned error message, for example:

  Found pods in error state: inference-perf-abc/harness (CrashLoopBackOff, last terminated: OOMKilled, exit_code=137)

  - Added a regression test covering a harness container with:
      - current state CrashLoopBackOff
      - previous termination reason OOMKilled
      - exit code 137

  ## Testing

  - python -m pytest tests/test_kube_helpers_pod_failures.py tests/test_deploy_harness_status.py -q
  - python -m py_compile llmdbenchmark/utilities/kube_helpers.py tests/test_kube_helpers_pod_failures.py
  - git diff --check

  Note: I attempted python -m pytest tests -q, but the current upstream main test collection did not complete within 45 seconds in my local environment. The focused tests above
  cover the changed path.

  ## Backward Compatibility

  This does not change pod deployment, waiting, cleanup, or result collection behavior. It only improves the error message produced when Kubernetes reports a terminal container
  failure.