### PR TITLE
Make time-series metric selection configurable

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1192,6 +1192,7 @@ Configured under the top-level `monitoring` section in `defaults.yaml`:
 | `monitoring.podmonitor.enabled` | `true` | Create PodMonitor resources for Prometheus scraping |
 | `monitoring.metricsPath` | `/metrics` | Prometheus scrape path |
 | `monitoring.scrapeInterval` | `"30s"` | Prometheus scrape interval |
+| `monitoring.timeSeriesMetrics` | See `defaults.yaml` | Metrics retained for processing, time-series graphs, and benchmark-report observability. Custom Prometheus metrics can be added without code changes. |
 | `monitoring.installPrometheusCrds` | `false` | Install Prometheus CRDs (PodMonitor, ServiceMonitor) during standup. Required for clusters without Prometheus Operator (e.g. Kind). |
 
 When `monitoring.enabled` is `true` and running on OpenShift, the `03_cluster-monitoring-config.yaml.j2` template renders a ConfigMap to enable user workload monitoring.

--- a/config/templates/jinja/20_harness_pod.yaml.j2
+++ b/config/templates/jinja/20_harness_pod.yaml.j2
@@ -113,6 +113,11 @@ spec:
       value: "{{ monitoring.metricsPath }}"
     - name: LLMDBENCH_EPP_METRICS_SECRET
       value: "{{ router.monitoring.secretName | default('inference-gateway-sa-metrics-reader-secret') }}"
+{% if monitoring.timeSeriesMetrics is defined %}
+    - name: LLMDBENCH_TIME_SERIES_METRICS
+      value: >-
+        {{ monitoring.timeSeriesMetrics | tojson }}
+{% endif %}
 {% endif %}
     - name: LLMDBENCH_STANDALONE_ENABLED
       value: "{{ standalone.enabled | lower }}"

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -502,6 +502,35 @@ monitoring:
   metricsPath: /metrics
   scrapeInterval: "30s"
   metricsScrapeEnabled: false
+  # Prometheus time-series metrics retained for processing, visualization,
+  # and benchmark-report observability entries. Add new metrics here without
+  # changing the analysis code.
+  timeSeriesMetrics:
+    - vllm:kv_cache_usage_perc
+    - vllm:gpu_cache_usage_perc
+    - vllm:cpu_cache_usage_perc
+    - vllm:gpu_memory_usage_bytes
+    - vllm:cpu_memory_usage_bytes
+    - container_memory_usage_bytes
+    - DCGM_FI_DEV_GPU_UTIL
+    - DCGM_FI_DEV_POWER_USAGE
+    - vllm:num_requests_running
+    - vllm:num_requests_waiting
+    - vllm:prefix_cache_hits_total
+    - vllm:prefix_cache_queries_total
+    - vllm:external_prefix_cache_hits_total
+    - vllm:external_prefix_cache_queries_total
+    - vllm:prefix_cache_hit_rate
+    - vllm:external_prefix_cache_hit_rate
+    - vllm:nixl_xfer_time_seconds_sum
+    - vllm:nixl_xfer_time_seconds_count
+    - vllm:nixl_bytes_transferred_sum
+    - vllm:nixl_bytes_transferred_count
+    - vllm:num_preemptions_total
+    - inference_pool_average_kv_cache_utilization
+    - inference_pool_average_queue_size
+    - inference_pool_average_running_requests
+    - inference_pool_ready_pods
 
 # ============================================================================
 # ACCELERATOR CONFIGURATION

--- a/docs/metrics_collection.md
+++ b/docs/metrics_collection.md
@@ -40,6 +40,21 @@ Harness Pod (in-cluster)
 
 Metrics collection can be enabled via CLI (`llmdbenchmark run --monitoring`) or via scenario config. The CLI flag sets `metricsScrapeEnabled: true` at runtime, overriding the scenario default.
 
+The metrics retained for processing, visualization, and benchmark-report
+observability are configured in one place:
+
+```yaml
+monitoring:
+  timeSeriesMetrics:
+    - vllm:kv_cache_usage_perc
+    - vllm:num_requests_running
+    - vllm:custom_scheduler_metric
+```
+
+The rendered list is passed to the harness pod and saved with the processed
+metrics, so later analysis uses the same selection. Metrics without built-in
+display metadata receive a generated title, filename, and report key.
+
 | Environment Variable | Default | Description |
 |---|---|---|
 | `LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED` | `false` | Enable/disable metrics collection. Set automatically when `--monitoring` is passed. |
