### PR TITLE
Fix KEDA ScaledObject poolName metric label filter

### DIFF
--- a/config/templates/jinja/30_epp-keda-saturation-scaledobject.yaml.j2
+++ b/config/templates/jinja/30_epp-keda-saturation-scaledobject.yaml.j2
@@ -65,7 +65,7 @@
 {% set hpa_name = model_id_label ~ '-decode' %}
 {% endif %}
 {% set epp_ns = eppKedaSaturation.namespace | default(namespace.name, true) %}
-{% set pool_name = eppKedaSaturation.epp.poolName | default(model_id_label ~ '-router-epp', true) %}
+{% set pool_name = eppKedaSaturation.epp.poolName | default(model_id_label ~ '-router', true) %}
 {% set prom_proxy_url = eppKedaSaturation.prometheus.proxyUrl | default('http://prometheus-proxy.openshift-keda:8080', true) %}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject


### PR DESCRIPTION
## Problem

KEDA autoscaling was not triggering because the ScaledObject's Prometheus metric query used an incorrect label filter:

**Broken Query:**
```promql
max(inference_pool_average_kv_cache_utilization{name="model-router-epp",...})
```

**Actual Prometheus Metric:**
```promql
max(inference_pool_average_kv_cache_utilization{name="model-router",...})
```

The mismatch caused KEDA's queries to always return empty results, preventing autoscaling from triggering even when metrics were flowing correctly.

## Root Cause

The Jinja template at `config/templates/jinja/30_epp-keda-saturation-scaledobject.yaml.j2:68` was appending `-router-epp` to construct the poolName metric label. However, Prometheus exports the metric with just the model name (e.g., `qwen-qwe-debb0c3c-wen3-32b-router`). The `-epp` suffix is part of the **service name**, not the **metric label**.

## Solution

Change the poolName default from:
```jinja
model_id_label ~ '-router-epp'
```

To:
```jinja
model_id_label ~ '-router'
```

## Verification

After this fix, KEDA's metric queries will correctly match Prometheus labels, enabling autoscaling to work as designed:

```
query: max(inference_pool_average_kv_cache_utilization{name="model-router",namespace="ns"})
```

This will return non-zero values when KV cache utilization > 0, allowing KEDA to trigger scale-up.