### PR TITLE
Add reset_caches option to clear vLLM caches between treatments

### DIFF
--- a/experiments/otel-session-rate-sweep.yaml
+++ b/experiments/otel-session-rate-sweep.yaml
@@ -18,6 +18,16 @@
 #     --workload otel_traces.yaml \
 #     --experiments experiments/otel-session-rate-sweep.yaml \
 #     --analyze
+#
+# Cache reset: with `reset_caches` enabled, before each treatment's run
+# the harness POSTs /reset_prefix_cache, /reset_mm_cache, and
+# /reset_encoder_cache to every vLLM serving pod, so every session-rate
+# treatment starts against cold caches without redeploying the stack.
+# Requires the server to run with VLLM_SERVER_DEV_MODE=1 (the repo
+# default via vllmCommon.flags.serverDevMode); if dev mode is off the
+# endpoints 404 and the reset is skipped with a warning (non-fatal).
+# Default false.
+reset_caches: true
 
 treatments:
   - name: rate0p02

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -810,6 +810,15 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
 
     experiments_file = experiment_file_override or getattr(args, "experiments", None)
 
+    # Honor the top-level ``reset_caches`` key in the experiment YAML. When
+    # set, step_07 POSTs the vLLM cache-reset endpoints (prefix/mm/encoder)
+    # to every serving pod before each treatment's run. Covers both the
+    # `run` and `experiment` subcommands, which both flow their file through
+    # ``experiments_file``.
+    from llmdbenchmark.experiment.parser import read_reset_caches
+
+    reset_caches = read_reset_caches(experiments_file)
+
     context = ExecutionContext(
         plan_dir=config.plan_dir,
         workspace=config.workspace,
@@ -842,6 +851,7 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         ),
         harness_debug=getattr(args, "debug", False),
         harness_skip_run=getattr(args, "skip", False),
+        reset_caches=reset_caches,
         harness_service_account=getattr(args, "serviceaccount", None),
         harness_envvars_to_pod=getattr(args, "envvarspod", None),
         analyze_locally=getattr(args, "analyze", False),

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -93,6 +93,13 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     harness_wait_timeout: int = 3600
     harness_debug: bool = False
     harness_skip_run: bool = False
+    # When True, reset the vLLM prefix, multimodal, and encoder caches
+    # (POST /reset_prefix_cache, /reset_mm_cache, /reset_encoder_cache) on
+    # every serving pod before each treatment's run, so every treatment
+    # starts against cold caches. Set via the top-level ``reset_caches`` key
+    # in the --experiments YAML. Requires the server to run with
+    # VLLM_SERVER_DEV_MODE=1 (the repo default); resets are non-fatal.
+    reset_caches: bool = False
     harness_service_account: str | None = None
     harness_envvars_to_pod: str | None = None
     analyze_locally: bool = False

--- a/llmdbenchmark/experiment/parser.py
+++ b/llmdbenchmark/experiment/parser.py
@@ -136,6 +136,29 @@ def _count_run_treatments(exp_data: dict) -> int:
     return 0
 
 
+def read_reset_caches(experiments_file: str | Path | None) -> bool:
+    """Read the top-level ``reset_caches`` flag from an experiment YAML.
+
+    Returns False when the file is unset, missing, unreadable, not a mapping,
+    or lacks the key -- the feature is strictly opt-in and never blocks a run
+    on a parse problem here. Consumed by the ``run``/``experiment`` CLI paths
+    to populate ``ExecutionContext.reset_caches``.
+    """
+    if not experiments_file:
+        return False
+    path = Path(experiments_file)
+    if not path.exists():
+        return False
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    return bool(data.get("reset_caches", False))
+
+
 def parse_experiment(path: Path) -> ExperimentPlan:
     """Parse an experiment YAML file into an ExperimentPlan."""
     path = Path(path).resolve()

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -29,6 +29,7 @@ from llmdbenchmark.utilities.kube_helpers import (
     capture_infrastructure_logs,
 )
 from llmdbenchmark.utilities.cloud_upload import upload_results_dir
+from llmdbenchmark.utilities.endpoint import reset_caches_pods
 
 
 class DeployHarnessStep(Step):
@@ -216,6 +217,29 @@ class DeployHarnessStep(Step):
                 if treatment
                 else profile_name
             )