@@ -47,6 +62,7 @@ Metrics collection can be enabled via CLI (`llmdbenchmark run --monitoring`) or 
 | `LLMDBENCH_VLLM_COMMON_METRICS_PORT` | `8200` | Prometheus metrics port (modelservice) |
 | `LLMDBENCH_VLLM_COMMON_INFERENCE_PORT` | `8000` | Fallback port (standalone vLLM) |
 | `LLMDBENCH_VLLM_MONITORING_METRICS_PATH` | `/metrics` | Prometheus endpoint path |
+| `LLMDBENCH_TIME_SERIES_METRICS` | Rendered from config | JSON representation of `monitoring.timeSeriesMetrics` passed to the harness pod |
 | `METRICS_CURL_TIMEOUT` | `30` | Max seconds per curl request |
 | `LLMDBENCH_METRICS_POD_PATTERN` | `decode` | Fallback pod name pattern for discovery |
 

--- a/llmdbenchmark/analysis/benchmark_report/metrics_processor.py
+++ b/llmdbenchmark/analysis/benchmark_report/metrics_processor.py
@@ -4,6 +4,7 @@ Process collected metrics and integrate into benchmark report.
 
 import json
 import os
+import re
 from typing import Any
 
 
@@ -184,6 +185,35 @@ def _graph_path(graph_file: str) -> str:
     return f"metrics/graphs/{graph_file}"
 
 
+def _load_time_series_metrics(metrics_dir: str) -> list[str]:
+    """Load configured metric names, with legacy defaults for older results."""
+    value = _load_json(
+        os.path.join(metrics_dir, "processed", "time_series_metrics.json")
+    )
+    if not isinstance(value, list):
+        return list(GRAPHED_METRICS)
+    return [name for name in value if isinstance(name, str) and name]
+
+
+def _metric_metadata(
+    prom_name: str, metrics_summary: dict[str, Any]
+) -> tuple[str, str, str]:
+    """Return report metadata, deriving sensible values for custom metrics."""
+    if prom_name in GRAPHED_METRICS:
+        return GRAPHED_METRICS[prom_name]
+
+    safe_name = re.sub(r"[^a-zA-Z0-9_]+", "_", prom_name).strip("_")
+    units = ""
+    for pod_name, pod_data in metrics_summary.items():
+        if pod_name.startswith("_"):
+            continue
+        metric_data = pod_data.get("metrics", {}).get(prom_name, {})
+        if metric_data:
+            units = metric_data.get("unit", "")
+            break
+    return safe_name, units, f"{safe_name}.png"
+
+
 # ---------------------------------------------------------------------------
 # Build observability entries
 # ---------------------------------------------------------------------------
