### PR TITLE
Make HTTPRoute request timeout configurable (default 300s)

### DIFF
--- a/config/scenarios/guides/agentic-serving.yaml
+++ b/config/scenarios/guides/agentic-serving.yaml
@@ -61,6 +61,20 @@ scenario:
     # =========================================================================
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      # 0s = no gateway request timeout. Agentic turns can exceed the 300s
+      # default; capping them here aborts long sessions with a 502 (seen as a
+      # routing-proxy loopback reset), so this deployment disables it.
+      requestTimeout: "0s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # -------------------------------------------------------------------------
     router:

--- a/config/scenarios/guides/flow-control.yaml
+++ b/config/scenarios/guides/flow-control.yaml
@@ -122,6 +122,17 @@ scenario:
     # =========================================================================
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # -------------------------------------------------------------------------
     router:

--- a/config/scenarios/guides/optimized-baseline.yaml
+++ b/config/scenarios/guides/optimized-baseline.yaml
@@ -135,6 +135,17 @@ scenario:
     # =========================================================================
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # -------------------------------------------------------------------------
     router:

--- a/config/scenarios/guides/pd-disaggregation.yaml
+++ b/config/scenarios/guides/pd-disaggregation.yaml
@@ -146,6 +146,17 @@ scenario:
     #     # cloud.google.com/gke-accelerator: nvidia-h100-80gb  # GKE
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # Reference: https://github.com/llm-d/llm-d/blob/main/guides/pd-disaggregation/router/pd-disaggregation.values.yaml
     # The plugins block uses the `llm-d.ai/v1alpha1` apiVersion shipped

--- a/config/scenarios/guides/precise-prefix-cache-routing.yaml
+++ b/config/scenarios/guides/precise-prefix-cache-routing.yaml
@@ -106,6 +106,17 @@ scenario:
         enabled: false
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # `sidecar.enabled: true` is mapped to the
     # `router.tokenizer.enabled: true` knob shipped by the

--- a/config/scenarios/guides/predicted-latency-routing.yaml
+++ b/config/scenarios/guides/predicted-latency-routing.yaml
@@ -122,6 +122,17 @@ scenario:
     # =========================================================================
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # -------------------------------------------------------------------------
     router:

--- a/config/scenarios/guides/tiered-prefix-cache.yaml
+++ b/config/scenarios/guides/tiered-prefix-cache.yaml
@@ -135,6 +135,17 @@ scenario:
     # =========================================================================
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # -------------------------------------------------------------------------
     router:

--- a/config/scenarios/guides/wide-ep-lws.yaml
+++ b/config/scenarios/guides/wide-ep-lws.yaml
@@ -161,6 +161,17 @@ scenario:
     #     # cloud.google.com/gke-accelerator: nvidia-h100-80gb  # GKE
 
     # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
+    # -------------------------------------------------------------------------
     # Routing / GAIE Configuration
     # Reference: https://github.com/llm-d/llm-d/blob/main/guides/wide-ep-lws/router/wide-ep-lws.values.yaml
     # The plugins block uses the `llm-d.ai/v1alpha1` apiVersion shipped

--- a/config/scenarios/guides/workload-autoscaling.yaml
+++ b/config/scenarios/guides/workload-autoscaling.yaml
@@ -253,6 +253,17 @@ scenario:
       # The upstream WVA README also pins this version.
       prometheusAdapter: 5.2.0
 
+    # -------------------------------------------------------------------------
+    # HTTPRoute Configuration
+    # requestTimeout: end-to-end Gateway-API HTTPRoute timeout the istio
+    # gateway enforces per request. Long agentic turns that exceed it are
+    # aborted by the gateway with a 502 (surfaces as "connection reset by
+    # peer" on the decode routing-proxy loopback hop). Set "0s" to disable.
+    # -------------------------------------------------------------------------
+    httpRoute:
+      requestTimeout: "300s"
+      backendRequestTimeout: "0s"
+
     # =========================================================================
     # ROUTING / GAIE CONFIGURATION
     # =========================================================================

