### PR TITLE
run: scope nop service lookup to namespace

### DIFF
--- a/config/templates/jinja/05_namespace_sa_rbac_secret.yaml.j2
+++ b/config/templates/jinja/05_namespace_sa_rbac_secret.yaml.j2
@@ -36,6 +36,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods/log"]
   verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 # Allow the metrics collector (collect_metrics.sh) to read the EPP
 # metrics-reader Secret so it can present its bearer token when scraping
 # the EPP /metrics endpoint (authn/authz filter is on by default).
@@ -80,42 +83,6 @@ roleRef:
   kind: ClusterRole
   name: system:openshift:scc:restricted
   apiGroup: rbac.authorization.k8s.io
-{% if not nonAdmin | default(false) %}
----
-# Cluster-scoped service viewer: nop harness uses
-# v1.list_service_for_all_namespaces() to find the standalone vLLM service
-# by ClusterIP. Namespace-scoped Role can't grant cluster-scope list, so
-# this ClusterRole + ClusterRoleBinding is required for the SA used by
-# the harness pod.
-#
-# Gated on --non-admin: a user without cluster-level RBAC permissions
-# cannot create these. Skipping is safe for the inference-perf, guidellm,
-# and vllm-benchmark harnesses (they target a known endpoint URL). The
-# 'nop' harness will not function in --non-admin deployments because it
-# relies on cluster-wide service listing -- pick a different harness or
-# have an admin pre-create inference-perf-service-viewer-<ns>.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: inference-perf-service-viewer-{{ namespace.name }}
-rules:
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: inference-perf-service-viewer-{{ namespace.name }}
-subjects:
-- kind: ServiceAccount
-  name: {{ serviceAccount.name }}
-  namespace: {{ namespace.name }}
-roleRef:
-  kind: ClusterRole
-  name: inference-perf-service-viewer-{{ namespace.name }}
-  apiGroup: rbac.authorization.k8s.io
-{% endif %}
 {% if huggingface.enabled %}
 ---
 apiVersion: v1

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -105,15 +105,9 @@ class RenderPlans:
         # in a multi-stack scenario.
         self._cli_model_multi_stack_warned: bool = False
 
