### PR TITLE
Add experiment per treatment retry

### DIFF
--- a/experiments/concurrent-sessions-sweep.yaml
+++ b/experiments/concurrent-sessions-sweep.yaml
@@ -1,0 +1,64 @@
+# =====================================================================
+# Experiment: OTEL Trace Replay Concurrent-Sessions Sweep (inference-perf)
+# =====================================================================
+#
+# Sweeps the number of concurrent replay sessions while replaying OTEL
+# traces. Runs every value against a single live deployment and clears the
+# vLLM caches between treatments with `reset_caches` (so each value still
+# starts against cold caches).
+#
+# Compatible harness: inference-perf
+# Compatible workload: otel_traces.yaml
+#
+# Usage (single run against an already-standing endpoint):
+#   llmdbenchmark --spec config/specification/examples/gpu.yaml.j2 run \
+#     --endpoint-url http://<HOST>:<PORT> \
+#     --model <MODEL_NAME> \
+#     --namespace <NAMESPACE> \
+#     --harness inference-perf \
+#     --workload otel_traces.yaml \
+#     --experiments experiments/concurrent-sessions-sweep.yaml \
+#     --monitoring -g METRICS_COLLECTION_INTERVAL \
+#     --wait-timeout 10800 \
+#     --analyze
+
+# Clear vLLM prefix/mm/encoder caches on every serving pod before each
+# treatment so every value starts cold. Requires VLLM_SERVER_DEV_MODE=1
+# (the repo default). Non-fatal if dev mode is off. Default false.
+reset_caches: true
+
+# Retry a failed treatment up to N times: its pods and faulty results are
+# deleted, then it re-runs with a fresh experiment_id (reset_caches fires
+# again). 1 = no retry.
+treatment_max_attempts: 5
+
+# Abort the whole run once a treatment exhausts its attempts, instead of
+# continuing to the remaining treatments. Default false.
+treatment_stop_on_error: true
+
+# Fail (and retry) a treatment when its summary_lifecycle_metrics.json
+# reports failures.count > 0 (or is missing/unparseable), even if the pod
+# exited cleanly. Only applies to the otel_traces workload (the schema is
+# workload-specific); other workloads warn and fall back to pod state.
+# Opt-in. Default false.
+validate_failures: true
+
+treatments:
+  - name: conc8
+    load.stages.0.concurrent_sessions: 8
+  - name: conc12
+    load.stages.0.concurrent_sessions: 12
+  - name: conc16
+    load.stages.0.concurrent_sessions: 16
+  - name: conc24
+    load.stages.0.concurrent_sessions: 24
+  - name: conc32
+    load.stages.0.concurrent_sessions: 32
+  - name: conc48
+    load.stages.0.concurrent_sessions: 48
+  - name: conc64
+    load.stages.0.concurrent_sessions: 64
+  - name: conc96
+    load.stages.0.concurrent_sessions: 96
+  - name: conc128
+    load.stages.0.concurrent_sessions: 128

--- a/llmdbenchmark/analysis/cross_treatment.py
+++ b/llmdbenchmark/analysis/cross_treatment.py
@@ -13,6 +13,8 @@ per-treatment analysis completes).
 from __future__ import annotations
 
 import csv