+
+            # Reset the vLLM prefix/multimodal/encoder caches before this
+            # treatment's run so it starts cold. Fires once per treatment
+            # (before the parallel-pod group), not per parallel pod: the
+            # parallel pods run concurrently against the same servers, so a
+            # reset between them would wipe a cache a sibling is actively
+            # warming. Non-fatal -- warnings only.
+            if (
+                context.reset_caches
+                and not context.dry_run
+                and not context.harness_debug
+            ):
+                inference_port = (
+                    (plan_config or {}).get("vllmCommon", {}).get("inferencePort", 8000)
+                )
+                reset_caches_pods(
+                    cmd,
+                    deploy_namespace or harness_ns,
+                    model_label,
+                    inference_port,
+                    plan_config=plan_config,
+                    logger=context.logger,
+                )
 
             for parallel_idx in range(1, parallelism + 1):
                 pod_suffix = self._rand_suffix(8)

--- a/llmdbenchmark/utilities/endpoint.py
+++ b/llmdbenchmark/utilities/endpoint.py
@@ -797,3 +797,167 @@ def test_model_serving(
         return None  # success
 
     return last_error
+
+
+# vLLM cache-reset endpoints hit on each serving pod when ``reset_caches``
+# is enabled. All are POST, take no body, and only exist when the server was
+# launched with VLLM_SERVER_DEV_MODE=1.
+_CACHE_RESET_ENDPOINTS = (
+    "/reset_prefix_cache",
+    "/reset_mm_cache",
+    "/reset_encoder_cache",
+)
+
+
+def reset_caches_pods(
+    cmd: CommandExecutor,
+    namespace: str,
+    model_label: str,
+    inference_port: str | int,
+    plan_config: dict | None = None,
+    logger=None,
+    timeout_seconds: int = 30,
+) -> list[str]:
+    """Reset the prefix, multimodal, and encoder caches on every vLLM pod.
+
+    Discovers running pods labelled ``llm-d.ai/model=<model_label>`` in
+    *namespace* (all stack types -- modelservice, standalone, FMA --
+    apply this label to their served vLLM pods) and issues a single
+    ephemeral curl pod that loops over every pod IP, POSTing each of
+    ``/reset_prefix_cache``, ``/reset_mm_cache``, and
+    ``/reset_encoder_cache`` to it on *inference_port*.
+
+    These reset endpoints only exist when the vLLM server was launched with
+    ``VLLM_SERVER_DEV_MODE=1`` (the repo default via
+    ``vllmCommon.flags.serverDevMode``); a scenario that turns it off gets
+    a 404. All failures here are non-fatal: this returns a list of warning
+    strings (also logged if *logger* is given) and never raises, so a
+    failed reset never aborts a benchmark run.
+    """
+    warnings: list[str] = []
+
+    def _warn(msg: str) -> None:
+        warnings.append(msg)
+        if logger:
+            logger.log_warning(msg)
+
+    if not model_label:
+        _warn(
+            "reset_caches: no model label resolved -- cannot select "
+            "vLLM pods, skipping reset."
+        )
+        return warnings
+
+    # Discover running pod IPs by the serving-pod label. The jsonpath must
+    # contain no spaces: cmd.kube() joins argv with spaces and hands the
+    # result to a shell, so a `{range .items[*]}...` template would be
+    # word-split and its tail mis-read by kubectl as a positional pod name
+    # (colliding with `-l`). The space-free `{.items[*].status.podIP}` form
+    # prints every IP separated by a single space instead.
+    ip_result = cmd.kube(
+        "get",
+        "pods",
+        "-l",
+        f"llm-d.ai/model={model_label}",
+        "--namespace",
+        namespace,
+        "--field-selector=status.phase=Running",
+        "-o",
+        "jsonpath={.items[*].status.podIP}",
+        check=False,
+    )
+    if ip_result.dry_run:
+        return warnings
+    if not ip_result.success:
+        _warn(
+            f"reset_caches: failed to list vLLM pods in ns/{namespace}: "
+            f"{(ip_result.stderr or ip_result.stdout)[:200]}"
+        )
+        return warnings
+
+    pod_ips = [ip for ip in ip_result.stdout.split() if ip and ip != "null"]
+    if not pod_ips:
+        _warn(
+            f"reset_caches: no running vLLM pods found for "
+            f"'llm-d.ai/model={model_label}' in ns/{namespace} -- skipping reset."
+        )
+        return warnings
+
+    # Batch every pod IP x every cache endpoint into a single ephemeral curl
+    # pod. `-w '\n%{http_code}'` appends each request's status so a total
+    # failure is still diagnosable; per-request failures are surfaced inline
+    # by curl's own stderr (folded in via 2>&1). Non-2xx (esp. 404 when dev
+    # mode is off) is a warning, not an error.
+    ip_list = " ".join(pod_ips)
+    endpoint_list = " ".join(_CACHE_RESET_ENDPOINTS)
+    reset_url_tmpl = f"http://$ip:{inference_port}$ep"
+    inner = (
+        f"for ip in {ip_list}; do "
+        f"for ep in {endpoint_list}; do "
+        f'echo "== $ip$ep =="; '
+        f"curl -sk --max-time {timeout_seconds} "
+        f'-w "\\n%{{http_code}}\\n" -X POST {reset_url_tmpl} 2>&1; '
+        f"done; "
+        f"done"
+    )
+    curl_cmd = f"'{inner}'"
+
+    override_args = _build_overrides(plan_config)
+    curl_image = "quay.io/fedora/fedora"
+    pod_name = f"reset-caches-{_rand_suffix()}"
+
+    kubectl_args = (
+        [
+            "run",
+            pod_name,
+            "--rm",
+            "--attach",
+            "--quiet",
+            "--restart=Never",
+            "--namespace",
+            namespace,
+            f"--image={curl_image}",
+        ]
+        + _ephemeral_label_args()
+        + override_args
+        + ["--command", "--", "sh", "-c", curl_cmd]
+    )
+
+    result = cmd.kube(*kubectl_args, check=False)
+
+    if result.dry_run:
+        return warnings
+
+    if not result.success:
+        _warn(
+            f"reset_caches: curl pod failed against "
+            f"{len(pod_ips)} vLLM pod(s): "
+            f"{(result.stderr or result.stdout)[:200]}"
+        )
+        return warnings
+
+    # Every request prints its own trailing HTTP status line. A non-2xx
+    # anywhere is worth a warning -- most commonly VLLM_SERVER_DEV_MODE not
+    # being enabled (404), or a cache the server build doesn't support.
+    statuses = [
+        line.strip() for line in result.stdout.splitlines() if line.strip().isdigit()
+    ]
+    bad = [s for s in statuses if not s.startswith("2")]
+    if bad:
+        hint = ""
+        if "404" in bad:
+            hint = (
+                " (endpoint not found -- was the server launched with "
+                "VLLM_SERVER_DEV_MODE=1?)"
+            )
+        _warn(
+            f"reset_caches: {len(bad)}/{len(statuses)} reset request(s) "
+            f"returned non-2xx (e.g. HTTP {bad[0]}){hint}"
+        )
+    elif logger:
+        logger.log_info(
+            f"Reset prefix/mm/encoder caches on {len(pod_ips)} vLLM pod(s) "
+            f"in ns/{namespace}"
+        )
+
+    return warnings

--- a/tests/test_deploy_harness_status.py
+++ b/tests/test_deploy_harness_status.py
@@ -138,3 +138,112 @@ def test_treatment_with_wait_errors_is_reported_failed(
     assert "harness pod failed" in result.errors
     assert any("Treatment 'default' failed" in error for error in logger.errors)
     assert not any("Treatment 'default' complete" in info for info in logger.infos)
+
+
+def _base_context(tmp_path: Path, logger: _Logger) -> ExecutionContext:
+    stack_path = tmp_path / "plan" / "stack"
+    stack_path.mkdir(parents=True)
+    (stack_path / "config.yaml").write_text(
+        yaml.safe_dump(_plan_config()),
+        encoding="utf-8",
+    )
+    context = ExecutionContext(
+        plan_dir=tmp_path / "plan",
+        workspace=tmp_path,
+        base_dir=Path(__file__).resolve().parents[1],
+        namespace="bench",
+        harness_namespace="bench",
+        logger=logger,
+        cmd=_Command(),
+    )
+    context.deployed_endpoints["stack"] = "http://endpoint"
+    return context, stack_path
+
+
+def _patch_run_helpers(monkeypatch: Any) -> None:
+    """Stub out the wait/collect/delete helpers so the loop completes."""
+    monkeypatch.setattr(
+        deploy_harness,
+        "wait_for_pods_by_label",
+        lambda *_a, **_k: [],
+    )
+    monkeypatch.setattr(
+        DeployHarnessStep,
+        "_collect_treatment_results_discovery",
+        lambda *_a, **_k: [],
+    )
+    monkeypatch.setattr(
+        deploy_harness,
+        "delete_pods_by_names",
+        lambda *_a, **_k: None,
+    )
+
+
+def test_reset_caches_called_once_per_treatment(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    context.reset_caches = True
+    context.experiment_treatments = [
+        {"name": "t0", "overrides": {}},
+        {"name": "t1", "overrides": {}},
+    ]
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        deploy_harness,
+        "reset_caches_pods",
+        lambda cmd, ns, label, port, **kw: calls.append((ns, label, port)) or [],
+    )
+    _patch_run_helpers(monkeypatch)
+
+    result = DeployHarnessStep().execute(context, stack_path)
+
+    assert result.success
+    # One reset per treatment, targeting the serving namespace, the model
+    # label, and vllmCommon.inferencePort from the fixture.
+    assert len(calls) == 2
+    assert all(ns == "bench" for ns, _label, _port in calls)
+    assert all(port == 8000 for _ns, _label, port in calls)
+
+
+def test_reset_caches_not_called_when_disabled(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    # reset_caches defaults to False.
+    context.experiment_treatments = [{"name": "t0", "overrides": {}}]
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        deploy_harness,
+        "reset_caches_pods",
+        lambda *a, **k: calls.append(a) or [],
+    )
+    _patch_run_helpers(monkeypatch)
+
+    result = DeployHarnessStep().execute(context, stack_path)
+
+    assert result.success
+    assert calls == []
+
+
+def test_reset_caches_skipped_in_dry_run(tmp_path: Path, monkeypatch: Any) -> None:
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    context.reset_caches = True
+    context.dry_run = True
+    context.experiment_treatments = [{"name": "t0", "overrides": {}}]
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        deploy_harness,
+        "reset_caches_pods",
+        lambda *a, **k: calls.append(a) or [],
+    )
+
+    DeployHarnessStep().execute(context, stack_path)
+
+    assert calls == []

--- a/tests/test_endpoint_reset.py
+++ b/tests/test_endpoint_reset.py
@@ -1,0 +1,117 @@
+"""Tests for ``reset_caches_pods`` in utilities/endpoint.py.
+
+The helper makes two ``cmd.kube`` calls: first a ``get pods`` to discover
+serving-pod IPs, then a single batched ephemeral curl pod that POSTs each of
+/reset_prefix_cache, /reset_mm_cache, and /reset_encoder_cache to every IP.
+All failures are non-fatal -- the helper returns a list of warning strings
+and never raises.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from llmdbenchmark.utilities.endpoint import (
+    reset_caches_pods,
+    _CACHE_RESET_ENDPOINTS,
+)
+
+
+def _result(stdout: str = "", success: bool = True, dry_run: bool = False):
+    r = MagicMock()
+    r.success = success
+    r.stdout = stdout
+    r.stderr = ""
+    r.dry_run = dry_run
+    return r
+
+
+def _cmd(side_effect):
+    cmd = MagicMock()
+    cmd.kube = MagicMock(side_effect=side_effect)
+    return cmd
+
+
+def test_posts_all_endpoints_to_every_pod_ip_in_one_batched_pod():
+    # get pods -> two IPs; then the curl pod succeeds with all-2xx statuses.
+    # kubectl -o jsonpath={.items[*].status.podIP} prints IPs space-separated.
+    list_result = _result(stdout="10.0.0.1 10.0.0.2")
+    ok = "\n".join(["== x ==\n\n200"] * (2 * len(_CACHE_RESET_ENDPOINTS)))
+    curl_result = _result(stdout=ok)
+    cmd = _cmd([list_result, curl_result])
+
+    warns = reset_caches_pods(cmd, "bench", "my-model", 8000, plan_config=None)
+
+    assert warns == []
+    # Two kube calls: list, then the ephemeral curl pod.
+    assert cmd.kube.call_count == 2
+    # The jsonpath handed to `get pods` must be space-free -- cmd.kube joins
+    # argv with spaces into a shell string, so a spaced `{range ...}` template
+    # would be word-split and mis-read by kubectl as a positional pod name.
+    list_args = cmd.kube.call_args_list[0].args
+    jsonpath = next(a for a in list_args if str(a).startswith("jsonpath="))
+    assert " " not in jsonpath
+    curl_args = cmd.kube.call_args_list[1].args
+    assert curl_args[0] == "run"
+    joined = " ".join(str(a) for a in curl_args)
+    # Both IPs and all three cache endpoints appear in the single command.
+    assert "10.0.0.1" in joined
+    assert "10.0.0.2" in joined
+    assert ":8000$ep" in joined
+    for ep in _CACHE_RESET_ENDPOINTS:
+        assert ep in joined
+    assert "/reset_prefix_cache" in joined
+    assert "/reset_mm_cache" in joined
+    assert "/reset_encoder_cache" in joined
+
+
+def test_empty_model_label_warns_and_makes_no_calls():
+    cmd = _cmd([])  # no kube results should be consumed
+    warns = reset_caches_pods(cmd, "bench", "", 8000)
+    assert len(warns) == 1
+    assert "no model label" in warns[0].lower()
+    cmd.kube.assert_not_called()
+
+
+def test_no_pods_found_warns_and_skips_curl():
+    cmd = _cmd([_result(stdout="\n")])  # list returns nothing usable
+    warns = reset_caches_pods(cmd, "bench", "my-model", 8000)
+    assert len(warns) == 1
+    assert "no running vllm pods" in warns[0].lower()
+    # Only the list call happened; no curl pod.
+    assert cmd.kube.call_count == 1
+
+
+def test_404_status_is_warned_not_raised():
+    list_result = _result(stdout="10.0.0.1\n")
+    # One endpoint 404s (dev mode off), others would too -- surface a warning.
+    curl_result = _result(stdout="== a ==\n\n404\n== b ==\n\n404\n== c ==\n\n404")
+    cmd = _cmd([list_result, curl_result])
+
+    warns = reset_caches_pods(cmd, "bench", "my-model", 8000)
+
+    assert len(warns) == 1
+    assert "404" in warns[0]
+    assert "VLLM_SERVER_DEV_MODE" in warns[0]
+
+
+def test_list_failure_is_non_fatal():
+    cmd = _cmd([_result(success=False)])
+    warns = reset_caches_pods(cmd, "bench", "my-model", 8000)
+    assert len(warns) == 1
+    assert "failed to list" in warns[0].lower()
+    assert cmd.kube.call_count == 1
+
+
+def test_dry_run_list_short_circuits_clean():
+    cmd = _cmd([_result(dry_run=True)])
+    warns = reset_caches_pods(cmd, "bench", "my-model", 8000)
+    assert warns == []
+    assert cmd.kube.call_count == 1
+
+
+def test_logger_receives_warnings():
+    logger = MagicMock()
+    cmd = _cmd([_result(stdout="\n")])
+    reset_caches_pods(cmd, "bench", "my-model", 8000, logger=logger)
+    assert logger.log_warning.called

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -839,3 +839,65 @@ class TestSetupTreatment:
         overrides = {"model": {"maxModelLen": 16000}}
         t = SetupTreatment(name="test", overrides=overrides)
         assert t.overrides == overrides
+
+
+class TestReadResetCaches:
+    """Tests for ``parser.read_reset_caches`` -- the top-level
+    ``reset_caches`` key plumbed from the experiment YAML."""
+
+    def _write(self, tmp_path: Path, body: str) -> Path:
+        p = tmp_path / "exp.yaml"
+        p.write_text(textwrap.dedent(body), encoding="utf-8")
+        return p
+
+    def test_true(self, tmp_path: Path):
+        from llmdbenchmark.experiment.parser import read_reset_caches
+
+        p = self._write(
+            tmp_path,
+            """
+            reset_caches: true
+            treatments:
+              - name: t0
+            """,
+        )
+        assert read_reset_caches(str(p)) is True
+
+    def test_false(self, tmp_path: Path):
+        from llmdbenchmark.experiment.parser import read_reset_caches
+
+        p = self._write(
+            tmp_path,
+            """
+            reset_caches: false
+            treatments:
+              - name: t0
+            """,
+        )
+        assert read_reset_caches(str(p)) is False
+
+    def test_absent_defaults_false(self, tmp_path: Path):
+        from llmdbenchmark.experiment.parser import read_reset_caches
+
+        p = self._write(
+            tmp_path,
+            """
+            treatments:
+              - name: t0
+            """,
+        )
+        assert read_reset_caches(str(p)) is False
+
+    def test_none_or_missing_file_defaults_false(self, tmp_path: Path):
+        from llmdbenchmark.experiment.parser import read_reset_caches
+
+        assert read_reset_caches(None) is False
+        assert read_reset_caches(str(tmp_path / "nope.yaml")) is False
+
+    def test_real_input_length_sweep_defaults_false(self):
+        """The shipped experiment file keeps the key commented out."""
+        from llmdbenchmark.experiment.parser import read_reset_caches
+
+        f = PROJECT_ROOT / "experiments" / "input-length-sweep.yaml"
+        if f.exists():
+            assert read_reset_caches(str(f)) is False


### PR DESCRIPTION
Add a top-level `reset_caches` key to experiment YAML files. When set, step_07 POSTs /reset_prefix_cache, /reset_mm_cache, and /reset_encoder_cache to every vLLM serving pod before each treatment's run, so every treatment starts against cold caches without redeploying the stack. Default is false.