### PR TITLE
add no-k8s deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,7 @@ The analysis pipeline generates per-request distribution plots, cross-treatment 
 - [Run](docs/run.md)
 - [Standup](docs/standup.md)
 - [Kustomize deploy method](docs/kustomize.md)
+- [No-Kubernetes (nok8s) deploy method](docs/nok8s.md)
 - [Reproducibility](docs/reproducibility.md)
 - [Observability](docs/observability.md)
 - [Quickstart](docs/quickstart.md)

--- a/config/README.md
+++ b/config/README.md
@@ -214,7 +214,7 @@ CLI arguments override both defaults, scenario values, and environment variables
 # Override namespace
 llmdbenchmark --spec my-spec.yaml.j2 standup -p my-namespace
 
-# Override deployment method
+# Override deployment method (standalone, modelservice, fma, kustomize, nok8s)
 llmdbenchmark --spec my-spec.yaml.j2 standup -t standalone
 
 # Override model
@@ -280,9 +280,13 @@ Jinja2 templates that produce Kubernetes resource definitions. Each template cor
 | `21_prometheus-adapter-values.yaml.j2` | Prometheus adapter values |
 | `22_prometheus-rbac.yaml.j2` | Prometheus RBAC resources |
 | `23_wva-namespace.yaml.j2` | WVA namespace resources |
+| `31_nok8s-epp-config.yaml.j2` | No-Kubernetes EPP (file-discovery) config |
+| `32_nok8s-epp-endpoints.yaml.j2` | No-Kubernetes EPP endpoints (worker list) |
+| `33_nok8s-envoy.yaml.j2` | No-Kubernetes Envoy bootstrap |
+| `34_nok8s-containers.yaml.j2` | No-Kubernetes container launch spec (see [nok8s](../docs/nok8s.md)) |
 | `_macros.j2` | Shared Jinja2 macros (vLLM command gen, etc.) |
 
-Templates use Jinja2 conditionals to skip rendering when their feature is disabled. For example, standalone templates only render when `standalone.enabled` is `true`. Steps check for empty rendered files via `_has_yaml_content()` and skip applying them.
+Templates use Jinja2 conditionals to skip rendering when their feature is disabled. For example, standalone templates only render when `standalone.enabled` is `true` (and the `nok8s` templates only when `nok8s.enabled` is `true`). Steps check for empty rendered files via `_has_yaml_content()` and skip applying them.
 
 ### `templates/values/defaults.yaml`
 
@@ -304,6 +308,7 @@ The base configuration file containing every configurable parameter with sensibl
 | `prefill` | Prefill pod configuration (disabled by default) |
 | `standalone` | Standalone deployment settings (disabled by default) |
 | `modelservice` | Modelservice deployment settings (enabled by default) |
+| `nok8s` | No-Kubernetes deployment settings (disabled by default) -- see [nok8s](../docs/nok8s.md) |
 | `images` | Container image repositories, tags, and pull policies |
 | `vllmCommon` | Shared vLLM settings (ports, KV transfer, flags, volumes) |
 | `harness` | Benchmark harness configuration |

--- a/config/scenarios/nok8s.yaml
+++ b/config/scenarios/nok8s.yaml
@@ -47,7 +47,16 @@ scenario:
         tag: v0.19.1
         hostPort: 8000
         tensorParallel: 1
+        # Accelerator: nvidia | amd | intel | gaudi | cpu | spyre.
+        # For non-NVIDIA, also change `image` to the matching vLLM backend and
+        # (for spyre/custom) set `deviceArgs`. Examples:
+        #   amd:    image: rocm/vllm         (device flags auto: /dev/kfd,/dev/dri)
+        #   intel:  image: intel vLLM XPU    (device flags auto: /dev/dri)
+        #   gaudi:  image: habana vLLM       (--runtime=habana)
+        #   spyre:  image: <IBM vLLM-Spyre>  deviceArgs: ["--device","/dev/vfio/..."]
+        accelerator: nvidia
         gpus: "all"
+        deviceArgs: []
         shmSize: "20g"
         hfCacheDir: "~/.cache/huggingface"
         replicas: 1

--- a/config/scenarios/nok8s.yaml
+++ b/config/scenarios/nok8s.yaml
@@ -1,0 +1,72 @@
+# No-Kubernetes (nok8s) scenario.
+#
+# Runs the llm-d routing stack (vLLM + EPP + Envoy) as plain docker/podman
+# containers on the local host -- no cluster. The benchmark harness also runs
+# as a local container against the Envoy front door (http://localhost:8081).
+#
+# Single-GPU friendly (e.g. one H100/H200). Defaults to a small ungated model
+# so a smoke run needs no Hugging Face token. Set the token in your shell so
+# the vLLM container can pull gated models:
+#     export HUGGING_FACE_HUB_TOKEN=hf_...
+#
+# Usage:
+#     llmdbenchmark --spec config/scenarios/nok8s.yaml standup --methods nok8s
+#     llmdbenchmark --spec config/scenarios/nok8s.yaml run
+#     llmdbenchmark --spec config/scenarios/nok8s.yaml teardown --methods nok8s
+
+scenario:
+  - name: "nok8s-single"
+
+    # Model served by vLLM (also the name benchmark requests must use).
+    # Set name and huggingfaceId together so the run phase (which reads
+    # huggingfaceId) and the container/endpoints templates (which read name)
+    # agree -- otherwise huggingfaceId falls back to the defaults model.
+    model:
+      name: Qwen/Qwen2.5-0.5B-Instruct
+      huggingfaceId: Qwen/Qwen2.5-0.5B-Instruct
+      shortName: qwen2-5-0-5b-instruct
+
+    # Deployment method: no Kubernetes. Disable the others explicitly
+    # (modelservice defaults to enabled) so the method is unambiguous even
+    # without passing --methods on the CLI.
+    modelservice:
+      enabled: false
+    standalone:
+      enabled: false
+    fma:
+      enabled: false
+    kustomize:
+      enabled: false
+    nok8s:
+      enabled: true
+      runtime: docker            # docker | podman
+      hfTokenEnv: HUGGING_FACE_HUB_TOKEN
+      workspaceHostDir: "~/.llmdbench/nok8s"
+      vllm:
+        image: docker.io/vllm/vllm-openai
+        tag: v0.19.1
+        hostPort: 8000
+        tensorParallel: 1
+        gpus: "all"
+        shmSize: "20g"
+        hfCacheDir: "~/.cache/huggingface"
+        replicas: 1
+        extraArgs: []
+      epp:
+        image: ghcr.io/llm-d/llm-d-router-endpoint-picker
+        tag: v0.9.0
+        grpcPort: 9002
+        grpcHealthPort: 9003
+        metricsPort: 9090
+        poolName: file-discovery
+        poolNamespace: default
+      envoy:
+        image: docker.io/envoyproxy/envoy
+        tag: distroless-v1.33.2
+        listenPort: 8081
+
+    # Benchmark harness (runs as a local container against :8081).
+    harness:
+      name: inference-perf
+      profile: sanity_random.yaml
+      waitTimeout: 1800

--- a/config/specification/nok8s.yaml.j2
+++ b/config/specification/nok8s.yaml.j2
@@ -1,0 +1,19 @@
+# No-Kubernetes (nok8s) Specification
+# Runs the llm-d stack + benchmark harness as local containers, no cluster.
+# See config/scenarios/nok8s.yaml for the scenario details.
+
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/nok8s.yaml