-        # ``--non-admin`` propagates into the Jinja render context as
-        # ``nonAdmin`` so templates can gate cluster-scoped resources
-        # (ClusterRole, ClusterRoleBinding, etc.) the namespaced user
-        # can't create. Currently consumed by
-        # ``05_namespace_sa_rbac_secret.yaml.j2`` to skip the
-        # ``inference-perf-service-viewer`` pair -- those are only
-        # required by the ``nop`` harness's cluster-wide service
-        # discovery, so dropping them is safe for the mainstream
-        # harnesses (inference-perf, guidellm, vllm-benchmark).
+        # Keep accepting --non-admin for CLI/API compatibility. Resource
+        # authorization is enforced by the execution context; the rendered
+        # namespace template no longer emits cluster-scoped resources.
         self.cli_non_admin: bool = bool(cli_non_admin)
 
         self.logger = logger or get_logger(
@@ -1878,7 +1872,6 @@ class RenderPlans:
         merged_values["siblingStacks"] = sibling_stacks or []
         merged_values["stackIndex"] = stack_index
         merged_values["sharedInfraStackIndex"] = shared_infra_stack_index
-        merged_values["nonAdmin"] = self.cli_non_admin
         merged_values["scenarioName"] = self.scenarios_file.stem
 
         epponly_errors = self._validate_epponly_constraints(

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -266,16 +266,6 @@ class ModelNamespaceStep(Step):
         if not ns_yaml:
             return
 
-        if context.non_admin:
-            # The render pipeline elides ClusterRole/ClusterRoleBinding when
-            # --non-admin is set; surface that here so it's not silent and
-            # so the 'nop' harness mismatch is callable out in the log.
-            context.logger.log_info(
-                "--non-admin: skipped ClusterRole/ClusterRoleBinding "
-                "'inference-perf-service-viewer' (only the 'nop' harness "
-                "needs them; use inference-perf / guidellm / vllm-benchmark)"
-            )
-
         result = cmd.kube("apply", "-f", str(ns_yaml))
         if not result.success:
             errors.append(f"Failed to apply namespace resources: {result.stderr}")

--- a/llmdbenchmark/teardown/steps/step_04_clean_cluster_roles.py
+++ b/llmdbenchmark/teardown/steps/step_04_clean_cluster_roles.py
@@ -15,6 +15,7 @@ _MODELSERVICE_ROLE_SUFFIXES = [
     "modelservice-editor",
     "modelservice-viewer",
 ]
+_LEGACY_NOP_SERVICE_VIEWER_PREFIX = "inference-perf-service-viewer-"
 
 
 class CleanClusterRolesStep(Step):
@@ -48,6 +49,7 @@ class CleanClusterRolesStep(Step):
 
         self._delete_matching(cmd, context, "ClusterRoleBinding", release, errors)
         self._delete_matching(cmd, context, "ClusterRole", release, errors)
+        self._delete_legacy_nop_service_viewers(cmd, context)
 
         context.logger.log_info("Deleting well-known modelservice ClusterRoles...")
         for suffix in _MODELSERVICE_ROLE_SUFFIXES:
@@ -101,6 +103,26 @@ class CleanClusterRolesStep(Step):
             success=True,
             message="Cluster-scoped resources cleaned",
         )
+
+    @staticmethod
+    def _delete_legacy_nop_service_viewers(cmd, context) -> None:
+        """Remove service-viewer roles emitted by releases before namespace scoping."""
+        namespaces = {
+            getattr(context, attribute, None)
+            for attribute in ("namespace", "harness_namespace", "wva_namespace")
+        }
+        for namespace in filter(None, namespaces):
+            role_name = f"{_LEGACY_NOP_SERVICE_VIEWER_PREFIX}{namespace}"
+            for kind in ("ClusterRoleBinding", "ClusterRole"):
+                context.logger.log_info(
+                    f"Deleting legacy {kind}/{role_name}", emoji="🗑️"
+                )
+                cmd.kube(
+                    "delete",
+                    "--ignore-not-found=true",
+                    kind,
+                    role_name,
+                )
 
     def _delete_matching(
         self,

--- a/tests/test_kube_helpers_pod_failures.py
+++ b/tests/test_kube_helpers_pod_failures.py
@@ -74,5 +74,9 @@ def test_wait_reports_current_and_previous_container_failure() -> None:
         "Found pods in error state: inference-perf-abc/harness "
         "(CrashLoopBackOff, last terminated: OOMKilled, exit_code=137)"
     ]
-    get_call = next(call for call in cmd.calls if call[-2:] == ("-o", "json"))
+    get_call = next(
+        call
+        for call in cmd.calls
+        if call[:2] == ("get", "pods") and not call[-1].startswith("jsonpath=")
+    )
     assert get_call[-2:] == ("-o", "json")

--- a/tests/test_nop_service_lookup.py
+++ b/tests/test_nop_service_lookup.py
@@ -1,0 +1,103 @@
+"""Tests for nop harness service lookup."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+_HARNESS_PATH = (
+    Path(__file__).resolve().parents[1] / "workload" / "harnesses" / "nop_functions.py"
+)
+_spec = importlib.util.spec_from_file_location("nop_functions_test", _HARNESS_PATH)
+nop_functions = importlib.util.module_from_spec(_spec)
+sys.modules["nop_functions_test"] = nop_functions
+_spec.loader.exec_module(nop_functions)
+
+
+class _CoreV1:
+    def __init__(self) -> None:
+        self.all_namespaces_called = False
+        self.namespaces: list[str] = []
+
+    def list_service_for_all_namespaces(self):
+        self.all_namespaces_called = True
+        raise AssertionError("cluster-scoped service listing should not be used")
+
+    def list_namespaced_service(self, namespace: str):
+        self.namespaces.append(namespace)
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    metadata=SimpleNamespace(name="other", namespace=namespace),
+                    spec=SimpleNamespace(cluster_ip="10.0.0.1"),
+                ),
+                SimpleNamespace(
+                    metadata=SimpleNamespace(name="target", namespace=namespace),
+                    spec=SimpleNamespace(cluster_ip="10.0.0.2"),
+                ),
+            ]
+        )
+
+
+def test_find_service_by_cluster_ip_uses_namespace_scope() -> None:
+    v1 = _CoreV1()
+
+    service = nop_functions.find_service_by_cluster_ip(v1, "bench", "10.0.0.2")
+
+    assert service.metadata.name == "target"
+    assert v1.namespaces == ["bench"]
+    assert not v1.all_namespaces_called
+
+
+def test_namespace_rbac_grants_services_without_cluster_viewer() -> None:
+    template_path = (
+        Path(__file__).resolve().parents[1]
+        / "config"
+        / "templates"
+        / "jinja"
+        / "05_namespace_sa_rbac_secret.yaml.j2"
+    )
+    renderer = RenderPlans.__new__(RenderPlans)
+    renderer.logger = None
+    renderer._jinja_env = None
+
+    rendered = renderer._render_template(
+        template_path.read_text(encoding="utf-8"),
+        {
+            "namespace": {
+                "name": "bench",
+                "labels": {
+                    "podSecurity": {
+                        "audit": "restricted",
+                        "warn": "restricted",
+                    }
+                },
+            },
+            "serviceAccount": {"name": "inference-perf-runner"},
+            "router": {
+                "monitoring": {
+                    "secretName": "inference-gateway-sa-metrics-reader-secret"
+                }
+            },
+            "fma": {"enabled": False},
+            "huggingface": {"enabled": False},
+            "nonAdmin": False,
+        },
+    )
+    docs = [doc for doc in yaml.safe_load_all(rendered) if doc]
+    names = {doc["metadata"]["name"] for doc in docs}
+
+    assert "inference-perf-service-viewer-bench" not in names
+
+    role = next(doc for doc in docs if doc["kind"] == "Role")
+    assert {
+        "apiGroups": [""],
+        "resources": ["services"],
+        "verbs": ["get", "list"],
+    } in role["rules"]

--- a/workload/harnesses/nop_functions.py
+++ b/workload/harnesses/nop_functions.py
@@ -934,9 +934,9 @@ def wake(base_url: str, timeout: float, wait: float):
             raise RuntimeError(f"Server failed sleeping status after {elapsed} secs.")
 
 
-def find_service_by_cluster_ip(v1: client.CoreV1Api, ip: str):
-    """find a clusterip service giving an ip"""
-    services = v1.list_service_for_all_namespaces().items
+def find_service_by_cluster_ip(v1: client.CoreV1Api, namespace: str, ip: str):
+    """Find a ClusterIP service by IP within the benchmark namespace."""
+    services = v1.list_namespaced_service(namespace=namespace).items
     for svc in services:
         if svc.spec.cluster_ip == ip:
             return svc
@@ -1876,7 +1876,7 @@ def benchmark_nop(  # pylint: disable=too-many-arguments,too-many-positional-arg
         raise RuntimeError(f"Unable to extract hostname from {endpoint_url}.")
 
     # it should be IP
-    svc = find_service_by_cluster_ip(v1, cluster_ip)
+    svc = find_service_by_cluster_ip(v1, namespace, cluster_ip)
     if not svc:
         raise RuntimeError(f"No service found with ClusterIP {cluster_ip}")
 


### PR DESCRIPTION
 ## Summary

  Fix the `nop` harness standalone path by resolving services within the benchmark namespace instead of listing services cluster-wide.

  ## Motivation

  Fixes #1278.

  The `nop` harness resolves the standalone service by matching the endpoint ClusterIP. It already receives `LLMDBENCH_VLLM_COMMON_NAMESPACE`, and later validates that the matched
  Service belongs to that namespace, but the lookup used:

  ```python
  v1.list_service_for_all_namespaces()

  On GKE/CKS this can fail with:

  services is forbidden: cannot list resource "services" at the cluster scope

  The cluster-wide list is unnecessary for standalone runs because the target namespace is already known.

  ## What changed

  - Changed find_service_by_cluster_ip() to use list_namespaced_service(namespace=...).
  - Passed the existing benchmark namespace into the service lookup.
  - Added namespace-scoped services get/list permissions to the harness Role.
  - Removed the no-longer-needed inference-perf-service-viewer ClusterRole and ClusterRoleBinding from the namespace/RBAC template.
  - Removed stale comments/logging that said nop required cluster-wide service discovery.
  - Added regression tests covering:
      - nop service lookup does not call list_service_for_all_namespaces().
      - rendered namespace RBAC grants namespaced service access without creating the old service-viewer ClusterRole.

  ## Testing

  - python -m pytest tests/test_nop_service_lookup.py -q
  - python -m pytest tests -q
  - python -m ruff check --unsafe-fixes --output-format=full workload/harnesses/nop_functions.py llmdbenchmark/parser/render_plans.py llmdbenchmark/standup/steps/
    step_04_model_namespace.py tests/test_nop_service_lookup.py

  - python -m ruff format --check --diff workload/harnesses/nop_functions.py llmdbenchmark/parser/render_plans.py llmdbenchmark/standup/steps/step_04_model_namespace.py tests/
    test_nop_service_lookup.py

  - python -m py_compile workload/harnesses/nop_functions.py llmdbenchmark/parser/render_plans.py llmdbenchmark/standup/steps/step_04_model_namespace.py tests/
    test_nop_service_lookup.py

  - git diff --check

  ## Backward Compatibility

  This preserves the existing ClusterIP matching behavior, but scopes the Kubernetes API request to the known namespace. Existing non-nop harnesses are unaffected.