### PR TITLE
feat: a new workflow for epp+keda baseline vs FMA with keda (warm/hot)

### DIFF
--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -1,0 +1,694 @@
+name: CI - Run Benchmark on OCP ("EPP+KEDA+FMA" autoscaling path)
+
+# Mirrors ci-benchmark-ocp-fma-wva.yaml but drives the EPP+KEDA
+# saturation autoscaling path instead of WVA: KEDA scales on EPP pool metrics
+# (inference_pool_average_kv_cache_utilization / _average_queue_size) with NO
+# WVA controller. Enabled purely via `eppKedaSaturation.enabled: true`.
+#
+# Three passes for direct comparison, under inference-perf load
+# (shared_prefix_synthetic_heavy.yaml, sized to push the EPP KV-cache / queue
+# gauges past the KEDA ScaledObject thresholds so it scales out):
+#   1. baseline (EPP+KEDA, no FMA)   -- `cicd/ocp-keda`
+#   2. FMA warm-start with EPP+KEDA  -- `cicd/ocp-keda-fma-warmstart`
+#   3. FMA hot-start with EPP+KEDA   -- `cicd/ocp-keda-fma-hotstart`
+#
+# Hot-start pre-loads all models during standup then scales to 1 (vLLM sleeps),
+# isolating scaling behavior from model-load latency.
+#
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenario_dir:
+        description: 'Directory housing the scenarios'
+        required: false
+        default: 'cicd'
+      baseline_scenario:
+        description: 'Baseline scenario (EPP+KEDA, no FMA)'
+        required: false
+        type: 'string'
+        default: 'ocp-keda'
+      standup_scenario:
+        description: 'EPP+KEDA with FMA scenario (warm-start)'
+        required: false
+        type: 'string'
+        default: 'ocp-keda-fma-warmstart'
+      hotstart_scenario:
+        description: 'EPP+KEDA with FMA scenario (hot-start)'
+        required: false
+        type: 'string'
+        default: 'ocp-keda-fma-hotstart'
+      decode_pods:
+        description: 'Number of decode pods (FMA path keeps decode at 0; baseline uses 1)'
+        required: false
+        type: 'string'
+        default: 'auto'
+      prefill_pods:
+        description: 'Number of prefill pods'
+        required: false
+        type: 'string'
+        default: 'auto'
+      accelerator_type:
+        description: 'Type of accelerator (kustomize only)'
+        required: false
+        type: 'string'
+        default: 'gpu'
+      backend_type:
+        description: 'Type of backend (kustomize only)'
+        required: false
+        type: 'string'
+        default: 'vllm'
+      infra_provider:
+        description: 'Target cloud provider (kustomize only)'
+        required: false
+        type: 'string'
+        default: 'ocp'
+      connector:
+        description: 'Accelerator offloading connector (kustomize only)'
+        required: false
+        type: 'string'
+        default: ''
+      bucket_project:
+        description: 'Project associated to the object storage bucket'
+        required: false
+        default: 'llm-d-scale'
+      bucket_provider:
+        description: 'Type (provider of) the bucket'
+        required: false
+        default: 'gcs'
+      bucket_path:
+        description: 'Path to object storage bucket'
+        required: false
+        default: 'llm-d-benchmarks/regressions'
+      gateway_class:
+        description: 'Class of gateway used (epponly for modelservice paths)'
+        required: false
+        default: 'epponly'
+      monitoring_enabled:
+        description: 'Enabled monitoring ("true", "false")'
+        required: true
+        type: 'string'
+        default: 'true'
+      dry_run:
+        description: 'Execute workflow in "dry-run" mode'
+        required: false
+        default: 'false'
+      verbose:
+        description: 'Execute workflow in "verbose" mode'
+        required: false
+        default: 'false'
+        type: 'string'
+      harness:
+        description: 'Harness ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "nop")'
+        required: false
+        default: 'inference-perf'
+        type: 'string'
+      workload:
+        description: 'Workload profile (under workload/profiles/<harness>/)'
+        required: false
+        # Default to the heavy variant (calibrated to drive EPP saturation
+        # past the KEDA scale-up thresholds). Override to shared_prefix_synthetic.yaml
+        # for a light-load smoke test of the deployment chain itself.
+        default: 'shared_prefix_synthetic_heavy.yaml'
+        type: 'string'
+      wait_timeout:
+        # The reusable workflow's default is 3600s, but CI runs of the
+        # FMA+KEDA (with the heavy RPS profile) take 20+ minutes for the
+        # inference-perf harness pod to drain its in-flight queue.
+        description: 'Run-phase wait timeout in seconds'
+        required: false
+        default: '5400'
+        type: 'string'
+
+jobs:
+  # =========================================================================
+  # Pass 1: EPP+KEDA without FMA
+  #
+  # EPP-only path — decode.replicas: 1 at idle, scaled by the KEDA-managed HPA
+  # on EPP pool metrics (kv-cache / queue). No FMA controllers, no launchers.
+  # =========================================================================
+  baseline:
+    name: Baseline (EPP+KEDA, no FMA)
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: 'modelservice'
+      standup_scenario: ${{ inputs.baseline_scenario || 'ocp-keda' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'ocp' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: 'llmdbenchcicdkbns-ocp'
+      helm_release: 'lmdbenchcicdkbr-ocp'
+      workspace_dir: '/tmp/llmdbenchcicdkb-ocp'
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
+      wait_timeout: ${{ inputs.wait_timeout || '5400' }}
+    secrets: inherit
+
+  # =========================================================================
+  # Pass 2: EPP+KEDA with FMA (Warm-Start)
+  #
+  # Same load against the same gateway/EPP path, but with FMA layered on:
+  # decode.replicas: 0, FMA's launcher pods serve traffic, requester
+  # Deployment is the KEDA scale target. Warm-start deploys 1 replica initially,
+  # model loads during warmup, then benchmark scales 1->N.
+  # =========================================================================
+  nightly:
+    name: EPP+KEDA with FMA (Warm-Start)
+    needs: [baseline]
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      # Both methods: this scenario deploys modelservice (gateway/EPP/
+      # InferencePool) AND layers FMA on top (launcher pods serve traffic
+      # via the modelservice gateway). Comma-separated value
+      # makes both code paths fire.
+      standup_method: 'modelservice,fma'
+      standup_scenario: ${{ inputs.standup_scenario || 'ocp-keda-fma-warmstart' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'ocp' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: 'llmdbenchcicdkwns-ocp'
+      helm_release: 'lmdbenchcicdkwr-ocp'
+      workspace_dir: '/tmp/llmdbenchcicdkw-ocp'
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
+      wait_timeout: ${{ inputs.wait_timeout || '5400' }}
+    secrets: inherit
+
+  # =========================================================================
+  # Pass 3: EPP+KEDA with FMA (Hot-Start)
+  #
+  # Hot-start variant: deploys all maxReplicas initially so all models load
+  # in parallel during standup. After loading, scales down to 1 (vLLM sleeps).
+  # Benchmark then scales 1->N, measuring pure HPA/KEDA behavior without model
+  # loading latency confounding the results.
+  # =========================================================================
+  hotstart:
+    name: EPP+KEDA with FMA (Hot-Start)
+    needs: [baseline]
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    with:
+      scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
+      standup_method: 'modelservice,fma'
+      standup_scenario: ${{ inputs.hotstart_scenario || 'ocp-keda-fma-hotstart' }}
+      decode_pods: ${{ inputs.decode_pods || 'auto' }}
+      prefill_pods: ${{ inputs.prefill_pods || 'auto' }}
+      accelerator_type: ${{ inputs.accelerator_type || 'gpu' }}
+      backend_type: ${{ inputs.backend_type || 'vllm' }}
+      infra_provider: ${{ inputs.infra_provider || 'ocp' }}
+      connector: ${{ inputs.connector || '' }}
+      cluster_namespace: 'llmdbenchcicdkhns-ocp'
+      helm_release: 'lmdbenchcicdkhr-ocp'
+      workspace_dir: '/tmp/llmdbenchcicdkh-ocp'
+      bucket_project: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      bucket_provider: ${{ inputs.bucket_provider || 'gcs' }}
+      bucket_path: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      gateway_class: ${{ inputs.gateway_class || 'epponly' }}
+      monitoring_enabled: ${{ inputs.monitoring_enabled || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
+      verbose: ${{ inputs.verbose || 'false' }}
+      harness: ${{ inputs.harness || 'inference-perf' }}
+      workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
+      wait_timeout: ${{ inputs.wait_timeout || '7200' }}
+    secrets: inherit
+
+  # =========================================================================
+  # Display: combine all three result sets in the GH Step Summary
+  # =========================================================================
+  display-results:
+    name: Display Results (Baseline + EPP+KEDA with FMA Warm-Start + Hot-Start)
+    needs: [baseline, nightly, hotstart]
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      GCS_PATH: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
+      GCP_PROJECT_ID: ${{ inputs.bucket_project || 'llm-d-scale' }}
+      LLMDBENCH_CICD_TARGET: ${{ inputs.infra_provider || 'ocp' }}
+      BASELINE_SCENARIO: ${{ inputs.baseline_scenario || 'ocp-keda' }}
+      FMA_WVA_WARMSTART_SCENARIO: ${{ inputs.standup_scenario || 'ocp-keda-fma-warmstart' }}
+      FMA_WVA_HOTSTART_SCENARIO: ${{ inputs.hotstart_scenario || 'ocp-keda-fma-hotstart' }}
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        with:
+          credentials_json: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Display results
+        run: |
+          set +e
+          BASELINE_DIR="/tmp/baseline-results"
+          FMA_WVA_WARMSTART_DIR="/tmp/fma-wva-warmstart-results"
+          FMA_WVA_HOTSTART_DIR="/tmp/fma-wva-hotstart-results"
+          mkdir -p "$BASELINE_DIR" "$FMA_WVA_WARMSTART_DIR" "$FMA_WVA_HOTSTART_DIR"
+
+          # Pick the most recent <date> subdir that actually has data
+          latest_date_under() {
+            # $1 = bucket prefix (e.g., gs://.../scenario/target/method/)
+            # Output: latest YYYY-MM-DD/, or empty if none.
+            gcloud storage ls "$1" 2>/dev/null \
+              | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}/$' \
+              | sort | tail -1
+          }
+          BL_PREFIX="gs://${GCS_PATH}/${BASELINE_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice/"
+          FW_WARMSTART_PREFIX="gs://${GCS_PATH}/${FMA_WVA_WARMSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
+          FW_HOTSTART_PREFIX="gs://${GCS_PATH}/${FMA_WVA_HOTSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
+          BL_DATE=$(latest_date_under "$BL_PREFIX")
+          FW_WARMSTART_DATE=$(latest_date_under "$FW_WARMSTART_PREFIX")
+          FW_HOTSTART_DATE=$(latest_date_under "$FW_HOTSTART_PREFIX")
+          echo "Baseline data date:           ${BL_DATE:-none found}"
+          echo "FMA+KEDA Warm-Start data date: ${FW_WARMSTART_DATE:-none found}"
+          echo "FMA+KEDA Hot-Start data date:  ${FW_HOTSTART_DATE:-none found}"
+
+          [ -n "$BL_DATE" ] && gcloud storage cp -r "${BL_PREFIX}${BL_DATE}" "$BASELINE_DIR/" || true
+          [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_WVA_WARMSTART_DIR/" || true
+          [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_WVA_HOTSTART_DIR/" || true
+
+          # PyYAML for cluster-state parsing in the timing-row computation
+          # below; ubuntu-latest doesn't have it pre-installed in the user
+          # site, but the system one does (apt-installed python3-yaml).
+          pip install --quiet pyyaml 2>/dev/null || true
+
+          # Locate, per pass:
+          #   - summary_lifecycle_metrics.json   (harness output, has latency)
+          #   - <exp_id>/wva-controller.log      (step_09a, has scale-up timestamp)
+          #   - <exp_id>/resources.yaml          (step_09a, has Pod Ready timestamps)
+          find_in_results() {
+            # $1 = pass dir, $2 = filename
+            find "$1" -path "*/results/*" -name "$2" 2>/dev/null | sort | tail -1
+          }
+          BL_SUM=$(find_in_results "$BASELINE_DIR"            "summary_lifecycle_metrics.json")
+          FW_WARMSTART_SUM=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "summary_lifecycle_metrics.json")
+          FW_HOTSTART_SUM=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "summary_lifecycle_metrics.json")
+          BL_WVA=$(find_in_results "$BASELINE_DIR"            "wva-controller.log")
+          FW_WARMSTART_WVA=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "wva-controller.log")
+          FW_HOTSTART_WVA=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "wva-controller.log")
+          BL_RES=$(find_in_results "$BASELINE_DIR"            "resources.yaml")
+          FW_WARMSTART_RES=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "resources.yaml")
+          FW_HOTSTART_RES=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "resources.yaml")
+          BL_EVENTS=$(find_in_results "$BASELINE_DIR"            "events.json")
+          FW_WARMSTART_EVENTS=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "events.json")
+          FW_HOTSTART_EVENTS=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "events.json")
+
+          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_WVA" "$FW_WARMSTART_WVA" "$FW_HOTSTART_WVA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" "$BL_EVENTS" "$FW_WARMSTART_EVENTS" "$FW_HOTSTART_EVENTS" \
+            >> "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json, sys, os, re, datetime
+          try:
+              import yaml
+              HAVE_YAML = True
+          except ImportError:
+              HAVE_YAML = False
+
+          (bl_sum, fw_ws_sum, fw_hs_sum,
+           bl_wva, fw_ws_wva, fw_hs_wva,
+           bl_res, fw_ws_res, fw_hs_res,
+           bl_events, fw_ws_events, fw_hs_events) = sys.argv[1:13]
+
+          def load_json(p):
+              if not p or not os.path.isfile(p):
+                  return None
+              try:
+                  with open(p) as f:
+                      return json.load(f)
+              except (json.JSONDecodeError, OSError):
+                  return None
+
+          bl = load_json(bl_sum)
+          fw_ws = load_json(fw_ws_sum)   # EPP+KEDA with FMA — warm start
+          fw_hs = load_json(fw_hs_sum)   # EPP+KEDA with FMA — hot start
+
+          def get(d, *keys, scale=1.0):
+              if d is None: return None
+              cur = d
+              for k in keys:
+                  if not isinstance(cur, dict) or k not in cur: return None
+                  cur = cur[k]
+              return cur * scale if isinstance(cur, (int, float)) else cur
+
+          def fmt(v, unit="", precision=1):
+              if v is None: return "_n/a_"
+              if isinstance(v, float): return f"{v:.{precision}f}{unit}"
+              return f"{v}{unit}"
+
+          # ----- Scale actuation timing (scaler-agnostic: pod lifecycle) -----
+          # FMA requester Deployment is scaled via a KEDAScaledObject -> HPA,
+          # so timing is measured from the captured resources.yaml (pod status)
+
+          # T_actuation: mean wall-clock from each serving container's START to
+          # its pod's Ready transition. Measuring from container start (not pod
+          # creation) excludes scheduling + image-pull + volume-mount overhead —
+          # matching FMA's httpstart, which times from container start.
+          def _iso_full(s):
+              """Parse an RFC3339 timestamp (with optional fractional seconds
+              and Z suffix) into a tz-aware datetime, or None on failure."""
+              if not s:
+                  return None
+              try:
+                  return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+              except (ValueError, TypeError):
+                  return None
+
+          # Serving-container names whose start marks the beginning of model
+          # actuation: "vllm" for the decode baseline,
+          # "inference-server" for FMA launcher & requester pods.
+          SERVING_CONTAINERS = ("inference-server", "vllm")
+
+          def _container_started(item):
+              for cs in item.get('status', {}).get('containerStatuses', []):
+                  if cs.get('name') in SERVING_CONTAINERS:
+                      running = (cs.get('state') or {}).get('running') or {}
+                      return _iso_full(running.get('startedAt'))
+              return None
+
+          def actuation_mean(resources_path):
+              if not HAVE_YAML or not resources_path or not os.path.isfile(resources_path):
+                  return None
+              try:
+                  with open(resources_path) as f:
+                      doc = yaml.safe_load(f)
+              except (yaml.YAMLError, OSError):
+                  return None
+              if not isinstance(doc, dict):
+                  return None
+              items = doc.get('items', []) if doc.get('kind') == 'List' else []
+              durs = []
+              for item in items:
+                  if item.get('kind') != 'Pod': continue
+                  name = item.get('metadata', {}).get('name', '')
+                  if 'fma-requester' not in name and '-decode-' not in name:
+                      continue
+                  start = _container_started(item) or _iso_full(item['metadata'].get('creationTimestamp'))
+                  ready = None
+                  for c in item.get('status', {}).get('conditions', []):
+                      if c.get('type') == 'Ready' and c.get('status') == 'True':
+                          ready = _iso_full(c.get('lastTransitionTime'))
+                          break
+                  if start and ready:
+                      durs.append((ready - start).total_seconds())
+              return sum(durs)/len(durs) if durs else None
+
+          bl_actuation = actuation_mean(bl_res)
+          fw_ws_actuation = actuation_mean(fw_ws_res)
+          fw_hs_actuation = actuation_mean(fw_hs_res)
+
+          # T_scale_up: autoscaler scale-UP latency, event-anchored. t0 = each
+          # HPA SuccessfulRescale scale-up event (where "New size" increases);
+          # t1 = that replica's Ready. Only scale-UPs count, so it's robust to
+          # the end-of-run scale-down that overwrites HPA.lastScaleTime. Reads
+          # events.json (absolute timestamps) + resources.yaml (pod Ready) --
+          # identical for WVA & EPP-KEDA (both drive a KEDA-managed HPA that
+          # emits SuccessfulRescale). Returns None if no scale-up event is found
+          # or the scaled-up pods were already deleted by capture time.
+          def t_scale_up_mean(events_path, resources_path):
+              if not HAVE_YAML or not events_path or not os.path.isfile(events_path):
+                  return None
+              try:
+                  with open(events_path) as f:
+                      ev = json.load(f)
+              except (ValueError, OSError):
+                  return None
+              size_rx = re.compile(r'New size:\s*(\d+)')
+              def _etime(e):
+                  return e.get('lastTimestamp') or e.get('eventTime') or e.get('firstTimestamp') or ''
+              ups, prev = [], None
+              evitems = ev.get('items', []) if isinstance(ev, dict) else []
+              for e in sorted(evitems, key=_etime):
+                  if e.get('reason') != 'SuccessfulRescale':
+                      continue
+                  if (e.get('involvedObject', {}) or {}).get('kind') != 'HorizontalPodAutoscaler':
+                      continue
+                  m = size_rx.search(e.get('message', '') or '')
+                  if not m:
+                      continue
+                  n = int(m.group(1))
+                  t = _iso_full(_etime(e))
+                  if t and (prev is None or n > prev):
+                      ups.append(t)
+                  prev = n
+              if not ups:
+                  return None
+              readies = []
+              if resources_path and os.path.isfile(resources_path):
+                  try:
+                      with open(resources_path) as f:
+                          doc = yaml.safe_load(f)
+                  except (yaml.YAMLError, OSError):
+                      doc = None
+                  ritems = doc.get('items', []) if isinstance(doc, dict) and doc.get('kind') == 'List' else []
+                  for item in ritems:
+                      if item.get('kind') != 'Pod':
+                          continue
+                      name = item.get('metadata', {}).get('name', '')
+                      if 'fma-requester' not in name and '-decode-' not in name:
+                          continue
+                      for c in item.get('status', {}).get('conditions', []):
+                          if c.get('type') == 'Ready' and c.get('status') == 'True':
+                              r = _iso_full(c.get('lastTransitionTime'))
+                              if r:
+                                  readies.append(r)
+              readies.sort()
+              used = [False] * len(readies)
+              durs = []
+              for t0 in ups:
+                  for i, r in enumerate(readies):
+                      if not used[i] and r >= t0:
+                          durs.append((r - t0).total_seconds())
+                          used[i] = True
+                          break
+              return sum(durs) / len(durs) if durs else None
+
+          bl_t_scale_up = t_scale_up_mean(bl_events, bl_res)
+          fw_ws_t_scale_up = t_scale_up_mean(fw_ws_events, fw_ws_res)
+          fw_hs_t_scale_up = t_scale_up_mean(fw_hs_events, fw_hs_res)
+
+          # ----- Render the table --------------------------------------------
+          print("| Metric | Baseline (EPP+KEDA, no FMA) | EPP+KEDA with FMA Warm Start | EPP+KEDA with FMA Hot Start |")
+          print("|---|---:|---:|---:|")
+
+          rows = [
+              ("Duration (s)",    "benchmark_time_seconds", None, 0, ""),
+              ("Total requests",  "load_summary", "count",  None, 0, ""),
+              ("Successes",       "successes", "count",     None, 0, ""),
+              ("Failures",        "failures", "count",      None, 0, ""),
+              ("Avg prompt len (tokens)",  "successes", "prompt_len", "mean", None, 1, ""),
+              ("Avg output len (tokens)",  "successes", "output_len", "mean", None, 1, ""),
+              ("Throughput (req/s)",       "successes", "throughput", "requests_per_sec",     None, 1, ""),
+              ("Throughput input (tok/s)", "successes", "throughput", "input_tokens_per_sec", None, 0, ""),
+              ("Throughput output (tok/s)","successes", "throughput", "output_tokens_per_sec",None, 0, ""),
+              ("Latency mean (ms)",  "successes", "latency", "request_latency", "mean",       1000, ""),
+              ("Latency p99 (ms)",   "successes", "latency", "request_latency", "p99",        1000, ""),
+              ("TTFT mean (ms)",     "successes", "latency", "time_to_first_token", "mean",   1000, ""),
+              ("TTFT p99 (ms)",      "successes", "latency", "time_to_first_token", "p99",    1000, ""),
+              ("TPOT mean (ms)",     "successes", "latency", "time_per_output_token", "mean", 1000, ""),
+              ("TPOT p99 (ms)",      "successes", "latency", "time_per_output_token", "p99",  1000, ""),
+              ("ITL mean (ms)",      "successes", "latency", "inter_token_latency", "mean",   1000, ""),
+              ("ITL p99 (ms)",       "successes", "latency", "inter_token_latency", "p99",    1000, ""),
+          ]
+          for row in rows:
+              label = row[0]
+              keys = [k for k in row[1:-2] if k is not None]
+              scale = row[-2] or 1.0
+              unit = row[-1]
+              prec = 0 if any(s in label for s in ("Total", "Successes", "Failures", "Duration", "tok/s")) else 1
+              bl_v = get(bl, *keys, scale=scale)
+              fw_ws_v = get(fw_ws, *keys, scale=scale)
+              fw_hs_v = get(fw_hs, *keys, scale=scale)
+              print(f"| {label} | {fmt(bl_v, unit, prec)} | {fmt(fw_ws_v, unit, prec)} | {fmt(fw_hs_v, unit, prec)} |")
+
+          print(f"| T_scale_up mean (s) — HPA scale→ready | {fmt(bl_t_scale_up, '', 1)} | {fmt(fw_ws_t_scale_up, '', 1)} | {fmt(fw_hs_t_scale_up, '', 1)} |")
+          print(f"| T_actuation mean (s) — container start→ready | {fmt(bl_actuation, '', 1)} | {fmt(fw_ws_actuation, '', 1)} | {fmt(fw_hs_actuation, '', 1)} |")
+
+          if bl is None:
+              print("\n_No baseline results found._")
+          if fw_ws is None:
+              print("\n_No EPP+KEDA with FMA warm-start results found._")
+          if fw_hs is None:
+              print("\n_No EPP+KEDA with FMA hot-start results found._")
+          if not HAVE_YAML:
+              print("\n_Note: PyYAML unavailable; scale-event timing rows skipped._")
+          PY
+        shell: bash
+
+      # =====================================================================
+      # Per-resource dump steps.
+      #
+      # Source for all dumps: results/<exp_id>/ — step_09a writes autoscaling
+      # diagnostics (hpa.txt, hpa-describe.txt, scaledobject.txt, all pod
+      # logs as <ns>__<pod>.log) directly into the experiment's results dir
+      # alongside the harness's benchmark output.
+      # =====================================================================
+
+      - name: Find latest experiment results dirs
+        if: always()
+        id: cs
+        run: |
+          set +e
+          for label in baseline fma_wva_warmstart fma_wva_hotstart; do
+            case $label in
+              baseline)          base=/tmp/baseline-results ;;
+              fma_wva_warmstart) base=/tmp/fma-wva-warmstart-results ;;
+              fma_wva_hotstart)  base=/tmp/fma-wva-hotstart-results ;;
+            esac
+            latest=$(find "$base" -type d -name "runner-*" 2>/dev/null | sort | tail -1)
+            exp=""
+            if [ -n "$latest" ]; then
+              exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d -exec test -f '{}/hpa.txt' \; -print 2>/dev/null | head -1)
+              if [ -z "$exp" ]; then
+                exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)
+              fi
+            fi
+            echo "${label}_exp=${exp}" >> "$GITHUB_OUTPUT"
+            echo "${label}_exp=${exp}"
+          done
+        shell: bash
+
+      # ---------------- Baseline (EPP+KEDA, no FMA) dumps -------------------
+
+      - name: Dump HPA — Baseline (EPP+KEDA, no FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/hpa.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for baseline"
+
+      - name: Dump HPA describe — Baseline (EPP+KEDA, no FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/hpa-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for baseline"
+
+      - name: Dump ScaledObject — Baseline (EPP+KEDA, no FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for baseline"
+
+      - name: Dump ScaledObject describe — Baseline (EPP+KEDA, no FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for baseline"
+
+      - name: Dump events — Baseline (EPP+KEDA, no FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/events.log"
+          [ -f "$f" ] && cat "$f" || echo "no events.log for baseline"
+
+      - name: Dump pods — Baseline (EPP+KEDA, no FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/pods.txt"
+          [ -f "$f" ] && cat "$f" || echo "no pods.txt for baseline"
+
+      # ---------------- EPP+KEDA with FMA (Warm-Start) dumps --------------------
+
+      - name: Dump HPA — EPP+KEDA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for warm-start"
+
+      - name: Dump HPA describe — EPP+KEDA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for warm-start"
+
+      - name: Dump ScaledObject — EPP+KEDA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for warm-start"
+
+      - name: Dump ScaledObject describe — EPP+KEDA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for warm-start"
+
+      - name: Dump FMA launcher-populator log tail — EPP+KEDA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f=$(find "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
+          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for warm-start"
+
+      - name: Dump events — EPP+KEDA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/events.log"
+          [ -f "$f" ] && cat "$f" || echo "no events.log for warm-start"
+
+      - name: Dump pods — EPP+KEDA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/pods.txt"
+          [ -f "$f" ] && cat "$f" || echo "no pods.txt for warm-start"
+
+      # ---------------- EPP+KEDA with FMA (Hot-Start) dumps ---------------------
+
+      - name: Dump HPA — EPP+KEDA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for hot-start"
+
+      - name: Dump HPA describe — EPP+KEDA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for hot-start"
+
+      - name: Dump ScaledObject — EPP+KEDA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for hot-start"
+
+      - name: Dump ScaledObject describe — EPP+KEDA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for hot-start"
+
+      - name: Dump FMA launcher-populator log tail — EPP+KEDA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f=$(find "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
+          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for hot-start"
+
+      - name: Dump events — EPP+KEDA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/events.log"
+          [ -f "$f" ] && cat "$f" || echo "no events.log for hot-start"
+
+      - name: Dump pods — EPP+KEDA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/pods.txt"
+          [ -f "$f" ] && cat "$f" || echo "no pods.txt for hot-start"

--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -1,9 +1,8 @@
 name: CI - Run Benchmark on OCP ("EPP+KEDA+FMA" autoscaling path)
 
-# Mirrors ci-benchmark-ocp-fma-wva.yaml but drives the EPP+KEDA
-# saturation autoscaling path instead of WVA: KEDA scales on EPP pool metrics
-# (inference_pool_average_kv_cache_utilization / _average_queue_size) with NO
-# WVA controller. Enabled purely via `eppKedaSaturation.enabled: true`.
+# Drives the EPP+KEDA saturation autoscaling path: KEDA scales on EPP pool
+# metrics (inference_pool_average_kv_cache_utilization / _average_queue_size).
+# Enabled purely via `eppKedaSaturation.enabled: true`.
 #
 # Three passes for direct comparison, under inference-perf load
 # (shared_prefix_synthetic_heavy.yaml, sized to push the EPP KV-cache / queue
@@ -246,8 +245,8 @@ jobs:
       GCP_PROJECT_ID: ${{ inputs.bucket_project || 'llm-d-scale' }}
       LLMDBENCH_CICD_TARGET: ${{ inputs.infra_provider || 'ocp' }}
       BASELINE_SCENARIO: ${{ inputs.baseline_scenario || 'ocp-keda' }}
-      FMA_WVA_WARMSTART_SCENARIO: ${{ inputs.standup_scenario || 'ocp-keda-fma-warmstart' }}
-      FMA_WVA_HOTSTART_SCENARIO: ${{ inputs.hotstart_scenario || 'ocp-keda-fma-hotstart' }}
+      FMA_KEDA_WARMSTART_SCENARIO: ${{ inputs.standup_scenario || 'ocp-keda-fma-warmstart' }}
+      FMA_KEDA_HOTSTART_SCENARIO: ${{ inputs.hotstart_scenario || 'ocp-keda-fma-hotstart' }}
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
@@ -263,9 +262,9 @@ jobs:
         run: |
           set +e
           BASELINE_DIR="/tmp/baseline-results"
-          FMA_WVA_WARMSTART_DIR="/tmp/fma-wva-warmstart-results"
-          FMA_WVA_HOTSTART_DIR="/tmp/fma-wva-hotstart-results"
-          mkdir -p "$BASELINE_DIR" "$FMA_WVA_WARMSTART_DIR" "$FMA_WVA_HOTSTART_DIR"
+          FMA_KEDA_WARMSTART_DIR="/tmp/fma-keda-warmstart-results"
+          FMA_KEDA_HOTSTART_DIR="/tmp/fma-keda-hotstart-results"
+          mkdir -p "$BASELINE_DIR" "$FMA_KEDA_WARMSTART_DIR" "$FMA_KEDA_HOTSTART_DIR"
 
           # Pick the most recent <date> subdir that actually has data
           latest_date_under() {
@@ -276,8 +275,8 @@ jobs:
               | sort | tail -1
           }
           BL_PREFIX="gs://${GCS_PATH}/${BASELINE_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice/"
-          FW_WARMSTART_PREFIX="gs://${GCS_PATH}/${FMA_WVA_WARMSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
-          FW_HOTSTART_PREFIX="gs://${GCS_PATH}/${FMA_WVA_HOTSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
+          FW_WARMSTART_PREFIX="gs://${GCS_PATH}/${FMA_KEDA_WARMSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
+          FW_HOTSTART_PREFIX="gs://${GCS_PATH}/${FMA_KEDA_HOTSTART_SCENARIO}/${LLMDBENCH_CICD_TARGET}/modelservice,fma/"
           BL_DATE=$(latest_date_under "$BL_PREFIX")
           FW_WARMSTART_DATE=$(latest_date_under "$FW_WARMSTART_PREFIX")
           FW_HOTSTART_DATE=$(latest_date_under "$FW_HOTSTART_PREFIX")
@@ -286,8 +285,8 @@ jobs:
           echo "FMA+KEDA Hot-Start data date:  ${FW_HOTSTART_DATE:-none found}"
 
           [ -n "$BL_DATE" ] && gcloud storage cp -r "${BL_PREFIX}${BL_DATE}" "$BASELINE_DIR/" || true
-          [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_WVA_WARMSTART_DIR/" || true
-          [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_WVA_HOTSTART_DIR/" || true
+          [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_KEDA_WARMSTART_DIR/" || true
+          [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_KEDA_HOTSTART_DIR/" || true
 
           # PyYAML for cluster-state parsing in the timing-row computation
           # below; ubuntu-latest doesn't have it pre-installed in the user
@@ -296,26 +295,26 @@ jobs:
 
           # Locate, per pass:
           #   - summary_lifecycle_metrics.json   (harness output, has latency)
-          #   - <exp_id>/wva-controller.log      (step_09a, has scale-up timestamp)
+          #   - <exp_id>/keda-controller.log      (step_09a; absent for the KEDA path)
           #   - <exp_id>/resources.yaml          (step_09a, has Pod Ready timestamps)
           find_in_results() {
             # $1 = pass dir, $2 = filename
             find "$1" -path "*/results/*" -name "$2" 2>/dev/null | sort | tail -1
           }
           BL_SUM=$(find_in_results "$BASELINE_DIR"            "summary_lifecycle_metrics.json")
-          FW_WARMSTART_SUM=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "summary_lifecycle_metrics.json")
-          FW_HOTSTART_SUM=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "summary_lifecycle_metrics.json")
-          BL_WVA=$(find_in_results "$BASELINE_DIR"            "wva-controller.log")
-          FW_WARMSTART_WVA=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "wva-controller.log")
-          FW_HOTSTART_WVA=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "wva-controller.log")
+          FW_WARMSTART_SUM=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "summary_lifecycle_metrics.json")
+          FW_HOTSTART_SUM=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "summary_lifecycle_metrics.json")
+          BL_KEDA=$(find_in_results "$BASELINE_DIR"            "keda-controller.log")
+          FW_WARMSTART_KEDA=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "keda-controller.log")
+          FW_HOTSTART_KEDA=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "keda-controller.log")
           BL_RES=$(find_in_results "$BASELINE_DIR"            "resources.yaml")
-          FW_WARMSTART_RES=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "resources.yaml")
-          FW_HOTSTART_RES=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "resources.yaml")
+          FW_WARMSTART_RES=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "resources.yaml")
+          FW_HOTSTART_RES=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "resources.yaml")
           BL_EVENTS=$(find_in_results "$BASELINE_DIR"            "events.json")