--- a/config/templates/jinja/08_httproute.yaml.j2
+++ b/config/templates/jinja/08_httproute.yaml.j2
@@ -19,6 +19,19 @@
                              no substitution token the stacks will collide
      httpRoute.rewriteTo    (default: "/v1")
 
+   Timeout knobs (both modes, optional; Gateway-API HTTPRoute timeouts):
+     httpRoute.requestTimeout         (default: "300s") - end-to-end request
+                             timeout the gateway enforces. Long agentic turns
+                             that exceed it are aborted with a 502; set "0s"
+                             to disable. Applies to every rule this template
+                             emits.
+     httpRoute.backendRequestTimeout  (default: "0s")  - per-retry backend
+                             timeout; "0s" disables.
+#}
+{% set _request_timeout = (httpRoute.requestTimeout if httpRoute is defined and httpRoute.requestTimeout is defined else '300s') %}
+{% set _backend_request_timeout = (httpRoute.backendRequestTimeout if httpRoute is defined and httpRoute.backendRequestTimeout is defined else '0s') %}
+{#
+
    `siblingStacks` and `stackIndex` are injected by
    llmdbenchmark.parser.render_plans._process_stack.
 #}
@@ -57,8 +70,8 @@ spec:
         port: {{ decode.vllm.servicePort }}
         weight: 1
       timeouts:
-        backendRequest: 0s
-        request: 300s
+        backendRequest: {{ _backend_request_timeout }}
+        request: {{ _request_timeout }}
       matches:
         - path:
             type: PathPrefix
@@ -90,8 +103,8 @@ spec:
         port: {{ decode.vllm.servicePort }}
         weight: 1
       timeouts:
-        backendRequest: 0s
-        request: 0s
+        backendRequest: {{ _backend_request_timeout }}
+        request: {{ _request_timeout }}
       matches:
         - path:
             type: PathPrefix
@@ -110,7 +123,7 @@ spec:
         port: {{ decode.vllm.servicePort }}
         weight: 1
       timeouts:
-        backendRequest: 0s
-        request: 0s
+        backendRequest: {{ _backend_request_timeout }}
+        request: {{ _request_timeout }}
 {% endif %}
 {% endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -707,6 +707,26 @@ routing:
     # zapTimeEncoding: epoch
 
 # ============================================================================
+# HTTPROUTE CONFIGURATION
+#
+# Gateway-API HTTPRoute settings consumed by 08_httproute.yaml.j2. Applies to
+# every rule the template emits (both per-stack and shared modes).
+#
+#   requestTimeout        End-to-end request timeout the gateway enforces.
+#                         Requests exceeding it are aborted with a 502 (which
+#                         surfaces as a "connection reset by peer" on the
+#                         decode routing-proxy loopback hop). Set "0s" to
+#                         disable -- appropriate for long agentic turns.
+#   backendRequestTimeout Per-retry backend timeout; "0s" disables.
+#
+# Shared-mode-only knobs (mode/name/pathPrefix/rewriteTo) are documented in
+# the template header and read with their own defaults.
+# ============================================================================
+httpRoute:
+  requestTimeout: "300s"
+  backendRequestTimeout: "0s"
+
+# ============================================================================
 # VLLM COMMON CONFIGURATION
 # ============================================================================
 vllmCommon:


### PR DESCRIPTION
The gateway-enforced HTTPRoute request timeout was hardcoded in 08_httproute.yaml.j2 (300s on shared-mode rules, 0s on per-stack). Long agentic turns that exceed it are aborted with a 502, which surfaces as a "connection reset by peer" on the decode routing-proxy loopback hop.

Expose it as httpRoute.requestTimeout / httpRoute.backendRequestTimeout, defaulting to 300s / 0s in defaults.yaml and applied to all three rule blocks. Guides carry an explicit httpRoute block; agentic-serving sets requestTimeout: 0s to disable the cap for long sessions.