--- a/config/templates/jinja/31_nok8s-epp-config.yaml.j2
+++ b/config/templates/jinja/31_nok8s-epp-config.yaml.j2
@@ -1,0 +1,45 @@
+{% if nok8s.enabled %}
+{# ============================================================================
+   nok8s EPP (Endpoint Picker) config — file-discovery mode.
+   Rendered only for the no-Kubernetes deployment method.  Staged to
+   {{ nok8s.epp.configMountDir }}/config.yaml on the host and bind-mounted
+   into the EPP container.  Mirrors the optimized-baseline plugin set with the
+   file-discovery plugin added so endpoints come from a YAML file instead of a
+   Kubernetes InferencePool.
+   ============================================================================ #}
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - name: file-discovery
+    type: file-discovery
+    parameters:
+      path: {{ nok8s.epp.configMountDir }}/endpoints.yaml
+      watchFile: true
+  - type: queue-scorer
+  - type: kv-cache-utilization-scorer
+  - type: prefix-cache-scorer
+  - type: no-hit-lru-scorer
+  - name: metrics-source
+    type: metrics-data-source
+  - name: metrics-extractor
+    type: core-metrics-extractor
+schedulingProfiles:
+  - name: default
+    plugins:
+      - pluginRef: queue-scorer
+        weight: 2
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 2
+      - pluginRef: prefix-cache-scorer
+        weight: 3
+      - pluginRef: no-hit-lru-scorer
+        weight: 2
+dataLayer:
+  injectDefaults: false
+  discovery:
+    pluginRef: file-discovery
+  sources:
+    - pluginRef: metrics-source
+      extractors:
+        - pluginRef: metrics-extractor
+{% endif %}

--- a/config/templates/jinja/32_nok8s-epp-endpoints.yaml.j2
+++ b/config/templates/jinja/32_nok8s-epp-endpoints.yaml.j2
@@ -1,0 +1,16 @@
+{% if nok8s.enabled %}
+{# ============================================================================
+   nok8s EPP endpoints file (file-discovery plugin input).
+   One entry per vLLM worker; worker i is published on hostPort + i.  Addresses
+   must be literal IPv4 (the plugin does not resolve hostnames).  With
+   watchFile: true the EPP reloads this on atomic rewrite.
+   ============================================================================ #}
+endpoints:
+{% for i in range(nok8s.vllm.replicas) %}
+  - name: vllm-{{ i }}
+    address: 127.0.0.1
+    port: "{{ nok8s.vllm.hostPort + i }}"
+    labels:
+      model: {{ model.name }}
+{% endfor %}
+{% endif %}

--- a/config/templates/jinja/33_nok8s-envoy.yaml.j2
+++ b/config/templates/jinja/33_nok8s-envoy.yaml.j2
@@ -1,0 +1,126 @@
+{% if nok8s.enabled %}
+{# ============================================================================
+   nok8s Envoy bootstrap.  Listener on envoy.listenPort, ext_proc to the EPP
+   on 127.0.0.1:epp.grpcPort, ORIGINAL_DST routing on the
+   x-gateway-destination-endpoint header the EPP sets.
+   ============================================================================ #}
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 19000
+
+static_resources:
+  listeners:
+    - name: vllm
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: {{ nok8s.envoy.listenPort }}
+      per_connection_buffer_limit_bytes: 32768
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: http-{{ nok8s.envoy.listenPort }}
+                route_config:
+                  name: vllm
+                  virtual_hosts:
+                    - name: vllm-default
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: original_destination_cluster
+                            timeout: 86400s
+                            idle_timeout: 86400s
+                            upgrade_configs:
+                              - upgrade_type: websocket
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_proc:
+                              "@type": type.googleapis.com/envoy.config.route.v3.FilterConfig
+                              config: {}
+                http_filters:
+                  - name: envoy.filters.http.ext_proc
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: ext_proc
+                          authority: localhost:{{ nok8s.epp.grpcPort }}
+                        timeout: 10s
+                      processing_mode:
+                        request_header_mode: SEND
+                        response_header_mode: SEND
+                        request_body_mode: FULL_DUPLEX_STREAMED
+                        response_body_mode: FULL_DUPLEX_STREAMED
+                        request_trailer_mode: SEND
+                        response_trailer_mode: SEND
+                      message_timeout: 1000s
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      suppress_envoy_headers: true
+                http2_protocol_options:
+                  max_concurrent_streams: 100
+                  initial_stream_window_size: 65536
+                  initial_connection_window_size: 1048576
+                use_remote_address: true
+                normalize_path: true
+                merge_slashes: true
+                server_header_transformation: PASS_THROUGH
+                common_http_protocol_options:
+                  headers_with_underscores_action: REJECT_REQUEST
+                path_with_escaped_slashes_action: UNESCAPE_AND_REDIRECT
+
+  clusters:
+    - name: original_destination_cluster
+      type: ORIGINAL_DST
+      connect_timeout: 1000s
+      lb_policy: CLUSTER_PROVIDED
+      circuit_breakers:
+        thresholds:
+          - max_connections: 40000
+            max_pending_requests: 40000
+            max_requests: 40000
+      original_dst_lb_config:
+        use_http_header: true
+        http_header_name: x-gateway-destination-endpoint
+
+    - name: ext_proc
+      type: STATIC
+      connect_timeout: 86400s
+      lb_policy: LEAST_REQUEST
+      circuit_breakers:
+        thresholds:
+          - max_connections: 40000
+            max_pending_requests: 40000
+            max_requests: 40000
+            max_retries: 1024
+      health_checks:
+        - timeout: 2s
+          interval: 10s
+          unhealthy_threshold: 3
+          healthy_threshold: 2
+          reuse_connection: true
+          grpc_health_check:
+            service_name: "envoy.service.ext_proc.v3.ExternalProcessor"
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options:
+              initial_stream_window_size: 65536
+              initial_connection_window_size: 1048576
+      load_assignment:
+        cluster_name: ext_proc
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: {{ nok8s.epp.grpcPort }}
+{% endif %}

--- a/config/templates/jinja/34_nok8s-containers.yaml.j2
+++ b/config/templates/jinja/34_nok8s-containers.yaml.j2
@@ -23,7 +23,9 @@ containers:
     image: "{{ nok8s.vllm.image }}:{{ nok8s.vllm.tag }}"
     hostPort: {{ nok8s.vllm.hostPort + i }}
     containerPort: {{ nok8s.vllm.containerPort }}
+    accelerator: {{ nok8s.vllm.accelerator | default('nvidia') }}
     gpus: "{{ nok8s.vllm.gpus }}"
+    deviceArgs: [{% for a in nok8s.vllm.deviceArgs | default([]) %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]
     shmSize: "{{ nok8s.vllm.shmSize }}"
     tensorParallel: {{ nok8s.vllm.tensorParallel }}
     extraArgs: [{% for a in nok8s.vllm.extraArgs %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]

--- a/config/templates/jinja/34_nok8s-containers.yaml.j2
+++ b/config/templates/jinja/34_nok8s-containers.yaml.j2
@@ -28,6 +28,8 @@ containers:
     deviceArgs: [{% for a in nok8s.vllm.deviceArgs | default([]) %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]
     shmSize: "{{ nok8s.vllm.shmSize }}"
     tensorParallel: {{ nok8s.vllm.tensorParallel }}
+    replicas: {{ nok8s.vllm.replicas }}
+    replicaIndex: {{ i }}
     extraArgs: [{% for a in nok8s.vllm.extraArgs %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 {% endfor %}
   - name: epp

--- a/config/templates/jinja/34_nok8s-containers.yaml.j2
+++ b/config/templates/jinja/34_nok8s-containers.yaml.j2
@@ -1,0 +1,45 @@
+{% if nok8s.enabled %}
+{# ============================================================================
+   nok8s container-launch spec.  This is NOT a Kubernetes object — it is an
+   authored manifest describing which containers step_06_nok8s_deploy.py must
+   launch (and step_06_nok8s_teardown.py must remove), plus the readiness
+   probes and the endpoint URL the run phase benchmarks against.  Rendering the
+   launch surface as data (rather than argv strings) keeps dry-run readable and
+   lets the step build docker vs podman commands correctly.
+   ============================================================================ #}
+runtime: {{ nok8s.runtime }}
+workspaceHostDir: "{{ nok8s.workspaceHostDir }}"
+hfTokenEnv: {{ nok8s.hfTokenEnv }}
+hfCacheDir: "{{ nok8s.vllm.hfCacheDir }}"
+model: {{ model.name }}
+endpoint: "http://localhost:{{ nok8s.envoy.listenPort }}"
+readiness:
+  vllmPorts: [{% for i in range(nok8s.vllm.replicas) %}{{ nok8s.vllm.hostPort + i }}{% if not loop.last %}, {% endif %}{% endfor %}]
+  envoyPort: {{ nok8s.envoy.listenPort }}
+containers:
+{% for i in range(nok8s.vllm.replicas) %}
+  - name: vllm-{{ i }}
+    kind: vllm
+    image: "{{ nok8s.vllm.image }}:{{ nok8s.vllm.tag }}"
+    hostPort: {{ nok8s.vllm.hostPort + i }}
+    containerPort: {{ nok8s.vllm.containerPort }}
+    gpus: "{{ nok8s.vllm.gpus }}"
+    shmSize: "{{ nok8s.vllm.shmSize }}"
+    tensorParallel: {{ nok8s.vllm.tensorParallel }}
+    extraArgs: [{% for a in nok8s.vllm.extraArgs %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+{% endfor %}
+  - name: epp
+    kind: epp
+    image: "{{ nok8s.epp.image }}:{{ nok8s.epp.tag }}"
+    grpcPort: {{ nok8s.epp.grpcPort }}
+    grpcHealthPort: {{ nok8s.epp.grpcHealthPort }}
+    metricsPort: {{ nok8s.epp.metricsPort }}
+    poolName: {{ nok8s.epp.poolName }}
+    poolNamespace: {{ nok8s.epp.poolNamespace }}
+    configMountDir: {{ nok8s.epp.configMountDir }}
+  - name: envoy
+    kind: envoy
+    image: "{{ nok8s.envoy.image }}:{{ nok8s.envoy.tag }}"
+    listenPort: {{ nok8s.envoy.listenPort }}
+    configMountPath: {{ nok8s.envoy.configMountPath }}
+{% endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1317,9 +1317,18 @@ nok8s:
     tag: *vllm-openai_version
     hostPort: 8000          # worker i is published on hostPort + i
     containerPort: 8000
-    tensorParallel: 1       # GPUs to shard each worker across
-    gpus: "all"             # docker --gpus value (podman uses CDI, see runtime)
-    shmSize: "20g"          # required for NCCL when tensorParallel > 1
+    tensorParallel: 1       # accelerators to shard each worker across
+    # Accelerator preset for exposing the device to the container:
+    #   nvidia | amd | intel | gaudi | cpu | spyre
+    # Only NVIDIA is validated end-to-end; others follow each backend's
+    # documented device flags. Change `image` to the matching vLLM backend.
+    accelerator: nvidia
+    gpus: "all"             # nvidia only: docker --gpus value (podman uses CDI)
+    # Raw runtime device flags; overrides the accelerator preset entirely.
+    # Use for IBM Spyre/AIU or any custom device wiring, e.g.
+    #   deviceArgs: ["--device", "/dev/kfd", "--device", "/dev/dri"]
+    deviceArgs: []
+    shmSize: "20g"          # required for NCCL/RCCL when tensorParallel > 1
     hfCacheDir: "~/.cache/huggingface"
     replicas: 1
     extraArgs: []           # appended after `serve <MODEL> --tensor-parallel-size=N`

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1330,6 +1330,10 @@ nok8s:
     deviceArgs: []
     shmSize: "20g"          # required for NCCL/RCCL when tensorParallel > 1
     hfCacheDir: "~/.cache/huggingface"
+    # Number of independent vLLM workers (EPP load-balances across them). With
+    # replicas > 1 each worker is pinned to its own slice of `tensorParallel`
+    # GPU indices (replica i -> devices i*TP .. i*TP+TP-1) via the accelerator's
+    # visible-devices env. Total GPUs used = replicas * tensorParallel.
     replicas: 1
     extraArgs: []           # appended after `serve <MODEL> --tensor-parallel-size=N`
 

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1293,6 +1293,56 @@ standalone:
   extraPodConfig: {}
 
 # ============================================================================
+# NO-KUBERNETES (nok8s) DEPLOYMENT CONFIGURATION
+# Runs the llm-d routing stack (vLLM + EPP + Envoy) as plain docker/podman
+# containers on the local host, with NO Kubernetes cluster.  The EPP uses the
+# file-discovery plugin (reads endpoints.yaml) instead of a k8s InferencePool.
+# Wired: client -> Envoy (listenPort) -> EPP (grpcPort) -> vLLM (hostPort).
+# Opt-in via `nok8s.enabled: true` in a scenario or `-t nok8s` on the CLI.
+# ============================================================================
+nok8s:
+  enabled: false
+  # Container runtime: "docker" or "podman".
+  runtime: docker
+  # Host env var read at standup time and passed to the vLLM container so it
+  # can pull gated models from Hugging Face.
+  hfTokenEnv: HUGGING_FACE_HUB_TOKEN
+  # Host directory where rendered EPP/Envoy configs are staged and bind-mounted
+  # from (avoids sudo writes to /etc).
+  workspaceHostDir: "~/.llmdbench/nok8s"
+
+  # vLLM inference worker(s)
+  vllm:
+    image: docker.io/vllm/vllm-openai
+    tag: *vllm-openai_version
+    hostPort: 8000          # worker i is published on hostPort + i
+    containerPort: 8000
+    tensorParallel: 1       # GPUs to shard each worker across
+    gpus: "all"             # docker --gpus value (podman uses CDI, see runtime)
+    shmSize: "20g"          # required for NCCL when tensorParallel > 1
+    hfCacheDir: "~/.cache/huggingface"
+    replicas: 1
+    extraArgs: []           # appended after `serve <MODEL> --tensor-parallel-size=N`
+
+  # Endpoint Picker (router brain), file-discovery mode
+  epp:
+    image: ghcr.io/llm-d/llm-d-router-endpoint-picker
+    tag: v0.9.0
+    grpcPort: 9002
+    grpcHealthPort: 9003
+    metricsPort: 9090
+    poolName: file-discovery
+    poolNamespace: default
+    configMountDir: /etc/epp
+
+  # Envoy front door
+  envoy:
+    image: docker.io/envoyproxy/envoy
+    tag: distroless-v1.33.2
+    listenPort: 8081
+    configMountPath: /etc/envoy/envoy.yaml
+
+# ============================================================================
 # KUSTOMIZE DEPLOYMENT CONFIGURATION
 # Opt-in via `kustomize.enabled: true` in a scenario or `-t kustomize` on
 # the CLI. Defined here (matching modelservice/standalone/fma) so the

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -1,0 +1,123 @@
+# No-Kubernetes (`nok8s`) deployment
+
+## Concept
+
+The `nok8s` deployment method runs the llm-d routing stack — **vLLM + EPP
+(router) + Envoy** — as plain `docker`/`podman` containers on a single host,
+with **no Kubernetes cluster**. The benchmark harness (`llmdbenchmark run`)
+also runs as a **local container** against the Envoy front door, so the entire
+standup → run → teardown lifecycle is cluster-free.
+
+```
+client ──▶ Envoy :8081 ──ext_proc──▶ EPP :9002 ──▶ picks a worker
+              │                        (reads endpoints.yaml, file-discovery)
+              └──────────────────────▶ vLLM :8000  (OpenAI-compatible API)
+```
+
+Instead of watching a Kubernetes `InferencePool`, the EPP reads its worker
+inventory from a YAML file via the file-discovery plugin. This is the harness
+equivalent of the upstream
+[llm-d no-Kubernetes guide](https://github.com/llm-d/llm-d/tree/main/guides/no-kubernetes-deployment).
+
+Use it for HPC/Slurm nodes, bare-metal boxes, or a single GPU workstation
+where standing up Kubernetes is not worth it.
+
+## Prerequisites
+
+`llmdbenchmark standup` validates these automatically in step 00; a missing or
+broken container runtime is fatal, the rest are warnings.
+
+| Requirement | Notes |
+|-------------|-------|
+| Linux host + NVIDIA GPU(s) | Images/flags are NVIDIA + vLLM specific |
+| NVIDIA driver | `nvidia-smi` must work |
+| Container runtime | **docker** or **podman** (`nok8s.runtime`) |
+| NVIDIA Container Toolkit | docker: `nvidia-ctk runtime configure --runtime=docker`; podman: `nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml` |
+| Hugging Face token | `export HUGGING_FACE_HUB_TOKEN=hf_...` (only for gated models) |
+| Free host ports | 8000 (vLLM), 8081 (Envoy), 9002/9003/9090 (EPP), 19000 (Envoy admin) |
+| Outbound network | to pull images (docker.io, ghcr.io) and model weights (Hugging Face) |
+| `llmdbenchmark` CLI | `./install.sh` (Python 3.11+) |
+
+**Not required:** Kubernetes, `kubectl`/`oc`, `helm`/`helmfile`, Gateway CRDs,
+PVCs, or any cluster access.
+
+Verify GPU-in-container before you start:
+```bash
+docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi
+```
+
+## Usage
+
+```bash
+export HUGGING_FACE_HUB_TOKEN=hf_...     # for gated models
+
+# Bring up vLLM + EPP + Envoy as local containers (step 00 runs the preflight).
+llmdbenchmark --spec config/specification/nok8s.yaml.j2 --base-dir . standup --methods nok8s
+
+# Benchmark it — the harness runs as a local container against http://localhost:8081.
+llmdbenchmark --spec config/specification/nok8s.yaml.j2 --base-dir . run
+
+# Remove the containers.
+llmdbenchmark --spec config/specification/nok8s.yaml.j2 --base-dir . teardown --methods nok8s
+```
+
+`--methods nok8s` is optional when the scenario sets `nok8s.enabled: true`
+(the method is auto-detected), but harmless to pass explicitly.
+
+Send your own requests to the Envoy front door:
+```bash
+curl -s http://localhost:8081/v1/completions -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen2.5-0.5B-Instruct","prompt":"Hello","max_tokens":32}'
+```
+
+## Configuration
+
+Selected by `nok8s.enabled: true` in a scenario (mutually exclusive with
+`modelservice`/`standalone`/`fma`/`kustomize`). See
+[`config/scenarios/nok8s.yaml`](../config/scenarios/nok8s.yaml) for a complete
+single-GPU example. Key fields (full defaults in
+`config/templates/values/defaults.yaml`):
+
+| Key | Meaning |
+|-----|---------|
+| `nok8s.runtime` | `docker` or `podman` (GPU flag switches to CDI for podman) |
+| `nok8s.hfTokenEnv` | Host env var passed to vLLM for HF auth |
+| `nok8s.workspaceHostDir` | Host dir where EPP/Envoy configs are staged + bind-mounted |
+| `nok8s.vllm.{image,tag,hostPort,tensorParallel,gpus,shmSize,replicas,extraArgs}` | vLLM worker(s); worker *i* is published on `hostPort + i` |
+| `nok8s.epp.{image,tag,grpcPort,grpcHealthPort,metricsPort}` | Endpoint Picker |
+| `nok8s.envoy.{image,tag,listenPort}` | Envoy front door (the run target) |
+| `model.{name,huggingfaceId}` | Set both; standup uses `name`, run reads `huggingfaceId` |
+
+Sizing (fp16, single GPU): ~16 GB → 7–8B · ~24 GB → 8B · ~40 GB → 14B ·
+~80 GB → 32B. For bigger models use `nok8s.vllm.extraArgs`
+(e.g. `["--max-model-len","16384","--gpu-memory-utilization","0.95"]`) or an
+FP8 checkpoint.
+
+## How it maps to the pipeline
+
+| Phase | nok8s behaviour |
+|-------|-----------------|
+| standup step 00 | Preflight: runtime / GPU / ports / token (replaces helm/kubectl checks) |
+| standup steps 02–05 | Skipped (no namespace, PVC, model-download Job) |
+| standup step 06 | `step_06_nok8s_deploy` launches the containers, waits for `/v1/models`, records `http://localhost:<listenPort>` |
+| run step 03 | Endpoint resolves to the local Envoy URL (no cluster query) |
+| run step 07 | `step_07_deploy_harness_local` runs the harness image locally with `--network host`; results land in `workspace/results/` via a bind-mount |
+| teardown step 06 | `step_06_nok8s_teardown` removes the containers |
+
+## Multiple workers
+
+Set `nok8s.vllm.replicas: N` (needs `N` GPUs, or a small model sharing one GPU
+with `--gpu-memory-utilization`). Each worker is published on `hostPort + i`
+and added to the EPP endpoints file, so the router load-balances / prefix-routes
+across them.
+
+## Troubleshooting
+
+- **Preflight fails on runtime** — install docker/podman or set `nok8s.runtime`.
+- **vLLM container exits at load** — usually a too-large model for VRAM or a bad
+  HF token; check `docker logs vllm-0`. Lower the model size or add
+  `--max-model-len`/`--gpu-memory-utilization` via `nok8s.vllm.extraArgs`.
+- **Envoy 503** — a worker isn't up; confirm `curl http://localhost:8000/v1/models`.
+- **podman + GPU** — ensure the CDI spec exists: `nvidia-ctk cdi list` should show
+  `nvidia.com/gpu=all`.
+- **Ports busy** — a stale run; `teardown --methods nok8s`, or change the ports.

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -93,6 +93,39 @@ Sizing (fp16, single GPU): ~16 GB → 7–8B · ~24 GB → 8B · ~40 GB → 14B 
 (e.g. `["--max-model-len","16384","--gpu-memory-utilization","0.95"]`) or an
 FP8 checkpoint.
 
+## Accelerators
+
+The router (EPP + Envoy) and the benchmark harness are accelerator-agnostic;
+only the **vLLM worker** is accelerator-specific. Select the accelerator with
+`nok8s.vllm.accelerator` and set `nok8s.vllm.image` to the matching vLLM
+backend. Only **NVIDIA is validated end-to-end**; the others use each backend's
+documented device flags.
+
+| `accelerator` | Device flags emitted | vLLM image (example) |
+|---------------|----------------------|----------------------|
+| `nvidia` (default) | `--gpus all` (docker) / `--device nvidia.com/gpu=all` (podman) | `vllm/vllm-openai` |
+| `amd` | `--device /dev/kfd --device /dev/dri --group-add video` | `rocm/vllm` |
+| `intel` | `--device /dev/dri` | Intel vLLM XPU image |
+| `gaudi` | `--runtime=habana -e HABANA_VISIBLE_DEVICES=all` | Habana vLLM image |
+| `cpu` | *(none)* | vLLM CPU build |
+| `spyre` | *(none -- set `deviceArgs`)* | IBM vLLM-Spyre image |
+
+For anything not covered by a preset — including **IBM Spyre / AIU** — use the
+raw escape hatch `nok8s.vllm.deviceArgs`, which overrides the preset entirely:
+
+```yaml
+nok8s:
+  vllm:
+    accelerator: spyre
+    image: <ibm-vllm-spyre-image>
+    deviceArgs: ["--device", "/dev/vfio/vfio", "--device", "/dev/vfio/<grp>"]
+    extraArgs: ["--..."]   # any Spyre-specific vLLM flags
+```
+
+Step 00 probes the accelerator when it can (`nvidia-smi`/`rocm-smi`/`xpu-smi`/
+`hl-smi`); `cpu`/`spyre`/custom are not probed (a note is logged) — ensure the
+device and image match yourself.
+
 ## How it maps to the pipeline
 
 | Phase | nok8s behaviour |

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -137,12 +137,39 @@ device and image match yourself.
 | run step 07 | `step_07_deploy_harness_local` runs the harness image locally with `--network host`; results land in `workspace/results/` via a bind-mount |
 | teardown step 06 | `step_06_nok8s_teardown` removes the containers |
 
-## Multiple workers
+## Multiple GPUs
 
-Set `nok8s.vllm.replicas: N` (needs `N` GPUs, or a small model sharing one GPU
-with `--gpu-memory-utilization`). Each worker is published on `hostPort + i`
-and added to the EPP endpoints file, so the router load-balances / prefix-routes
-across them.
+Two modes, driven by `tensorParallel` and `replicas`:
+
+**One model sharded across GPUs (tensor parallelism)** — serve a large model:
+```yaml
+nok8s:
+  vllm:
+    tensorParallel: 4      # shard one model across 4 GPUs
+    replicas: 1
+    shmSize: "40g"         # bump for NCCL/RCCL with TP > 1
+```
+→ `--gpus all --tensor-parallel-size=4`.
+
+**Multiple independent workers (throughput / router load-balancing)** — set
+`replicas: N`. Each worker is published on `hostPort + i`, added to the EPP
+endpoints file (so the router load-balances / prefix-routes across them), and
+**pinned to its own slice of `tensorParallel` GPU indices** (replica *i* →
+devices `i*TP .. i*TP+TP-1`) via the accelerator's visible-devices env
+(`CUDA_VISIBLE_DEVICES` / `HIP_VISIBLE_DEVICES` / `ZE_AFFINITY_MASK`) so workers
+don't contend for the same GPUs.
+
+**Total GPUs used = `replicas × tensorParallel`.** Examples on an 8-GPU host:
+| Goal | `replicas` | `tensorParallel` |
+|------|-----------|------------------|
+| One big model sharded 8-way | 1 | 8 |
+| 8 workers, 1 GPU each (max throughput) | 8 | 1 |
+| 2 workers, each sharded over 4 | 2 | 4 |
+
+Step 00 warns if `replicas × tensorParallel` exceeds the detected GPU count
+(NVIDIA). Per-replica pinning uses index-based env vars for nvidia/amd/intel;
+for gaudi/spyre or custom wiring, set `nok8s.vllm.deviceArgs` (which disables
+auto-pinning and puts you in control).
 
 ## Troubleshooting
 

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -83,7 +83,7 @@ single-GPU example. Key fields (full defaults in
 | `nok8s.runtime` | `docker` or `podman` (GPU flag switches to CDI for podman) |
 | `nok8s.hfTokenEnv` | Host env var passed to vLLM for HF auth |
 | `nok8s.workspaceHostDir` | Host dir where EPP/Envoy configs are staged + bind-mounted |
-| `nok8s.vllm.{image,tag,hostPort,tensorParallel,gpus,shmSize,replicas,extraArgs}` | vLLM worker(s); worker *i* is published on `hostPort + i` |
+| `nok8s.vllm.{image,tag,hostPort,tensorParallel,accelerator,gpus,deviceArgs,shmSize,replicas,extraArgs}` | vLLM worker(s); worker *i* is published on `hostPort + i` (see Accelerators for `accelerator`/`deviceArgs`) |
 | `nok8s.epp.{image,tag,grpcPort,grpcHealthPort,metricsPort}` | Endpoint Picker |
 | `nok8s.envoy.{image,tag,listenPort}` | Envoy front door (the run target) |
 | `model.{name,huggingfaceId}` | Set both; standup uses `name`, run reads `huggingfaceId` |

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -5,9 +5,10 @@
 In order to allow reproducible and flexible experiments, and taking into account that the configuration paramaters have significant impact on the overall performance, it is necessary to provide the user with the ability to `standup` and `teardown` stacks.
 
 ## Methods
-Currently, two main standup methods are supported
+Currently, the following standup methods are supported
 a) "Standalone", with multiple VLLM `pods` controlled by a `deployment` behind a single `service`
 b) "llm-d", which leverages a combination of [llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra.git) and [llm-d-modelservice](https://github.com/llm-d/llm-d-model-service.git) to deploy a full-fledged `llm-d` stack
+c) "No-Kubernetes (`nok8s`)", which runs the routing stack (vLLM + EPP + Envoy) as plain `docker`/`podman` containers on a single host, with **no cluster** -- see [No-Kubernetes deploy method](nok8s.md)
 
 ## Scenarios
 All the information required for the standup of a stack is contained on a "scenario file". This information is encoded in the form of environment variables, with default values defined in `config/defaults.yaml` which can be then overriden inside a [scenario file](../config/scenarios) (YAML-based) or via [specification templates](../config/specification) (Jinja2 `.yaml.j2` files).

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-07-10 18:59:33` (UTC)
-- Generated against git ref: `b26be2d5caa9a161d3d90cd5bf68908ac952f4ff`
+- Generated at: `2026-07-13 21:15:16` (UTC)
+- Generated against git ref: `af463d9747e97e364313276ad1eb9b5f897c69ce`
 
 ## System Tool Dependencies
 
@@ -108,7 +108,7 @@ annotated with their `pyproject.toml` line.
 | **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
 | **annotated-doc** | `0.0.4` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
 | **annotated-types** | `0.7.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
-| **anyio** | `4.14.1` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
+| **anyio** | `4.14.2` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
 | **attrs** | `26.1.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
 | **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
 | **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
@@ -128,7 +128,7 @@ annotated with their `pyproject.toml` line.
 | **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
 | **fsspec** | `2026.6.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
 | **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
-| **GitPython** | `3.1.50` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
+| **GitPython** | `3.1.51` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
 | **google-api-core** | `2.31.0` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
 | **google-auth** | `2.55.2` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
 | **google-cloud-core** | `2.6.0` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
@@ -187,7 +187,7 @@ annotated with their `pyproject.toml` line.
 | **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
 | **python-multipart** | `0.0.32` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
 | **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
-| **regex** | `2026.6.28` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
+| **regex** | `2026.7.10` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
 | **requests** | `2.34.2` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
 | **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
@@ -202,14 +202,14 @@ annotated with their `pyproject.toml` line.
 | **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
 | **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
 | **tqdm** | `4.68.4` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
-| **transformers** | `5.13.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **transformers** | `5.13.1` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
 | **typer** | `0.26.8` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
 | **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
 | **typing_extensions** | `4.16.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
 | **urllib3** | `2.7.0` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
 | **uvicorn** | `0.48.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
 | **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
-| **virtualenv** | `21.6.0` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
+| **virtualenv** | `21.6.1` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
 | **watchfiles** | `1.2.0` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
 | **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
 | **websockets** | `16.1` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -679,7 +679,8 @@ def _print_standup_summary(context, result, logger):
     logger.log_info("  STANDUP COMPLETE")
     logger.log_info("=" * W)
     logger.log_info(f"  User:       {username}")
-    logger.log_info(f"  Platform:   {platform}")
+    if not context.container_only:
+        logger.log_info(f"  Platform:   {platform}")
     logger.log_info(f"  Mode:       {mode}")
     if len(stack_models) > 1:
         logger.log_info(f"  Models:     {len(stack_models)} (one per stack)")
@@ -690,18 +691,22 @@ def _print_standup_summary(context, result, logger):
             stack_models[0][1] if stack_models else (context.model_name or "unknown")
         )
         logger.log_info(f"  Model:      {single_model}")
-    logger.log_info(f"  Namespace:  {ns}")
-    if harness_ns != ns:
-        logger.log_info(f"  Harness NS: {harness_ns}")
+    # Namespace / Harness NS / Gateway are Kubernetes concepts; omit them for
+    # the no-Kubernetes (container_only) path.
+    if not context.container_only:
+        logger.log_info(f"  Namespace:  {ns}")
+        if harness_ns != ns:
+            logger.log_info(f"  Harness NS: {harness_ns}")
     logger.log_info(f"  Methods:    {methods}")
-    # Gateway class only takes effect on the modelservice path; for the
-    # other deploy methods the label says "n/a (...)" so the operator
-    # isn't misled by the scenario's default value.
-    from llmdbenchmark.utilities.cluster import resolve_phase_gateway_label
+    if not context.container_only:
+        # Gateway class only takes effect on the modelservice path; for the
+        # other deploy methods the label says "n/a (...)" so the operator
+        # isn't misled by the scenario's default value.
+        from llmdbenchmark.utilities.cluster import resolve_phase_gateway_label
 
-    gateway_label = resolve_phase_gateway_label(context)
-    if gateway_label:
-        logger.log_info(f"  Gateway:    {gateway_label}")
+        gateway_label = resolve_phase_gateway_label(context)
+        if gateway_label:
+            logger.log_info(f"  Gateway:    {gateway_label}")
     logger.log_info(f"  Stacks:     {stacks}")
 
     total_steps = len(result.global_results)

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1124,7 +1124,8 @@ def _execute_run(args, logger, render_plan_errors):
             stack_models[0][1] if stack_models else (context.model_name or "unknown")
         )
         logger.log_info(f"  Model:         {single_model}")
-    logger.log_info(f"  Namespace:     {namespace}")
+    if not context.container_only:
+        logger.log_info(f"  Namespace:     {namespace}")
     logger.log_info(f"  Mode:          {mode}")
     logger.log_info(f"  Parallelism:   {parallelism}")
     if experiment_ids:
@@ -1139,13 +1140,16 @@ def _execute_run(args, logger, render_plan_errors):
                     logger.log_info(
                         f"      [{i}/{parallelism}] {local_path.name} ({file_count} files)"
                     )
-    kube_bin = "oc" if context.is_openshift else "kubectl"
     logger.log_info(f"  Local results: {results_dir}")
-    logger.log_info(
-        f"  PVC results:   {kube_bin} exec -n {namespace} "
-        f"$({kube_bin} get pod -n {namespace} -l role=llm-d-benchmark-data-access "
-        f"-o jsonpath='{{.items[0].metadata.name}}') -- ls /requests/"
-    )
+    # The PVC/data-access-pod hint is Kubernetes-only; nok8s writes results
+    # straight to the local dir shown above.
+    if not context.container_only:
+        kube_bin = "oc" if context.is_openshift else "kubectl"
+        logger.log_info(
+            f"  PVC results:   {kube_bin} exec -n {namespace} "
+            f"$({kube_bin} get pod -n {namespace} -l role=llm-d-benchmark-data-access "
+            f"-o jsonpath='{{.items[0].metadata.name}}') -- ls /requests/"
+        )
     logger.log_info("=" * 60)
     logger.log_info(
         f"Run complete (mode={mode}, harness={harness}).",
@@ -1153,7 +1157,11 @@ def _execute_run(args, logger, render_plan_errors):
     )
 
     # --- Store run parameters as ConfigMap in namespace ---
-    if not context.dry_run:
+    # Skipped for nok8s (container_only): the store applies a ConfigMap via
+    # kubectl, and there is no cluster. Per-experiment run_metadata is already
+    # written into the local results dir by the harness, so the audit trail
+    # remains on disk.
+    if not context.dry_run and not context.container_only:
         _store_run_parameters_configmap(
             context, harness, workload, experiment_ids, logger
         )

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -296,6 +296,15 @@ def _load_stack_info_from_config(config_file, stack_name=""):
                 "kustomize_enabled": (
                     plan_config.get("kustomize", {}).get("enabled", False)
                 ),
+                "nok8s_enabled": (plan_config.get("nok8s", {}).get("enabled", False)),
+                "nok8s_listen_port": (
+                    plan_config.get("nok8s", {})
+                    .get("envoy", {})
+                    .get("listenPort", 8081)
+                ),
+                "nok8s_runtime": (
+                    plan_config.get("nok8s", {}).get("runtime", "docker")
+                ),
                 "harness": plan_config.get("harness", {}),
             }
     except (OSError, _yaml.YAMLError):
@@ -374,6 +383,7 @@ def _resolve_deploy_methods(args, plan_info, logger, phase="standup"):
     fma = plan_info.get("fma_enabled", False)
     modelservice = plan_info.get("modelservice_enabled", False)
     kustomize = plan_info.get("kustomize_enabled", False)
+    nok8s = plan_info.get("nok8s_enabled", False)
 
     if phase == "run":
         # Run phase returns all enabled methods for endpoint detection
@@ -386,6 +396,8 @@ def _resolve_deploy_methods(args, plan_info, logger, phase="standup"):
             methods.append("modelservice")
         if kustomize:
             methods.append("kustomize")
+        if nok8s:
+            methods.append("nok8s")
         if methods:
             logger.log_info(
                 f"Auto-detected deploy method(s) from plan: {', '.join(methods)}"
@@ -393,6 +405,9 @@ def _resolve_deploy_methods(args, plan_info, logger, phase="standup"):
             return methods
     else:
         # Standup/teardown: treat as mutually exclusive
+        if nok8s:
+            logger.log_info("Auto-detected deploy method from plan: nok8s")
+            return ["nok8s"]
         if kustomize:
             logger.log_info("Auto-detected deploy method from plan: kustomize")
             return ["kustomize"]
@@ -432,7 +447,8 @@ def _do_standup(args, logger, render_plan_errors):
         plan_info,
     )
 
-    if not namespace:
+    container_only = "nok8s" in deployed_methods
+    if not namespace and not container_only:
         raise PhaseError(
             "No namespace specified. Set 'namespace.name' in your scenario "
             "YAML, defaults.yaml, or pass --namespace on the CLI."
@@ -453,6 +469,9 @@ def _do_standup(args, logger, render_plan_errors):
         harness_namespace=harness_ns,
         model_name=plan_info.get("model_name"),
         logger=logger,
+        container_only=container_only,
+        container_runtime=plan_info.get("nok8s_runtime", "docker"),
+        nok8s_deploy_timeout=int(getattr(args, "nok8s_deploy_timeout", 900) or 900),
         standalone_deploy_timeout=int(
             getattr(args, "standalone_deploy_timeout", 900) or 900
         ),
@@ -497,8 +516,12 @@ def _execute_standup(args, logger, render_plan_errors):
 
     _print_standup_summary(context, result, logger)
 
-    # Auto-chain smoketest after standup unless --skip-smoketest
-    skip_smoketest = getattr(args, "skip_smoketest", False)
+    # Auto-chain smoketest after standup unless --skip-smoketest.
+    # nok8s has no cluster/namespace for the smoketest pod and the deploy step
+    # already curls /v1/models for readiness, so skip the chained smoketest.
+    skip_smoketest = getattr(args, "skip_smoketest", False) or (
+        "nok8s" in (context.deployed_methods or [])
+    )
     if not skip_smoketest:
         logger.log_info("")
         logger.log_info(
@@ -721,7 +744,8 @@ def _do_teardown(args, logger, render_plan_errors):
         plan_info,
     )
 
-    if not namespace:
+    container_only = "nok8s" in deployed_methods
+    if not namespace and not container_only:
         raise PhaseError(
             "No namespace specified. Set 'namespace.name' in your scenario "
             "YAML, defaults.yaml, or pass --namespace on the CLI."
@@ -738,6 +762,8 @@ def _do_teardown(args, logger, render_plan_errors):
         current_phase=Phase.TEARDOWN,
         kubeconfig=getattr(args, "kubeconfig", None),
         deployed_methods=deployed_methods,
+        container_only=container_only,
+        container_runtime=plan_info.get("nok8s_runtime", "docker"),
         deep_clean=getattr(args, "deep", False),
         release=getattr(args, "release", "llmdbench"),
         namespace=namespace,
@@ -800,6 +826,12 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
 
     endpoint_url = getattr(args, "endpoint_url", None)
     run_config_file = getattr(args, "run_config", None)
+    container_only = "nok8s" in deployed_methods
+    # No-Kubernetes: default the benchmark target to the local Envoy front door
+    # so the run is fully cluster-free (flips is_run_only_mode, skipping k8s
+    # endpoint discovery and namespace validation).
+    if container_only and not endpoint_url:
+        endpoint_url = f"http://localhost:{plan_info.get('nok8s_listen_port', 8081)}"
     is_run_only = bool(endpoint_url or run_config_file)
 
     if not namespace and not is_run_only:
@@ -857,6 +889,8 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         analyze_locally=getattr(args, "analyze", False),
         endpoint_url=endpoint_url,
         run_config_file=run_config_file,
+        container_only=container_only,
+        container_runtime=plan_info.get("nok8s_runtime", "docker"),
         generate_config_only=getattr(args, "generate_config", False),
         dataset_url=getattr(args, "dataset", None),
         harness_data_access_timeout=int(

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -117,8 +117,15 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # Standup pod deployment timeouts
     kustomize_deploy_timeout: int = 900
     standalone_deploy_timeout: int = 900
+    nok8s_deploy_timeout: int = 900
     gateway_deploy_timeout: int = 120
     modelservice_deploy_timeout: int = 1500
+
+    # No-Kubernetes (nok8s) deployment: run the stack + harness as local
+    # containers on the host, with no cluster at all.  When container_only is
+    # True, cluster resolution is skipped and steps talk to docker/podman.
+    container_only: bool = False
+    container_runtime: str = "docker"
 
     pvc_bind_timeout: int = 240
 
@@ -162,6 +169,12 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     def resolve_cluster(self) -> None:
         """Resolve cluster connectivity and metadata (idempotent)."""
         if self._cluster_resolved:
+            return
+        # No-Kubernetes deployment: there is no cluster to resolve.  Still
+        # build a CommandExecutor so steps can invoke docker/podman.
+        if self.container_only:
+            self.rebuild_cmd()
+            self._cluster_resolved = True
             return
         from llmdbenchmark.utilities.cluster import resolve_cluster as _resolve
 

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -36,7 +36,7 @@ def add_subcommands(
         "-t",
         "--methods",
         default=env("LLMDBENCH_METHODS"),
-        help="Deploy method used during standup (standalone, modelservice, or custom resource name).",
+        help="Deploy method used during standup (standalone, modelservice, nok8s, or custom resource name).",
     )
     run_parser.add_argument(
         "--gateway-class",

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -45,7 +45,7 @@ def add_subcommands(
         "-t",
         "--methods",
         default=env("LLMDBENCH_METHODS"),
-        help="Standup methods (standalone, modelservice, fma, kustomize).",
+        help="Standup methods (standalone, modelservice, fma, kustomize, nok8s).",
     )
     standup_parser.add_argument(
         "--gateway-class",
@@ -127,6 +127,12 @@ def add_subcommands(
         type=int,
         default=env_int("LLMDBENCH_STANDALONE_DEPLOY_TIMEOUT"),
         help="Seconds to wait for the vLLM pods to deploy during standup in standalone mode.",
+    )
+    standup_parser.add_argument(
+        "--nok8s-deploy-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_NOK8S_DEPLOY_TIMEOUT"),
+        help="Seconds to wait for the vLLM/EPP/Envoy containers to become ready in nok8s mode.",
     )
     standup_parser.add_argument(
         "--gateway-deploy-timeout",

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -582,7 +582,7 @@ class RenderPlans:
         """Override deploy method based on CLI ``--methods`` flag.
 
         Accepts ``--methods standalone``, ``--methods modelservice``,
-        ``--methods fma`` or ``--methods kustomize``.
+        ``--methods fma``, ``--methods kustomize`` or ``--methods nok8s``.
         Only one method may be active at a time.
 
         Without ``--methods``, the scenario YAML value is used as-is.
@@ -612,23 +612,41 @@ class RenderPlans:
                 "choose one. Using kustomize."
             )
             methods = ["kustomize"]
+        if "nok8s" in methods and any(
+            m in methods for m in ("standalone", "modelservice", "fma", "kustomize")
+        ):
+            self.logger.log_warning(
+                "Cannot combine nok8s with another deploy method -- "
+                "choose one. Using nok8s."
+            )
+            methods = ["nok8s"]
 
         standalone_config = result.setdefault("standalone", {})
         modelservice_config = result.setdefault("modelservice", {})
         fma_config = result.setdefault("fma", {})
         kustomize_config = result.setdefault("kustomize", {})
+        nok8s_config = result.setdefault("nok8s", {})
 
-        if "standalone" in methods:
+        if "nok8s" in methods:
+            standalone_config["enabled"] = False
+            modelservice_config["enabled"] = False
+            fma_config["enabled"] = False
+            kustomize_config["enabled"] = False
+            nok8s_config["enabled"] = True
+            self.logger.log_info("Deploy method from CLI: nok8s")
+        elif "standalone" in methods:
             standalone_config["enabled"] = True
             modelservice_config["enabled"] = False
             fma_config["enabled"] = False
             kustomize_config["enabled"] = False
+            nok8s_config["enabled"] = False
             self.logger.log_info("Deploy method from CLI: standalone")
         elif "kustomize" in methods:
             standalone_config["enabled"] = False
             modelservice_config["enabled"] = False
             fma_config["enabled"] = False
             kustomize_config["enabled"] = True
+            nok8s_config["enabled"] = False
             self.logger.log_info("Deploy method from CLI: kustomize")
         elif "modelservice" in methods or "fma" in methods:
             # Either or both. FMA layers on top of modelservice (or runs
@@ -637,6 +655,7 @@ class RenderPlans:
             # _resolve_deploy_methods returns both when both are enabled.
             standalone_config["enabled"] = False
             kustomize_config["enabled"] = False
+            nok8s_config["enabled"] = False
             modelservice_config["enabled"] = "modelservice" in methods
             fma_config["enabled"] = "fma" in methods
             chosen = [m for m in ("modelservice", "fma") if m in methods]
@@ -1548,8 +1567,15 @@ class RenderPlans:
                     f"Version resolution had issues for stack {stack_name}: {e}"
                 )
 
-        # Raises RuntimeError if "auto" values are present but cluster is unreachable
-        if self.cluster_resource_resolver:
+        # Raises RuntimeError if "auto" values are present but cluster is
+        # unreachable. Skipped for the no-Kubernetes (nok8s) method: there is
+        # no cluster to scan, and the accelerator auto-detection fields belong
+        # to the (disabled) k8s methods.
+        cli_nok8s = bool(self.cli_methods) and "nok8s" in [
+            m.strip() for m in self.cli_methods.split(",")
+        ]
+        is_nok8s = cli_nok8s or merged_values.get("nok8s", {}).get("enabled", False)
+        if self.cluster_resource_resolver and not is_nok8s:
             merged_values = self.cluster_resource_resolver.resolve_all(merged_values)
 
         merged_values = self._resolve_namespace(merged_values)

--- a/llmdbenchmark/run/steps/__init__.py
+++ b/llmdbenchmark/run/steps/__init__.py
@@ -13,6 +13,9 @@ from llmdbenchmark.run.steps.step_06_create_profile_configmap import (
     CreateProfileConfigmapStep,
 )
 from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
+from llmdbenchmark.run.steps.step_07_deploy_harness_local import (
+    DeployHarnessLocalStep,
+)
 from llmdbenchmark.run.steps.step_08_wait_completion import WaitCompletionStep
 from llmdbenchmark.run.steps.step_09a_capture_cluster_state import (
     CaptureClusterStateStep,
@@ -37,6 +40,7 @@ def get_run_steps() -> list[Step]:
         RenderProfilesStep(),
         CreateProfileConfigmapStep(),
         DeployHarnessStep(),
+        DeployHarnessLocalStep(),
         WaitCompletionStep(),
         CollectResultsStep(),
         CaptureClusterStateStep(),

--- a/llmdbenchmark/run/steps/step_01_cleanup_previous.py
+++ b/llmdbenchmark/run/steps/step_01_cleanup_previous.py
@@ -19,7 +19,9 @@ class RunCleanupPreviousStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip cleanup in skip-run mode (collecting results only)."""
+        """Skip cleanup in skip-run mode, or for nok8s (no cluster)."""
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         return context.harness_skip_run
 
     def execute(

--- a/llmdbenchmark/run/steps/step_02_harness_namespace.py
+++ b/llmdbenchmark/run/steps/step_02_harness_namespace.py
@@ -31,5 +31,10 @@ class HarnessNamespaceStep(_HarnessNamespaceStep):
         PVC. Prepare it here regardless of deploy method (idempotent if a
         non-kustomize standup already created it). Only skip in collect-only
         (skip-run) mode, where no harness pod is deployed.
+
+        Also skipped for nok8s: the harness runs as a local container writing
+        to a host bind-mount, so no k8s namespace/PVC/data-access pod exists.
         """
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         return context.harness_skip_run

--- a/llmdbenchmark/run/steps/step_04_verify_model.py
+++ b/llmdbenchmark/run/steps/step_04_verify_model.py
@@ -20,7 +20,14 @@ class VerifyModelStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip model verification in skip-run mode or fma."""
+        """Skip in skip-run mode, fma, or nok8s.
+
+        nok8s: ``test_model_serving`` probes from an in-cluster curl pod, which
+        cannot run without a cluster; standup already verified /v1/models
+        locally, so verification here would be a futile kubectl call.
+        """
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         return context.harness_skip_run or is_fma_only_mode(context)
 
     def execute(

--- a/llmdbenchmark/run/steps/step_06_create_profile_configmap.py
+++ b/llmdbenchmark/run/steps/step_06_create_profile_configmap.py
@@ -21,6 +21,11 @@ class CreateProfileConfigmapStep(Step):
             per_stack=True,
         )
 
+    def should_skip(self, context: ExecutionContext) -> bool:
+        # nok8s runs the harness as a local container with profiles and
+        # scripts bind-mounted from disk -- no ConfigMaps needed.
+        return "nok8s" in (context.deployed_methods or [])
+
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
     ) -> StepResult:

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -45,7 +45,9 @@ class DeployHarnessStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip deployment in skip-run mode."""
+        """Skip in skip-run mode, or for nok8s (handled by the local step)."""
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         return context.harness_skip_run
 
     def execute(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements

--- a/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
@@ -146,6 +146,10 @@ class DeployHarnessLocalStep(Step):
                     f"-e LLMDBENCH_RUN_EXPERIMENT_ID={experiment_id} "
                     f"-e LLMDBENCH_DEPLOY_METHODS={deploy_method} "
                     f"-e LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_PREFIX=/requests "
+                    # Harness reads the profile from
+                    # $LLMDBENCH_RUN_WORKSPACE_DIR/profiles/<harness>/<workload>;
+                    # keep it in sync with the profiles bind-mount below.
+                    f"-e LLMDBENCH_RUN_WORKSPACE_DIR=/workspace "
                     f"-e {hf_token_env} "
                     f"-v {results_dir}:/requests "
                     f"-v {profiles_dir}:/workspace/profiles "

--- a/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
@@ -151,7 +151,9 @@ class DeployHarnessLocalStep(Step):
                     f"-v {profiles_dir}:/workspace/profiles "
                     f"-v {harnesses_dir}:/workspace/harnesses:ro "
                     f"-v {entry_host}:/tmp/harness-entry.sh:ro "
-                    f"{image} sh /tmp/harness-entry.sh"
+                    # Override the image ENTRYPOINT (llm-d-benchmark.sh) so our
+                    # setup script runs -- mirrors the k8s pod's command:[sh,-c].
+                    f"--entrypoint sh {image} /tmp/harness-entry.sh"
                 )
                 cmd.execute(f"{runtime} rm -f {name}", check=False)
                 result = cmd.execute(run_cmd, check=False)

--- a/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
@@ -1,0 +1,221 @@
+"""Step 07 (nok8s) -- Run the benchmark harness as a LOCAL container.
+
+The default DeployHarnessStep launches the load generator as a Kubernetes Pod.
+For the no-Kubernetes (nok8s) method there is no cluster, so this step runs the
+same harness image as a docker/podman container on the host, pointed at the
+local Envoy endpoint (http://localhost:<listenPort>).  Results are written
+straight to the host results dir via a bind-mount -- no PVC or data-access pod.
+
+Reuses DeployHarnessStep's static command/name helpers so the in-container
+harness invocation matches the pod path exactly.
+"""
+
+import time
+from pathlib import Path
+
+from llmdbenchmark.executor.step import Step, StepResult, Phase
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
+
+
+class DeployHarnessLocalStep(Step):
+    """Run harness container(s) locally against the nok8s endpoint."""
+
+    def __init__(self):
+        super().__init__(
+            number=7,
+            name="deploy_harness_local",
+            description="Run benchmark harness as a local container (no k8s)",
+            phase=Phase.RUN,
+            per_stack=True,
+        )
+
+    def should_skip(self, context: ExecutionContext) -> bool:
+        if context.harness_skip_run:
+            return True
+        return "nok8s" not in (context.deployed_methods or [])
+
+    def execute(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        self, context: ExecutionContext, stack_path: Path | None = None
+    ) -> StepResult:
+        if stack_path is None:
+            return self._fail(None, "No stack path provided for per-stack step")
+
+        stack_name = stack_path.name
+        cmd = context.require_cmd()
+        plan_config = self._load_stack_config(stack_path)
+        runtime = context.container_runtime or "docker"
+
+        harness_name = self._resolve(
+            plan_config,
+            "harness.name",
+            context_value=context.harness_name,
+            default="inference-perf",
+        )
+        model_name = self._resolve(
+            plan_config, "model.name", context_value=context.model_name, default=""
+        )
+        endpoint_url = (
+            context.deployed_endpoints.get(stack_name) or context.endpoint_url
+        )
+        if not endpoint_url:
+            return self._fail(stack_path, "No endpoint URL resolved for nok8s run")
+
+        harness_executable = self._resolve(
+            plan_config, "harness.executable", default="llm-d-benchmark.sh"
+        )
+        entrypoint = (plan_config.get("harness") or {}).get(
+            "entrypoint", "llm-d-benchmark.sh"
+        )
+        profile_name = self._resolve(
+            plan_config,
+            "harness.experimentProfile",
+            "harness.profile",
+            context_value=context.harness_profile,
+            default="sanity_random.yaml",
+        )
+        if profile_name.endswith(".in"):
+            profile_name = profile_name[:-3]
+
+        images = plan_config.get("images", {}).get("benchmark", {})
+        image = (
+            f"{images.get('repository', 'ghcr.io/llm-d/llm-d-benchmark')}"
+            f":{images.get('tag', 'latest')}"
+        )
+        hf_token_env = (plan_config.get("nok8s") or {}).get(
+            "hfTokenEnv", "HUGGING_FACE_HUB_TOKEN"
+        )
+        deploy_method = ",".join(context.deployed_methods or ["nok8s"])
+
+        base_dir = context.base_dir or Path(__file__).resolve().parents[3]
+        harnesses_dir = base_dir / "workload" / "harnesses"
+        profiles_dir = context.workload_profiles_dir()
+        results_dir = context.run_results_dir()
+        timeout = context.harness_wait_timeout
+
+        treatments = context.experiment_treatments or [None]
+        parallelism = context.harness_parallelism
+        errors: list[str] = []
+
+        for treatment in treatments:
+            experiment_id = self._experiment_id(harness_name, treatment)
+            pod_profile_name = (
+                DeployHarnessStep._treatment_profile_name(profile_name, treatment)
+                if treatment
+                else profile_name
+            )
+
+            names: list[str] = []
+            for i in range(1, parallelism + 1):
+                name = f"{harness_name}-{experiment_id}-{i}".lower()
+                exp_results = f"/requests/{experiment_id}_{i}"
+                if context.harness_debug:
+                    harness_command = "sleep infinity"
+                else:
+                    harness_command = DeployHarnessStep._build_harness_command(
+                        harness_executable=harness_executable,
+                        profile_name=pod_profile_name,
+                        harness_name=harness_name,
+                        results_dir=exp_results,
+                        entrypoint=entrypoint,
+                        dataset_url=context.dataset_url,
+                    )
+
+                # Write the in-container entry script to disk and mount it, to
+                # avoid shell-quoting issues with the harness command.
+                entry_host = results_dir / f".harness-entry-{name}.sh"
+                if not context.dry_run:
+                    entry_host.write_text(
+                        "#!/bin/sh\n"
+                        "for s in /workspace/harnesses/*.sh; do "
+                        'cp "$s" /usr/local/bin/ 2>/dev/null; '
+                        'chmod +x "/usr/local/bin/$(basename "$s")" 2>/dev/null; '
+                        "done\n"
+                        f"{harness_command}\n",
+                        encoding="utf-8",
+                    )
+
+                run_cmd = (
+                    f"{runtime} run -d --name {name} --network host "
+                    f"-e LLMDBENCH_RUN_EXPERIMENT_LAUNCHER=1 "
+                    f"-e LLMDBENCH_HARNESS_STACK_ENDPOINT_URL={endpoint_url} "
+                    f"-e LLMDBENCH_HARNESS_STACK_TYPE=vllm-prod "
+                    f"-e LLMDBENCH_DEPLOY_CURRENT_MODEL={model_name} "
+                    f"-e LLMDBENCH_DEPLOY_CURRENT_TOKENIZER={model_name} "
+                    f"-e LLMDBENCH_HARNESS_NAME={harness_name} "
+                    f"-e LLMDBENCH_RUN_EXPERIMENT_ID={experiment_id} "
+                    f"-e LLMDBENCH_DEPLOY_METHODS={deploy_method} "
+                    f"-e LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR_PREFIX=/requests "
+                    f"-e {hf_token_env} "
+                    f"-v {results_dir}:/requests "
+                    f"-v {profiles_dir}:/workspace/profiles "
+                    f"-v {harnesses_dir}:/workspace/harnesses:ro "
+                    f"-v {entry_host}:/tmp/harness-entry.sh:ro "
+                    f"{image} sh /tmp/harness-entry.sh"
+                )
+                cmd.execute(f"{runtime} rm -f {name}", check=False)
+                result = cmd.execute(run_cmd, check=False)
+                if not result.success and not context.dry_run:
+                    errors.append(f"Failed to start harness container {name}")
+                else:
+                    names.append(name)
+
+            context.logger.log_info(
+                f"Launched {len(names)} harness container(s) for "
+                f"experiment '{experiment_id}' -> {endpoint_url}"
+            )
+
+            if not context.dry_run and names:
+                # Block until all containers exit (or the wait times out).
+                cmd.execute(
+                    f"timeout {timeout} {runtime} wait {' '.join(names)}",
+                    check=False,
+                    force=True,
+                )
+                for name in names:
+                    self._capture_and_remove(cmd, runtime, name, results_dir)
+
+            context.experiment_ids.append(experiment_id)
+
+        if errors:
+            return self._fail(stack_path, "; ".join(errors), errors)
+
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=True,
+            message=(
+                f"Ran {len(context.experiment_ids)} experiment(s) locally "
+                f"against {endpoint_url}"
+            ),
+            stack_name=stack_name,
+        )
+
+    # ------------------------------------------------------------------ #
+    def _experiment_id(self, harness_name: str, treatment) -> str:
+        timestamp = int(time.time())
+        rand = DeployHarnessStep._rand_suffix(6)
+        tname = treatment.get("name", "") if isinstance(treatment, dict) else ""
+        if tname:
+            return f"{harness_name}-{tname}-{timestamp}-{rand}"
+        return f"{harness_name}-{timestamp}-{rand}"
+
+    def _capture_and_remove(self, cmd, runtime, name, results_dir: Path) -> None:
+        result = cmd.execute(f"{runtime} logs {name}", check=False, force=True)
+        try:
+            (results_dir / f"{name}.log").write_text(
+                (result.stdout or "") + (result.stderr or ""), encoding="utf-8"
+            )
+        except OSError:
+            pass
+        cmd.execute(f"{runtime} rm -f {name}", check=False)
+
+    def _fail(self, stack_path, message, errors=None) -> StepResult:
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=False,
+            message=message,
+            errors=errors or [message],
+            stack_name=stack_path.name if stack_path else None,
+        )

--- a/llmdbenchmark/run/steps/step_08_wait_completion.py
+++ b/llmdbenchmark/run/steps/step_08_wait_completion.py
@@ -20,7 +20,9 @@ class WaitCompletionStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip waiting in skip-run mode."""
+        """Skip in skip-run mode, or for nok8s (the local step waits inline)."""
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         return context.harness_skip_run
 
     def execute(

--- a/llmdbenchmark/run/steps/step_09_collect_results.py
+++ b/llmdbenchmark/run/steps/step_09_collect_results.py
@@ -20,7 +20,9 @@ class CollectResultsStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip if step 06 already collected results locally."""
+        """Skip if results are already local (nok8s bind-mount, or step 06)."""
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         results_dir = context.run_results_dir()
         if results_dir.exists() and any(results_dir.iterdir()):
             return True

--- a/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
+++ b/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
@@ -60,6 +60,8 @@ class CaptureClusterStateStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         return context.harness_skip_run
 
     def execute(

--- a/llmdbenchmark/run/steps/step_11_cleanup_post.py
+++ b/llmdbenchmark/run/steps/step_11_cleanup_post.py
@@ -23,7 +23,9 @@ class RunCleanupPostStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip cleanup in debug mode (keep pods alive for inspection)."""
+        """Skip cleanup in debug mode, or for nok8s (no cluster resources)."""
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         return context.harness_debug
 
     def execute(

--- a/llmdbenchmark/standup/steps/__init__.py
+++ b/llmdbenchmark/standup/steps/__init__.py
@@ -19,6 +19,7 @@ from llmdbenchmark.standup.steps.step_05_harness_namespace import HarnessNamespa
 from llmdbenchmark.standup.steps.step_06_fma_deploy import FMADeployStep
 from llmdbenchmark.standup.steps.step_06_standalone_deploy import StandaloneDeployStep
 from llmdbenchmark.standup.steps.step_06_kustomize_deploy import KustomizeDeployStep
+from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
 from llmdbenchmark.standup.steps.step_07_deploy_setup import DeploySetupStep
 from llmdbenchmark.standup.steps.step_08_deploy_router import DeployRouterStep
 from llmdbenchmark.standup.steps.step_09_deploy_modelservice import (
@@ -37,6 +38,7 @@ def get_standup_steps() -> list[Step]:
         FMADeployStep(),
         StandaloneDeployStep(),
         KustomizeDeployStep(),
+        NoK8sDeployStep(),
         DeploySetupStep(),
         DeployRouterStep(),
         DeployModelserviceStep(),

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -126,6 +126,7 @@ class EnsureInfraStep(Step):
         runtime = context.container_runtime or "docker"
         plan_config = self._load_plan_config(context) or {}
         nok8s = plan_config.get("nok8s", {})
+        accelerator = str(nok8s.get("vllm", {}).get("accelerator", "nvidia")).lower()
         hf_env = nok8s.get("hfTokenEnv", "HUGGING_FACE_HUB_TOKEN")
         ports = [
             nok8s.get("vllm", {}).get("hostPort", 8000),
@@ -138,7 +139,7 @@ class EnsureInfraStep(Step):
         if context.dry_run:
             context.logger.log_info(
                 f"[dry-run] nok8s preflight: would verify '{runtime}' runtime, "
-                f"GPU (nvidia-smi), free ports {ports}, and ${hf_env}."
+                f"'{accelerator}' accelerator, free ports {ports}, and ${hf_env}."
             )
             return StepResult(
                 step_number=self.number,
@@ -167,14 +168,26 @@ class EnsureInfraStep(Step):
                 f"permissions). Verify with '{runtime} info'."
             )
 
-        # 2. NVIDIA GPU visible on the host (warning).
-        if not cmd.execute(
-            "nvidia-smi -L", check=False, force=True, silent=True
-        ).success:
-            warnings.append(
-                "nvidia-smi found no GPU/driver; vLLM requires an NVIDIA GPU + "
-                "driver, and the NVIDIA Container Toolkit configured for "
-                f"'{runtime}'."
+        # 2. Accelerator visible on the host (warning). Probe depends on the
+        #    configured accelerator; cpu/spyre/custom are not probed here.
+        probe = {
+            "nvidia": "nvidia-smi -L",
+            "amd": "rocm-smi --showid",
+            "intel": "xpu-smi discovery",
+            "gaudi": "hl-smi -L",
+        }.get(accelerator)
+        if probe:
+            if not cmd.execute(probe, check=False, force=True, silent=True).success:
+                tool = probe.split()[0]
+                warnings.append(
+                    f"'{tool}' found no {accelerator} accelerator; vLLM needs the "
+                    f"device + driver present, the matching vLLM image, and the "
+                    f"container toolkit configured for '{runtime}'."
+                )
+        else:
+            context.logger.log_info(
+                f"    accelerator='{accelerator}': skipping device probe "
+                f"(cpu/spyre/custom -- ensure nok8s.vllm.deviceArgs + image match)."
             )
 
         # 3. Hugging Face token (warning).

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -1,5 +1,6 @@
 """Step 00 -- Validate system dependencies and print cluster summary banner."""
 
+import os
 from pathlib import Path
 
 from llmdbenchmark.executor.step import Step, StepResult, Phase
@@ -30,6 +31,11 @@ class EnsureInfraStep(Step):
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
     ) -> StepResult:
+        # No-Kubernetes: validate the container runtime + GPU + ports + token
+        # instead of the helm/kubectl/cluster toolchain.
+        if "nok8s" in (context.deployed_methods or []):
+            return self._check_nok8s_infra(context)
+
         errors = []
 
         py_ok, py_version = check_python_version()
@@ -111,4 +117,100 @@ class EnsureInfraStep(Step):
                 "cluster_name": context.cluster_name,
                 "cluster_server": context.cluster_server,
             },
+        )
+
+    def _check_nok8s_infra(self, context: ExecutionContext) -> StepResult:
+        """Preflight for the no-Kubernetes method: container runtime, GPU,
+        ports, and HF token. Only a missing/broken runtime is fatal; the rest
+        are loud warnings (vLLM surfaces GPU/token issues clearly at launch)."""
+        runtime = context.container_runtime or "docker"
+        plan_config = self._load_plan_config(context) or {}
+        nok8s = plan_config.get("nok8s", {})
+        hf_env = nok8s.get("hfTokenEnv", "HUGGING_FACE_HUB_TOKEN")
+        ports = [
+            nok8s.get("vllm", {}).get("hostPort", 8000),
+            nok8s.get("envoy", {}).get("listenPort", 8081),
+            nok8s.get("epp", {}).get("grpcPort", 9002),
+            nok8s.get("epp", {}).get("grpcHealthPort", 9003),
+            nok8s.get("epp", {}).get("metricsPort", 9090),
+        ]
+
+        if context.dry_run:
+            context.logger.log_info(
+                f"[dry-run] nok8s preflight: would verify '{runtime}' runtime, "
+                f"GPU (nvidia-smi), free ports {ports}, and ${hf_env}."
+            )
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=True,
+                message="nok8s preflight skipped (dry-run)",
+            )
+
+        cmd = context.require_cmd()
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        # 1. Container runtime present and usable (fatal).
+        if not cmd.execute(
+            f"command -v {runtime}", check=False, force=True, silent=True
+        ).success:
+            errors.append(
+                f"Container runtime '{runtime}' not found on PATH. Install docker "
+                f"or podman (or set nok8s.runtime to the one you have)."
+            )
+        elif not cmd.execute(
+            f"{runtime} info", check=False, force=True, silent=True
+        ).success:
+            errors.append(
+                f"'{runtime}' is installed but not usable (daemon down or "
+                f"permissions). Verify with '{runtime} info'."
+            )
+
+        # 2. NVIDIA GPU visible on the host (warning).
+        if not cmd.execute(
+            "nvidia-smi -L", check=False, force=True, silent=True
+        ).success:
+            warnings.append(
+                "nvidia-smi found no GPU/driver; vLLM requires an NVIDIA GPU + "
+                "driver, and the NVIDIA Container Toolkit configured for "
+                f"'{runtime}'."
+            )
+
+        # 3. Hugging Face token (warning).
+        if not os.environ.get(hf_env):
+            warnings.append(
+                f"${hf_env} is not set; gated Hugging Face models will fail to "
+                f"download in the vLLM container."
+            )
+
+        # 4. Required host ports free (warning).
+        res = cmd.execute("ss -ltn", check=False, force=True, silent=True)
+        if res.success and res.stdout:
+            busy = [p for p in ports if f":{p} " in res.stdout]
+            if busy:
+                warnings.append(
+                    f"Host ports already in use: {busy}. Free them, run "
+                    f"'teardown', or change the nok8s ports."
+                )
+
+        for w in warnings:
+            context.logger.log_warning(f"    {w}")
+        if errors:
+            for e in errors:
+                context.logger.log_error(f"    {e}")
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="nok8s infrastructure checks failed",
+                errors=errors,
+            )
+
+        context.logger.log_info(f"nok8s preflight passed (runtime={runtime}).")
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=True,
+            message=f"nok8s infrastructure ready (runtime={runtime})",
         )

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -190,6 +190,25 @@ class EnsureInfraStep(Step):
                 f"(cpu/spyre/custom -- ensure nok8s.vllm.deviceArgs + image match)."
             )
 
+        # 2b. GPU capacity: replicas x tensorParallel must fit the host's GPUs.
+        #     Only checkable for nvidia (nvidia-smi -L enumerates devices).
+        vllm = nok8s.get("vllm", {})
+        replicas = int(vllm.get("replicas", 1) or 1)
+        tp = int(vllm.get("tensorParallel", 1) or 1)
+        needed = replicas * tp
+        if accelerator == "nvidia" and needed > 1:
+            res_gpu = cmd.execute("nvidia-smi -L", check=False, force=True, silent=True)
+            if res_gpu.success and res_gpu.stdout:
+                count = sum(
+                    1 for ln in res_gpu.stdout.splitlines() if ln.startswith("GPU ")
+                )
+                if count and needed > count:
+                    warnings.append(
+                        f"nok8s.vllm needs {needed} GPUs (replicas {replicas} x "
+                        f"tensorParallel {tp}) but only {count} detected -- workers "
+                        f"will contend for devices or fail to start."
+                    )
+
         # 3. Hugging Face token (warning).
         if not os.environ.get(hf_env):
             warnings.append(

--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -84,6 +84,8 @@ class AdminPrerequisitesStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         if context.non_admin:
             return True
         if self._kustomize_only(context):

--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -28,9 +28,11 @@ class WorkloadMonitoringStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
+        methods = context.deployed_methods or []
+        if "nok8s" in methods:
+            return True
         if context.non_admin:
             return True
-        methods = context.deployed_methods or []
         if methods == ["kustomize"] and context.kustomize_skip_infra:
             return True
         return False

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -26,6 +26,10 @@ class ModelNamespaceStep(Step):
 
     def should_skip(self, context: ExecutionContext) -> bool:
         methods = context.deployed_methods or []
+        if "nok8s" in methods:
+            # vLLM pulls the model from Hugging Face at container runtime;
+            # no k8s namespace/PVC/download Job is needed.
+            return True
         return methods == ["kustomize"] and context.kustomize_skip_infra
 
     def execute(

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -23,6 +23,8 @@ class HarnessNamespaceStep(Step):
 
     def should_skip(self, context: ExecutionContext) -> bool:
         methods = context.deployed_methods or []
+        if "nok8s" in methods:
+            return True
         return methods == ["kustomize"] and context.kustomize_skip_infra
 
     def execute(

--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -141,11 +141,12 @@ class NoK8sDeployStep(Step):
         kind = c["kind"]
         image = c["image"]
         if kind == "vllm":
-            gpu_flag = self._gpu_flag(runtime, c.get("gpus", "all"))
+            device = self._device_args(runtime, c)
             extra = " ".join(c.get("extraArgs") or [])
             return (
-                f"{runtime} run -d --name {c['name']} {gpu_flag} "
-                f"--shm-size={c.get('shmSize', '20g')} "
+                f"{runtime} run -d --name {c['name']}"
+                + (f" {device}" if device else "")
+                + f" --shm-size={c.get('shmSize', '20g')} "
                 f"-p {c['hostPort']}:{c.get('containerPort', 8000)} "
                 f"-e {hf_token_env} "
                 f"-v {hf_cache}:/root/.cache/huggingface "
@@ -179,10 +180,36 @@ class NoK8sDeployStep(Step):
         raise ValueError(f"Unknown nok8s container kind: {kind}")
 
     @staticmethod
-    def _gpu_flag(runtime: str, gpus: str) -> str:
-        """docker uses --gpus; podman uses CDI --device nvidia.com/gpu=..."""
-        if runtime == "podman":
-            return f"--device nvidia.com/gpu={gpus}"
+    def _device_args(runtime: str, c: dict) -> str:
+        """Runtime flags to expose the accelerator to the vLLM container.
+
+        ``deviceArgs`` (if set) is a raw override -- use it for anything not
+        covered by the presets below (e.g. IBM Spyre/AIU). Otherwise the
+        ``accelerator`` field selects a preset. Only NVIDIA is validated
+        end-to-end; the others follow each backend's documented device flags.
+        """
+        raw = c.get("deviceArgs")
+        if raw:
+            return " ".join(raw)
+        accel = str(c.get("accelerator") or "nvidia").lower()
+        gpus = c.get("gpus", "all")
+        if accel == "nvidia":
+            # docker: --gpus; podman: CDI device.
+            return (
+                f"--device nvidia.com/gpu={gpus}"
+                if runtime == "podman"
+                else f"--gpus {gpus}"
+            )
+        if accel == "amd":
+            return "--device /dev/kfd --device /dev/dri --group-add video"
+        if accel == "intel":
+            return "--device /dev/dri"
+        if accel == "gaudi":
+            return "--runtime=habana -e HABANA_VISIBLE_DEVICES=all"
+        if accel in ("cpu", "spyre"):
+            # cpu: no device; spyre/AIU: supply nok8s.vllm.deviceArgs.
+            return ""
+        # Unknown accelerator: fall back to NVIDIA behaviour.
         return f"--gpus {gpus}"
 
     def _wait_ready(

--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -142,10 +142,12 @@ class NoK8sDeployStep(Step):
         image = c["image"]
         if kind == "vllm":
             device = self._device_args(runtime, c)
+            pin = self._pin_env(c)
             extra = " ".join(c.get("extraArgs") or [])
             return (
                 f"{runtime} run -d --name {c['name']}"
                 + (f" {device}" if device else "")
+                + (f" {pin}" if pin else "")
                 + f" --shm-size={c.get('shmSize', '20g')} "
                 f"-p {c['hostPort']}:{c.get('containerPort', 8000)} "
                 f"-e {hf_token_env} "
@@ -178,6 +180,36 @@ class NoK8sDeployStep(Step):
                 f"--drain-strategy immediate --drain-time-s 60 -c {mount_path}"
             )
         raise ValueError(f"Unknown nok8s container kind: {kind}")
+
+    # Per-accelerator env var that pins a process to a subset of devices.
+    _VISIBLE_DEVICE_ENV = {
+        "nvidia": "CUDA_VISIBLE_DEVICES",
+        "amd": "HIP_VISIBLE_DEVICES",
+        "intel": "ZE_AFFINITY_MASK",
+    }
+
+    @classmethod
+    def _pin_env(cls, c: dict) -> str:
+        """Per-replica GPU pinning flag (``-e <VISIBLE_DEVICES>=<slice>``).
+
+        With ``replicas > 1`` each replica is pinned to its own contiguous slice
+        of ``tensorParallel`` device indices (replica *i* -> devices
+        ``i*TP .. i*TP+TP-1``) so workers don't contend for the same GPUs.
+        Returns "" for a single replica (keeps the current --gpus all behaviour),
+        when ``deviceArgs`` is set (caller controls devices), or for accelerators
+        without an index-based visible-devices env (gaudi/cpu/spyre).
+        """
+        replicas = int(c.get("replicas", 1) or 1)
+        if replicas <= 1 or c.get("deviceArgs"):
+            return ""
+        accel = str(c.get("accelerator") or "nvidia").lower()
+        var = cls._VISIBLE_DEVICE_ENV.get(accel)
+        if not var:
+            return ""
+        tp = int(c.get("tensorParallel", 1) or 1)
+        idx = int(c.get("replicaIndex", 0) or 0)
+        devices = ",".join(str(d) for d in range(idx * tp, idx * tp + tp))
+        return f"-e {var}={devices}"
 
     @staticmethod
     def _device_args(runtime: str, c: dict) -> str:

--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -1,0 +1,237 @@
+"""Step 06 -- Deploy the llm-d stack as local containers (no Kubernetes).
+
+Launches vLLM worker(s) + EPP (router) + Envoy as docker/podman containers on
+the host, driven by the rendered ``34_nok8s-containers.yaml`` launch spec and
+the ``31/32/33_nok8s-*`` config files.  No cluster is involved; the EPP uses
+the file-discovery plugin (reads endpoints.yaml).
+"""
+
+import os
+import time
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.executor.step import Step, StepResult, Phase
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.executor.command import CommandExecutor
+
+
+class NoK8sDeployStep(Step):
+    """Deploy the llm-d routing stack as local containers, no Kubernetes."""
+
+    def __init__(self):
+        super().__init__(
+            number=6,
+            name="nok8s_deploy",
+            description="Deploy vLLM + EPP + Envoy as local containers (no k8s)",
+            phase=Phase.STANDUP,
+            per_stack=True,
+        )
+
+    def should_skip(self, context: ExecutionContext) -> bool:
+        return "nok8s" not in context.deployed_methods
+
+    def execute(  # pylint: disable=too-many-branches,too-many-locals,too-many-return-statements
+        self, context: ExecutionContext, stack_path: Path | None = None
+    ) -> StepResult:
+        if stack_path is None:
+            return self._fail(None, "No stack path provided for per-stack step")
+
+        cmd = context.require_cmd()
+
+        spec_yaml = self._find_yaml(stack_path, "34_nok8s-containers")
+        if not spec_yaml or not self._has_yaml_content(spec_yaml):
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=True,
+                message="No nok8s container spec found, skipping",
+                stack_name=stack_path.name,
+            )
+        spec = yaml.safe_load(spec_yaml.read_text(encoding="utf-8")) or {}
+
+        runtime = spec.get("runtime", context.container_runtime or "docker")
+        workspace = Path(os.path.expanduser(spec["workspaceHostDir"]))
+        hf_cache = os.path.expanduser(spec.get("hfCacheDir", "~/.cache/huggingface"))
+        hf_token_env = spec.get("hfTokenEnv", "HUGGING_FACE_HUB_TOKEN")
+        model = spec["model"]
+        endpoint = spec["endpoint"]
+        containers = spec.get("containers", [])
+
+        # Record the endpoint up front so downstream (even dry-run) can use it.
+        context.deployed_endpoints[stack_path.name] = endpoint
+
+        if hf_token_env not in os.environ and not context.dry_run:
+            context.logger.log_warning(
+                f"{hf_token_env} not set in the environment; gated Hugging Face "
+                f"models will fail to download in the vLLM container."
+            )
+
+        # Stage the EPP/Envoy config files to the host workspace dir.
+        epp_dir = workspace / "epp"
+        if not context.dry_run:
+            self._stage_configs(stack_path, workspace, epp_dir)
+        else:
+            context.logger.log_info(
+                f"[dry-run] would stage nok8s configs under {workspace}"
+            )
+
+        errors: list[str] = []
+        launched: list[str] = []
+        for c in containers:
+            name = c["name"]
+            # Idempotency: remove any prior container with this name.
+            cmd.execute(f"{runtime} rm -f {name}", check=False)
+            run_cmd = self._build_run_command(
+                c, runtime, workspace, epp_dir, hf_cache, hf_token_env, model
+            )
+            result = cmd.execute(run_cmd, check=False)
+            if not result.success and not context.dry_run:
+                errors.append(f"Failed to start container {name}: {result.stderr}")
+                self._dump_logs(cmd, runtime, name, context)
+            else:
+                launched.append(name)
+
+        if errors:
+            return self._fail(stack_path, "; ".join(errors), errors)
+
+        # Readiness: each vLLM worker, then Envoy.
+        if not context.dry_run:
+            ready_err = self._wait_ready(cmd, runtime, spec, context)
+            if ready_err:
+                self._dump_logs(cmd, runtime, "envoy", context)
+                return self._fail(stack_path, ready_err, [ready_err])
+
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=True,
+            message=f"nok8s stack up: {', '.join(launched)} -> {endpoint}",
+            stack_name=stack_path.name,
+        )
+
+    # ------------------------------------------------------------------ #
+    # helpers
+    # ------------------------------------------------------------------ #
+    def _stage_configs(self, stack_path: Path, workspace: Path, epp_dir: Path) -> None:
+        """Copy rendered EPP/Envoy config files to the host workspace dir."""
+        epp_dir.mkdir(parents=True, exist_ok=True)
+        mapping = {
+            "31_nok8s-epp-config": epp_dir / "config.yaml",
+            "32_nok8s-epp-endpoints": epp_dir / "endpoints.yaml",
+            "33_nok8s-envoy": workspace / "envoy.yaml",
+        }
+        for prefix, dest in mapping.items():
+            src = self._find_yaml(stack_path, prefix)
+            if src and self._has_yaml_content(src):
+                dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+    def _build_run_command(  # pylint: disable=too-many-arguments
+        self,
+        c: dict,
+        runtime: str,
+        workspace: Path,
+        epp_dir: Path,
+        hf_cache: str,
+        hf_token_env: str,
+        model: str,
+    ) -> str:
+        """Build the docker/podman run command for one container from its spec."""
+        kind = c["kind"]
+        image = c["image"]
+        if kind == "vllm":
+            gpu_flag = self._gpu_flag(runtime, c.get("gpus", "all"))
+            extra = " ".join(c.get("extraArgs") or [])
+            return (
+                f"{runtime} run -d --name {c['name']} {gpu_flag} "
+                f"--shm-size={c.get('shmSize', '20g')} "
+                f"-p {c['hostPort']}:{c.get('containerPort', 8000)} "
+                f"-e {hf_token_env} "
+                f"-v {hf_cache}:/root/.cache/huggingface "
+                f"--entrypoint vllm {image} "
+                f"serve {model} "
+                f"--disable-access-log-for-endpoints=/health,/metrics,/v1/models "
+                f"--tensor-parallel-size={c.get('tensorParallel', 1)}"
+                + (f" {extra}" if extra else "")
+            )
+        if kind == "epp":
+            mount_dir = c.get("configMountDir", "/etc/epp")
+            return (
+                f"{runtime} run -d --name {c['name']} --network host "
+                f"-v {epp_dir}:{mount_dir}:ro {image} "
+                f"--config-file={mount_dir}/config.yaml "
+                f"--pool-name={c.get('poolName', 'file-discovery')} "
+                f"--pool-namespace={c.get('poolNamespace', 'default')} "
+                f"--grpc-port={c['grpcPort']} "
+                f"--grpc-health-port={c['grpcHealthPort']} "
+                f"--metrics-port={c['metricsPort']} "
+                f"--secure-serving=false --v=2"
+            )
+        if kind == "envoy":
+            mount_path = c.get("configMountPath", "/etc/envoy/envoy.yaml")
+            return (
+                f"{runtime} run -d --name {c['name']} --network host "
+                f"-v {workspace / 'envoy.yaml'}:{mount_path}:ro {image} "
+                f"--service-node envoy-proxy --log-level warn --concurrency 8 "
+                f"--drain-strategy immediate --drain-time-s 60 -c {mount_path}"
+            )
+        raise ValueError(f"Unknown nok8s container kind: {kind}")
+
+    @staticmethod
+    def _gpu_flag(runtime: str, gpus: str) -> str:
+        """docker uses --gpus; podman uses CDI --device nvidia.com/gpu=..."""
+        if runtime == "podman":
+            return f"--device nvidia.com/gpu={gpus}"
+        return f"--gpus {gpus}"
+
+    def _wait_ready(
+        self, cmd: CommandExecutor, runtime: str, spec: dict, context: ExecutionContext
+    ) -> str | None:
+        """Poll vLLM workers then Envoy for /v1/models. Returns error string or None."""
+        readiness = spec.get("readiness", {})
+        ports = list(readiness.get("vllmPorts", [])) + [readiness.get("envoyPort")]
+        timeout = context.nok8s_deploy_timeout
+        for port in ports:
+            if port is None:
+                continue
+            url = f"http://localhost:{port}/v1/models"
+            deadline = time.time() + timeout
+            ok = False
+            while time.time() < deadline:
+                result = cmd.execute(f"curl -fsS {url}", check=False, force=True)
+                if result.success:
+                    ok = True
+                    break
+                time.sleep(10)
+            if not ok:
+                return f"Timed out waiting for {url} after {timeout}s"
+            context.logger.log_info(f"nok8s endpoint ready: {url}")
+        return None
+
+    def _dump_logs(
+        self, cmd: CommandExecutor, runtime: str, name: str, context: ExecutionContext
+    ) -> None:
+        """Best-effort capture of a container's logs into the setup logs dir."""
+        result = cmd.execute(
+            f"{runtime} logs {name} --tail 100", check=False, force=True
+        )
+        try:
+            log_path = context.setup_logs_dir() / f"nok8s-{name}.log"
+            log_path.write_text(
+                (result.stdout or "") + (result.stderr or ""), encoding="utf-8"
+            )
+        except OSError:
+            pass
+
+    def _fail(
+        self, stack_path: Path | None, message: str, errors: list[str] | None = None
+    ) -> StepResult:
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=False,
+            message=message,
+            errors=errors or [message],
+            stack_name=stack_path.name if stack_path else None,
+        )

--- a/llmdbenchmark/teardown/steps/__init__.py
+++ b/llmdbenchmark/teardown/steps/__init__.py
@@ -12,6 +12,7 @@ from llmdbenchmark.teardown.steps.step_04_clean_cluster_roles import (
 from llmdbenchmark.teardown.steps.step_05_kustomize_teardown import (
     KustomizeTeardownStep,
 )
+from llmdbenchmark.teardown.steps.step_06_nok8s_teardown import NoK8sTeardownStep
 
 
 def get_teardown_steps() -> list[Step]:
@@ -23,4 +24,5 @@ def get_teardown_steps() -> list[Step]:
         DeleteResourcesStep(),
         CleanClusterRolesStep(),
         KustomizeTeardownStep(),
+        NoK8sTeardownStep(),
     ]

--- a/llmdbenchmark/teardown/steps/step_00_preflight.py
+++ b/llmdbenchmark/teardown/steps/step_00_preflight.py
@@ -21,6 +21,10 @@ class TeardownPreflightStep(Step):
             per_stack=False,
         )
 
+    def should_skip(self, context: ExecutionContext) -> bool:
+        # nok8s has no cluster/namespace; the nok8s teardown step handles it.
+        return "nok8s" in (context.deployed_methods or [])
+
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
     ) -> StepResult:

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -47,6 +47,8 @@ class UninstallHelmStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         # We still run for WVA-enabled stacks even when neither
         # modelservice nor fma is in deployed_methods, so the VA+HPA
         # resources get cleaned up.

--- a/llmdbenchmark/teardown/steps/step_02_clean_harness.py
+++ b/llmdbenchmark/teardown/steps/step_02_clean_harness.py
@@ -19,6 +19,9 @@ class CleanHarnessStep(Step):
             per_stack=False,
         )
 
+    def should_skip(self, context: ExecutionContext) -> bool:
+        return "nok8s" in (context.deployed_methods or [])
+
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
     ) -> StepResult:

--- a/llmdbenchmark/teardown/steps/step_03_delete_resources.py
+++ b/llmdbenchmark/teardown/steps/step_03_delete_resources.py
@@ -85,6 +85,9 @@ class DeleteResourcesStep(Step):
             per_stack=False,
         )
 
+    def should_skip(self, context: ExecutionContext) -> bool:
+        return "nok8s" in (context.deployed_methods or [])
+
     def execute(
         self, context: ExecutionContext, stack_path: Path | None = None
     ) -> StepResult:

--- a/llmdbenchmark/teardown/steps/step_04_clean_cluster_roles.py
+++ b/llmdbenchmark/teardown/steps/step_04_clean_cluster_roles.py
@@ -30,6 +30,8 @@ class CleanClusterRolesStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
+        if "nok8s" in (context.deployed_methods or []):
+            return True
         if context.non_admin:
             return True
         if "modelservice" not in context.deployed_methods:

--- a/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
+++ b/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
@@ -1,0 +1,59 @@
+"""Step 06 -- Teardown the nok8s container stack (no Kubernetes).
+
+Removes the vLLM/EPP/Envoy containers launched by
+step_06_nok8s_deploy.py, driven by the rendered ``34_nok8s-containers.yaml``
+launch spec.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.executor.step import Step, StepResult, Phase
+from llmdbenchmark.executor.context import ExecutionContext
+
+
+class NoK8sTeardownStep(Step):
+    """Remove the local container stack deployed by the nok8s method."""
+
+    def __init__(self):
+        super().__init__(
+            number=6,
+            name="nok8s_teardown",
+            description="Remove nok8s containers (vLLM + EPP + Envoy)",
+            phase=Phase.TEARDOWN,
+            per_stack=True,
+        )
+
+    def should_skip(self, context: ExecutionContext) -> bool:
+        return "nok8s" not in (context.deployed_methods or [])
+
+    def execute(
+        self, context: ExecutionContext, stack_path: Path | None = None
+    ) -> StepResult:
+        cmd = context.require_cmd()
+        runtime = context.container_runtime or "docker"
+
+        names: list[str] = []
+        spec_yaml = (
+            self._find_yaml(stack_path, "34_nok8s-containers") if stack_path else None
+        )
+        if spec_yaml and self._has_yaml_content(spec_yaml):
+            spec = yaml.safe_load(spec_yaml.read_text(encoding="utf-8")) or {}
+            runtime = spec.get("runtime", runtime)
+            names = [c["name"] for c in spec.get("containers", [])]
+
+        # Fallback to the well-known names if the spec is unavailable.
+        if not names:
+            names = ["envoy", "epp", "vllm-0"]
+
+        for name in names:
+            cmd.execute(f"{runtime} rm -f {name}", check=False)
+
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=True,
+            message=f"Removed nok8s containers: {', '.join(names)}",
+            stack_name=stack_path.name if stack_path else None,
+        )

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -1,0 +1,187 @@
+"""Tests for the nok8s (no-Kubernetes) deployment method.
+
+Covers render-time gating (templates + config.yaml flags) and the step
+should_skip selection logic, without needing a cluster or GPUs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_DIR = REPO_ROOT / "config" / "templates" / "jinja"
+DEFAULTS_FILE = REPO_ROOT / "config" / "templates" / "values" / "defaults.yaml"
+NOK8S_SCENARIO = REPO_ROOT / "config" / "scenarios" / "nok8s.yaml"
+
+
+class _Logger:
+    def log_info(self, *_: Any, **__: Any) -> None:
+        pass
+
+    log_warning = log_error = log_debug = log_info
+
+    def line_break(self) -> None:
+        pass
+
+
+def _render(tmp_path: Path, cli_methods: str | None = None):
+    return RenderPlans(
+        template_dir=TEMPLATE_DIR,
+        defaults_file=DEFAULTS_FILE,
+        scenarios_file=NOK8S_SCENARIO,
+        output_dir=tmp_path / "plan",
+        logger=_Logger(),
+        cli_methods=cli_methods,
+    ).eval()
+
+
+def _stack_dir(result) -> Path:
+    paths = getattr(result, "rendered_paths", None) or []
+    assert paths, "no rendered stacks produced"
+    return Path(paths[0])
+
+
+def test_nok8s_scenario_renders_templates_and_flags(tmp_path: Path) -> None:
+    stack = _stack_dir(_render(tmp_path))
+
+    # config.yaml: nok8s enabled, the other methods disabled.
+    cfg = yaml.safe_load((stack / "config.yaml").read_text(encoding="utf-8"))
+    assert cfg["nok8s"]["enabled"] is True
+    assert cfg["standalone"]["enabled"] is False
+    assert cfg["modelservice"]["enabled"] is False
+    assert cfg["kustomize"]["enabled"] is False
+    assert cfg["fma"]["enabled"] is False
+
+    # All four nok8s artifacts rendered with content.
+    for prefix in (
+        "31_nok8s-epp-config",
+        "32_nok8s-epp-endpoints",
+        "33_nok8s-envoy",
+        "34_nok8s-containers",
+    ):
+        matches = list(stack.glob(f"{prefix}*"))
+        assert matches, f"missing rendered file for {prefix}"
+        assert matches[0].read_text(encoding="utf-8").strip(), f"{prefix} is empty"
+
+    # endpoints file lists the single worker with the model label.
+    endpoints = yaml.safe_load(
+        next(stack.glob("32_nok8s-epp-endpoints*")).read_text(encoding="utf-8")
+    )
+    assert endpoints["endpoints"][0]["address"] == "127.0.0.1"
+    assert endpoints["endpoints"][0]["port"] == "8000"
+    assert endpoints["endpoints"][0]["labels"]["model"] == "Qwen/Qwen2.5-0.5B-Instruct"
+
+    # container launch spec exposes the local endpoint.
+    spec = yaml.safe_load(
+        next(stack.glob("34_nok8s-containers*")).read_text(encoding="utf-8")
+    )
+    assert spec["endpoint"] == "http://localhost:8081"
+    kinds = sorted(c["kind"] for c in spec["containers"])
+    assert kinds == ["envoy", "epp", "vllm"]
+
+
+def test_should_skip_selects_by_method() -> None:
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+    from llmdbenchmark.run.steps.step_07_deploy_harness_local import (
+        DeployHarnessLocalStep,
+    )
+    from llmdbenchmark.executor.context import ExecutionContext
+
+    nok8s_ctx = ExecutionContext(
+        plan_dir=Path("/tmp"), workspace=Path("/tmp"), deployed_methods=["nok8s"]
+    )
+    other_ctx = ExecutionContext(
+        plan_dir=Path("/tmp"), workspace=Path("/tmp"), deployed_methods=["standalone"]
+    )
+
+    assert NoK8sDeployStep().should_skip(nok8s_ctx) is False
+    assert NoK8sDeployStep().should_skip(other_ctx) is True
+
+    assert DeployHarnessLocalStep().should_skip(other_ctx) is True
+    assert DeployHarnessLocalStep().should_skip(nok8s_ctx) is False
+
+
+class _FakeResult:
+    def __init__(self, success: bool, stdout: str = "") -> None:
+        self.success = success
+        self.stdout = stdout
+        self.stderr = ""
+        self.exit_code = 0 if success else 1
+
+
+class _FakeCmd:
+    """Maps command substrings to success/failure for preflight testing."""
+
+    def __init__(self, fail_substrings=(), stdout_for=None) -> None:
+        self.fail_substrings = fail_substrings
+        self.stdout_for = stdout_for or {}
+
+    def execute(self, cmd, *_, **__):
+        ok = not any(s in cmd for s in self.fail_substrings)
+        out = ""
+        for key, val in self.stdout_for.items():
+            if key in cmd:
+                out = val
+        return _FakeResult(ok, out)
+
+
+def _nok8s_ctx(tmp_path: Path, cmd):
+    from llmdbenchmark.executor.context import ExecutionContext
+
+    ctx = ExecutionContext(
+        plan_dir=tmp_path,
+        workspace=tmp_path,
+        deployed_methods=["nok8s"],
+        container_only=True,
+        container_runtime="docker",
+    )
+    ctx.cmd = cmd
+    ctx.logger = _Logger()
+    return ctx
+
+
+def test_nok8s_preflight_fatal_when_runtime_missing(tmp_path: Path) -> None:
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(tmp_path, _FakeCmd(fail_substrings=("command -v docker",)))
+    result = EnsureInfraStep().execute(ctx)
+    assert result.success is False
+    assert any("runtime" in e.lower() for e in result.errors)
+
+
+def test_nok8s_preflight_passes_when_runtime_and_gpu_present(tmp_path: Path) -> None:
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    # Everything succeeds; ss reports no listeners -> no busy ports.
+    ctx = _nok8s_ctx(tmp_path, _FakeCmd(stdout_for={"ss -ltn": "State  Recv-Q\n"}))
+    import os
+
+    os.environ["HUGGING_FACE_HUB_TOKEN"] = "hf_test"
+    try:
+        result = EnsureInfraStep().execute(ctx)
+    finally:
+        os.environ.pop("HUGGING_FACE_HUB_TOKEN", None)
+    assert result.success is True
+
+
+def test_resolve_deploy_method_forces_nok8s() -> None:
+    """--methods nok8s wins and disables the other methods (mutual exclusion)."""
+    rp = RenderPlans(
+        template_dir=TEMPLATE_DIR,
+        defaults_file=DEFAULTS_FILE,
+        scenarios_file=NOK8S_SCENARIO,
+        output_dir=Path("/tmp/unused-nok8s-plan"),
+        logger=_Logger(),
+        cli_methods="nok8s",
+    )
+    out = rp._resolve_deploy_method(
+        {"standalone": {"enabled": True}, "modelservice": {"enabled": True}}
+    )
+    assert out["nok8s"]["enabled"] is True
+    assert out["standalone"]["enabled"] is False
+    assert out["modelservice"]["enabled"] is False

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -194,6 +194,38 @@ def test_device_args_per_accelerator() -> None:
     )
 
 
+def test_pin_env_per_replica() -> None:
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    pin = NoK8sDeployStep._pin_env
+    # Single replica -> no pinning (back-compat, uses --gpus all).
+    assert pin({"replicas": 1, "accelerator": "nvidia"}) == ""
+    # 3 replicas, TP=1 -> one GPU each, distinct indices.
+    assert pin({"replicas": 3, "replicaIndex": 0, "tensorParallel": 1}) == (
+        "-e CUDA_VISIBLE_DEVICES=0"
+    )
+    assert pin({"replicas": 3, "replicaIndex": 2, "tensorParallel": 1}) == (
+        "-e CUDA_VISIBLE_DEVICES=2"
+    )
+    # 2 replicas, TP=4 -> contiguous 4-GPU slices.
+    assert pin({"replicas": 2, "replicaIndex": 1, "tensorParallel": 4}) == (
+        "-e CUDA_VISIBLE_DEVICES=4,5,6,7"
+    )
+    # accelerator-specific env var.
+    assert pin({"replicas": 2, "replicaIndex": 1, "accelerator": "amd"}) == (
+        "-e HIP_VISIBLE_DEVICES=1"
+    )
+    assert pin({"replicas": 2, "replicaIndex": 0, "accelerator": "intel"}) == (
+        "-e ZE_AFFINITY_MASK=0"
+    )
+    # gaudi/spyre/cpu -> no index-pinning env.
+    assert pin({"replicas": 2, "replicaIndex": 0, "accelerator": "gaudi"}) == ""
+    # deviceArgs override disables auto-pinning (caller controls devices).
+    assert (
+        pin({"replicas": 2, "replicaIndex": 1, "deviceArgs": ["--device", "x"]}) == ""
+    )
+
+
 def test_resolve_deploy_method_forces_nok8s() -> None:
     """--methods nok8s wins and disables the other methods (mutual exclusion)."""
     rp = RenderPlans(

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -169,6 +169,31 @@ def test_nok8s_preflight_passes_when_runtime_and_gpu_present(tmp_path: Path) -> 
     assert result.success is True
 
 
+def test_device_args_per_accelerator() -> None:
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    dev = NoK8sDeployStep._device_args
+    assert dev("docker", {"accelerator": "nvidia", "gpus": "all"}) == "--gpus all"
+    assert (
+        dev("podman", {"accelerator": "nvidia", "gpus": "all"})
+        == "--device nvidia.com/gpu=all"
+    )
+    assert "/dev/kfd" in dev("docker", {"accelerator": "amd"})
+    assert dev("docker", {"accelerator": "intel"}) == "--device /dev/dri"
+    assert "habana" in dev("docker", {"accelerator": "gaudi"})
+    assert dev("docker", {"accelerator": "cpu"}) == ""
+    # spyre has no preset -> expects deviceArgs; empty without it.
+    assert dev("docker", {"accelerator": "spyre"}) == ""
+    # raw deviceArgs override wins regardless of accelerator.
+    assert (
+        dev(
+            "docker",
+            {"accelerator": "spyre", "deviceArgs": ["--device", "/dev/vfio/1"]},
+        )
+        == "--device /dev/vfio/1"
+    )
+
+
 def test_resolve_deploy_method_forces_nok8s() -> None:
     """--methods nok8s wins and disables the other methods (mutual exclusion)."""
     rp = RenderPlans(


### PR DESCRIPTION
Adds a `no-Kubernetes` deploy method so `llmdbenchmark standup/run/teardown` run the `llm-d` stack (vLLM + EPP + Envoy) and the benchmark harness as local `docker/podman` containers — no cluster.

```bash
# standup
llmdbenchmark --spec config/specification/nok8s.yaml.j2 standup --methods nok8s

# run
llmdbenchmark --spec config/specification/nok8s.yaml.j2 run

# teardown
llmdbenchmark --spec config/specification/nok8s.yaml.j2 teardown --methods nok8s
```