-          FW_WARMSTART_EVENTS=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "events.json")
-          FW_HOTSTART_EVENTS=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "events.json")
+          FW_WARMSTART_EVENTS=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "events.json")
+          FW_HOTSTART_EVENTS=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "events.json")
 
-          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_WVA" "$FW_WARMSTART_WVA" "$FW_HOTSTART_WVA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" "$BL_EVENTS" "$FW_WARMSTART_EVENTS" "$FW_HOTSTART_EVENTS" \
+          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_KEDA" "$FW_WARMSTART_KEDA" "$FW_HOTSTART_KEDA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" "$BL_EVENTS" "$FW_WARMSTART_EVENTS" "$FW_HOTSTART_EVENTS" \
             >> "$GITHUB_STEP_SUMMARY" <<'PY'
           import json, sys, os, re, datetime
           try:
@@ -325,7 +324,7 @@ jobs:
               HAVE_YAML = False
 
           (bl_sum, fw_ws_sum, fw_hs_sum,
-           bl_wva, fw_ws_wva, fw_hs_wva,
+           bl_keda, fw_ws_keda, fw_hs_keda,
            bl_res, fw_ws_res, fw_hs_res,
            bl_events, fw_ws_events, fw_hs_events) = sys.argv[1:13]
 
@@ -421,8 +420,8 @@ jobs:
           # t1 = that replica's Ready. Only scale-UPs count, so it's robust to
           # the end-of-run scale-down that overwrites HPA.lastScaleTime. Reads
           # events.json (absolute timestamps) + resources.yaml (pod Ready) --