+import glob
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -258,6 +260,9 @@ def generate_cross_treatment_summary(
 
     # Generate overlaid per-request CDF plots across treatments
     plot_count += _generate_overlaid_cdf_plots(results_dir, output_dir, context)
+
+    # Generate overlaid vLLM cache-vs-time plots across treatments
+    plot_count += _generate_overlaid_cache_plots(results_dir, output_dir, context)
 
     return len(rows)
 
@@ -897,6 +902,276 @@ def _extract_per_request_metrics(pr_file: Path) -> dict[str, list[float]]:
                 metrics["itl"].append(token_times[i] - token_times[i - 1])
 
     return metrics
+
+
+# vLLM cache-vs-time overlay across treatments, keyed by treatment name (the
+# raw swept value is not recoverable from result dir names).
+
+_CACHE_RAW_GLOB = "metrics/raw/*_metrics.log"
+_CACHE_KV = "vllm:kv_cache_usage_perc"
+_CACHE_QUERIES = "vllm:prefix_cache_queries_total"
+_CACHE_HITS = "vllm:prefix_cache_hits_total"
+_CACHE_EPS = 1e-9
+_CACHE_TRIM_PAD_SEC = 1.0
+_CACHE_METRIC_RE = re.compile(
+    r"([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{[^}]*\})? ([\d.eE+-]+)(?:\s+\d+)?$"
+)
+
+
+def _cache_epoch_from_name(path: Path) -> float | None:
+    m = re.search(r"_(\d+)_metrics\.log$", path.name)
+    return float(m.group(1)) if m else None
+
+
+def _cache_parse_snapshot(path: Path) -> dict[str, float]:
+    """Parse one raw snapshot: {KV: mean, QUERIES: sum, HITS: sum} if present."""
+    buckets: dict[str, list[float]] = {
+        _CACHE_KV: [],
+        _CACHE_QUERIES: [],
+        _CACHE_HITS: [],
+    }
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                m = _CACHE_METRIC_RE.match(line)
+                if not m:
+                    continue
+                name = m.group(1)
+                if name in buckets:
+                    buckets[name].append(float(m.group(2)))
+    except OSError:
+        return {}
+    out: dict[str, float] = {}
+    if buckets[_CACHE_KV]:
+        out[_CACHE_KV] = sum(buckets[_CACHE_KV]) / len(buckets[_CACHE_KV])
+    if buckets[_CACHE_QUERIES]:
+        out[_CACHE_QUERIES] = sum(buckets[_CACHE_QUERIES])
+    if buckets[_CACHE_HITS]:
+        out[_CACHE_HITS] = sum(buckets[_CACHE_HITS])
+    return out
+
+
+def _cache_trim_to_active(
+    series: list[tuple[float, dict[str, float]]],
+) -> list[tuple[float, dict[str, float]]]:
+    """Clip a run's series to its active window (idle pre/post scrapes off)."""
+    n = len(series)
+    if n == 0:
+        return series
+    active = [False] * n
+    prev_q: float | None = None
+    for i, (_, values) in enumerate(series):
+        kv = values.get(_CACHE_KV)
+        if kv is not None and kv > _CACHE_EPS:
+            active[i] = True
+        q = values.get(_CACHE_QUERIES)
+        if q is not None:
+            if prev_q is not None and q - prev_q > 0:
+                active[i] = True
+            prev_q = q
+    if not any(active):
+        return series
+    first = active.index(True)
+    last = n - 1 - active[::-1].index(True)
+    lo = max(0, first - 1)
+    hi = min(n - 1, last + 1)
+    while lo > 0 and series[lo][0] - series[lo - 1][0] <= _CACHE_TRIM_PAD_SEC:
+        lo -= 1
+    while hi < n - 1 and series[hi + 1][0] - series[hi][0] <= _CACHE_TRIM_PAD_SEC:
+        hi += 1
+    return series[lo : hi + 1]
+
+
+def _cache_load_series(results_dir: Path) -> list[tuple[float, dict[str, float]]]:
+    """Return [(elapsed_sec, {metric: value}), ...] for one treatment, trimmed to its active window and re-based to t=0."""
+    files = sorted(glob.glob(str(results_dir / _CACHE_RAW_GLOB)))
+    samples: list[tuple[float, dict[str, float]]] = []
+    for f in files:
+        p = Path(f)
+        epoch = _cache_epoch_from_name(p)
+        if epoch is None:
+            continue
+        values = _cache_parse_snapshot(p)
+        if values:
+            samples.append((epoch, values))
+    if not samples:
+        return []
+    samples.sort(key=lambda s: s[0])
+    t0 = samples[0][0]
+    series = [(epoch - t0, values) for epoch, values in samples]
+    series = _cache_trim_to_active(series)
+    if series:
+        base = series[0][0]
+        series = [(t - base, values) for t, values in series]
+    return series
+
+
+def _generate_overlaid_cache_plots(
+    results_dir: Path,
+    output_dir: Path,
+    context: "ExecutionContext | None" = None,
+) -> int:
+    """Overlay each treatment's vLLM cache time series on shared axes.
+
+    Emits three PNGs (KV usage, prefix-cache totals, prefix-cache hit rate),
+    one line per treatment. No-op with fewer than 2 treatments having snapshots.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return 0
+
+    colors = [
+        "#1f77b4",
+        "#ff7f0e",
+        "#2ca02c",
+        "#d62728",
+        "#9467bd",
+        "#8c564b",
+        "#e377c2",
+        "#17becf",
+    ]
+
+    # points: [(treatment_label, series), ...]
+    points: list[tuple[str, list[tuple[float, dict[str, float]]]]] = []
+    for subdir in sorted(results_dir.iterdir()):
+        if not subdir.is_dir():
+            continue
+        series = _cache_load_series(subdir)
+        if series:
+            points.append((_shorten_treatment_label(subdir.name), series))
+
+    if len(points) < 2:
+        return 0
+
+    generated = 0
+
+    def _color(idx: int) -> str:
+        return colors[idx % len(colors)]
+
+    # 1) KV-cache usage over time
+    fig, ax = plt.subplots(figsize=(14, 5))
+    drew = False
+    for idx, (label, series) in enumerate(points):
+        xs = [t for t, v in series if _CACHE_KV in v]
+        ys = [v[_CACHE_KV] for _, v in series if _CACHE_KV in v]
+        if not xs:
+            continue
+        ax.plot(
+            xs,
+            ys,
+            marker="o",
+            markersize=1.5,
+            linewidth=1.6,
+            color=_color(idx),
+            label=label,
+        )
+        drew = True
+    ax.set_xlabel("time since run start (sec)")
+    ax.set_ylabel("KV cache usage (fraction)")
+    ax.set_title("KV cache usage over time (per treatment)")
+    ax.grid(True, alpha=0.3)
+    if drew:
+        ax.legend(loc="best")
+        fig.tight_layout()
+        fig.savefig(str(output_dir / "cache_overlay_kv_cache_usage.png"), dpi=150)
+        generated += 1
+    plt.close(fig)
+
+    # 2) Prefix-cache cumulative queries (solid) / hits (dashed) over time
+    fig, ax = plt.subplots(figsize=(14, 5))
+    drew = False
+    for idx, (label, series) in enumerate(points):
+        color = _color(idx)
+        q_xs = [t for t, v in series if _CACHE_QUERIES in v]
+        q_ys = [v[_CACHE_QUERIES] for _, v in series if _CACHE_QUERIES in v]
+        h_xs = [t for t, v in series if _CACHE_HITS in v]
+        h_ys = [v[_CACHE_HITS] for _, v in series if _CACHE_HITS in v]
+        if q_xs:
+            ax.plot(
+                q_xs,
+                q_ys,
+                linestyle="-",
+                linewidth=1.6,
+                color=color,
+                label=f"{label} queries",
+            )
+            drew = True
+        if h_xs:
+            ax.plot(
+                h_xs,
+                h_ys,
+                linestyle="--",
+                linewidth=1.6,
+                color=color,
+                label=f"{label} hits",
+            )
+            drew = True
+    ax.set_xlabel("time since run start (sec)")
+    ax.set_ylabel("cumulative tokens")
+    ax.set_title("Prefix cache queries/hits (cumulative) over time (per treatment)")
+    ax.grid(True, alpha=0.3)
+    if drew:
+        ax.legend(loc="best", fontsize=8)
+        fig.tight_layout()
+        fig.savefig(str(output_dir / "cache_overlay_prefix_cache_totals.png"), dpi=150)
+        generated += 1
+    plt.close(fig)
+
+    # 3) Derived per-interval prefix-cache hit rate over time
+    fig, ax = plt.subplots(figsize=(14, 5))
+    drew = False
+    for idx, (label, series) in enumerate(points):
+        pts = [
+            (t, v[_CACHE_QUERIES], v[_CACHE_HITS])
+            for t, v in series
+            if _CACHE_QUERIES in v and _CACHE_HITS in v
+        ]
+        xs: list[float] = []
+        ys: list[float] = []
+        for (_, q0, h0), (t1, q1, h1) in zip(pts, pts[1:]):
+            dq = q1 - q0
+            dh = h1 - h0
+            if dq <= 0 or dh < 0:
+                continue
+            xs.append(t1)
+            ys.append(100.0 * dh / dq)
+        if not xs:
+            continue
+        ax.plot(
+            xs,
+            ys,
+            marker="o",
+            markersize=3,
+            linewidth=1.6,
+            color=_color(idx),
+            label=label,
+        )
+        drew = True
+    ax.set_xlabel("time since run start (sec)")
+    ax.set_ylabel("prefix cache hit rate (%)")
+    ax.set_title("Prefix cache hit rate (per-interval) over time (per treatment)")
+    ax.set_ylim(0, 100)
+    ax.grid(True, alpha=0.3)
+    if drew:
+        ax.legend(loc="best")
+        fig.tight_layout()
+        fig.savefig(
+            str(output_dir / "cache_overlay_prefix_cache_hit_rate.png"), dpi=150
+        )
+        generated += 1
+    plt.close(fig)
+
+    if generated:
+        _log(context, f"Generated {generated} overlaid cache plot(s)")
+
+    return generated
 
 
 def _generate_overlaid_cdf_plots(

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -815,9 +815,31 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
     # to every serving pod before each treatment's run. Covers both the
     # `run` and `experiment` subcommands, which both flow their file through
     # ``experiments_file``.
-    from llmdbenchmark.experiment.parser import read_reset_caches
+    from llmdbenchmark.experiment.parser import read_reset_caches, read_run_controls
 
     reset_caches = read_reset_caches(experiments_file)
+
+    # Per-treatment retry / result-gating controls: YAML value, overridden by
+    # the matching CLI flag when set, else the default.
+    _run_controls = read_run_controls(experiments_file)
+    _cli_max_attempts = getattr(args, "treatment_max_attempts", None)
+    treatment_max_attempts = (
+        max(1, int(_cli_max_attempts))
+        if _cli_max_attempts is not None
+        else _run_controls["treatment_max_attempts"]
+    )
+    _cli_stop_on_error = getattr(args, "treatment_stop_on_error", None)
+    treatment_stop_on_error = (
+        bool(_cli_stop_on_error)
+        if _cli_stop_on_error is not None
+        else _run_controls["treatment_stop_on_error"]
+    )
+    _cli_validate_failures = getattr(args, "validate_failures", None)
+    validate_failures = (
+        bool(_cli_validate_failures)
+        if _cli_validate_failures is not None
+        else _run_controls["validate_failures"]
+    )
 
     context = ExecutionContext(
         plan_dir=config.plan_dir,
@@ -852,6 +874,9 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         harness_debug=getattr(args, "debug", False),
         harness_skip_run=getattr(args, "skip", False),
         reset_caches=reset_caches,
+        treatment_max_attempts=treatment_max_attempts,
+        treatment_stop_on_error=treatment_stop_on_error,
+        validate_failures=validate_failures,
         harness_service_account=getattr(args, "serviceaccount", None),
         harness_envvars_to_pod=getattr(args, "envvarspod", None),
         analyze_locally=getattr(args, "analyze", False),

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -100,6 +100,17 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # in the --experiments YAML. Requires the server to run with
     # VLLM_SERVER_DEV_MODE=1 (the repo default); resets are non-fatal.
     reset_caches: bool = False
+    # Retry a failed treatment up to this many times, each attempt deleting
+    # its pods and faulty results and re-running with a fresh experiment_id
+    # (so reset_caches re-fires). 1 = no retry.
+    treatment_max_attempts: int = 1
+    # Abort the treatment loop once a treatment exhausts its attempts, instead
+    # of recording it failed and continuing to the remaining treatments.
+    treatment_stop_on_error: bool = False
+    # Gate treatment success on the harness-reported failure count, not just
+    # pod state. Workload-specific (see _FAILURE_VALIDATORS in step_07); an
+    # unrecognized workload warns and falls back to pod state.
+    validate_failures: bool = False
     harness_service_account: str | None = None
     harness_envvars_to_pod: str | None = None
     analyze_locally: bool = False

--- a/llmdbenchmark/experiment/parser.py
+++ b/llmdbenchmark/experiment/parser.py
@@ -159,6 +159,49 @@ def read_reset_caches(experiments_file: str | Path | None) -> bool:
     return bool(data.get("reset_caches", False))
 
 
+# Defaults for the run-loop control knobs (no retry, do-not-abort, no gating).
+RUN_CONTROL_DEFAULTS = {
+    "treatment_max_attempts": 1,
+    "treatment_stop_on_error": False,
+    "validate_failures": False,
+}
+
+
+def read_run_controls(experiments_file: str | Path | None) -> dict:
+    """Read the top-level run-loop control keys from an experiment YAML.
+
+    Returns a dict keyed as in ``RUN_CONTROL_DEFAULTS``. Fail-open: any
+    unreadable/non-mapping file or absent/unparseable key falls back to the
+    default, so a parse problem here never blocks a run.
+    """
+    controls = dict(RUN_CONTROL_DEFAULTS)
+    if not experiments_file:
+        return controls
+    path = Path(experiments_file)
+    if not path.exists():
+        return controls
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return controls
+    if not isinstance(data, dict):
+        return controls
+
+    if "treatment_max_attempts" in data:
+        try:
+            controls["treatment_max_attempts"] = max(
+                1, int(data["treatment_max_attempts"])
+            )
+        except (TypeError, ValueError):
+            pass
+    if "treatment_stop_on_error" in data:
+        controls["treatment_stop_on_error"] = bool(data["treatment_stop_on_error"])
+    if "validate_failures" in data:
+        controls["validate_failures"] = bool(data["validate_failures"])
+    return controls
+
+
 def parse_experiment(path: Path) -> ExperimentPlan:
     """Parse an experiment YAML file into an ExperimentPlan."""
     path = Path(path).resolve()

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -139,6 +139,40 @@ def add_subcommands(
         help="Seconds to wait for harness completion (0 = do not wait).",
     )
     run_parser.add_argument(
+        "--treatment-max-attempts",
+        type=int,
+        default=env_int("LLMDBENCH_TREATMENT_MAX_ATTEMPTS"),
+        help=(
+            "Retry a failed treatment up to N times: delete its pods and faulty "
+            "results dir, then re-run with a fresh experiment_id (so reset_caches "
+            "fires again for cold caches). 1 = no retry (default). Overrides the "
+            "top-level treatment_max_attempts key in --experiments YAML."
+        ),
+    )
+    run_parser.add_argument(
+        "--treatment-stop-on-error",
+        action="store_true",
+        default=None,
+        help=(
+            "Abort the run's treatment loop once a treatment exhausts its "
+            "attempts, instead of recording it failed and continuing. Default: "
+            "continue remaining treatments. Overrides the top-level "
+            "treatment_stop_on_error key in --experiments YAML."
+        ),
+    )
+    run_parser.add_argument(
+        "--validate-failures",
+        action="store_true",
+        default=None,
+        help=(
+            "Fail (and retry) a treatment when its summary_lifecycle_metrics.json "
+            "reports failures.count > 0, or the file is missing/unparseable. "
+            "Only applies to the otel_traces workload; other workloads warn and "
+            "fall back to Kubernetes pod state. Default: pod state only. "
+            "Overrides the top-level validate_failures key in --experiments YAML."
+        ),
+    )
+    run_parser.add_argument(
         "-x",
         "--dataset",
         default=env("LLMDBENCH_DATASET"),

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -8,7 +8,9 @@ cluster resources.
 """
 
 import base64
+import json
 import random
+import shutil
 import string
 import time
 from pathlib import Path
@@ -183,301 +185,362 @@ class DeployHarnessStep(Step):
         total_deployed = 0
 
         for treatment_idx, treatment in enumerate(treatments, 1):
-            treatment_start = time.time()
-            treatment_errors: list[str] = []
-
-            # Generate experiment ID
-            timestamp = int(time.time())
-            rand_suffix = self._rand_suffix(6)
             treatment_name = ""
             if treatment and isinstance(treatment, dict):
                 treatment_name = treatment.get("name", "")
-            if treatment_name:
-                experiment_id = (
-                    f"{harness_name}-{treatment_name}-{timestamp}-{rand_suffix}"
-                )
-            else:
-                experiment_id = f"{harness_name}-{timestamp}-{rand_suffix}"
-
             treatment_label = treatment_name or "default"
-            context.logger.log_info(
-                f"[{treatment_idx}/{total_treatments}] Treatment '{treatment_label}': "
-                f"deploying {parallelism} pod(s)...",
-                emoji="\U0001f680",
-            )
 
-            # --- Phase 1: Deploy this treatment's pods ---
-            treatment_pod_names: list[str] = []
-            deploy_errors: list[str] = []
+            # Per-treatment retry loop: each attempt gets a fresh experiment_id
+            # so reset_caches (if enabled) re-fires and the treatment starts
+            # cold. max_attempts == 1 means no retry.
+            max_attempts = max(1, context.treatment_max_attempts)
+            treatment_succeeded = False
+            last_attempt_errors: list[str] = []
 
-            # Resolve the treatment-specific profile once (same for all
-            # parallel pods within a treatment).
-            pod_profile_name = (
-                self._treatment_profile_name(profile_name, treatment)
-                if treatment
-                else profile_name
-            )
+            for attempt in range(1, max_attempts + 1):
+                treatment_start = time.time()
+                treatment_errors = []
 
-            # Reset the vLLM prefix/multimodal/encoder caches before this
-            # treatment's run so it starts cold. Fires once per treatment
-            # (before the parallel-pod group), not per parallel pod: the
-            # parallel pods run concurrently against the same servers, so a
-            # reset between them would wipe a cache a sibling is actively
-            # warming. Non-fatal -- warnings only.
-            if (
-                context.reset_caches
-                and not context.dry_run
-                and not context.harness_debug
-            ):
-                inference_port = (
-                    (plan_config or {}).get("vllmCommon", {}).get("inferencePort", 8000)
-                )
-                reset_caches_pods(
-                    cmd,
-                    deploy_namespace or harness_ns,
-                    model_label,
-                    inference_port,
-                    plan_config=plan_config,
-                    logger=context.logger,
-                )
-
-            for parallel_idx in range(1, parallelism + 1):
-                pod_suffix = self._rand_suffix(8)
-                pod_name = f"{harness_name}-{pod_suffix}"
-
-                # Per-pod results directory -- each parallel pod writes to
-                # its own sub-directory with an _${i} suffix, matching bash.
-                results_dir = f"{results_dir_prefix}/{experiment_id}_{parallel_idx}"
-
-                # Build harness command per pod (results_dir differs)
-                if context.harness_debug:
-                    harness_command = "sleep infinity"
-                else:
-                    harness_cfg = plan_config.get("harness", {}) if plan_config else {}
-                    entrypoint = harness_cfg.get("entrypoint", "llm-d-benchmark.sh")
-                    harness_command = self._build_harness_command(
-                        harness_executable=harness_executable,
-                        profile_name=pod_profile_name,
-                        harness_name=harness_name,
-                        results_dir=results_dir,
-                        entrypoint=entrypoint,
-                        dataset_url=context.dataset_url,
-                    )
-
-                # Build template values by merging plan_config with runtime values
-                template_values = dict(plan_config) if plan_config else {}
-                # Determine deploy method for benchmark report population
-                deploy_method = "modelservice"
-                if context.deployed_methods:
-                    deploy_method = ",".join(context.deployed_methods)
-                elif plan_config:
-                    if plan_config.get("standalone", {}).get("enabled"):
-                        deploy_method = "standalone"
-                    elif plan_config.get("fma", {}).get("enabled"):
-                        deploy_method = "fma"
-
-                template_values.update(
-                    {
-                        "pod_name": pod_name,
-                        "harness_command": harness_command,
-                        "endpoint_url": endpoint_url,
-                        "experiment_id": experiment_id,
-                        "results_dir": results_dir,
-                        "stack_type": stack_type,
-                        "deploy_method": deploy_method,
-                        "cluster_type": context.platform_type,
-                    }
-                )
-
-                # Inject base64-encoded kubeconfig so kubectl works inside the pod
-                # (needed by collect_metrics.sh and llm-d-benchmark.sh vLLM scraping)
-                kubeconfig_path = context.kubeconfig
-                if kubeconfig_path and Path(kubeconfig_path).exists():
-                    template_values["base64_context_contents"] = self._b64encode_filter(
-                        Path(kubeconfig_path).read_text(encoding="utf-8")
-                    )
-
-                # Ensure required nested keys exist with defaults
-                template_values.setdefault("harness", {})
-                template_values["harness"]["name"] = harness_name
-                template_values["harness"]["namespace"] = harness_ns
-                template_values.setdefault("namespace", {})
-                template_values["namespace"]["name"] = harness_ns
-                template_values.setdefault("model", {})
-                if model_name:
-                    template_values["model"]["name"] = model_name
-                template_values.setdefault("images", {}).setdefault("benchmark", {})
-
-                # Service account precedence: CLI override (-q) > scenario's
-                # harness.serviceAccount > global serviceAccount.name default.
-                if context.harness_service_account:
-                    template_values["harness"]["serviceAccount"] = (
-                        context.harness_service_account
-                    )
-                elif plan_config and plan_config.get("harness", {}).get(
-                    "serviceAccount"
-                ):
-                    template_values["harness"]["serviceAccount"] = plan_config[
-                        "harness"
-                    ]["serviceAccount"]
-                elif plan_config and "serviceAccount" in plan_config:
-                    template_values["harness"]["serviceAccount"] = plan_config[
-                        "serviceAccount"
-                    ].get("name", "default")
-
-                # Extra env vars to propagate into pod (-g)
-                if context.harness_envvars_to_pod:
-                    import os
-
-                    extra_env = []
-                    for var_name in context.harness_envvars_to_pod.split(","):
-                        var_name = var_name.strip()
-                        if var_name and var_name in os.environ:
-                            extra_env.append(
-                                {
-                                    "name": var_name,
-                                    "value": os.environ[var_name],
-                                }
-                            )
-                    if extra_env:
-                        template_values["harness"]["extraEnvVars"] = extra_env
-
-                if context.dry_run:
-                    context.logger.log_info(
-                        f"[DRY RUN] Would deploy pod '{pod_name}' "
-                        f"(experiment={experiment_id}, parallel={parallel_idx}/{parallelism})"
-                    )
-                    treatment_pod_names.append(pod_name)
-                    continue
-
-                # Render the template
-                try:
-                    rendered = self._render_template(template_content, template_values)
-                except Exception as exc:
-                    deploy_errors.append(
-                        f"Failed to render harness pod template: {exc}"
-                    )
-                    continue
-
-                # Write and apply
-                pod_yaml_path = context.run_dir() / f"{pod_name}.yaml"
-                pod_yaml_path.write_text(rendered, encoding="utf-8")
-
-                result = cmd.kube(
-                    "apply",
-                    "-f",
-                    str(pod_yaml_path),
-                    "--namespace",
-                    harness_ns,
-                    check=False,
-                )
-                if not result.success:
-                    deploy_errors.append(
-                        f"Failed to deploy pod '{pod_name}': {result.stderr}"
+                timestamp = int(time.time())
+                rand_suffix = self._rand_suffix(6)
+                if treatment_name:
+                    experiment_id = (
+                        f"{harness_name}-{treatment_name}-{timestamp}-{rand_suffix}"
                     )
                 else:
-                    treatment_pod_names.append(pod_name)
-                    context.logger.log_info(
-                        f"Deployed pod '{pod_name}' "
-                        f"(experiment={experiment_id}, "
-                        f"parallel={parallel_idx}/{parallelism})"
-                    )
+                    experiment_id = f"{harness_name}-{timestamp}-{rand_suffix}"
 
-            if deploy_errors:
-                errors.extend(deploy_errors)
-                treatment_errors.extend(deploy_errors)
-
-            if not treatment_pod_names:
-                no_pods_error = f"No pods deployed for treatment '{treatment_label}'"
-                errors.append(no_pods_error)
-                treatment_errors.append(no_pods_error)
-                context.logger.log_error(
+                attempt_suffix = (
+                    f" (attempt {attempt}/{max_attempts})" if max_attempts > 1 else ""
+                )
+                context.logger.log_info(
                     f"[{treatment_idx}/{total_treatments}] Treatment "
-                    f"'{treatment_label}' failed: {no_pods_error}"
+                    f"'{treatment_label}'{attempt_suffix}: "
+                    f"deploying {parallelism} pod(s)...",
+                    emoji="\U0001f680",
                 )
-                continue
 
-            total_deployed += len(treatment_pod_names)
+                # Phase 1: deploy this treatment's pods
+                treatment_pod_names: list[str] = []
+                deploy_errors: list[str] = []
 
-            # --- Phase 2: Wait for this treatment's pods ---
-            if not context.dry_run and not context.harness_debug and timeout != 0:
-                wait_errors = wait_for_pods_by_label(
-                    cmd, pod_label, harness_ns, timeout, context
+                # Resolve the treatment-specific profile once (same for all
+                # parallel pods within a treatment).
+                pod_profile_name = (
+                    self._treatment_profile_name(profile_name, treatment)
+                    if treatment
+                    else profile_name
                 )
-                if wait_errors:
-                    errors.extend(wait_errors)
-                    treatment_errors.extend(wait_errors)
 
-            # --- Phase 3: Collect this treatment's results ---
-            if not context.dry_run and not context.harness_debug:
-                collect_errors = self._collect_treatment_results_discovery(
-                    cmd,
-                    experiment_id,
-                    harness_ns,
-                    results_dir_prefix,
-                    context,
+                # Reset the vLLM caches so this treatment starts cold. Fires
+                # once per treatment, not per parallel pod: siblings run
+                # concurrently against the same servers, so a reset between them
+                # would wipe a cache another pod is warming. Non-fatal.
+                if (
+                    context.reset_caches
+                    and not context.dry_run
+                    and not context.harness_debug
+                ):
+                    inference_port = (
+                        (plan_config or {})
+                        .get("vllmCommon", {})
+                        .get("inferencePort", 8000)
+                    )
+                    reset_caches_pods(
+                        cmd,
+                        deploy_namespace or harness_ns,
+                        model_label,
+                        inference_port,
+                        plan_config=plan_config,
+                        logger=context.logger,
+                    )
+
+                for parallel_idx in range(1, parallelism + 1):
+                    pod_suffix = self._rand_suffix(8)
+                    pod_name = f"{harness_name}-{pod_suffix}"
+
+                    # Per-pod results directory, suffixed with the pod index.
+                    results_dir = f"{results_dir_prefix}/{experiment_id}_{parallel_idx}"
+
+                    # Build harness command per pod (results_dir differs)
+                    if context.harness_debug:
+                        harness_command = "sleep infinity"
+                    else:
+                        harness_cfg = (
+                            plan_config.get("harness", {}) if plan_config else {}
+                        )
+                        entrypoint = harness_cfg.get("entrypoint", "llm-d-benchmark.sh")
+                        harness_command = self._build_harness_command(
+                            harness_executable=harness_executable,
+                            profile_name=pod_profile_name,
+                            harness_name=harness_name,
+                            results_dir=results_dir,
+                            entrypoint=entrypoint,
+                            dataset_url=context.dataset_url,
+                        )
+
+                    # Build template values by merging plan_config with runtime values
+                    template_values = dict(plan_config) if plan_config else {}
+                    # Determine deploy method for benchmark report population
+                    deploy_method = "modelservice"
+                    if context.deployed_methods:
+                        deploy_method = ",".join(context.deployed_methods)
+                    elif plan_config:
+                        if plan_config.get("standalone", {}).get("enabled"):
+                            deploy_method = "standalone"
+                        elif plan_config.get("fma", {}).get("enabled"):
+                            deploy_method = "fma"
+
+                    template_values.update(
+                        {
+                            "pod_name": pod_name,
+                            "harness_command": harness_command,
+                            "endpoint_url": endpoint_url,
+                            "experiment_id": experiment_id,
+                            "results_dir": results_dir,
+                            "stack_type": stack_type,
+                            "deploy_method": deploy_method,
+                            "cluster_type": context.platform_type,
+                        }
+                    )
+
+                    # Inject base64-encoded kubeconfig so kubectl works inside the pod
+                    # (needed by collect_metrics.sh and llm-d-benchmark.sh vLLM scraping)
+                    kubeconfig_path = context.kubeconfig
+                    if kubeconfig_path and Path(kubeconfig_path).exists():
+                        template_values["base64_context_contents"] = (
+                            self._b64encode_filter(
+                                Path(kubeconfig_path).read_text(encoding="utf-8")
+                            )
+                        )
+
+                    # Ensure required nested keys exist with defaults
+                    template_values.setdefault("harness", {})
+                    template_values["harness"]["name"] = harness_name
+                    template_values["harness"]["namespace"] = harness_ns
+                    template_values.setdefault("namespace", {})
+                    template_values["namespace"]["name"] = harness_ns
+                    template_values.setdefault("model", {})
+                    if model_name:
+                        template_values["model"]["name"] = model_name
+                    template_values.setdefault("images", {}).setdefault("benchmark", {})
+
+                    # Service account precedence: CLI override (-q) > scenario's
+                    # harness.serviceAccount > global serviceAccount.name default.
+                    if context.harness_service_account:
+                        template_values["harness"]["serviceAccount"] = (
+                            context.harness_service_account
+                        )
+                    elif plan_config and plan_config.get("harness", {}).get(
+                        "serviceAccount"
+                    ):
+                        template_values["harness"]["serviceAccount"] = plan_config[
+                            "harness"
+                        ]["serviceAccount"]
+                    elif plan_config and "serviceAccount" in plan_config:
+                        template_values["harness"]["serviceAccount"] = plan_config[
+                            "serviceAccount"
+                        ].get("name", "default")
+
+                    # Extra env vars to propagate into pod (-g)
+                    if context.harness_envvars_to_pod:
+                        import os
+
+                        extra_env = []
+                        for var_name in context.harness_envvars_to_pod.split(","):
+                            var_name = var_name.strip()
+                            if var_name and var_name in os.environ:
+                                extra_env.append(
+                                    {
+                                        "name": var_name,
+                                        "value": os.environ[var_name],
+                                    }
+                                )
+                        if extra_env:
+                            template_values["harness"]["extraEnvVars"] = extra_env
+
+                    if context.dry_run:
+                        context.logger.log_info(
+                            f"[DRY RUN] Would deploy pod '{pod_name}' "
+                            f"(experiment={experiment_id}, parallel={parallel_idx}/{parallelism})"
+                        )
+                        treatment_pod_names.append(pod_name)
+                        continue
+
+                    # Render the template
+                    try:
+                        rendered = self._render_template(
+                            template_content, template_values
+                        )
+                    except Exception as exc:
+                        deploy_errors.append(
+                            f"Failed to render harness pod template: {exc}"
+                        )
+                        continue
+
+                    # Write and apply
+                    pod_yaml_path = context.run_dir() / f"{pod_name}.yaml"
+                    pod_yaml_path.write_text(rendered, encoding="utf-8")
+
+                    result = cmd.kube(
+                        "apply",
+                        "-f",
+                        str(pod_yaml_path),
+                        "--namespace",
+                        harness_ns,
+                        check=False,
+                    )
+                    if not result.success:
+                        deploy_errors.append(
+                            f"Failed to deploy pod '{pod_name}': {result.stderr}"
+                        )
+                    else:
+                        treatment_pod_names.append(pod_name)
+                        context.logger.log_info(
+                            f"Deployed pod '{pod_name}' "
+                            f"(experiment={experiment_id}, "
+                            f"parallel={parallel_idx}/{parallelism})"
+                        )
+
+                # Accumulate into treatment_errors during the attempt; the outer
+                # ``errors`` list is only extended once retries are exhausted, so
+                # an attempt that later succeeds on retry doesn't pollute it.
+                if deploy_errors:
+                    treatment_errors.extend(deploy_errors)
+
+                no_pods = not treatment_pod_names
+                if no_pods:
+                    no_pods_error = (
+                        f"No pods deployed for treatment '{treatment_label}'"
+                    )
+                    treatment_errors.append(no_pods_error)
+                    context.logger.log_error(
+                        f"[{treatment_idx}/{total_treatments}] Treatment "
+                        f"'{treatment_label}' failed: {no_pods_error}"
+                    )
+
+                if not no_pods:
+                    total_deployed += len(treatment_pod_names)
+
+                # Phase 2: wait for this treatment's pods
+                if (
+                    not no_pods
+                    and not context.dry_run
+                    and not context.harness_debug
+                    and timeout != 0
+                ):
+                    wait_errors = wait_for_pods_by_label(
+                        cmd, pod_label, harness_ns, timeout, context
+                    )
+                    if wait_errors:
+                        treatment_errors.extend(wait_errors)
+
+                # Phase 3: collect this treatment's results
+                if not no_pods and not context.dry_run and not context.harness_debug:
+                    collect_errors = self._collect_treatment_results_discovery(
+                        cmd,
+                        experiment_id,
+                        harness_ns,
+                        results_dir_prefix,
+                        context,
+                    )
+                    if collect_errors:
+                        treatment_errors.extend(collect_errors)
+
+                # Phase 4: capture pod logs (when monitoring is enabled)
+                monitoring = (plan_config or {}).get("monitoring", {})
+                metrics_enabled = (
+                    str(monitoring.get("metricsScrapeEnabled", False)).lower() == "true"
                 )
-                if collect_errors:
-                    errors.extend(collect_errors)
-                    treatment_errors.extend(collect_errors)
+                if not no_pods and not context.dry_run and metrics_enabled:
+                    infra_ns = deploy_namespace or context.namespace or harness_ns
+                    local_results_dir = context.run_results_dir()
 
-            # --- Phase 4: Capture pod logs (when monitoring is enabled) ---
-            monitoring = (plan_config or {}).get("monitoring", {})
-            metrics_enabled = (
-                str(monitoring.get("metricsScrapeEnabled", False)).lower() == "true"
-            )
-            if not context.dry_run and metrics_enabled:
-                infra_ns = deploy_namespace or context.namespace or harness_ns
-                local_results_dir = context.run_results_dir()
+                    # Capture logs into each parallel pod's results directory.
+                    for i in range(1, parallelism + 1):
+                        pod_results_dir = local_results_dir / f"{experiment_id}_{i}"
+                        pod_log_dir = pod_results_dir / "logs"
+                        pod_log_dir.mkdir(parents=True, exist_ok=True)
 
-                # Capture logs into each parallel pod's results directory,
-                # matching the original bash behavior.
-                for i in range(1, parallelism + 1):
-                    pod_results_dir = local_results_dir / f"{experiment_id}_{i}"
-                    pod_log_dir = pod_results_dir / "logs"
-                    pod_log_dir.mkdir(parents=True, exist_ok=True)
+                        capture_pod_logs(
+                            cmd,
+                            treatment_pod_names,
+                            harness_ns,
+                            pod_log_dir,
+                            context,
+                        )
+                        capture_infrastructure_logs(
+                            cmd,
+                            infra_ns,
+                            pod_log_dir,
+                            model_label,
+                            pod_results_dir,
+                            context,
+                        )
 
-                    capture_pod_logs(
+                # Phase 5: clean up this treatment's pods
+                if (
+                    treatment_pod_names
+                    and not context.dry_run
+                    and not context.harness_debug
+                ):
+                    delete_pods_by_names(
                         cmd,
                         treatment_pod_names,
                         harness_ns,
-                        pod_log_dir,
-                        context,
-                    )
-                    capture_infrastructure_logs(
-                        cmd,
-                        infra_ns,
-                        pod_log_dir,
-                        model_label,
-                        pod_results_dir,
                         context,
                     )
 
-            # --- Phase 5: Clean up this treatment's pods ---
-            if not context.dry_run and not context.harness_debug:
-                delete_pods_by_names(
-                    cmd,
-                    treatment_pod_names,
-                    harness_ns,
-                    context,
-                )
+                # Result validation gate (opt-in): fail the attempt if the
+                # harness reported failed sessions, even when every phase above
+                # succeeded.
+                if (
+                    not treatment_errors
+                    and context.validate_failures
+                    and not context.dry_run
+                    and not context.harness_debug
+                ):
+                    validation_errors = self._validate_failures(
+                        context, experiment_id, parallelism, profile_name
+                    )
+                    if validation_errors:
+                        treatment_errors.extend(validation_errors)
 
-            # Track experiment ID for upload step
-            context.experiment_ids.append(experiment_id)
+                elapsed = time.time() - treatment_start
 
-            elapsed = time.time() - treatment_start
-            if treatment_errors:
+                if not treatment_errors:
+                    # Attempt succeeded: record its ID for upload and stop retrying.
+                    context.experiment_ids.append(experiment_id)
+                    treatment_succeeded = True
+                    context.logger.log_info(
+                        f"[{treatment_idx}/{total_treatments}] Treatment "
+                        f"'{treatment_label}' complete ({int(elapsed)}s)"
+                        f"{attempt_suffix}",
+                        emoji="\u2705",
+                    )
+                    break
+
+                # Attempt failed: remember its errors and, if more attempts
+                # remain, delete the faulty results so the next one starts clean.
+                last_attempt_errors = treatment_errors
                 context.logger.log_error(
                     f"[{treatment_idx}/{total_treatments}] Treatment "
-                    f"'{treatment_label}' failed ({int(elapsed)}s): "
+                    f"'{treatment_label}' failed ({int(elapsed)}s){attempt_suffix}: "
                     f"{len(treatment_errors)} error(s)"
                 )
-            else:
-                context.logger.log_info(
-                    f"[{treatment_idx}/{total_treatments}] Treatment "
-                    f"'{treatment_label}' complete ({int(elapsed)}s)",
-                    emoji="\u2705",
-                )
+                if attempt < max_attempts and not context.dry_run:
+                    self._delete_faulty_results(context, experiment_id, parallelism)
+
+            if not treatment_succeeded:
+                errors.extend(last_attempt_errors)
+                if context.treatment_stop_on_error:
+                    # Abort the loop, leaving remaining treatments un-run;
+                    # ``errors`` is non-empty so the run reports success=False.
+                    context.logger.log_error(
+                        f"Treatment '{treatment_label}' failed after "
+                        f"{max_attempts} attempt(s) -- aborting run"
+                    )
+                    break
 
         if errors:
             return StepResult(
@@ -499,6 +562,102 @@ class DeployHarnessStep(Step):
             ),
             stack_name=stack_name,
         )
+
+    # Per-treatment retry helpers
+
+    @staticmethod
+    def _profile_stem(profile_name: str | None) -> str:
+        """Strip path and known suffixes from a workload profile name."""
+        stem = (profile_name or "").rsplit("/", 1)[-1]
+        for suffix in (".in", ".yaml", ".yml", ".json"):
+            if stem.endswith(suffix):
+                stem = stem[: -len(suffix)]
+        return stem
+
+    def _validate_failures(
+        self,
+        context: ExecutionContext,
+        experiment_id: str,
+        parallelism: int,
+        profile_name: str | None = None,
+    ) -> list[str]:
+        """Dispatch to a per-workload validator (result formats differ by
+        workload); a workload with no validator warns and falls back to pod state.
+        """
+        stem = self._profile_stem(profile_name)
+        for prefix, validator in self._FAILURE_VALIDATORS.items():
+            if stem == prefix or stem.startswith(prefix):
+                return validator(self, context, experiment_id, parallelism)
+
+        context.logger.log_warning(
+            f"validate_failures: no result-failure check implemented for workload "
+            f"'{profile_name}'; falling back to pod state for treatment success. "
+            f"(Implemented: {', '.join(self._FAILURE_VALIDATORS) or 'none'}.)"
+        )
+        return []
+
+    def _validate_failures_otel(
+        self,
+        context: ExecutionContext,
+        experiment_id: str,
+        parallelism: int,
+    ) -> list[str]:
+        """otel_traces validator: fail if any per-pod
+        summary_lifecycle_metrics.json is missing, unparseable, or reports
+        failures.count > 0.
+        """
+        errs: list[str] = []
+        base = context.run_results_dir()
+        for i in range(1, parallelism + 1):
+            pod_dir = base / f"{experiment_id}_{i}"
+            summary = pod_dir / "summary_lifecycle_metrics.json"
+            if not summary.exists():
+                summary = pod_dir / "analysis" / "summary_lifecycle_metrics.json"
+            if not summary.exists():
+                errs.append(
+                    f"validate_failures: missing summary_lifecycle_metrics.json "
+                    f"under {pod_dir}"
+                )
+                continue
+            try:
+                with open(summary, encoding="utf-8") as f:
+                    count = json.load(f)["failures"]["count"]
+                count = int(count)
+            except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+                errs.append(
+                    f"validate_failures: cannot parse failures.count from {summary}"
+                )
+                continue
+            if count > 0:
+                errs.append(
+                    f"validate_failures: {count} failed session(s) reported in "
+                    f"{summary}"
+                )
+        return errs
+
+    # Result-failure validators keyed by profile-stem prefix. Add an entry to
+    # support a new workload; unlisted workloads fall back to pod state.
+    _FAILURE_VALIDATORS = {
+        "otel_traces": _validate_failures_otel,
+    }
+
+    @staticmethod
+    def _delete_faulty_results(
+        context: ExecutionContext,
+        experiment_id: str,
+        parallelism: int,
+    ) -> None:
+        """Delete a failed attempt's per-pod result dirs (and any dir matching
+        the experiment_id) so the next attempt starts clean.
+        """
+        base = context.run_results_dir()
+        for i in range(1, parallelism + 1):
+            pod_dir = base / f"{experiment_id}_{i}"
+            if pod_dir.exists():
+                shutil.rmtree(pod_dir, ignore_errors=True)
+        for extra in base.glob(f"*{experiment_id}*"):
+            if extra.is_dir():
+                shutil.rmtree(extra, ignore_errors=True)
 
     # ------------------------------------------------------------------
     # Per-treatment result collection

--- a/llmdbenchmark/utilities/profile_renderer.py
+++ b/llmdbenchmark/utilities/profile_renderer.py
@@ -114,15 +114,10 @@ def render_profile_file(
 
 
 # Dotted-key prefixes that flag a workload-treatment override as actually
-# being a plan/scenario field. Putting any of these under top-level
-# ``treatments:`` (or ``--overrides``) is a silent no-op today -- the value
-# lands in a corner of the override dict that ``apply_overrides`` walks
-# against the workload profile YAML, where the key path never exists.
-#
-# To actually vary these fields, the user wants ``setup.treatments`` in an
-# experiment YAML (modelservice/standalone), or ``kustomize.extraHelmSets``
-# (kustomize). ``classify_override_miss`` returns a sharper hint when it
-# sees one of these prefixes.
+# being a plan/scenario field. These never match the workload profile YAML,
+# so a treatment override on one is a silent no-op; to vary them the user
+# wants ``setup.treatments`` or ``kustomize.extraHelmSets`` instead.
+# ``classify_override_miss`` returns a sharper hint for these prefixes.
 _PLAN_LEVEL_PREFIXES: tuple[str, ...] = (
     "decode.",
     "prefill.",
@@ -168,21 +163,62 @@ def classify_override_miss(key: str) -> str:
     )
 
 
+_MISSING = object()
+
+
+def _descend(container: Any, part: str) -> Any:
+    """Step one level into a dict key or a list index.
+
+    Returns the child node, or ``_MISSING`` if ``part`` doesn't address an
+    existing element. Integer-looking ``part`` values index into lists, so
+    dotted paths can traverse list elements.
+    """
+    if isinstance(container, dict):
+        return container[part] if part in container else _MISSING
+    if isinstance(container, list):
+        try:
+            idx = int(part)
+        except ValueError:
+            return _MISSING
+        if -len(container) <= idx < len(container):
+            return container[idx]
+    return _MISSING
+
+
+def _assign(container: Any, part: str, value: Any) -> bool:
+    """Set ``part`` on the parent ``container`` (dict key or list index).
+
+    Returns True on success. A list index must already be in range (we set,
+    never append/grow); a bad index or non-container parent fails.
+    """
+    if isinstance(container, dict):
+        container[part] = value
+        return True
+    if isinstance(container, list):
+        try:
+            idx = int(part)
+        except ValueError:
+            return False
+        if -len(container) <= idx < len(container):
+            container[idx] = value
+            return True
+    return False
+
+
 def apply_overrides(
     profile_content: str, overrides: dict[str, str]
 ) -> tuple[str, list[str]]:
     """Apply dotted key=value overrides to a rendered YAML profile.
 
-    Parses the YAML, walks dotted keys to set values, and re-dumps.
+    Parses the YAML, walks dotted keys to set values, and re-dumps. Path
+    segments address dict keys or (when integer-looking) list indices.
 
-    Returns ``(rendered_content, unmatched_keys)``. ``unmatched_keys`` is the
-    list of override keys whose dotted path did not exist in the profile --
-    they were silently dropped under the old API. The caller is expected to
-    log a warning per unmatched key (see :func:`classify_override_miss` for a
-    pre-built hint).
+    Returns ``(rendered_content, unmatched_keys)``, where ``unmatched_keys``
+    are override keys whose dotted path did not exist in the profile. The
+    caller is expected to log a warning per unmatched key (see
+    :func:`classify_override_miss` for a pre-built hint).
 
-    Falls back to ``(original_content, [])`` if YAML parsing fails (we can't
-    even tell what would have matched).
+    Falls back to ``(original_content, [])`` if YAML parsing fails.
     """
     import yaml  # pylint: disable=import-outside-toplevel
 
@@ -191,26 +227,23 @@ def apply_overrides(
         if not isinstance(data, dict):
             return profile_content, []
 
-        # An override is "unmatched" when one of the PARENT keys along its
-        # dotted path doesn't exist -- in that case we can't even reach the
-        # leaf to write to, and silently dropping it is the bug we're
-        # warning about. A missing LEAF is still allowed (intentional
-        # add-new-field overrides keep working), but in practice a missing
-        # leaf with all parents present is unusual; we don't warn on it.
+        # An override is "unmatched" when a PARENT key along its dotted path
+        # doesn't exist, so we can't reach the leaf to write to. A missing
+        # leaf on a dict parent is still allowed (add-new-field overrides);
+        # a list parent requires an in-range index (see _assign).
         unmatched: list[str] = []
         for key, value in overrides.items():
             parts = key.split(".")
             target = data
             parent_chain_intact = True
             for part in parts[:-1]:
-                if isinstance(target, dict) and part in target:
-                    target = target[part]
-                else:
+                target = _descend(target, part)
+                if target is _MISSING:
                     parent_chain_intact = False
                     break
-            if parent_chain_intact and isinstance(target, dict):
-                target[parts[-1]] = _coerce_value(value)
-            else:
+            if not parent_chain_intact or not _assign(
+                target, parts[-1], _coerce_value(value)
+            ):
                 unmatched.append(key)
 
         return (

--- a/tests/test_apply_overrides_warning.py
+++ b/tests/test_apply_overrides_warning.py
@@ -103,17 +103,31 @@ class TestApplyOverridesMatching:
             "router.epp.pluginsConfigFile",
         }
 
-    def test_list_indexed_path_is_currently_reported_as_unmatched(self):
-        """``load.stages.0.rate`` -- the walker hits the ``stages`` list and
-        ``"0" in <list>`` is False, so the path is reported as unmatched.
+    def test_list_indexed_path_is_applied(self):
+        """An integer segment indexes into a list, so the override reaches
+        the leaf and is applied."""
+        import yaml
 
-        This is a pre-existing limitation of apply_overrides (it only walks
-        dicts), unrelated to the plan-level warning. We pin it here so a
-        future contributor who adds list-index support gets a failing test
-        to update, rather than silently changing the warning surface.
-        """
-        _, unmatched = apply_overrides(PROFILE, {"load.stages.0.rate": "10"})
-        assert unmatched == ["load.stages.0.rate"]
+        content, unmatched = apply_overrides(PROFILE, {"load.stages.0.rate": "10"})
+        assert unmatched == []
+        assert yaml.safe_load(content)["load"]["stages"][0]["rate"] == 10
+
+    def test_negative_list_index_is_applied(self):
+        import yaml
+
+        content, unmatched = apply_overrides(PROFILE, {"load.stages.-1.duration": "90"})
+        assert unmatched == []
+        assert yaml.safe_load(content)["load"]["stages"][-1]["duration"] == 90
+
+    def test_out_of_range_list_index_is_reported(self):
+        """A list index past the end can't be reached (we set, never grow)."""
+        _, unmatched = apply_overrides(PROFILE, {"load.stages.5.rate": "10"})
+        assert unmatched == ["load.stages.5.rate"]
+
+    def test_non_integer_list_index_is_reported(self):
+        """A non-integer segment against a list parent doesn't address anything."""
+        _, unmatched = apply_overrides(PROFILE, {"load.stages.foo.rate": "10"})
+        assert unmatched == ["load.stages.foo.rate"]
 
     def test_yaml_parse_failure_returns_original_and_empty_unmatched(self):
         bad = "this: is:\n  - broken: ["

--- a/tests/test_deploy_harness_status.py
+++ b/tests/test_deploy_harness_status.py
@@ -247,3 +247,171 @@ def test_reset_caches_skipped_in_dry_run(tmp_path: Path, monkeypatch: Any) -> No
     DeployHarnessStep().execute(context, stack_path)
 
     assert calls == []
+
+
+def test_treatment_retries_then_succeeds(tmp_path: Path, monkeypatch: Any) -> None:
+    """A treatment that fails once then passes succeeds within max_attempts."""
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    context.treatment_max_attempts = 3
+    context.experiment_treatments = [{"name": "t0", "overrides": {}}]
+
+    # Fail the wait on the first attempt, pass on the second.
+    attempts = {"n": 0}
+
+    def _wait(*_a, **_k):
+        attempts["n"] += 1
+        return ["wait failed"] if attempts["n"] == 1 else []
+
+    monkeypatch.setattr(deploy_harness, "wait_for_pods_by_label", _wait)
+    monkeypatch.setattr(
+        DeployHarnessStep, "_collect_treatment_results_discovery", lambda *_a, **_k: []
+    )
+    monkeypatch.setattr(deploy_harness, "delete_pods_by_names", lambda *_a, **_k: None)
+
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        DeployHarnessStep,
+        "_delete_faulty_results",
+        staticmethod(lambda _ctx, eid, _par: deleted.append(eid)),
+    )
+
+    result = DeployHarnessStep().execute(context, stack_path)
+
+    assert result.success
+    assert attempts["n"] == 2  # retried once
+    assert len(deleted) == 1  # faulty results cleaned before the retry
+    assert len(context.experiment_ids) == 1  # only the successful attempt recorded
+
+
+def test_treatment_exhausts_attempts_records_failure(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    context.treatment_max_attempts = 2
+    context.experiment_treatments = [{"name": "t0", "overrides": {}}]
+
+    monkeypatch.setattr(
+        deploy_harness, "wait_for_pods_by_label", lambda *_a, **_k: ["wait failed"]
+    )
+    monkeypatch.setattr(
+        DeployHarnessStep, "_collect_treatment_results_discovery", lambda *_a, **_k: []
+    )
+    monkeypatch.setattr(deploy_harness, "delete_pods_by_names", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        DeployHarnessStep, "_delete_faulty_results", staticmethod(lambda *_a: None)
+    )
+
+    result = DeployHarnessStep().execute(context, stack_path)
+
+    assert not result.success
+    assert "wait failed" in result.errors
+    # A failed treatment records no experiment_id (kept out of the upload step).
+    assert context.experiment_ids == []
+
+
+def test_stop_on_error_aborts_remaining_treatments(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    context.treatment_stop_on_error = True
+    context.experiment_treatments = [
+        {"name": "t0", "overrides": {}},
+        {"name": "t1", "overrides": {}},
+    ]
+
+    seen: list[str] = []
+
+    def _collect(_cmd, experiment_id, *_a, **_k):
+        seen.append(experiment_id)
+        return []
+
+    # Fail the first treatment's wait; it has no retries (default 1), so
+    # stop_on_error should abort before the second treatment runs.
+    monkeypatch.setattr(
+        deploy_harness, "wait_for_pods_by_label", lambda *_a, **_k: ["wait failed"]
+    )
+    monkeypatch.setattr(
+        DeployHarnessStep,
+        "_collect_treatment_results_discovery",
+        staticmethod(_collect),
+    )
+    monkeypatch.setattr(deploy_harness, "delete_pods_by_names", lambda *_a, **_k: None)
+
+    result = DeployHarnessStep().execute(context, stack_path)
+
+    assert not result.success
+    # Only the first treatment (t0) ran; t1 was never collected.
+    assert all("-t0-" in eid for eid in seen)
+    assert not any("-t1-" in eid for eid in seen)
+
+
+def test_validate_failures_fails_clean_run(tmp_path: Path, monkeypatch: Any) -> None:
+    """A pod that exits clean but reports failures.count>0 fails the treatment."""
+    import json as _json
+
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    context.validate_failures = True
+    # The failures.count check is specific to the otel_traces workload.
+    context.harness_profile = "otel_traces.yaml"
+    context.experiment_treatments = [{"name": "t0", "overrides": {}}]
+
+    # Collect writes a summary with a positive failure count into the pod dir.
+    def _collect(_cmd, experiment_id, *_a, **_k):
+        d = context.run_results_dir() / f"{experiment_id}_1"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "summary_lifecycle_metrics.json").write_text(
+            _json.dumps({"failures": {"count": 2}}), encoding="utf-8"
+        )
+        return []
+
+    monkeypatch.setattr(deploy_harness, "wait_for_pods_by_label", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        DeployHarnessStep,
+        "_collect_treatment_results_discovery",
+        staticmethod(_collect),
+    )
+    monkeypatch.setattr(deploy_harness, "delete_pods_by_names", lambda *_a, **_k: None)
+
+    result = DeployHarnessStep().execute(context, stack_path)
+
+    assert not result.success
+    assert any("failed session" in e for e in result.errors)
+
+
+def test_validate_failures_falls_back_for_non_otel_workload(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """validate_failures on a non-otel workload warns and passes on pod state."""
+    import json as _json
+
+    logger = _Logger()
+    context, stack_path = _base_context(tmp_path, logger)
+    context.validate_failures = True
+    context.harness_profile = "random_concurrent.yaml"  # not otel_traces
+    context.experiment_treatments = [{"name": "t0", "overrides": {}}]
+
+    def _collect(_cmd, experiment_id, *_a, **_k):
+        d = context.run_results_dir() / f"{experiment_id}_1"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "summary_lifecycle_metrics.json").write_text(
+            _json.dumps({"failures": {"count": 7}}), encoding="utf-8"
+        )
+        return []
+
+    monkeypatch.setattr(deploy_harness, "wait_for_pods_by_label", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        DeployHarnessStep,
+        "_collect_treatment_results_discovery",
+        staticmethod(_collect),
+    )
+    monkeypatch.setattr(deploy_harness, "delete_pods_by_names", lambda *_a, **_k: None)
+
+    result = DeployHarnessStep().execute(context, stack_path)
+
+    # The positive failure count is ignored for a non-otel workload: the pods
+    # exited clean, so the treatment succeeds.
+    assert result.success

--- a/tests/test_run_controls.py
+++ b/tests/test_run_controls.py
@@ -1,0 +1,225 @@
+"""Tests for the run-loop control knobs: ``read_run_controls`` parsing and the
+step_07 ``_validate_failures`` / ``_delete_faulty_results`` retry helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.experiment.parser import RUN_CONTROL_DEFAULTS, read_run_controls
+
+_STEP_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "llmdbenchmark"
+    / "run"
+    / "steps"
+    / "step_07_deploy_harness.py"
+)
+_spec = importlib.util.spec_from_file_location("step_07_run_controls", _STEP_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["step_07_run_controls"] = _mod
+_spec.loader.exec_module(_mod)
+DeployHarnessStep = _mod.DeployHarnessStep
+
+
+# ---------------------------------------------------------------------------
+# read_run_controls
+# ---------------------------------------------------------------------------
+
+
+def test_read_run_controls_none_returns_defaults():
+    assert read_run_controls(None) == RUN_CONTROL_DEFAULTS
+
+
+def test_read_run_controls_missing_file_returns_defaults(tmp_path: Path):
+    assert read_run_controls(tmp_path / "nope.yaml") == RUN_CONTROL_DEFAULTS
+
+
+def test_read_run_controls_reads_all_keys(tmp_path: Path):
+    p = tmp_path / "exp.yaml"
+    p.write_text(
+        "treatment_max_attempts: 5\n"
+        "treatment_stop_on_error: true\n"
+        "validate_failures: true\n"
+        "treatments:\n  - {name: a, foo: 1}\n",
+        encoding="utf-8",
+    )
+    controls = read_run_controls(p)
+    assert controls == {
+        "treatment_max_attempts": 5,
+        "treatment_stop_on_error": True,
+        "validate_failures": True,
+    }
+
+
+def test_read_run_controls_absent_keys_fall_back(tmp_path: Path):
+    p = tmp_path / "exp.yaml"
+    p.write_text("treatments:\n  - {name: a, foo: 1}\n", encoding="utf-8")
+    assert read_run_controls(p) == RUN_CONTROL_DEFAULTS
+
+
+def test_read_run_controls_clamps_attempts_to_min_one(tmp_path: Path):
+    p = tmp_path / "exp.yaml"
+    p.write_text("treatment_max_attempts: 0\n", encoding="utf-8")
+    assert read_run_controls(p)["treatment_max_attempts"] == 1
+
+
+def test_read_run_controls_bad_attempts_falls_back(tmp_path: Path):
+    p = tmp_path / "exp.yaml"
+    p.write_text("treatment_max_attempts: not-a-number\n", encoding="utf-8")
+    assert read_run_controls(p)["treatment_max_attempts"] == 1
+
+
+def test_read_run_controls_non_mapping_returns_defaults(tmp_path: Path):
+    p = tmp_path / "exp.yaml"
+    p.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    assert read_run_controls(p) == RUN_CONTROL_DEFAULTS
+
+
+# ---------------------------------------------------------------------------
+# _validate_failures
+# ---------------------------------------------------------------------------
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def log_warning(self, message, *_a, **_k) -> None:
+        self.warnings.append(message)
+
+    def __getattr__(self, _name):  # log_info/log_error/etc. are no-ops
+        return lambda *a, **k: None
+
+
+# The otel_traces workload is the one _validate_failures knows how to read.
+_OTEL = "otel_traces.yaml"
+
+
+def _ctx(tmp_path: Path) -> ExecutionContext:
+    return ExecutionContext(workspace=tmp_path, plan_dir=tmp_path, logger=_Logger())
+
+
+def _write_summary(pod_dir: Path, failures_count):
+    pod_dir.mkdir(parents=True, exist_ok=True)
+    (pod_dir / "summary_lifecycle_metrics.json").write_text(
+        json.dumps({"failures": {"count": failures_count}}), encoding="utf-8"
+    )
+
+
+def test_validate_failures_passes_when_zero(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    _write_summary(ctx.run_results_dir() / f"{eid}_1", 0)
+    assert DeployHarnessStep()._validate_failures(ctx, eid, 1, _OTEL) == []
+
+
+def test_validate_failures_flags_positive_count(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    _write_summary(ctx.run_results_dir() / f"{eid}_1", 3)
+    errs = DeployHarnessStep()._validate_failures(ctx, eid, 1, _OTEL)
+    assert len(errs) == 1 and "3 failed session" in errs[0]
+
+
+def test_validate_failures_flags_missing_file(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    # No dir/file created.
+    errs = DeployHarnessStep()._validate_failures(ctx, eid, 1, _OTEL)
+    assert len(errs) == 1 and "missing" in errs[0]
+
+
+def test_validate_failures_analysis_fallback(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    pod_dir = ctx.run_results_dir() / f"{eid}_1"
+    _write_summary(pod_dir / "analysis", 0)  # only under analysis/
+    assert DeployHarnessStep()._validate_failures(ctx, eid, 1, _OTEL) == []
+
+
+def test_validate_failures_unparseable(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    pod_dir = ctx.run_results_dir() / f"{eid}_1"
+    pod_dir.mkdir(parents=True, exist_ok=True)
+    (pod_dir / "summary_lifecycle_metrics.json").write_text("{bad", encoding="utf-8")
+    errs = DeployHarnessStep()._validate_failures(ctx, eid, 1, _OTEL)
+    assert len(errs) == 1 and "cannot parse" in errs[0]
+
+
+def test_validate_failures_checks_each_parallel_pod(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    _write_summary(ctx.run_results_dir() / f"{eid}_1", 0)
+    _write_summary(ctx.run_results_dir() / f"{eid}_2", 5)
+    errs = DeployHarnessStep()._validate_failures(ctx, eid, 2, _OTEL)
+    assert len(errs) == 1 and "_2" in errs[0]
+
+
+def test_validate_failures_accepts_dot_in_suffix(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    _write_summary(ctx.run_results_dir() / f"{eid}_1", 0)
+    # profile name may carry the .yaml.in / path form.
+    assert (
+        DeployHarnessStep()._validate_failures(
+            ctx, eid, 1, "workload/profiles/inference-perf/otel_traces.yaml.in"
+        )
+        == []
+    )
+
+
+def test_validate_failures_falls_back_for_other_workload(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "vllm-benchmark-conc8-1-abc"
+    # A positive count would fail for otel, but this is a different workload:
+    # the check must be skipped (no errors) and a warning logged.
+    _write_summary(ctx.run_results_dir() / f"{eid}_1", 9)
+    errs = DeployHarnessStep()._validate_failures(ctx, eid, 1, "random_concurrent.yaml")
+    assert errs == []
+    assert any("no result-failure check implemented" in w for w in ctx.logger.warnings)
+
+
+def test_validate_failures_falls_back_for_unknown_profile(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    errs = DeployHarnessStep()._validate_failures(ctx, eid, 1, None)
+    assert errs == []
+    assert ctx.logger.warnings  # warned about the missing/unknown profile
+
+
+# ---------------------------------------------------------------------------
+# _delete_faulty_results
+# ---------------------------------------------------------------------------
+
+
+def test_delete_faulty_results_removes_pod_dirs(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    d1 = ctx.run_results_dir() / f"{eid}_1"
+    d2 = ctx.run_results_dir() / f"{eid}_2"
+    _write_summary(d1, 0)
+    _write_summary(d2, 0)
+    # An unrelated treatment dir must survive.
+    keep = ctx.run_results_dir() / "inference-perf-conc16-2-xyz_1"
+    _write_summary(keep, 0)
+
+    DeployHarnessStep._delete_faulty_results(ctx, eid, 2)
+
+    assert not d1.exists()
+    assert not d2.exists()
+    assert keep.exists()
+
+
+def test_delete_faulty_results_sweeps_discovery_named_dirs(tmp_path: Path):
+    ctx = _ctx(tmp_path)
+    eid = "inference-perf-conc8-1-abc"
+    # A discovery-named dir that contains the experiment_id but not the _<i> form.
+    disc = ctx.run_results_dir() / f"{eid}_run_extra"
+    disc.mkdir(parents=True, exist_ok=True)
+    DeployHarnessStep._delete_faulty_results(ctx, eid, 1)
+    assert not disc.exists()


### PR DESCRIPTION
Two changes, one minor (fix the apply_overrides), one medium (add the capability to retry a failed treatment in an experiment).

Note, the only implemented "validate_failures" function is the one for the otel traces reply test. Other harnesses/profiles combo will fall back to the pod failure