### PR TITLE
fix: nop harness starts before launchers are ready for Requestors, adding GPU info to analysis table

### DIFF
--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -119,7 +119,6 @@ scenario:
       #   3. Scale requester Deployment down to 1 (vLLM sleeps on 9 pods)
       #   4. Confirm sleeping vLLM instances are present
       warmupTimeout: 1200  # ← Increased: 10-20 min model load + scale-down verification
-      warmupBufferSeconds: 0  # ← No buffer needed
 
     # =========================================================================
     # WVA CONFIGURATION

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -146,8 +146,6 @@ scenario:
       # Warmup: a deliberate wait inserted in the run phase before the
       # benchmark fires.
       warmupTimeout: 600
-      warmupBufferSeconds: 240          # ~4 min; covers Qwen3-32B model load
-                                        # on remaining launchers in the pool
 
     # =========================================================================
     # WVA CONFIGURATION

--- a/config/templates/jinja/18_podmonitor.yaml.j2
+++ b/config/templates/jinja/18_podmonitor.yaml.j2
@@ -31,7 +31,6 @@ spec:
       # `llm-d.ai/guide` on serving pods (FMA via 24_fma-deployment.yaml.j2's
       # ISC labels stamped at bind time; modelservice via 13_ms-values.yaml.j2).
       # Selecting on `guide` keeps the PodMonitor identical for both paths
-      # — same as Braulio's working FMA+WVA setup in PR #552/#579.
       llm-d.ai/guide: "{{ wva.wellLitPath }}"
 {% else %}
       llm-d.ai/inferenceServing: "{{ labels.inferenceServing }}"

--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_1.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_1.py
@@ -2547,6 +2547,7 @@ def import_nop(results_file: str) -> BenchmarkReportV01:
                     "units": Units.S,
                     "value": requester_info.get("container_start_timestamp", 0.0),
                 }
+                ri["gpu_uuids"] = requester_info.get("gpu_uuids", "")
                 info["requester_info"] = ri
 
                 info["actuation_condition"] = launcher_info["actuation_condition"]

--- a/llmdbenchmark/analysis/scripts/nop-analyze_results.py
+++ b/llmdbenchmark/analysis/scripts/nop-analyze_results.py
@@ -374,6 +374,7 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
                     "Iteration": iteration["iteration"]["value"],
                     "vLLM Name": launcher_info["name"],
                     "Node": node,
+                    "GPU UUID": launcher_info["requester_info"].get("gpu_uuids", ""),
                     "Actuation Condition": actuation_condition,
                     "T_actuation(s)": ttrr,
                     "T_hot(s)": t_hot_val,

--- a/llmdbenchmark/run/steps/step_02a_fma_warmup.py
+++ b/llmdbenchmark/run/steps/step_02a_fma_warmup.py
@@ -1,8 +1,7 @@
 """Step 02a -- Wait for FMA launcher pool to warm up before benchmarking.
 
-Mirrors Braulio's pattern in llm-d-fast-model-actuation PR #579: after
-standup completes, deliberately wait for the fma-requester Deployment to
-become ``Available`` (i.e. at least one launcher is bound and its vLLM
+Wait for the fma-requester Deployment to become ``Available``
+(i.e. at least one launcher is bound and its vLLM
 container is fully initialized) before driving load.
 
 Why this lives in the run phase rather than at the end of standup: HPA
@@ -23,7 +22,6 @@ A scenario may select an alternate warmup by setting the top-level
 vLLM, then benchmark scales back up).
 """
 
-import time
 from pathlib import Path
 
 from llmdbenchmark.executor.step import Step, StepResult, Phase
@@ -87,6 +85,45 @@ class FMAWarmupStep(Step):
                 stack_name=stack_name,
             )
 
+        cmd = context.require_cmd()
+        namespace = context.require_namespace()
+        model_id_label = plan_config.get("model_id_label", "")
+        if not model_id_label:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="model_id_label missing from plan_config",
+                errors=["model_id_label is required for FMA warmup"],
+                stack_name=stack_name,
+            )
+
+        timeout = int(self._resolve(plan_config, "fma.warmupTimeout", default=300))
+
+        # Stage 0: Wait for the launcher pods' to reach the
+        # Ready condition so the requester scale-up doesn't race launcher
+        # container startup (image pull + launcher.py bind).
+        launcher_selector = (
+            f"stood-up-via=fma,"
+            f"dual-pods.llm-d.ai/launcher-config-name=fma-{model_id_label}"
+        )
+        context.logger.log_info(
+            f"⏳ FMA warmup: waiting up to {timeout}s for launcher pods "
+            f"({launcher_selector}) to be Ready in ns/{namespace}"
+        )
+        launcher_wait = cmd.wait_for_pods(
+            label=launcher_selector,
+            namespace=namespace,
+            timeout=timeout,
+            poll_interval=10,
+            description=f"FMA launchers ready (model={model_id_label})",
+        )
+        if not launcher_wait.success:
+            context.logger.log_warning(
+                f"FMA warmup: launcher pods not all Ready within {timeout}s in "
+                f"ns/{namespace}. {launcher_wait.stderr.strip()[:200]}"
+            )
+
         replicas = int(
             self._resolve(plan_config, "fma.requester.replicas", default=0) or 0
         )