-          # identical for WVA & EPP-KEDA (both drive a KEDA-managed HPA that
-          # emits SuccessfulRescale). Returns None if no scale-up event is found
+          # all passes drive a KEDA-managed HPA that emits SuccessfulRescale.
+          # Returns None if no scale-up event is found
           # or the scaled-up pods were already deleted by capture time.
           def t_scale_up_mean(events_path, resources_path):
               if not HAVE_YAML or not events_path or not os.path.isfile(events_path):
@@ -548,11 +547,11 @@ jobs:
         id: cs
         run: |
           set +e
-          for label in baseline fma_wva_warmstart fma_wva_hotstart; do
+          for label in baseline fma_keda_warmstart fma_keda_hotstart; do
             case $label in
               baseline)          base=/tmp/baseline-results ;;
-              fma_wva_warmstart) base=/tmp/fma-wva-warmstart-results ;;
-              fma_wva_hotstart)  base=/tmp/fma-wva-hotstart-results ;;
+              fma_keda_warmstart) base=/tmp/fma-keda-warmstart-results ;;
+              fma_keda_hotstart)  base=/tmp/fma-keda-hotstart-results ;;
             esac
             latest=$(find "$base" -type d -name "runner-*" 2>/dev/null | sort | tail -1)
             exp=""
@@ -610,43 +609,43 @@ jobs:
       - name: Dump HPA — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa.txt"
+          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/hpa.txt"
           [ -f "$f" ] && cat "$f" || echo "no hpa.txt for warm-start"
 
       - name: Dump HPA describe — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa-describe.txt"
