### PR TITLE
Fix automatic image tag selection by version

### DIFF
--- a/llmdbenchmark/parser/version_resolver.py
+++ b/llmdbenchmark/parser/version_resolver.py
@@ -1,6 +1,7 @@
 """Resolve ``"auto"`` image tags and chart versions via skopeo/helm."""
 
 import json
+import re
 import subprocess
 from copy import deepcopy
 
@@ -19,6 +20,19 @@ class VersionResolver:
 
     def __init__(self, logger, dry_run: bool = False):
         self.logger = logger
+
+    @staticmethod
+    def _latest_version_tag(tags: list[str]) -> str | None:
+        """Select the greatest tag using natural version-aware ordering."""
+
+        def version_key(tag: str) -> tuple:
+            return tuple(
+                (1, int(part), len(part)) if part.isdigit() else (0, part.casefold())
+                for part in re.split(r"(\d+)", tag)
+                if part
+            )
+
+        return max(tags, key=version_key) if tags else None
 
     def resolve_image_tag(self, registry: str, repository: str) -> str:
         """Resolve the latest tag for an image via skopeo, falling back to podman."""
@@ -61,23 +75,22 @@ class VersionResolver:
                     for line in result.stdout.strip().split("\n")
                     if line.strip()
                 ]
-                if lines:
-                    return lines[-1]
+                return self._latest_version_tag(lines)
         except FileNotFoundError:
             pass
         return None
 
     def _resolve_via_skopeo(self, image_ref: str) -> str | None:
         """Resolve latest tag using skopeo list-tags."""
-        cmd = f"skopeo list-tags docker://{image_ref} | jq -r '.Tags[]' | sort -V"
+        cmd = ["skopeo", "list-tags", f"docker://{image_ref}"]
         try:
-            result = subprocess.run(
-                cmd.split(), capture_output=True, text=True, check=True
-            )
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
             tags_data = json.loads(result.stdout)
             tags = tags_data.get("Tags", [])
-            if tags:
-                return tags[-1]
+            if isinstance(tags, list):
+                return self._latest_version_tag(
+                    [tag for tag in tags if isinstance(tag, str) and tag]
+                )
         except (subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError):
             pass
         return None
@@ -90,12 +103,12 @@ class VersionResolver:
                 cmd.split(), capture_output=True, text=True, check=False
             )
             if result.returncode == 0:
-                lines = result.stdout.strip().split("\n")
-                if lines:
-                    last_line = lines[-1]
-                    parts = last_line.split()
-                    if len(parts) >= 2:
-                        return parts[1]
+                tags = []
+                for line in result.stdout.strip().split("\n"):
+                    parts = line.split()
+                    if len(parts) >= 2 and parts[1].casefold() != "tag":
+                        tags.append(parts[1])
+                return self._latest_version_tag(tags)
         except FileNotFoundError:
             pass
         return None

--- a/tests/test_version_resolver.py
+++ b/tests/test_version_resolver.py
@@ -6,6 +6,8 @@ These tests stub the registry resolution so they don't hit the network.
 
 from __future__ import annotations
 
+import json
+from subprocess import CompletedProcess
 from typing import Any
 
 import pytest
@@ -73,6 +75,28 @@ def _images() -> dict:
             "tag": "v1",
         },
     }
+
+
+# ---------------------------------------------------------------------------
+# Registry tag ordering
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryTagOrdering:
+    def test_skopeo_selects_latest_tag_by_version(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tags = ["v0.20.1", "v0.9.2", "v0.10.0"]
+
+        def _run(*args: Any, **kwargs: Any) -> CompletedProcess[str]:
+            return CompletedProcess(args[0], 0, stdout=json.dumps({"Tags": tags}))
+
+        monkeypatch.setattr(
+            "llmdbenchmark.parser.version_resolver.subprocess.run", _run
+        )
+        resolver = VersionResolver(_StubLogger())
+
+        assert resolver._resolve_via_skopeo("docker.io/vllm/vllm-openai") == ("v0.20.1")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Select automatically resolved image tags by version number instead of lexicographic or registry-provided order.

## Motivation

Fixes #1060.

When image tags are resolved automatically, lexicographic ordering can treat `v0.9.2` as newer than `v0.20.1`. The existing skopeo command also passes the intended `jq` and `sort -V` pipeline as literal arguments, so version sorting is never executed.

## What changed

- Added natural, version-aware tag ordering that compares numeric components numerically.
- Changed the skopeo resolver to execute `skopeo list-tags` directly, parse its JSON response, and select the greatest version tag.
- Applied the same version-aware selection to the crane and podman fallback resolvers.
- Added a regression test covering `v0.20.1`, `v0.10.0`, and `v0.9.2` in registry order.

## Testing

- `pytest -q tests/test_version_resolver.py`
- `ruff check llmdbenchmark/parser/version_resolver.py tests/test_version_resolver.py`
- `git diff --check upstream/main...HEAD`

## Backward Compatibility

This does not change image registry lookup order or fallback behavior. It only changes how a successful tag list is ordered before selecting the most recent tag.