@@ -102,28 +139,10 @@ class FMAWarmupStep(Step):
                 stack_name=stack_name,
             )
 
-        cmd = context.require_cmd()
-        namespace = context.require_namespace()
-        model_id_label = plan_config.get("model_id_label", "")
-        if not model_id_label:
-            return StepResult(
-                step_number=self.number,
-                step_name=self.name,
-                success=False,
-                message="model_id_label missing from plan_config",
-                errors=["model_id_label is required for FMA warmup"],
-                stack_name=stack_name,
-            )
-
-        deploy_name = f"fma-requester-{model_id_label}"
-        timeout = int(self._resolve(plan_config, "fma.warmupTimeout", default=600))
-        buffer_seconds = int(
-            self._resolve(plan_config, "fma.warmupBufferSeconds", default=0)
-        )
-
         # Stage 1: kubectl wait Deployment Available. With replicas=N, this
         # succeeds when N requester pods are Ready -- i.e. N launchers have
-        # vLLM serving. Same gate Braulio uses in PR #579's demo script.
+        # vLLM serving.
+        deploy_name = f"fma-requester-{model_id_label}"
         context.logger.log_info(
             f"⏳ FMA warmup: waiting up to {timeout}s for Deployment/"
             f"{deploy_name} to become Available in ns/{namespace}"
@@ -150,31 +169,10 @@ class FMAWarmupStep(Step):
                 stack_name=stack_name,
             )
 
-        # Stage 2: optional buffer sleep so off-axis launchers (the ones
-        # NOT bound to the initial requester replicas) finish loading model
-        # weights before HPA scale-up fires. With launcher-populator
-        # creating one launcher per node and only `replicas` of them bound
-        # initially, the rest are still in vLLM-startup at end of stage 1
-        # and scale-up to maxReplicas would race them. 0 = opt-out (matches
-        # Braulio's demo, which doesn't add a buffer).
-        if buffer_seconds > 0:
-            context.logger.log_info(
-                f"⏳ FMA warmup: sleeping {buffer_seconds}s buffer for "
-                f"off-axis launcher vLLM init to complete"
-            )
-            time.sleep(buffer_seconds)
-
         return StepResult(
             step_number=self.number,
             step_name=self.name,
             success=True,
-            message=(
-                f"FMA warmup: Deployment/{deploy_name} Available"
-                + (
-                    f" (+ {buffer_seconds}s off-axis-launcher buffer)"
-                    if buffer_seconds > 0
-                    else ""
-                )
-            ),
+            message=(f"FMA warmup: Deployment/{deploy_name} Available"),
             stack_name=stack_name,
         )

--- a/workload/harnesses/fma_functions.py
+++ b/workload/harnesses/fma_functions.py
@@ -36,6 +36,7 @@ from nop_functions import (
 logger = logging.getLogger(__name__)
 
 DUAL_LABEL = "dual-pods.llm-d.ai/dual"
+ACCELERATORS_ANNOTATION = "dual-pods.llm-d.ai/accelerators"
 FMA_TIMEOUT = 10.0 * 60.0  # time (seconds) to wait
 
 # Name of the requester container whose start time is the actuation baseline
@@ -52,6 +53,7 @@ class FMARequesterInfo:
     ready_timestamp: float = 0.0
     dual_label_timestamp: float = 0.0
     container_start_timestamp: float = 0.0
+    gpu_uuids: str = ""
     pod: Any | None = None
 
     def dump(self) -> dict[str, Any]:
@@ -470,6 +472,9 @@ def wait_for_requester_pods(  # pylint: disable=too-many-arguments,too-many-posi
         requester_info.ready_timestamp = get_ready_timestamp(p)
         requester_info.dual_label_timestamp = get_dual_label_timestamp(p)
         requester_info.container_start_timestamp = get_container_start_timestamp(p)
+        requester_info.gpu_uuids = (p.metadata.annotations or {}).get(
+            ACCELERATORS_ANNOTATION, ""
+        )
         requester_info.pod = p
         all_requester_pods[p.metadata.name] = requester_info
 
@@ -524,6 +529,11 @@ def wait_for_requester_pods(  # pylint: disable=too-many-arguments,too-many-posi
                     requester_info.container_start_timestamp = (
                         get_container_start_timestamp(pod)
                     )
+                    _gpu = (pod.metadata.annotations or {}).get(
+                        ACCELERATORS_ANNOTATION, ""
+                    )
+                    if _gpu:
+                        requester_info.gpu_uuids = _gpu
                     # only calculate if it wasn't already calculated
                     if requester_info.dual_label_timestamp == 0.0:
                         requester_info.dual_label_timestamp = get_dual_label_timestamp(


### PR DESCRIPTION
- [x] GPU UUID in the actuation report: captures the requester's assigned GPU from the `dual-pods.llm-d.ai/accelerators` annotation → adds a GPU column to `result.txt`. Lets you see per-iteration which GPU was used (warm/hot ↔ GPU).
- [x] Launcher-readiness barrier before the benchmark starts: waits for most launcher pods to be Ready so iteration 1 doesn't race launcher container startup (the "first-warm is 2×") instead of doing just `time.sleep(buffer_seconds)`