+          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/hpa-describe.txt"
           [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for warm-start"
 
       - name: Dump ScaledObject — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject.txt"
+          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/scaledobject.txt"
           [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for warm-start"
 
       - name: Dump ScaledObject describe — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject-describe.txt"
+          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/scaledobject-describe.txt"
           [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for warm-start"
 
       - name: Dump FMA launcher-populator log tail — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f=$(find "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
+          f=$(find "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
           [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for warm-start"
 
       - name: Dump events — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/events.log"
+          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/events.log"
           [ -f "$f" ] && cat "$f" || echo "no events.log for warm-start"
 
       - name: Dump pods — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/pods.txt"
+          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/pods.txt"
           [ -f "$f" ] && cat "$f" || echo "no pods.txt for warm-start"
 
       # ---------------- EPP+KEDA with FMA (Hot-Start) dumps ---------------------
@@ -654,41 +653,41 @@ jobs:
       - name: Dump HPA — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa.txt"
+          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/hpa.txt"
           [ -f "$f" ] && cat "$f" || echo "no hpa.txt for hot-start"
 
       - name: Dump HPA describe — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa-describe.txt"
+          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/hpa-describe.txt"
           [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for hot-start"
 
       - name: Dump ScaledObject — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject.txt"
+          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/scaledobject.txt"
           [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for hot-start"
 
       - name: Dump ScaledObject describe — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject-describe.txt"
+          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/scaledobject-describe.txt"
           [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for hot-start"
 
       - name: Dump FMA launcher-populator log tail — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f=$(find "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
+          f=$(find "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
           [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for hot-start"
 
       - name: Dump events — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/events.log"
+          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/events.log"
           [ -f "$f" ] && cat "$f" || echo "no events.log for hot-start"
 
       - name: Dump pods — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/pods.txt"
+          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/pods.txt"
           [ -f "$f" ] && cat "$f" || echo "no pods.txt for hot-start"

--- a/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
@@ -1,4 +1,4 @@
-name: CI - Nightly Run Benchmark on OCP ("WVA+FMA" autoscaling path)
+name: CI - Run Benchmark on OCP ("WVA+FMA" autoscaling path)
 
 # Mirrors ci-nightly-benchmark-ocp-fma.yaml but targets the WVA(modelservice)+FMA scenario
 # under inference-perf load. Default harness is inference-perf +
@@ -314,8 +314,11 @@ jobs:
           BL_RES=$(find_in_results "$BASELINE_DIR"            "resources.yaml")
           FW_WARMSTART_RES=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "resources.yaml")
           FW_HOTSTART_RES=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "resources.yaml")
+          BL_EVENTS=$(find_in_results "$BASELINE_DIR"            "events.json")
+          FW_WARMSTART_EVENTS=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "events.json")
+          FW_HOTSTART_EVENTS=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "events.json")
 
-          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_WVA" "$FW_WARMSTART_WVA" "$FW_HOTSTART_WVA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" \
+          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_WVA" "$FW_WARMSTART_WVA" "$FW_HOTSTART_WVA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" "$BL_EVENTS" "$FW_WARMSTART_EVENTS" "$FW_HOTSTART_EVENTS" \
             >> "$GITHUB_STEP_SUMMARY" <<'PY'
           import json, sys, os, re, datetime
           try:
@@ -326,7 +329,8 @@ jobs:
 
           (bl_sum, fw_ws_sum, fw_hs_sum,
            bl_wva, fw_ws_wva, fw_hs_wva,
-           bl_res, fw_ws_res, fw_hs_res) = sys.argv[1:10]
+           bl_res, fw_ws_res, fw_hs_res,
+           bl_events, fw_ws_events, fw_hs_events) = sys.argv[1:13]
 
           def load_json(p):
               if not p or not os.path.isfile(p):
@@ -354,52 +358,9 @@ jobs:
               if isinstance(v, float): return f"{v:.{precision}f}{unit}"
               return f"{v}{unit}"
 
-          # ----- Scale-event timing (single-source: WVA controller log) -----
-          # Cold-start mean = mean delta between each `"shouldScaleUp":true`
-          # event and the FIRST subsequent reconcile where WVA observes the
-          # replica count has increased (`"totalReplicas":N+1`)
-          ISO_RE = re.compile(r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})Z')
-
-          def parse_iso(s):
-              if not s: return None
-              try:
-                  return datetime.datetime.strptime(s.split('.')[0].rstrip('Z'),
-                                                    '%Y-%m-%dT%H:%M:%S')
-              except ValueError:
-                  return None
-
-          def cold_start_mean(log_path):
-              if not log_path or not os.path.isfile(log_path):
-                  return None
-              scale_up_rx = re.compile(r'"shouldScaleUp":\s*true')
-              total_rx = re.compile(r'"totalReplicas":\s*(\d+)')
-              pending_decision_ts = None
-              last_observed_n = None
-              deltas = []
-              with open(log_path) as f:
-                  for line in f:
-                      m = ISO_RE.match(line)
-                      if not m:
-                          continue
-                      ts = parse_iso(m.group(1))
-                      if ts is None:
-                          continue
-                      n_match = total_rx.search(line)
-                      if n_match:
-                          n = int(n_match.group(1))
-                          if (pending_decision_ts is not None
-                                  and last_observed_n is not None
-                                  and n > last_observed_n):
-                              deltas.append((ts - pending_decision_ts).total_seconds())
-                              pending_decision_ts = None
-                          last_observed_n = n
-                      if scale_up_rx.search(line) and pending_decision_ts is None:
-                          pending_decision_ts = ts
-              return sum(deltas) / len(deltas) if deltas else None
-
-          bl_cold_start = cold_start_mean(bl_wva)
-          fw_ws_cold_start = cold_start_mean(fw_ws_wva)
-          fw_hs_cold_start = cold_start_mean(fw_hs_wva)
+          # ----- Scale actuation timing (scaler-agnostic: pod lifecycle) -----
+          # FMA requester Deployment is scaled via a KEDAScaledObject -> HPA,
+          # so timing is measured from the captured resources.yaml (pod status)
 
           # T_actuation: mean wall-clock from each serving container's START to
           # its pod's Ready transition. Measuring from container start (not pod
@@ -458,6 +419,76 @@ jobs:
           fw_ws_actuation = actuation_mean(fw_ws_res)
           fw_hs_actuation = actuation_mean(fw_hs_res)
 
+          # T_scale_up: autoscaler scale-UP latency, event-anchored. t0 = each
+          # HPA SuccessfulRescale scale-up event (where "New size" increases);
+          # t1 = that replica's Ready. Only scale-UPs count, so it's robust to
+          # the end-of-run scale-down that overwrites HPA.lastScaleTime. Reads
+          # events.json (absolute timestamps) + resources.yaml (pod Ready) --
+          # identical for WVA & EPP-KEDA (both drive a KEDA-managed HPA that
+          # emits SuccessfulRescale). Returns None if no scale-up event is found
+          # or the scaled-up pods were already deleted by capture time.
+          def t_scale_up_mean(events_path, resources_path):
+              if not HAVE_YAML or not events_path or not os.path.isfile(events_path):
+                  return None
+              try:
+                  with open(events_path) as f:
+                      ev = json.load(f)
+              except (ValueError, OSError):
+                  return None
+              size_rx = re.compile(r'New size:\s*(\d+)')
+              def _etime(e):
+                  return e.get('lastTimestamp') or e.get('eventTime') or e.get('firstTimestamp') or ''
+              ups, prev = [], None
+              evitems = ev.get('items', []) if isinstance(ev, dict) else []
+              for e in sorted(evitems, key=_etime):
+                  if e.get('reason') != 'SuccessfulRescale':
+                      continue
+                  if (e.get('involvedObject', {}) or {}).get('kind') != 'HorizontalPodAutoscaler':
+                      continue
+                  m = size_rx.search(e.get('message', '') or '')
+                  if not m:
+                      continue
+                  n = int(m.group(1))
+                  t = _iso_full(_etime(e))
+                  if t and (prev is None or n > prev):
+                      ups.append(t)
+                  prev = n
+              if not ups:
+                  return None
+              readies = []
+              if resources_path and os.path.isfile(resources_path):
+                  try:
+                      with open(resources_path) as f:
+                          doc = yaml.safe_load(f)
+                  except (yaml.YAMLError, OSError):
+                      doc = None
+                  ritems = doc.get('items', []) if isinstance(doc, dict) and doc.get('kind') == 'List' else []
+                  for item in ritems:
+                      if item.get('kind') != 'Pod':
+                          continue
+                      name = item.get('metadata', {}).get('name', '')
+                      if 'fma-requester' not in name and '-decode-' not in name:
+                          continue
+                      for c in item.get('status', {}).get('conditions', []):
+                          if c.get('type') == 'Ready' and c.get('status') == 'True':
+                              r = _iso_full(c.get('lastTransitionTime'))
+                              if r:
+                                  readies.append(r)
+              readies.sort()
+              used = [False] * len(readies)
+              durs = []
+              for t0 in ups:
+                  for i, r in enumerate(readies):
+                      if not used[i] and r >= t0:
+                          durs.append((r - t0).total_seconds())
+                          used[i] = True
+                          break
+              return sum(durs) / len(durs) if durs else None
+
+          bl_t_scale_up = t_scale_up_mean(bl_events, bl_res)
+          fw_ws_t_scale_up = t_scale_up_mean(fw_ws_events, fw_ws_res)
+          fw_hs_t_scale_up = t_scale_up_mean(fw_hs_events, fw_hs_res)
+
           # ----- Render the table --------------------------------------------
           print("| Metric | Baseline (WVA without FMA) | WVA with FMA Warm Start | WVA with FMA Hot Start |")
           print("|---|---:|---:|---:|")
@@ -492,9 +523,7 @@ jobs:
               fw_hs_v = get(fw_hs, *keys, scale=scale)
               print(f"| {label} | {fmt(bl_v, unit, prec)} | {fmt(fw_ws_v, unit, prec)} | {fmt(fw_hs_v, unit, prec)} |")
 
-          print(f"| Cold-start mean (s) — wva log | {fmt(bl_cold_start, '', 1)} | {fmt(fw_ws_cold_start, '', 1)} | {fmt(fw_hs_cold_start, '', 1)} |")
-
-          # Mean serving-container start→Ready.
+          print(f"| T_scale_up mean (s) — HPA scale→ready | {fmt(bl_t_scale_up, '', 1)} | {fmt(fw_ws_t_scale_up, '', 1)} | {fmt(fw_hs_t_scale_up, '', 1)} |")
           print(f"| T_actuation mean (s) — container start→ready | {fmt(bl_actuation, '', 1)} | {fmt(fw_ws_actuation, '', 1)} | {fmt(fw_hs_actuation, '', 1)} |")
 
           if bl is None:
@@ -555,6 +584,18 @@ jobs:
           f="${{ steps.cs.outputs.baseline_exp }}/hpa-describe.txt"
           [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for baseline"
 
+      - name: Dump ScaledObject — Baseline (WVA without FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for baseline"
+
+      - name: Dump ScaledObject describe — Baseline (WVA without FMA)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for baseline"
+
       - name: Dump WVA controller log tail — Baseline (WVA without FMA)
         if: always()
         run: |
@@ -586,6 +627,18 @@ jobs:
         run: |
           f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa-describe.txt"
           [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for warm-start"
+
+      - name: Dump ScaledObject — WVA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for warm-start"
+
+      - name: Dump ScaledObject describe — WVA with FMA (Warm-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for warm-start"
 
       - name: Dump WVA controller log tail — WVA with FMA (Warm-Start)
         if: always()
@@ -624,6 +677,18 @@ jobs:
         run: |
           f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa-describe.txt"
           [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for hot-start"
+
+      - name: Dump ScaledObject — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for hot-start"
+
+      - name: Dump ScaledObject describe — WVA with FMA (Hot-Start)
+        if: always()
+        run: |
+          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject-describe.txt"
+          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for hot-start"
 
       - name: Dump WVA controller log tail — WVA with FMA (Hot-Start)
         if: always()

--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -1,0 +1,269 @@
+# CI/CD WVA + FMA HOT-START benchmark scenario (OpenShift).
+#
+# Hot-start variant of ocp-wva-fma-warmstart.yaml. Measures WVA scaling behavior
+# isolated from model loading latency. Goal: identical 1->N scaling as warm-start
+# but without model load time confounding the results.
+#
+# Standup Phase:
+#   1. Deploy all 10 requester pods immediately (vs. 1 in warm-start)
+#   2. All launcher pods simultaneously load Qwen3-32B (~10-20 min total)
+#   3. After all pods ready, scale requester pods down to 1 (vLLM sleeps)
+#   4. Confirm all launcher pods have sleeping vLLM instance
+#
+# Benchmark Phase:
+#   - HPA scales 1->10 as load arrives (IDENTICAL to warm-start)
+#   - Difference: No model load latency; scaling measures ONLY HPA/WVA behavior
+#   - All models pre-loaded in memory, so scale-up is instantaneous
+#
+# The WVA+FMA arm of the FMA-vs-WVA comparison nightly. Its no-FMA baseline is
+# cicd/ocp-wva; the two are kept apples-to-apples (same model, WVA config,
+# and heavy workload profile, both with vLLM prefix caching off) so the
+# comparison measures the scaling path, not the prefix cache. For the
+# user-facing WVA well-lit path that the WVA make targets consume, use
+# guides/workload-autoscaling (WVA-only).
+#
+# All HPA / VariantAutoscaling knobs are listed below even when they match
+# defaults.yaml, so the full surface area is visible in one place.
+#
+# Note: FMA owns the elastic vLLM tier here, so the modelservice decode and
+# prefill Deployments are explicitly disabled below (decode.enabled: false,
+# prefill.enabled: false). modelservice still renders the gateway / EPP /
+# InferencePool that route to the FMA launcher pods.
+#
+# WVA scales an FMA-served model deployment. Topology:
+#
+#   modelservice (decode.enabled: false) provides gateway / EPP / InferencePool
+#     / PodMonitor; its decode Deployment is disabled — FMA owns the
+#     elastic vLLM tier instead.
+#
+#   FMA (fma.enabled: true)           launcher pods host vLLM and serve
+#     inference traffic; the requester Deployment holds the GPU lease
+#     that FMA scales.
+#
+#   WVA (wva.enabled: true)           scales the FMA requester Deployment;
+#     FMA's launcher-populator reconciles launcher pods to match.
+#
+# How EPP reaches FMA: 12_router-values.yaml.j2 emits a router.modelServers
+# selector matching `llm-d.ai/inferenceServing=true, llm-d.ai/model=<id>`.
+# 24_fma-deployment.yaml.j2 puts those labels on the InferenceServerConfig's
+# `modelServerConfig.labels` (NOT on the LauncherConfig pod template) — the
+# dual-pods controller propagates them to the launcher pod at BIND time, so
+# only launchers actually serving traffic show up in the InferencePool.
+#
+# How WVA tracks FMA: launcher pods carry `llm-d.ai/variant=<id>-fma` (also
+# applied at bind time via the ISC; label-based variant identification per
+# WVA repo PR #1145). Templates 27/28 retarget the VariantAutoscaling + HPA
+# at the FMA requester Deployment (`fma-requester-<id>`) when fma.enabled.
+#
+# Based on:
+#   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+#
+# Running:
+#
+#   llmdbenchmark --spec cicd/ocp-wva-fma-hotstart standup -p <namespace>
+#
+# `wva.enabled: true` and `fma.enabled: true` are already set below, so no CLI
+# flag is needed to enable them for this scenario.
+
+scenario:
+  # ============================================================================
+  # CI/CD WVA + FMA HOT-START - Qwen3-32B served by FMA launchers, autoscaled by WVA
+  # ============================================================================
+  - name: "ocp-keda-fma-hotstart-cicd"
+
+    kustomize:
+      enabled: false
+
+    # =========================================================================
+    # MODEL CONFIGURATION
+    # =========================================================================
+    model:
+      name: Qwen/Qwen3-32B
+      shortName: qwen-qwen3-32b
+      path: models/Qwen/Qwen3-32B
+      huggingfaceId: Qwen/Qwen3-32B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+
+    # =========================================================================
+    # DEPLOYMENT METHOD
+    # =========================================================================
+    modelservice:
+      enabled: true
+
+    standalone:
+      enabled: false
+
+    gateway:
+      className: epponly
+
+    fma:
+      enabled: true
+      iterations: 1
+
+      # Opt in to pinning: step_06 picks ONE GPU node whose GPUs are all one
+      # type and all free, labels it, and pins the LauncherPopulationPolicy +
+      # requester Deployment to it; launcherCount/replicas are sized to that
+      # node's GPU count. Standup fails if no fully-free single-type GPU node.
+      launcherNodeSelection:
+        enabled: true
+        nodeLabel: fma-hotstart
+
+      # HOT-START CHANGE #1: Deploy all replicas at standup for parallel model loading
+      # Initially set to maxReplicas so all launcher pods load models simultaneously
+      # during standup. After model loading completes, the warmup step scales this
+      # down to 1 to put vLLM servers into sleep state while keeping models in memory.
+      # Benchmark then scales 1->N, measuring pure HPA/WVA behavior (identical to
+      # warm-start) without model load latency.
+      requester:
+        replicas: 10  # ← Match maxReplicas; will be scaled down after warmup
+
+      # HOT-START CHANGE #2: Extended warmup for parallel model loading + scale-down
+      # Warmup sequence:
+      #   1. Wait for Deployment to be Available (all 10 pods Ready)
+      #   2. No additional buffer (models already loaded on all pods)
+      #   3. Scale requester Deployment down to 1 (vLLM sleeps on 9 pods)
+      #   4. Confirm sleeping vLLM instances are present
+      warmupTimeout: 1200  # ← Increased: 10-20 min model load + scale-down verification
+
+    # =========================================================================
+    # WVA CONFIGURATION
+    # =========================================================================
+    eppKedaSaturation:
+      enabled: true
+
+      namespace: ""              # defaults to deploy namespace (first slot of `-p`)
+
+      prometheus:
+        baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+        port: 9091
+
+      epp:
+        poolName: ""             # defaults to model_id_label at render time
+        metricsPortName: http-metrics
+        metricsPort: 9090
+        prometheusServiceAccount: thanos-querier
+        prometheusServiceAccountNamespace: openshift-monitoring
+
+      scaledObject:
+        minReplicas: 1
+        maxReplicas: 10
+        pollingInterval: 15
+        kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
+        queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
+        activationThreshold: "0"
+        unsafeSsl: true
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 180
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 300
+
+    # =========================================================================
+    # WVA-RELATED CHART VERSIONS
+    # =========================================================================
+    chartVersions:
+      wva: 0.6.0
+      prometheusAdapter: 5.2.0
+
+    # =========================================================================
+    # ROUTING / GAIE CONFIGURATION
+    # =========================================================================
+    router: {}
+
+    # =========================================================================
+    # PREFILL / DECODE CONFIGURATION
+    # =========================================================================
+    prefill:
+      enabled: false
+
+    decode:
+      enabled: false
+      replicas: 0
+      # The FMA requester's nodeAffinity borrows decode.acceleratorType.labelValue
+      # (24_fma-deployment.yaml.j2), and WVA's saturation engine reads it back off
+      # the requester. The cluster resolver skips auto-detection for disabled
+      # sections, so pin the product explicitly here (pokprod = H100) — otherwise
+      # the requester's affinity stays "auto" and it never schedules. Non-"auto"
+      # values are left untouched by the resolver.
+      acceleratorType:
+        labelKey: nvidia.com/gpu.product
+        labelValue: NVIDIA-H100-80GB-HBM3
+
+    # =========================================================================
+    # VLLM COMMON CONFIGURATION
+    # =========================================================================
+    vllmCommon:
+      kvTransfer:
+        enabled: true
+        connector: NixlConnector
+        role: kv_both
+
+      flags:
+        enforceEager: false
+        disableLogRequests: true
+        disableUvicornAccessLog: true
+        allowLongMaxModelLen: "1"
+        serverDevMode: "1"
+
+      volumes:
+        - name: shared-config
+          type: emptyDir
+          emptyDir: {}
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: shared-config
+          mountPath: /shared-config
+
+    # =========================================================================
+    # STORAGE
+    # =========================================================================
+    storage:
+      modelPvc:
+        size: 1Ti
+
+    # =========================================================================
+    # WORKLOAD / HARNESS
+    # =========================================================================
+    workDir: "/tmp/llmdbenchcicd-ocp-keda-fma-hotstart/"
+
+    # Custom run-phase warmup step for hot-start scenario.
+    # Specifies step_02a_fma_warmup_hotstart instead of the default
+    # step_02a_fma_warmup. Hot-start warmup:
+    #   1. Waits for all N replicas to load (all launchers hot)
+    #   2. Scales down to minReplicas (puts vLLM to sleep, keeps models in memory)
+    #   3. Verifies launcher pods exist with sleeping vLLM instances
+    # Benchmark then scales 1->N (same as warm-start) but without load latency.
+    fmaWarmupStep: step_02a_fma_warmup_hotstart
+
+    harness:
+      name: inference-perf
+      experimentProfile: shared_prefix_synthetic_heavy.yaml
+      # The heavy profile drives high RPS against Qwen3-32B; the infra
+      # reusable does not pass --wait-timeout on the CLI so the CLI falls
+      # back to this field (see cli.py harness_wait_timeout resolution).
+      # Hot-start uses a larger value than warm-start/baseline (5400): its
+      # standup loads all 10 launchers in parallel (~10-20 min) before the
+      # run even begins, matching the hot-start job's wait_timeout: 7200.
+      waitTimeout: 7200
+
+    images:
+      benchmark:
+        tag: nightly

--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -1,6 +1,6 @@
-# CI/CD WVA + FMA HOT-START benchmark scenario (OpenShift).
+# CI/CD EPP+KEDA + FMA HOT-START benchmark scenario (OpenShift).
 #
-# Hot-start variant of ocp-wva-fma-warmstart.yaml. Measures WVA scaling behavior
+# Hot-start variant of ocp-keda-fma-warmstart.yaml. Measures KEDA scaling behavior
 # isolated from model loading latency. Goal: identical 1->N scaling as warm-start
 # but without model load time confounding the results.
 #
@@ -11,18 +11,16 @@
 #   4. Confirm all launcher pods have sleeping vLLM instance
 #
 # Benchmark Phase:
-#   - HPA scales 1->10 as load arrives (IDENTICAL to warm-start)
-#   - Difference: No model load latency; scaling measures ONLY HPA/WVA behavior
+#   - KEDA scales 1->10 as load arrives (IDENTICAL to warm-start)
+#   - Difference: No model load latency; scaling measures ONLY KEDA/HPA behavior
 #   - All models pre-loaded in memory, so scale-up is instantaneous
 #
-# The WVA+FMA arm of the FMA-vs-WVA comparison nightly. Its no-FMA baseline is
-# cicd/ocp-wva; the two are kept apples-to-apples (same model, WVA config,
-# and heavy workload profile, both with vLLM prefix caching off) so the
-# comparison measures the scaling path, not the prefix cache. For the
-# user-facing WVA well-lit path that the WVA make targets consume, use
-# guides/workload-autoscaling (WVA-only).
+# The EPP+KEDA+FMA arm of the FMA-vs-baseline comparison nightly. Its no-FMA
+# baseline is cicd/ocp-keda; the two are kept apples-to-apples (same model, KEDA
+# config, and heavy workload profile, both with vLLM prefix caching off) so the
+# comparison measures the scaling path, not the prefix cache.
 #
-# All HPA / VariantAutoscaling knobs are listed below even when they match
+# All KEDA ScaledObject knobs are listed below even when they match
 # defaults.yaml, so the full surface area is visible in one place.
 #
 # Note: FMA owns the elastic vLLM tier here, so the modelservice decode and
@@ -30,7 +28,7 @@
 # prefill.enabled: false). modelservice still renders the gateway / EPP /
 # InferencePool that route to the FMA launcher pods.
 #
-# WVA scales an FMA-served model deployment. Topology:
+# KEDA scales an FMA-served model deployment. Topology:
 #
 #   modelservice (decode.enabled: false) provides gateway / EPP / InferencePool
 #     / PodMonitor; its decode Deployment is disabled — FMA owns the
@@ -38,10 +36,11 @@
 #
 #   FMA (fma.enabled: true)           launcher pods host vLLM and serve
 #     inference traffic; the requester Deployment holds the GPU lease
-#     that FMA scales.
+#     that KEDA scales.
 #
-#   WVA (wva.enabled: true)           scales the FMA requester Deployment;
-#     FMA's launcher-populator reconciles launcher pods to match.
+#   KEDA (eppKedaSaturation.enabled: true)  scales the FMA requester Deployment
+#     on EPP pool saturation metrics; FMA's launcher-populator reconciles
+#     launcher pods to match.
 #
 # How EPP reaches FMA: 12_router-values.yaml.j2 emits a router.modelServers
 # selector matching `llm-d.ai/inferenceServing=true, llm-d.ai/model=<id>`.
@@ -50,24 +49,21 @@
 # dual-pods controller propagates them to the launcher pod at BIND time, so
 # only launchers actually serving traffic show up in the InferencePool.
 #
-# How WVA tracks FMA: launcher pods carry `llm-d.ai/variant=<id>-fma` (also
-# applied at bind time via the ISC; label-based variant identification per
-# WVA repo PR #1145). Templates 27/28 retarget the VariantAutoscaling + HPA
-# at the FMA requester Deployment (`fma-requester-<id>`) when fma.enabled.
-#
-# Based on:
-#   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+# How KEDA scales FMA: the KEDA ScaledObject (30_epp-keda-saturation-scaledobject.yaml.j2)
+# targets the FMA requester Deployment (`fma-requester-<id>`) and scales it on EPP
+# pool saturation metrics (pool-average KV-cache utilization and queue size)
+# scraped from the EPP via Prometheus/Thanos.
 #
 # Running:
 #
-#   llmdbenchmark --spec cicd/ocp-wva-fma-hotstart standup -p <namespace>
+#   llmdbenchmark --spec cicd/ocp-keda-fma-hotstart standup -p <namespace>
 #
-# `wva.enabled: true` and `fma.enabled: true` are already set below, so no CLI
-# flag is needed to enable them for this scenario.
+# `eppKedaSaturation.enabled: true` and `fma.enabled: true` are already set below,
+# so no CLI flag is needed to enable them for this scenario.
 
 scenario:
   # ============================================================================
-  # CI/CD WVA + FMA HOT-START - Qwen3-32B served by FMA launchers, autoscaled by WVA
+  # CI/CD EPP+KEDA + FMA HOT-START - Qwen3-32B served by FMA launchers, autoscaled by KEDA
   # ============================================================================
   - name: "ocp-keda-fma-hotstart-cicd"
 
@@ -115,7 +111,7 @@ scenario:
       # Initially set to maxReplicas so all launcher pods load models simultaneously
       # during standup. After model loading completes, the warmup step scales this
       # down to 1 to put vLLM servers into sleep state while keeping models in memory.
-      # Benchmark then scales 1->N, measuring pure HPA/WVA behavior (identical to
+      # Benchmark then scales 1->N, measuring pure HPA/KEDA behavior (identical to
       # warm-start) without model load latency.
       requester:
         replicas: 10  # ← Match maxReplicas; will be scaled down after warmup
@@ -129,7 +125,7 @@ scenario:
       warmupTimeout: 1200  # ← Increased: 10-20 min model load + scale-down verification
 
     # =========================================================================
-    # WVA CONFIGURATION
+    # EPP + KEDA SATURATION CONFIGURATION
     # =========================================================================
     eppKedaSaturation:
       enabled: true
@@ -170,10 +166,9 @@ scenario:
                 periodSeconds: 300
 
     # =========================================================================
-    # WVA-RELATED CHART VERSIONS
+    # CHART VERSIONS
     # =========================================================================
     chartVersions:
-      wva: 0.6.0
       prometheusAdapter: 5.2.0
 
     # =========================================================================
@@ -191,11 +186,10 @@ scenario:
       enabled: false
       replicas: 0
       # The FMA requester's nodeAffinity borrows decode.acceleratorType.labelValue
-      # (24_fma-deployment.yaml.j2), and WVA's saturation engine reads it back off
-      # the requester. The cluster resolver skips auto-detection for disabled
-      # sections, so pin the product explicitly here (pokprod = H100) — otherwise
-      # the requester's affinity stays "auto" and it never schedules. Non-"auto"
-      # values are left untouched by the resolver.
+      # (24_fma-deployment.yaml.j2). The cluster resolver skips auto-detection for
+      # disabled sections, so pin the product explicitly here (pokprod = H100) —
+      # otherwise the requester's affinity stays "auto" and it never schedules.
+      # Non-"auto" values are left untouched by the resolver.
       acceleratorType:
         labelKey: nvidia.com/gpu.product
         labelValue: NVIDIA-H100-80GB-HBM3

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -1,0 +1,332 @@
+# CI/CD WVA + FMA benchmark scenario (OpenShift).
+#
+# The WVA+FMA arm of the FMA-vs-WVA comparison nightly. Its no-FMA baseline is
+# cicd/ocp-wva; the two are kept apples-to-apples (same model, WVA config,
+# and heavy workload profile, both with vLLM prefix caching off) so the
+# comparison measures the scaling path, not the prefix cache. For the
+# user-facing WVA well-lit path that the WVA make targets consume, use
+# guides/workload-autoscaling (WVA-only).
+#
+# All HPA / VariantAutoscaling knobs are listed below even when they match
+# defaults.yaml, so the full surface area is visible in one place.
+#
+# Note: FMA owns the elastic vLLM tier here, so the modelservice decode and
+# prefill Deployments are explicitly disabled below (decode.enabled: false,
+# prefill.enabled: false). modelservice still renders the gateway / EPP /
+# InferencePool that route to the FMA launcher pods.
+#
+# WVA scales an FMA-served model deployment. Topology:
+#
+#   modelservice (decode.enabled: false) provides gateway / EPP / InferencePool
+#     / PodMonitor; its decode Deployment is disabled — FMA owns the
+#     elastic vLLM tier instead.
+#
+#   FMA (fma.enabled: true)           launcher pods host vLLM and serve
+#     inference traffic; the requester Deployment holds the GPU lease
+#     that FMA scales.
+#
+#   WVA (wva.enabled: true)           scales the FMA requester Deployment;
+#     FMA's launcher-populator reconciles launcher pods to match.
+#
+# How EPP reaches FMA: 12_router-values.yaml.j2 emits a router.modelServers
+# selector matching `llm-d.ai/inferenceServing=true, llm-d.ai/model=<id>`.
+# 24_fma-deployment.yaml.j2 puts those labels on the InferenceServerConfig's
+# `modelServerConfig.labels` (NOT on the LauncherConfig pod template) — the
+# dual-pods controller propagates them to the launcher pod at BIND time, so
+# only launchers actually serving traffic show up in the InferencePool.
+#
+# How WVA tracks FMA: launcher pods carry `llm-d.ai/variant=<id>-fma` (also
+# applied at bind time via the ISC; label-based variant identification per
+# WVA repo PR #1145). Templates 27/28 retarget the VariantAutoscaling + HPA
+# at the FMA requester Deployment (`fma-requester-<id>`) when fma.enabled.
+#
+# Based on:
+#   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+#
+# Running:
+#
+#   llmdbenchmark --spec cicd/ocp-wva-fma-warmstart standup -p <namespace>
+#
+# `wva.enabled: true` and `fma.enabled: true` are already set below, so no CLI
+# flag is needed to enable them for this scenario.
+
+scenario:
+  # ============================================================================
+  # CI/CD WVA + FMA - Qwen3-32B served by FMA launchers, autoscaled by WVA
+  # ============================================================================
+  - name: "ocp-keda-fma-warmstart-cicd"
+
+    # =========================================================================
+    # KUSTOMIZE DEPLOY METHOD   (scope: the ENTIRE stack)
+    # -------------------------------------------------------------------------
+    # When kustomize.enabled is true (or `-t kustomize` is passed) this
+    # scenario is deployed by applying the UPSTREAM llm-d guide directly
+    # (guides/<guideName> in the llm-d repo). In that mode the deployment is
+    # defined ENTIRELY by the guide's own manifests:
+    #
+    #   * EVERYTHING ELSE in this scenario is IGNORED -- model, modelservice,
+    #     standalone, decode/prefill, vllmCommon, storage, harness model, etc.
+    #   * `-m/--models` and all other CLI/scenario tuning are ignored.
+    #   * DoE `experiment` SETUP sweeps do NOT alter a kustomize deploy
+    #     (only run/workload treatments still apply).
+    #
+    # The ONLY way to modify a kustomize deployment is the kustomize.* keys
+    # below:
+    #   patches / overlayPath           -> modelserver (the workload pods)
+    #   extraHelmValues / extraHelmSets -> router / GAIE helm release
+    #   guideVariableOverrides          -> override the guide README's ${VAR}
+    # See docs/kustomize.md for the full reference and worked examples.
+    #
+    # NOT SUPPORTED with kustomize: multi-model / multi-stack scenarios
+    # (the deploy is keyed on guideName with no per-stack uniquification --
+    # stacks would collide). Use the modelservice method for multi-model.
+    #
+    # When kustomize.enabled is false (the DEFAULT) this whole block is
+    # inert and the scenario deploys via modelservice/standalone as
+    # configured further below.
+    # =========================================================================
+    kustomize:
+      enabled: false
+
+      guideName: "workload-autoscaling"
+      repoPath: ""
+      repoRef: "main"
+      gaieVersion: ""
+      acceleratorBackend: "gpu/vllm"
+      monitoring: false
+      overlayPath: ""
+      extraHelmValues: []
+      extraHelmSets: {}
+      guideVariableOverrides: {}   # override/fill the guide README's ${VAR}
+
+      # Inline kustomize strategic merge patches applied on top of the
+      # guide's modelserver base.  For gated models, add an HF_TOKEN
+      # env var patch (the secret is auto-created from HF_TOKEN env):
+      # Default is empty -- upstream guide already injects HF_TOKEN from
+      # the `llm-d-hf-token` Secret (auto-created by standup). Add entries
+      # here only for non-token overrides (e.g. bump replicas, pin a
+      # priorityClassName) -- see optimized-baseline.yaml for an example.
+      patches: []
+
+    # =========================================================================
+    # MODEL CONFIGURATION
+    # =========================================================================
+    model:
+      name: Qwen/Qwen3-32B
+      shortName: qwen-qwen3-32b
+      path: models/Qwen/Qwen3-32B
+      huggingfaceId: Qwen/Qwen3-32B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+
+    # =========================================================================
+    # DEPLOYMENT METHOD
+    # =========================================================================
+    modelservice:
+      enabled: true
+
+    standalone:
+      enabled: false
+
+    gateway:
+      className: epponly
+    fma:
+      enabled: true                    # launcher pods host vLLM and serve traffic;
+                                       # WVA scales the requester Deployment
+      iterations: 1                    # only matters for nop-harness actuation timing
+                                       # runs; with inference-perf the requester pods
+                                       # are created once at standup and WVA drives
+                                       # scale during the run.
+
+      requester:
+        replicas: 1
+
+      # Warmup: a deliberate wait inserted in the run phase before the
+      # benchmark fires.
+      warmupTimeout: 1200               # Qwen3-32B fresh vLLM load (warm start)
+                                        # is a 10-20 min op; 600s timed out. Match
+                                        # the hotstart arm's 1200s
+
+    # =========================================================================
+    # WVA CONFIGURATION
+    #
+    # Edit any field below to change WVA behavior for this scenario.
+    # Remove a field to fall back to its default.
+    # =========================================================================
+    eppKedaSaturation:
+      enabled: true
+
+      namespace: ""              # defaults to deploy namespace (first slot of `-p`)
+
+      prometheus:
+        baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+        port: 9091
+
+      epp:
+        poolName: ""             # defaults to model_id_label at render time
+        metricsPortName: http-metrics
+        metricsPort: 9090
+        prometheusServiceAccount: thanos-querier
+        prometheusServiceAccountNamespace: openshift-monitoring
+
+      scaledObject:
+        minReplicas: 1
+        maxReplicas: 10
+        pollingInterval: 15
+        kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
+        queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
+        activationThreshold: "0"
+        unsafeSsl: true
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 180
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 300
+
+    # =========================================================================
+    # WVA-RELATED CHART VERSIONS
+    #
+    # Pins for the helm charts that step_03 installs as part of the WVA
+    # pipeline. Bump these to track upstream releases; align with what the
+    # upstream WVA guide currently calls for so the rule format and chart
+    # values stay compatible.
+    #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+    # =========================================================================
+    chartVersions:
+      # WVA controller chart (oci://ghcr.io/llm-d/workload-variant-autoscaler)
+      wva: 0.6.0
+      # prometheus-adapter chart (prometheus-community/prometheus-adapter).
+      # Pinned because newer releases have broken external-metric
+      # compatibility with the rule format the WVA chart emits.
+      # The upstream WVA README also pins this version.
+      prometheusAdapter: 5.2.0
+
+    # =========================================================================
+    # ROUTING / GAIE CONFIGURATION
+    # =========================================================================
+    # WVA autoscaling is driven by EPP queue depth, so we must enable the
+    # `flowControl` feature gate in the EPP's EndpointPickerConfig. That gate
+    # is not on by default, and toggling it requires shipping a custom
+    # EndpointPickerConfig (the default one the gaie chart ships has no
+    # `featureGates` block). We inline it here and point `pluginsConfigFile`
+    # at this filename so the chart mounts it as the active config.
+    router: {}
+
+    # =========================================================================
+    # PREFILL / DECODE CONFIGURATION
+    #
+    # FMA owns the elastic vLLM tier under this topology, so the modelservice
+    # decode and prefill Deployments are disabled here (enabled: false ->
+    # 13_ms-values.yaml.j2 sets create: false). The router chart still renders
+    # gateway, EPP, and InferencePool independently.
+    # =========================================================================
+    prefill:
+      enabled: false
+
+    decode:
+      enabled: false                   # FMA launcher pods serve traffic, not decode
+      replicas: 0
+      # The FMA requester's nodeAffinity borrows decode.acceleratorType.labelValue
+      # (24_fma-deployment.yaml.j2), and WVA's saturation engine reads it back off
+      # the requester. The cluster resolver skips auto-detection for disabled
+      # sections, so pin the product explicitly here (pokprod = H100) — otherwise
+      # the requester's affinity stays "auto" and it never schedules. Non-"auto"
+      # values are left untouched by the resolver.
+      acceleratorType:
+        labelKey: nvidia.com/gpu.product
+        labelValue: NVIDIA-H100-80GB-HBM3
+
+    # =========================================================================
+    # FMA LAUNCHER POD MONITORING (REQUIRED for WVA)
+    #
+    # WVA reads vLLM metrics via prometheus-adapter → user-workload-monitoring.
+    # No PodMonitor → no metrics → HPA TARGETS stays `<unknown>` indefinitely
+    # → autoscaling silently broken.
+    #
+    #
+    # The PodMonitor template requires:
+    #   - selector matchLabels: llm-d.ai/inferenceServing=true,
+    #                           llm-d.ai/model=<model_id_label>
+    #   - endpoints[].relabelings (NOT metricRelabelings — see WVA repo
+    #     docs/design/controller-behavior.md):
+    #         sourceLabels: [__meta_kubernetes_pod_label_llm_d_ai_variant]
+    #         targetLabel: llm_d_ai_variant
+    #         action: replace
+    #   - chart label: release=llmd (so user-workload-monitoring discovers it)
+    # =========================================================================
+
+    # =========================================================================
+    # VLLM COMMON CONFIGURATION
+    # =========================================================================
+    vllmCommon:
+#      priorityClassName: nightly-gpu-critical
+      kvTransfer:
+        enabled: true
+        connector: NixlConnector
+        role: kv_both
+
+      flags:
+        # enforceEager: false (overrides the defaults.yaml default of true).
+        # Cosmetic for the FMA path itself — FMA's launcher options are
+        # hard-coded in 24_fma-deployment.yaml.j2 and don't read this flag —
+        # but kept here to mirror the baseline scenario and to document intent
+        # if FMA's template ever starts honoring vllmCommon.flags.
+        enforceEager: false
+        disableLogRequests: true
+        disableUvicornAccessLog: true
+        allowLongMaxModelLen: "1"
+        serverDevMode: "1"
+
+      volumes:
+        - name: shared-config
+          type: emptyDir
+          emptyDir: {}
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: shared-config
+          mountPath: /shared-config
+
+    # =========================================================================
+    # STORAGE
+    # =========================================================================
+    storage:
+      modelPvc:
+        size: 1Ti
+
+    # =========================================================================
+    # WORKLOAD / HARNESS
+    # =========================================================================
+    workDir: "/tmp/llmdbenchcicd-ocp-keda-fma-warmstart/"
+
+    harness:
+      name: inference-perf
+      # Use the heavy variant of shared_prefix_synthetic (8 parallel workers,
+      # ~200 RPS aggregate, larger prompts) calibrated to drive WVA's
+      # saturation gauges past the optimizer's threshold so OPTIMIZED
+      # actually climbs above 1 on this small model.
+      experimentProfile: shared_prefix_synthetic_heavy.yaml
+      # The heavy profile drives high RPS against Qwen3-32B; the infra
+      # reusable does not pass --wait-timeout on the CLI so the CLI falls
+      # back to this field (see cli.py harness_wait_timeout resolution).
+      waitTimeout: 5400
+
+    images:
+      benchmark:
+        tag: nightly

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -1,13 +1,11 @@
-# CI/CD WVA + FMA benchmark scenario (OpenShift).
+# CI/CD EPP+KEDA + FMA benchmark scenario (OpenShift).
 #
-# The WVA+FMA arm of the FMA-vs-WVA comparison nightly. Its no-FMA baseline is
-# cicd/ocp-wva; the two are kept apples-to-apples (same model, WVA config,
-# and heavy workload profile, both with vLLM prefix caching off) so the
-# comparison measures the scaling path, not the prefix cache. For the
-# user-facing WVA well-lit path that the WVA make targets consume, use
-# guides/workload-autoscaling (WVA-only).
+# The EPP+KEDA+FMA arm of the FMA-vs-baseline comparison nightly. Its no-FMA
+# baseline is cicd/ocp-keda; the two are kept apples-to-apples (same model, KEDA
+# config, and heavy workload profile, both with vLLM prefix caching off) so the
+# comparison measures the scaling path, not the prefix cache.
 #
-# All HPA / VariantAutoscaling knobs are listed below even when they match
+# All KEDA ScaledObject knobs are listed below even when they match
 # defaults.yaml, so the full surface area is visible in one place.
 #
 # Note: FMA owns the elastic vLLM tier here, so the modelservice decode and
@@ -15,7 +13,7 @@
 # prefill.enabled: false). modelservice still renders the gateway / EPP /
 # InferencePool that route to the FMA launcher pods.
 #
-# WVA scales an FMA-served model deployment. Topology:
+# KEDA scales an FMA-served model deployment. Topology:
 #
 #   modelservice (decode.enabled: false) provides gateway / EPP / InferencePool
 #     / PodMonitor; its decode Deployment is disabled — FMA owns the
@@ -23,10 +21,11 @@
 #
 #   FMA (fma.enabled: true)           launcher pods host vLLM and serve
 #     inference traffic; the requester Deployment holds the GPU lease
-#     that FMA scales.
+#     that KEDA scales.
 #
-#   WVA (wva.enabled: true)           scales the FMA requester Deployment;
-#     FMA's launcher-populator reconciles launcher pods to match.
+#   KEDA (eppKedaSaturation.enabled: true)  scales the FMA requester Deployment
+#     on EPP pool saturation metrics; FMA's launcher-populator reconciles
+#     launcher pods to match.
 #
 # How EPP reaches FMA: 12_router-values.yaml.j2 emits a router.modelServers
 # selector matching `llm-d.ai/inferenceServing=true, llm-d.ai/model=<id>`.
@@ -35,24 +34,21 @@
 # dual-pods controller propagates them to the launcher pod at BIND time, so
 # only launchers actually serving traffic show up in the InferencePool.
 #
-# How WVA tracks FMA: launcher pods carry `llm-d.ai/variant=<id>-fma` (also
-# applied at bind time via the ISC; label-based variant identification per
-# WVA repo PR #1145). Templates 27/28 retarget the VariantAutoscaling + HPA
-# at the FMA requester Deployment (`fma-requester-<id>`) when fma.enabled.
-#
-# Based on:
-#   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+# How KEDA scales FMA: the KEDA ScaledObject (30_epp-keda-saturation-scaledobject.yaml.j2)
+# targets the FMA requester Deployment (`fma-requester-<id>`) and scales it on EPP
+# pool saturation metrics (pool-average KV-cache utilization and queue size)
+# scraped from the EPP via Prometheus/Thanos.
 #
 # Running:
 #
-#   llmdbenchmark --spec cicd/ocp-wva-fma-warmstart standup -p <namespace>
+#   llmdbenchmark --spec cicd/ocp-keda-fma-warmstart standup -p <namespace>
 #
-# `wva.enabled: true` and `fma.enabled: true` are already set below, so no CLI
-# flag is needed to enable them for this scenario.
+# `eppKedaSaturation.enabled: true` and `fma.enabled: true` are already set below,
+# so no CLI flag is needed to enable them for this scenario.
 
 scenario:
   # ============================================================================
-  # CI/CD WVA + FMA - Qwen3-32B served by FMA launchers, autoscaled by WVA
+  # CI/CD EPP+KEDA + FMA - Qwen3-32B served by FMA launchers, autoscaled by KEDA
   # ============================================================================
   - name: "ocp-keda-fma-warmstart-cicd"
 
@@ -134,10 +130,10 @@ scenario:
       className: epponly
     fma:
       enabled: true                    # launcher pods host vLLM and serve traffic;
-                                       # WVA scales the requester Deployment
+                                       # KEDA scales the requester Deployment
       iterations: 1                    # only matters for nop-harness actuation timing
                                        # runs; with inference-perf the requester pods
-                                       # are created once at standup and WVA drives
+                                       # are created once at standup and KEDA drives
                                        # scale during the run.
 
       requester:
@@ -150,9 +146,9 @@ scenario:
                                         # the hotstart arm's 1200s
 
     # =========================================================================
-    # WVA CONFIGURATION
+    # EPP + KEDA SATURATION CONFIGURATION
     #
-    # Edit any field below to change WVA behavior for this scenario.
+    # Edit any field below to change KEDA scaling behavior for this scenario.
     # Remove a field to fall back to its default.
     # =========================================================================
     eppKedaSaturation:
@@ -194,32 +190,23 @@ scenario:
                 periodSeconds: 300
 
     # =========================================================================
-    # WVA-RELATED CHART VERSIONS
+    # CHART VERSIONS
     #
-    # Pins for the helm charts that step_03 installs as part of the WVA
-    # pipeline. Bump these to track upstream releases; align with what the
-    # upstream WVA guide currently calls for so the rule format and chart
-    # values stay compatible.
-    #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+    # Pins for the helm charts that step_03 installs. Bump these to track
+    # upstream releases.
     # =========================================================================
     chartVersions:
-      # WVA controller chart (oci://ghcr.io/llm-d/workload-variant-autoscaler)
-      wva: 0.6.0
       # prometheus-adapter chart (prometheus-community/prometheus-adapter).
-      # Pinned because newer releases have broken external-metric
-      # compatibility with the rule format the WVA chart emits.
-      # The upstream WVA README also pins this version.
+      # Pinned because newer releases have broken external-metric compatibility.
       prometheusAdapter: 5.2.0
 
     # =========================================================================
     # ROUTING / GAIE CONFIGURATION
     # =========================================================================
-    # WVA autoscaling is driven by EPP queue depth, so we must enable the
-    # `flowControl` feature gate in the EPP's EndpointPickerConfig. That gate
-    # is not on by default, and toggling it requires shipping a custom
-    # EndpointPickerConfig (the default one the gaie chart ships has no
-    # `featureGates` block). We inline it here and point `pluginsConfigFile`
-    # at this filename so the chart mounts it as the active config.
+    # EPP+KEDA queries inference_pool_average_kv_cache_utilization and
+    # inference_pool_average_queue_size directly from EPP's /metrics endpoint.
+    # These gauges are emitted by default; no special plugin config needed, so
+    # router.epp.pluginsConfigFile is left at its default.
     router: {}
 
     # =========================================================================
@@ -237,32 +224,23 @@ scenario:
       enabled: false                   # FMA launcher pods serve traffic, not decode
       replicas: 0
       # The FMA requester's nodeAffinity borrows decode.acceleratorType.labelValue
-      # (24_fma-deployment.yaml.j2), and WVA's saturation engine reads it back off
-      # the requester. The cluster resolver skips auto-detection for disabled
-      # sections, so pin the product explicitly here (pokprod = H100) — otherwise
-      # the requester's affinity stays "auto" and it never schedules. Non-"auto"
-      # values are left untouched by the resolver.
+      # (24_fma-deployment.yaml.j2). The cluster resolver skips auto-detection for
+      # disabled sections, so pin the product explicitly here (pokprod = H100) —
+      # otherwise the requester's affinity stays "auto" and it never schedules.
+      # Non-"auto" values are left untouched by the resolver.
       acceleratorType:
         labelKey: nvidia.com/gpu.product
         labelValue: NVIDIA-H100-80GB-HBM3
 
     # =========================================================================
-    # FMA LAUNCHER POD MONITORING (REQUIRED for WVA)
+    # EPP METRICS MONITORING (REQUIRED for KEDA)
     #
-    # WVA reads vLLM metrics via prometheus-adapter → user-workload-monitoring.
-    # No PodMonitor → no metrics → HPA TARGETS stays `<unknown>` indefinitely
-    # → autoscaling silently broken.
-    #
-    #
-    # The PodMonitor template requires:
-    #   - selector matchLabels: llm-d.ai/inferenceServing=true,
-    #                           llm-d.ai/model=<model_id_label>
-    #   - endpoints[].relabelings (NOT metricRelabelings — see WVA repo
-    #     docs/design/controller-behavior.md):
-    #         sourceLabels: [__meta_kubernetes_pod_label_llm_d_ai_variant]
-    #         targetLabel: llm_d_ai_variant
-    #         action: replace
-    #   - chart label: release=llmd (so user-workload-monitoring discovers it)
+    # KEDA scales on EPP pool saturation metrics (inference_pool_average_kv_cache_
+    # utilization / inference_pool_average_queue_size). The EPP-monitoring template
+    # (29_epp-keda-saturation-epp-monitoring.yaml.j2) scrapes those into
+    # user-workload-monitoring / Thanos, which the ScaledObject's Prometheus
+    # trigger then queries. Without it the ScaledObject has no metric source and
+    # never scales.
     # =========================================================================
 
     # =========================================================================
@@ -318,9 +296,9 @@ scenario:
     harness:
       name: inference-perf
       # Use the heavy variant of shared_prefix_synthetic (8 parallel workers,
-      # ~200 RPS aggregate, larger prompts) calibrated to drive WVA's
-      # saturation gauges past the optimizer's threshold so OPTIMIZED
-      # actually climbs above 1 on this small model.
+      # ~200 RPS aggregate, larger prompts) calibrated to drive the EPP pool
+      # saturation metrics (KV cache / queue) past the ScaledObject thresholds
+      # so KEDA scales the requester Deployment above 1 on this small model.
       experimentProfile: shared_prefix_synthetic_heavy.yaml
       # The heavy profile drives high RPS against Qwen3-32B; the infra
       # reusable does not pass --wait-timeout on the CLI so the CLI falls

--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -1,12 +1,12 @@
 # OpenShift CI/CD Scenario - EPP+KEDA baseline (no FMA)
 #
-# EPP-only (direct KEDA saturation autoscaling) baseline for the WVA+FMA-style
+# EPP-only (direct KEDA saturation autoscaling) baseline for the EPP+KEDA+FMA
 # nightly's KEDA path. Derived from guides/epp-keda-saturation.yaml (all its
 # settings preserved) with cicd conventions layered on: epponly gateway,
 # enforceEager:false (matched to the FMA launcher for fair comparison),
-# decode.replicas:1 (= KEDA minReplicas, matched to the WVA baseline), a /tmp
-# workDir, and the heavy load profile. No WVA controller / VariantAutoscaling /
-# prometheus-adapter. `eppKedaSaturation.enabled: true` drives the KEDA path.
+# decode.replicas:1 (= KEDA minReplicas), a /tmp workDir, and the heavy load
+# profile. `eppKedaSaturation.enabled: true` drives the KEDA saturation path
+# directly via the KEDA ScaledObject.
 
 scenario:
   # =========================================================================
@@ -92,8 +92,7 @@ scenario:
     #
     # EPP+KEDA queries inference_pool_average_kv_cache_utilization and
     # inference_pool_average_queue_size directly from EPP's /metrics endpoint.
-    # These gauges are emitted by default; no special plugin config needed
-    # (unlike WVA's flowControl feature gate).
+    # These gauges are emitted by default; no special plugin config needed.
     #
     # Do NOT set router.epp.pluginsConfigFile — let it default to
     # "default-plugins.yaml" which already includes metrics-data-source +
@@ -228,6 +227,6 @@ scenario:
 
     harness:
       name: inference-perf
-      # Heavy variant -- matched RPS with the WVA baseline and the FMA passes.
+      # Heavy variant -- matched RPS across the baseline and FMA passes.
       experimentProfile: shared_prefix_synthetic_heavy.yaml
       waitTimeout: 5400

--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -1,0 +1,233 @@
+# OpenShift CI/CD Scenario - EPP+KEDA baseline (no FMA)
+#
+# EPP-only (direct KEDA saturation autoscaling) baseline for the WVA+FMA-style
+# nightly's KEDA path. Derived from guides/epp-keda-saturation.yaml (all its
+# settings preserved) with cicd conventions layered on: epponly gateway,
+# enforceEager:false (matched to the FMA launcher for fair comparison),
+# decode.replicas:1 (= KEDA minReplicas, matched to the WVA baseline), a /tmp
+# workDir, and the heavy load profile. No WVA controller / VariantAutoscaling /
+# prometheus-adapter. `eppKedaSaturation.enabled: true` drives the KEDA path.
+
+scenario:
+  # =========================================================================
+  # EPP+KEDA SATURATION AUTOSCALING - Qwen3-32B with 2 decode pods
+  # =========================================================================
+  - name: "ocp-keda-cicd"
+
+    # =========================================================================
+    # MODEL CONFIGURATION
+    # =========================================================================
+    model:
+      name: Qwen/Qwen3-32B
+      shortName: qwen-qwen3-32b
+      path: models/Qwen/Qwen3-32B
+      huggingfaceId: Qwen/Qwen3-32B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+
+    # =========================================================================
+    # DEPLOYMENT METHOD
+    # =========================================================================
+    modelservice:
+      enabled: true
+
+    standalone:
+      enabled: false
+
+    gateway:
+      className: epponly
+
+    # =========================================================================
+    # EPP+KEDA SATURATION CONFIGURATION
+    #
+    # Direct KEDA autoscaling using EPP pool metrics. All thresholds and
+    # behavior parameters are spelled out below so users can tweak them
+    # per-experiment without editing defaults.yaml.
+    # =========================================================================
+    eppKedaSaturation:
+      enabled: true
+
+      namespace: ""              # defaults to deploy namespace (first slot of `-p`)
+
+      prometheus:
+        baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
+        port: 9091
+
+      epp:
+        poolName: ""             # defaults to model_id_label at render time
+        metricsPortName: http-metrics
+        metricsPort: 9090
+        prometheusServiceAccount: thanos-querier
+        prometheusServiceAccountNamespace: openshift-monitoring
+
+      scaledObject:
+        minReplicas: 1
+        maxReplicas: 10
+        pollingInterval: 15
+        kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
+        queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
+        activationThreshold: "0"
+        unsafeSsl: true
+        behavior:
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              # Adjust periodSeconds to match actual pod startup time.
+              # GPU hardware (H100/A100): 180 seconds
+              # Simulator / kind cluster (fast startup): 30 seconds
+              - type: Pods
+                value: 1
+                periodSeconds: 180
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 300
+
+    # =========================================================================
+    # ROUTING / GAIE CONFIGURATION
+    #
+    # EPP+KEDA queries inference_pool_average_kv_cache_utilization and
+    # inference_pool_average_queue_size directly from EPP's /metrics endpoint.
+    # These gauges are emitted by default; no special plugin config needed
+    # (unlike WVA's flowControl feature gate).
+    #
+    # Do NOT set router.epp.pluginsConfigFile — let it default to
+    # "default-plugins.yaml" which already includes metrics-data-source +
+    # core-metrics-extractor plugins required for these gauges.
+    # =========================================================================
+    router: {}
+
+    # =========================================================================
+    # PREFILL / DECODE CONFIGURATION (same as inference-scheduling.yaml)
+    # =========================================================================
+    prefill:
+      enabled: false
+      replicas: 0
+
+    decode:
+      replicas: 1
+
+      initContainers:
+        - name: preprocess
+          imageKey: benchmark
+          imagePullPolicy: Always
+          command: ["set_llmdbench_environment.py", "-e", "/shared-config/llmdbench_env.sh", "-i"]
+          volumeMounts:
+            - name: shared-config
+              mountPath: /shared-config
+
+      parallelism:
+        tensor: 1
+        data: 1
+        dataLocal: 1
+        workers: 1
+
+      resources:
+        limits:
+          memory: 64Gi
+          cpu: "16"
+        requests:
+          memory: 64Gi
+          cpu: "16"
+
+      extraEnvVars: []
+
+      extraContainerConfig:
+        ports:
+          - containerPort: 5557
+            protocol: TCP
+          - containerPort: 8200
+            name: metrics
+            protocol: TCP
+        securityContext:
+          capabilities:
+            add:
+              - "IPC_LOCK"
+              - "SYS_RAWIO"
+          runAsGroup: 0
+          runAsUser: 0
+        imagePullPolicy: Always
+
+      additionalVolumeMounts: []
+      additionalVolumes: []
+
+      probes:
+        startup:
+          path: /v1/models
+          failureThreshold: 60
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          timeoutSeconds: 5
+        liveness:
+          path: /health
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readiness:
+          path: /v1/models
+          failureThreshold: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+
+      monitoring:
+        podmonitor:
+          enabled: true
+          portName: metrics
+          path: /metrics
+          interval: 30s
+          labels:
+            release: llmd
+
+    # =========================================================================
+    # VLLM COMMON CONFIGURATION
+    # =========================================================================
+    vllmCommon:
+      kvTransfer:
+        enabled: true
+        connector: NixlConnector
+        role: kv_both
+
+      flags:
+        enforceEager: false  # match FMA launcher (never --enforce-eager); fair comparison
+        disableLogRequests: true
+        disableUvicornAccessLog: true
+        allowLongMaxModelLen: "1"
+        serverDevMode: "1"
+
+      volumes:
+        - name: shared-config
+          type: emptyDir
+          emptyDir: {}
+        - name: dshm
+          type: emptyDir
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+
+      volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+        - name: shared-config
+          mountPath: /shared-config
+
+    # =========================================================================
+    # STORAGE
+    # =========================================================================
+    storage:
+      modelPvc:
+        size: 1Ti
+
+    # =========================================================================
+    # WORKLOAD / HARNESS
+    # =========================================================================
+    workDir: "/tmp/llmdbenchcicd-ocp-keda/"
+
+    harness:
+      name: inference-perf
+      # Heavy variant -- matched RPS with the WVA baseline and the FMA passes.
+      experimentProfile: shared_prefix_synthetic_heavy.yaml
+      waitTimeout: 5400

--- a/config/specification/cicd/ocp-keda-fma-hotstart.yaml.j2
+++ b/config/specification/cicd/ocp-keda-fma-hotstart.yaml.j2
@@ -1,0 +1,17 @@
+# OpenShift Container Platform CI/CD Specification - EPP+KEDA + FMA (hot-start)
+
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml

--- a/config/specification/cicd/ocp-keda-fma-warmstart.yaml.j2
+++ b/config/specification/cicd/ocp-keda-fma-warmstart.yaml.j2
@@ -1,0 +1,17 @@
+# OpenShift Container Platform CI/CD Specification - EPP+KEDA + FMA
+
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml

--- a/config/specification/cicd/ocp-keda.yaml.j2
+++ b/config/specification/cicd/ocp-keda.yaml.j2
@@ -1,0 +1,17 @@
+# OpenShift Container Platform CI/CD Specification - EPP+KEDA + modelservice baseline (no FMA)
+
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/cicd/ocp-keda.yaml

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-07-15 03:16:39` (UTC)
-- Generated against git ref: `a4885ada651ee454f0b909f38ba0a7f0babc235f`
+- Generated at: `2026-07-15 03:23:20` (UTC)
+- Generated against git ref: `308c9ed47837b764c43e0b5484186fe1d90c07a4`
 
 ## System Tool Dependencies
 

--- a/llmdbenchmark/run/steps/step_02a_fma_warmup_hotstart.py
+++ b/llmdbenchmark/run/steps/step_02a_fma_warmup_hotstart.py
@@ -25,8 +25,8 @@ Used by workload-autoscaling-hotstart scenario.
 import time
 from pathlib import Path
 
-from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.executor.step import Phase, Step, StepResult
 
 
 class FMAWarmupHotStartStep(Step):
@@ -101,6 +101,34 @@ class FMAWarmupHotStartStep(Step):
         # generic label if unset.
         model_name = self._resolve(plan_config, "model.name", default="the model")
         deploy_name = f"fma-requester-{model_id_label}"
+
+        # When launcher node-pinning is enabled, step_06 scales the requester to
+        # the pinned node's GPU count. step_06 persists that to config.yaml, but
+        # the run phase RE-RENDERS the plan from the scenario, so the persisted
+        # value is gone by the time we get here
+        live = cmd.kube(
+            "get",
+            f"deployment/{deploy_name}",
+            "-o",
+            "jsonpath={.spec.replicas}",
+            "--namespace",
+            namespace,
+            check=False,
+        )
+        live_replicas = 0
+        if live.success:
+            try:
+                live_replicas = int((live.stdout or "").strip() or 0)
+            except ValueError:
+                live_replicas = 0
+        if live_replicas > 0 and live_replicas != replicas:
+            context.logger.log_info(
+                f"    | Using Deployment/{deploy_name} spec.replicas="
+                f"{live_replicas} for the warmup gate (rendered config placeholder "
+                f"was {replicas}; node-pinning resized it)"
+            )
+            replicas = live_replicas
+
         timeout = int(self._resolve(plan_config, "fma.warmupTimeout", default=1200))
         # Scale-down floor: read the HPA's minReplicas, since the HPA is what
         # actually enforces the requester Deployment's replica count during the

--- a/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
+++ b/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
@@ -1,9 +1,9 @@
-"""Step 09a -- Capture WVA + FMA cluster state right after results are collected.
+"""Step 09a -- Capture WVA/KEDA + FMA cluster state right after results are collected.
 
-Snapshots HPA/VA/Deployment YAML, events, WVA controller logs, and the
+Snapshots HPA/ScaledObject/Deployment YAML, events, controller logs, and the
 logs of every pod in the deploy and WVA namespaces to ``results/<exp_id>/``
-— alongside the harness's benchmark output. Skipped when ``wva.enabled``
-is false.
+— alongside the harness's benchmark output. Skipped only when neither
++``wva.enabled`` nor ``eppKedaSaturation.enabled`` is set.
 
 Runs AFTER step_09_collect_results so the local results dir already exists
 and won't trip step_09's "skip if results dir non-empty" gate.
@@ -12,9 +12,8 @@ and won't trip step_09's "skip if results dir non-empty" gate.
 import time
 from pathlib import Path
 
-from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
-
+from llmdbenchmark.executor.step import Phase, Step, StepResult
 
 # Kubelet/API-server transient errors when the
 # pod-log symlink path is being rotated mid-call.
@@ -48,13 +47,13 @@ def _kube_logs_with_retry(cmd, *args, attempts: int = 3, backoff: float = 2.0):
 
 
 class CaptureClusterStateStep(Step):
-    """Snapshot HPA/VA/Deployment/events + WVA controller logs to workspace."""
+    """Snapshot HPA/ScaledObject/Deployment/events + WVA controller logs to workspace."""
 
     def __init__(self):
         super().__init__(
             number=9,
             name="capture_cluster_state",
-            description="Capture WVA HPA/VA/Deployment state and controller logs",
+            description="Capture WVA HPA/ScaledObject/Deployment state and controller logs",
             phase=Phase.RUN,
             per_stack=True,
         )
@@ -80,12 +79,20 @@ class CaptureClusterStateStep(Step):
         cmd = context.require_cmd()
 
         plan_config = self._load_stack_config(stack_path)
-        if not self._resolve(plan_config, "wva.enabled", default=False):
+        # Capture for any KEDA-driven autoscaling path.
+        wva_enabled = self._resolve(plan_config, "wva.enabled", default=False)
+        epp_keda_enabled = self._resolve(
+            plan_config, "eppKedaSaturation.enabled", default=False
+        )
+        if not (wva_enabled or epp_keda_enabled):
             return StepResult(
                 step_number=self.number,
                 step_name=self.name,
                 success=True,
-                message="wva.enabled is false; skipping cluster-state capture",
+                message=(
+                    "wva.enabled and eppKedaSaturation.enabled both false; "
+                    "skipping cluster-state capture"
+                ),
                 stack_name=stack_name,
             )
 
@@ -109,10 +116,12 @@ class CaptureClusterStateStep(Step):
         captured: list[str] = []
         warnings: list[str] = []
 
-        # 1. Full YAML of WVA-relevant resources in the deploy namespace.
+        # 1. Full YAML of WVA/KEDA-relevant resources in the deploy namespace.
+
         result = cmd.kube(
             "get",
-            "pods,hpa,variantautoscaling,deployments,replicasets",
+            "pods,hpa,scaledobjects.keda.sh,triggerauthentications.keda.sh,"
+            "deployments,replicasets",
             "--namespace",
             deploy_ns,
             "-o",
@@ -146,6 +155,37 @@ class CaptureClusterStateStep(Step):
         else:
             warnings.append(f"get hpa failed: {result.stderr[:200]}")
 
+        # 3b. ScaledObject (KEDA) state -- READY / ACTIVE / TRIGGERS columns
+        result = cmd.kube(
+            "get",
+            "scaledobjects.keda.sh",
+            "--namespace",
+            deploy_ns,
+            "-o",
+            "wide",
+            check=False,
+        )
+        if result.success:
+            (out_dir / "scaledobject.txt").write_text(result.stdout, encoding="utf-8")
+            captured.append("scaledobject.txt")
+        else:
+            warnings.append(f"get scaledobject failed: {result.stderr[:200]}")
+
+        result = cmd.kube(
+            "describe",
+            "scaledobjects.keda.sh",
+            "--namespace",
+            deploy_ns,
+            check=False,
+        )
+        if result.success:
+            (out_dir / "scaledobject-describe.txt").write_text(
+                result.stdout, encoding="utf-8"
+            )
+            captured.append("scaledobject-describe.txt")
+        else:
+            warnings.append(f"describe scaledobject failed: {result.stderr[:200]}")
+
         # 4. Events — sorted by time so a HPA scale-up event is easy to spot.
         result = cmd.kube(
             "get",
@@ -160,6 +200,19 @@ class CaptureClusterStateStep(Step):
             captured.append("events.log")
         else:
             warnings.append(f"get events failed: {result.stderr[:200]}")
+
+        # 4b. Events as JSON — the table above uses relative "LAST SEEN" ages,
+        # which can't be parsed for timing. JSON carries absolute timestamps so
+        # the display job can measure T_scale_up from each HPA SuccessfulRescale
+        # scale-up event to the new replica's Ready.
+        result = cmd.kube(
+            "get", "events", "--namespace", deploy_ns, "-o", "json", check=False
+        )
+        if result.success:
+            (out_dir / "events.json").write_text(result.stdout, encoding="utf-8")
+            captured.append("events.json")
+        else:
+            warnings.append(f"get events json failed: {result.stderr[:200]}")
 
         # 5. WVA controller logs — every reconcile loop logs the OPTIMIZED
         # replica count it computed. Capped to keep the upload reasonable;
@@ -200,28 +253,7 @@ class CaptureClusterStateStep(Step):
         else:
             warnings.append(f"get pods failed: {result.stderr[:200]}")
 
-        # 7. External metrics API — what HPA actually reads. If this returns
-        # the metric, prometheus-adapter is healthy and the WVA→Prom→adapter
-        # →HPA chain works; if not, the chain is broken between those stages.
-        result = cmd.kube(
-            "get",
-            "--raw",
-            f"/apis/external.metrics.k8s.io/v1beta1/namespaces/{deploy_ns}/wva_desired_replicas",
-            check=False,
-        )
-        if result.success:
-            (out_dir / "external-metric.json").write_text(
-                result.stdout, encoding="utf-8"
-            )
-            captured.append("external-metric.json")
-        else:
-            (out_dir / "external-metric.error").write_text(
-                result.stderr, encoding="utf-8"
-            )
-            captured.append("external-metric.error")
-            warnings.append(f"external-metric query failed: {result.stderr[:200]}")
-
-        # 7a. Thanos diagnostic queries — proves whether vLLM saturation
+        # 7. Thanos diagnostic queries — proves whether vLLM saturation
         # series in Thanos actually carry the `llm_d_ai_variant` label our
         # PodMonitor relabel is supposed to lift. WVA's saturation engine
         # joins on this label; missing-or-empty means the engine emits
@@ -239,6 +271,11 @@ class CaptureClusterStateStep(Step):
             ),
             ("vllm-cache-no-variant", 'vllm:gpu_cache_usage_perc{llm_d_ai_variant=""}'),
             ("vllm-cache-all", "vllm:gpu_cache_usage_perc"),
+            (
+                "epp-pool-kv-cache",
+                "inference_pool_average_kv_cache_utilization",
+            ),
+            ("epp-pool-queue-size", "inference_pool_average_queue_size"),
         ]
         for label, query in thanos_queries:
             result = cmd.kube(
@@ -299,67 +336,6 @@ class CaptureClusterStateStep(Step):
 
         if pod_log_count > 0:
             captured.append(f"{pod_log_count} pod log(s)")
-
-        # 10. prometheus-adapter — cluster-scoped install.
-        adapter_pods = cmd.kube(
-            "get",
-            "pods",
-            "--all-namespaces",
-            "-l",
-            "app.kubernetes.io/name=prometheus-adapter",
-            "--no-headers",
-            check=False,
-        )
-        adapter_count = 0
-        if adapter_pods.success:
-            for line in adapter_pods.stdout.split("\n"):
-                line = line.strip()
-                if not line:
-                    continue
-                parts = line.split()
-                if len(parts) < 2:
-                    continue
-                ns, pod_name = parts[0], parts[1]
-                log_result = _kube_logs_with_retry(
-                    cmd,
-                    pod_name,
-                    "--namespace",
-                    ns,
-                    "--all-containers=true",
-                    "--tail=5000",
-                )
-                if log_result.success and log_result.stdout:
-                    is_kubelet_error = _is_kubelet_log_sentinel(log_result.stdout)
-                    suffix = ".kubelet-error" if is_kubelet_error else ".log"
-                    log_path = out_dir / f"{ns}__{pod_name}{suffix}"
-                    log_path.write_text(log_result.stdout, encoding="utf-8")
-                    if not is_kubelet_error:
-                        adapter_count += 1
-        else:
-            warnings.append(
-                f"list prometheus-adapter pods failed: {adapter_pods.stderr[:200]}"
-            )
-
-        if adapter_count > 0:
-            captured.append(f"prometheus-adapter logs ({adapter_count} pod(s))")
-
-        # 11. external-metrics discovery — lists what prometheus-adapter is
-        # actually advertising. If wva_desired_replicas is not in this list,
-        # the adapter rule format doesn't match what the WVA controller emits
-        # and HPA will never see the metric.
-        result = cmd.kube(
-            "get",
-            "--raw",
-            "/apis/external.metrics.k8s.io/v1beta1",
-            check=False,
-        )
-        if result.success:
-            (out_dir / "external-metric-discovery.json").write_text(
-                result.stdout, encoding="utf-8"
-            )
-            captured.append("external-metric-discovery.json")
-        else:
-            warnings.append(f"external-metric discovery failed: {result.stderr[:200]}")
 
         for w in warnings:
             context.logger.log_warning(f"cluster-state: {w}")


### PR DESCRIPTION
Adds a new OpenShift nightly (`ci-nightly-benchmark-ocp-fma-keda.yaml`) that benchmarks the direct EPP+KEDA saturation autoscaling path (no WVA controller):

1. Baseline (EPP+KEDA, no FMA) — cicd/ocp-keda
2. FMA warm-start with EPP+KEDA — cicd/ocp-keda-fma-warmstart
3. FMA hot-start with EPP+KEDA — cicd/ocp-keda-fma-hotstart

KEDA scales the decode/FMA-requester Deployment on EPP pool metrics (`inference_pool_average_kv_cache_utilization > 0.7`, i`nference_pool_average_queue_size > 2`) via a ScaledObject → HPA, enabled purely through `eppKedaSaturation.enabled: true` — no VariantAutoscaling, no prometheus-adapter.

Shared observability:
- New T_scale_up metric — autoscaler scale-up latency = HPA status.lastScaleTime → newest replica Ready. Replaces the old WVA-controller-log-derived "cold-start" row (which didn't exist on the EPP-KEDA path and is deprecated now that WVA scales via KEDA). Scaler-agnostic (reads resources.yaml), so it's identical for both nightlies. Sits alongside T_actuation (container start → Ready).
- step_09a capture step:
  - Captures KEDA CRs (scaledobjects.keda.sh, triggerauthentications.keda.sh) in resources.yaml, plus scaledobject.txt and scaledobject-describe.txt
  - Adds EPP pool trigger-metric Thanos queries (kv-cache utilization, queue size)
  - Removes deprecated prometheus-adapter-era captures (external-metric query/discovery, prometheus-adapter logs) and the VariantAutoscaling CR
- Display dumps: per-arm Dump ScaledObject + Dump ScaledObject describe (both nightlies); KEDA workflow drops the dead WVA-controller-log dump, WVA workflow keeps it.

🤖 Generated with Claude Code (https://claude.com/claude-code)