@@ -191,6 +221,7 @@ def _graph_path(graph_file: str) -> str:
 
 def _build_per_metric_entries(
     metrics_summary: dict[str, Any],
+    metric_names: list[str],
 ) -> dict[str, Any]:
     """Build per-metric observability entries with per-component statistics.
 
@@ -206,9 +237,10 @@ def _build_per_metric_entries(
         role = _detect_role(pod_name)
         comp_id = _component_id(role)
 
-        for prom_name, (report_key, units, graph_file) in GRAPHED_METRICS.items():
+        for prom_name in metric_names:
             if prom_name not in metrics:
                 continue
+            report_key, units, graph_file = _metric_metadata(prom_name, metrics_summary)
 
             component_entry = {
                 "component_id": comp_id,
@@ -229,12 +261,14 @@ def _build_per_metric_entries(
 def _build_aggregated_entries(
     metrics_summary: dict[str, Any],
     obs: dict[str, Any],
+    metric_names: list[str],
 ) -> None:
     """Add cluster-wide aggregated stats to existing observability entries."""
     aggregated = metrics_summary.get("_aggregated", {}).get("metrics", {})
-    for prom_name, (report_key, units, _) in GRAPHED_METRICS.items():
+    for prom_name in metric_names:
         if prom_name not in aggregated:
             continue
+        report_key, units, _ = _metric_metadata(prom_name, metrics_summary)
         entry = obs.setdefault(report_key, {})
         entry["aggregated"] = _make_stats_dict(aggregated[prom_name], units)
 
@@ -315,8 +349,9 @@ def add_metrics_to_benchmark_report(
         os.path.join(metrics_dir, "processed", "metrics_summary.json")
     )
     if metrics_summary:
-        obs.update(_build_per_metric_entries(metrics_summary))
-        _build_aggregated_entries(metrics_summary, obs)
+        metric_names = _load_time_series_metrics(metrics_dir)
+        obs.update(_build_per_metric_entries(metrics_summary, metric_names))
+        _build_aggregated_entries(metrics_summary, obs, metric_names)
 
     # EPP log-derived metrics
     epp_summary = _load_json(os.path.join(metrics_dir, "epp_metrics_summary.json"))

--- a/llmdbenchmark/analysis/visualize_metrics.py
+++ b/llmdbenchmark/analysis/visualize_metrics.py
@@ -34,8 +34,9 @@ AGGREGATE_METRICS = {
     "vllm:num_preemptions_total",
 }
 
-# Metrics to visualize: prometheus_name -> (title, ylabel)
-METRICS_TO_PLOT = {
+# Display metadata for known metrics. Metrics not present here still receive a
+# graph using a generated title and the Prometheus name as the Y-axis label.
+METRIC_DISPLAY = {
     "vllm:kv_cache_usage_perc": ("KV Cache Usage", "Usage (%)"),
     "vllm:gpu_cache_usage_perc": ("GPU Cache Usage", "Usage (%)"),
     "vllm:cpu_cache_usage_perc": ("CPU Cache Usage", "Usage (%)"),
@@ -91,6 +92,24 @@ RATIO_METRICS = [
         "vllm_external_prefix_cache_hit_rate",
     ),
 ]
+
+
+def _load_time_series_metrics(metrics_dir):
+    """Load the metric selection persisted by process_metrics.py."""
+    config_path = os.path.join(metrics_dir, "processed", "time_series_metrics.json")
+    try:
+        with open(config_path, "r") as config_file:
+            value = json.load(config_file)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return list(METRIC_DISPLAY)
+    if not isinstance(value, list):
+        return list(METRIC_DISPLAY)
+    return [name for name in value if isinstance(name, str) and name]
+
+
+def _metric_title(metric_name):
+    """Generate a readable title for a metric without display metadata."""
+    return metric_name.replace(":", " ").replace("_", " ").title()
 
 
 # ---------------------------------------------------------------------------
@@ -391,9 +410,13 @@ def generate_all_visualizations(metrics_dir, output_dir=None, context=None):
         return 0
 
     plot_count = 0
+    configured_metrics = _load_time_series_metrics(metrics_dir)
+    configured_metric_set = set(configured_metrics)
 
     # Ratio metrics (computed from pairs of counters)
     for numerator, denominator, title, ylabel, output_name in RATIO_METRICS:
+        if output_name not in configured_metric_set:
+            continue
         ratio_data = {}
         for pod_name, metrics in pod_data.items():
             if numerator in metrics and denominator in metrics:
@@ -422,10 +445,16 @@ def generate_all_visualizations(metrics_dir, output_dir=None, context=None):
             plot_count += 1
 
     # Standard time series plots
-    for metric_name, (title, ylabel) in METRICS_TO_PLOT.items():
+    ratio_output_names = {ratio[4] for ratio in RATIO_METRICS}
+    for metric_name in configured_metrics:
+        if metric_name in ratio_output_names:
+            continue
         has_metric = any(metric_name in m for m in pod_data.values())
         if has_metric:
-            safe_name = metric_name.replace(":", "_")
+            title, ylabel = METRIC_DISPLAY.get(
+                metric_name, (_metric_title(metric_name), metric_name)
+            )
+            safe_name = re.sub(r"[^a-zA-Z0-9_.-]+", "_", metric_name)
             plot_metric_time_series(
                 pod_data,
                 metric_name,

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -852,6 +852,7 @@ class DeployHarnessStep(Step):
         env.filters["is_empty"] = DeployHarnessStep._is_empty_filter
         env.filters["default_if_empty"] = DeployHarnessStep._default_if_empty_filter
         env.filters["b64encode"] = DeployHarnessStep._b64encode_filter
+        env.filters["tojson"] = lambda value: json.dumps(value, separators=(",", ":"))
 
         template = env.from_string(template_content)
         return template.render(**values)

--- a/tests/test_harness_pod_template_scripts.py
+++ b/tests/test_harness_pod_template_scripts.py
@@ -89,3 +89,35 @@ def test_harness_pod_copies_configmap_scripts_before_launch() -> None:
     assert launch_script.index("/workspace/harnesses") < launch_script.index(
         "llm-d-benchmark.sh"
     )
+
+
+def test_harness_pod_receives_configured_time_series_metrics() -> None:
+    template_path = (
+        Path(__file__).resolve().parent.parent
+        / "config"
+        / "templates"
+        / "jinja"
+        / "20_harness_pod.yaml.j2"
+    )
+    values = _template_values()
+    values.update(
+        {
+            "monitoring": {
+                "metricsScrapeEnabled": True,
+                "metricsPath": "/metrics",
+                "timeSeriesMetrics": ["vllm:custom_metric"],
+            },
+            "decode": {"vllm": {"port": 8000}},
+            "router": {"monitoring": {}},
+        }
+    )
+
+    rendered = DeployHarnessStep._render_template(
+        template_path.read_text(encoding="utf-8"), values
+    )
+    pod = yaml.safe_load(rendered)
+    env = {
+        item["name"]: item.get("value") for item in pod["spec"]["containers"][0]["env"]
+    }
+
+    assert env["LLMDBENCH_TIME_SERIES_METRICS"] == '["vllm:custom_metric"]'

--- a/tests/test_time_series_metrics_config.py
+++ b/tests/test_time_series_metrics_config.py
@@ -1,0 +1,128 @@
+"""Tests for configurable Prometheus time-series metric selection."""
+
+from __future__ import annotations
+
+import json
+import runpy
+from datetime import datetime, timezone
+from pathlib import Path
+
+from llmdbenchmark.analysis import visualize_metrics
+from llmdbenchmark.analysis.benchmark_report.metrics_processor import (
+    add_metrics_to_benchmark_report,
+)
+
+
+def test_process_metrics_uses_configured_metric_list(
+    tmp_path: Path, monkeypatch
+) -> None:
+    metrics_dir = tmp_path / "metrics"
+    raw_dir = metrics_dir / "raw"
+    processed_dir = metrics_dir / "processed"
+    raw_dir.mkdir(parents=True)
+    processed_dir.mkdir()
+    (raw_dir / "pod-1_metrics.log").write_text(
+        "# Timestamp: 2026-07-14T00:00:00Z\n"
+        "# Pod: pod-1\n"
+        "# Namespace: bench\n"
+        "vllm:custom_metric 42\n"
+        "vllm:num_requests_running 7\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("METRICS_DIR", str(metrics_dir))
+    monkeypatch.setenv("LLMDBENCH_TIME_SERIES_METRICS", '["vllm:custom_metric"]')
+
+    module = runpy.run_path(
+        "workload/harnesses/process_metrics.py", run_name="process_metrics_test"
+    )
+    summary = module["aggregate_metrics"]()
+
+    assert set(summary["pod-1"]["metrics"]) == {"vllm:custom_metric"}
+    assert set(summary["_aggregated"]["metrics"]) == {"vllm:custom_metric"}
+    assert json.loads(
+        (processed_dir / "time_series_metrics.json").read_text(encoding="utf-8")
+    ) == ["vllm:custom_metric"]
+
+
+def test_visualization_loads_persisted_metric_list(tmp_path: Path) -> None:
+    processed_dir = tmp_path / "processed"
+    processed_dir.mkdir()
+    (processed_dir / "time_series_metrics.json").write_text(
+        '["vllm:custom_metric"]', encoding="utf-8"
+    )
+
+    assert visualize_metrics._load_time_series_metrics(str(tmp_path)) == [
+        "vllm:custom_metric"
+    ]
+
+
+def test_visualization_plots_configured_custom_metric(
+    tmp_path: Path, monkeypatch
+) -> None:
+    processed_dir = tmp_path / "processed"
+    processed_dir.mkdir()
+    (processed_dir / "time_series_metrics.json").write_text(
+        '["vllm:custom_metric"]', encoding="utf-8"
+    )
+    plotted: list[str] = []
+    monkeypatch.setattr(visualize_metrics, "MATPLOTLIB_AVAILABLE", True)
+    monkeypatch.setattr(
+        visualize_metrics,
+        "collect_time_series_data",
+        lambda _metrics_dir: {
+            "pod-1": {
+                "vllm:custom_metric": [
+                    (datetime(2026, 7, 14, tzinfo=timezone.utc), 42.0)
+                ]
+            }
+        },
+    )
+    monkeypatch.setattr(
+        visualize_metrics,
+        "plot_metric_time_series",
+        lambda _pod_data, metric_name, *_args, **_kwargs: plotted.append(metric_name),
+    )
+    monkeypatch.setattr(
+        visualize_metrics, "plot_pod_startup_times", lambda *_args: None
+    )
+    monkeypatch.setattr(visualize_metrics, "plot_replica_status", lambda *_args: None)
+
+    count = visualize_metrics.generate_all_visualizations(str(tmp_path))
+
+    assert plotted == ["vllm:custom_metric"]
+    assert count == 3
+
+
+def test_report_includes_configured_custom_metric(tmp_path: Path) -> None:
+    processed_dir = tmp_path / "processed"
+    processed_dir.mkdir()
+    (processed_dir / "time_series_metrics.json").write_text(
+        '["vllm:custom_metric"]', encoding="utf-8"
+    )
+    (processed_dir / "metrics_summary.json").write_text(
+        json.dumps(
+            {
+                "pod-1": {
+                    "metrics": {
+                        "vllm:custom_metric": {
+                            "mean": 42.0,
+                            "p50": 42.0,
+                            "p99": 42.0,
+                            "stddev": 0.0,
+                            "unit": "requests",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = add_metrics_to_benchmark_report({}, str(tmp_path))
+    metric = report["results"]["observability"]["vllm_custom_metric"]
+
+    assert metric["components"][0]["statistics"]["mean"] == 42.0
+    assert metric["components"][0]["statistics"]["units"] == "requests"
+    assert metric["components"][0]["statistics"]["graph_path"].endswith(
+        "vllm_custom_metric.png"
+    )

--- a/workload/harnesses/process_metrics.py
+++ b/workload/harnesses/process_metrics.py
@@ -19,8 +19,31 @@ metrics_dir = os.environ.get("METRICS_DIR", "metrics")
 raw_dir = os.path.join(metrics_dir, "raw")
 processed_dir = os.path.join(metrics_dir, "processed")
 
-# Metrics to aggregate across all pods for cluster-wide stats
-AGGREGATE_METRICS = {
+
+def _load_time_series_metrics():
+    """Load the configured metric names passed by the harness pod."""
+    raw_value = os.environ.get("LLMDBENCH_TIME_SERIES_METRICS")
+    if not raw_value:
+        return None
+    try:
+        value = json.loads(raw_value)
+    except json.JSONDecodeError:
+        print("Warning: LLMDBENCH_TIME_SERIES_METRICS is not valid JSON")
+        return None
+    if not isinstance(value, list):
+        print("Warning: LLMDBENCH_TIME_SERIES_METRICS must be a JSON list")
+        return None
+    return [name for name in value if isinstance(name, str) and name]
+
+
+TIME_SERIES_METRICS = _load_time_series_metrics()
+TIME_SERIES_METRIC_SET = (
+    set(TIME_SERIES_METRICS) if TIME_SERIES_METRICS is not None else None
+)
+
+# Legacy aggregation defaults used when the script is run without a rendered
+# monitoring.timeSeriesMetrics configuration.
+LEGACY_AGGREGATE_METRICS = {
     "vllm:kv_cache_usage_perc",
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
@@ -33,6 +56,11 @@ AGGREGATE_METRICS = {
     "inference_pool_average_running_requests",
     "inference_pool_ready_pods",
 }
+AGGREGATE_METRICS = (
+    TIME_SERIES_METRIC_SET
+    if TIME_SERIES_METRIC_SET is not None
+    else LEGACY_AGGREGATE_METRICS
+)
 
 # Ratio metrics: (output_name, numerator_metric, denominator_metric)
 RATIO_METRICS = [
@@ -47,6 +75,11 @@ RATIO_METRICS = [
         "vllm:external_prefix_cache_queries_total",
     ),
 ]
+RATIO_INPUT_METRICS = {
+    metric_name
+    for _, numerator_metric, denominator_metric in RATIO_METRICS
+    for metric_name in (numerator_metric, denominator_metric)
+}
 
 # Metric name -> unit mapping
 METRIC_UNITS = {
@@ -227,6 +260,12 @@ def aggregate_metrics():
 
     all_files = glob.glob(os.path.join(raw_dir, "*_metrics.log"))
 
+    if TIME_SERIES_METRICS is not None:
+        _save_json(
+            os.path.join(processed_dir, "time_series_metrics.json"),
+            TIME_SERIES_METRICS,
+        )
+
     if not all_files:
         print("Warning: No raw files found to process")
         print(f"Checked directory: {raw_dir}")
@@ -258,11 +297,21 @@ def aggregate_metrics():
             pod_metadata[pod_name]["files"].append(os.path.basename(file_path))
 
             for metric_name, values in metrics.items():
-                pod_metrics[pod_name][metric_name].extend(values)
+                if (
+                    TIME_SERIES_METRIC_SET is None
+                    or metric_name in TIME_SERIES_METRIC_SET
+                    or metric_name in RATIO_INPUT_METRICS
+                ):
+                    pod_metrics[pod_name][metric_name].extend(values)
 
     # Compute ratio metrics per-pod before aggregation
     for pod_name, metrics in pod_metrics.items():
         for ratio_name, num_metric, den_metric in RATIO_METRICS:
+            if (
+                TIME_SERIES_METRIC_SET is not None
+                and ratio_name not in TIME_SERIES_METRIC_SET
+            ):
+                continue
             if num_metric in metrics and den_metric in metrics:
                 num_vals = metrics[num_metric]
                 den_vals = metrics[den_metric]
@@ -282,6 +331,7 @@ def aggregate_metrics():
                 name: _compute_stats(values, METRIC_UNITS.get(name, ""))
                 for name, values in metrics.items()
                 if values
+                and (TIME_SERIES_METRIC_SET is None or name in TIME_SERIES_METRIC_SET)
             },
         }
 


### PR DESCRIPTION
## Summary

Make the Prometheus time-series metrics retained, visualized, and added to benchmark reports configurable through `monitoring.timeSeriesMetrics`.

## Motivation

Fixes #1065.

The metric selection is currently hard-coded independently in `process_metrics.py`, `visualize_metrics.py`, and `metrics_processor.py`. Adding a metric therefore requires coordinated code changes in several places even when the metric is already exposed by vLLM or another component.

## What changed

- Added `monitoring.timeSeriesMetrics` with reasonable defaults in `config/templates/values/defaults.yaml`.
- Pass the rendered metric list to harness pods through `LLMDBENCH_TIME_SERIES_METRICS`.
- Filter and aggregate processed Prometheus data using the configured list.
- Persist the selected list alongside processed metrics so visualization and report generation use the exact same configuration.
- Generate titles, graph filenames, and benchmark-report keys automatically for custom metrics without built-in display metadata.
- Preserve computed cache-hit ratio support when the ratio metric is selected.
- Document the configuration and environment-variable flow.
- Add regression coverage for harness rendering, processing, visualization, and report integration with a custom metric.

## Testing

- `python -m pytest tests/test_time_series_metrics_config.py tests/test_harness_pod_template_scripts.py tests/test_deploy_harness_status.py tests/test_config_schema.py tests/test_run_only_report_conversion.py tests/test_benchmark_report_v0_2_1_compat.py -q`
- `ruff format --check llmdbenchmark/analysis/benchmark_report/metrics_processor.py llmdbenchmark/analysis/visualize_metrics.py llmdbenchmark/run/steps/step_07_deploy_harness.py workload/harnesses/process_metrics.py tests/test_harness_pod_template_scripts.py tests/test_time_series_metrics_config.py`
- `ruff check llmdbenchmark/analysis/benchmark_report/metrics_processor.py llmdbenchmark/analysis/visualize_metrics.py llmdbenchmark/run/steps/step_07_deploy_harness.py workload/harnesses/process_metrics.py tests/test_harness_pod_template_scripts.py tests/test_time_series_metrics_config.py`
- `git diff --check upstream/main...HEAD`

## Backward Compatibility

The default configuration preserves the existing time-series metric selection. Older result directories without a persisted metric list continue to use the existing built-in metric metadata. Prometheus scraping intervals, endpoints, pod discovery, and infrastructure metric collection are unchanged.
