### PR TITLE
Improve harness pod failure reporting

### DIFF
--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -7,6 +7,7 @@ step_08, and step_10.
 
 from __future__ import annotations
 
+import json
 import shutil
 import time
 from pathlib import Path
@@ -27,6 +28,66 @@ CRASH_STATES = {
 }
 
 DATA_ACCESS_LABEL = "role=llm-d-benchmark-data-access"
+
+
+def _terminated_state_detail(prefix: str, state: dict) -> str:
+    """Format a terminated container state for a user-facing error."""
+    reason = state.get("reason") or "unknown reason"
+    detail = f"{prefix}{reason}"
+    if state.get("exitCode") is not None:
+        detail += f", exit_code={state['exitCode']}"
+    return detail
+
+
+def _pod_crash_details(pod: dict) -> list[str]:
+    """Return concrete crash details for containers in a pod."""
+    metadata = pod.get("metadata", {})
+    status = pod.get("status", {})
+    pod_name = metadata.get("name", "unknown-pod")
+    failures: list[str] = []
+
+    status_groups = (
+        status.get("initContainerStatuses", []),
+        status.get("containerStatuses", []),
+        status.get("ephemeralContainerStatuses", []),
+    )
+    for container_statuses in status_groups:
+        for container_status in container_statuses or []:
+            state = container_status.get("state", {})
+            details: list[str] = []
+
+            waiting = state.get("waiting") or {}
+            waiting_reason = waiting.get("reason")
+            if waiting_reason in CRASH_STATES:
+                details.append(waiting_reason)
+
+            terminated = state.get("terminated") or {}
+            terminated_reason = terminated.get("reason")
+            terminated_exit_code = terminated.get("exitCode")
+            if terminated and (
+                terminated_reason in CRASH_STATES
+                or (terminated_exit_code is not None and terminated_exit_code != 0)
+            ):
+                details.append(_terminated_state_detail("terminated: ", terminated))
+
+            if not details:
+                continue
+
+            last_terminated = (container_status.get("lastState") or {}).get(
+                "terminated"
+            )
+            if last_terminated:
+                details.append(
+                    _terminated_state_detail("last terminated: ", last_terminated)
+                )
+
+            container_name = container_status.get("name", "unknown-container")
+            failures.append(f"{pod_name}/{container_name} ({', '.join(details)})")
+
+    if not failures and status.get("reason") in CRASH_STATES:
+        failures.append(f"{pod_name} ({status['reason']})")
+
+    return failures
 
 
 # ---------------------------------------------------------------------------
@@ -211,18 +272,18 @@ def wait_for_pods_by_label(
         f"app={label}",
         "--namespace",
         namespace,
-        "--no-headers",
+        "-o",
+        "json",
         check=False,
     )
     if check_result.success and check_result.stdout:
-        for state in CRASH_STATES:
-            if state in check_result.stdout:
-                errors.append(
-                    f"Found pods in error state. Run: "
-                    f"kubectl --namespace {namespace} get pods "
-                    f"-l app={label}"
-                )
-                break
+        try:
+            pods = json.loads(check_result.stdout).get("items", [])
+        except (json.JSONDecodeError, AttributeError):
+            pods = []
+        crash_details = [detail for pod in pods for detail in _pod_crash_details(pod)]
+        if crash_details:
+            errors.append("Found pods in error state: " + "; ".join(crash_details))
 
     if not errors:
         context.logger.log_info("All pods completed successfully")

--- a/tests/test_kube_helpers_pod_failures.py
+++ b/tests/test_kube_helpers_pod_failures.py
@@ -1,0 +1,76 @@
+"""Tests for informative harness pod failure reporting."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from llmdbenchmark.utilities.kube_helpers import wait_for_pods_by_label
+
+
+class _Logger:
+    def log_info(self, *_: Any, **__: Any) -> None:
+        pass
+
+
+class _Result:
+    def __init__(
+        self, *, success: bool = True, stdout: str = "", stderr: str = ""
+    ) -> None:
+        self.success = success
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _Command:
+    def __init__(self, pod_list: dict) -> None:
+        self.pod_list = pod_list
+        self.calls: list[tuple[str, ...]] = []
+
+    def kube(self, *args: str, **_: Any) -> _Result:
+        self.calls.append(args)
+        if args[:2] == ("get", "pods"):
+            return _Result(stdout=json.dumps(self.pod_list))
+        return _Result()
+
+
+def test_wait_reports_current_and_previous_container_failure() -> None:
+    pod_list = {
+        "items": [
+            {
+                "metadata": {"name": "inference-perf-abc"},
+                "status": {
+                    "containerStatuses": [
+                        {
+                            "name": "harness",
+                            "state": {"waiting": {"reason": "CrashLoopBackOff"}},
+                            "lastState": {
+                                "terminated": {
+                                    "reason": "OOMKilled",
+                                    "exitCode": 137,
+                                }
+                            },
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    cmd = _Command(pod_list)
+    context = SimpleNamespace(logger=_Logger())
+
+    errors = wait_for_pods_by_label(
+        cmd,
+        "llmdbench-harness-launcher",
+        "bench",
+        3600,
+        context,
+    )
+
+    assert errors == [
+        "Found pods in error state: inference-perf-abc/harness "
+        "(CrashLoopBackOff, last terminated: OOMKilled, exit_code=137)"
+    ]
+    get_call = next(call for call in cmd.calls if call[:2] == ("get", "pods"))
+    assert get_call[-2:] == ("-o", "json")


### PR DESCRIPTION
## Summary

Improve run-phase harness pod failure reporting by surfacing concrete pod/container crash reasons such as OOMKilled.

## Motivation

Fixes #1397.

When long-running inference-perf workloads fail because the harness pod is OOMKilled, llm-d-benchmark can currently report only a generic run failure such as:

```
[07] deploy_harness: FAILED - Some treatments had errors
```

or:

```
Found pods in error state
```

This makes it hard to distinguish an application-level benchmark failure from a Kubernetes container termination such as OOMKilled.

## What changed

- Changed the final harness pod crash-state check in `wait_for_pods_by_label()` to read `kubectl get pods -o json`.
- Extract pod/container crash details from:
  - `containerStatuses[*].state`
  - `containerStatuses[*].lastState`
  - init and ephemeral container statuses
- Include concrete failure details in the returned error message, for example:

```
Found pods in error state: inference-perf-abc/harness (CrashLoopBackOff, last terminated: OOMKilled, exit_code=137)
```

- Added a regression test covering a harness container with:
  - current state `CrashLoopBackOff`
  - previous termination reason `OOMKilled`
  - exit code `137`

## Testing

- `python -m pytest tests/test_kube_helpers_pod_failures.py tests/test_deploy_harness_status.py -q`
- `ruff check llmdbenchmark/utilities/kube_helpers.py tests/test_kube_helpers_pod_failures.py tests/test_deploy_harness_status.py`
- `git diff --check upstream/main...HEAD`

## Backward Compatibility

This does not change pod deployment, waiting, cleanup, or result collection behavior. It only improves the error message produced when Kubernetes reports a terminal container failure.
