### PR TITLE
chore: remove dead chartVersions.wva now that WVA installs via kustomize

### DIFF
--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -180,10 +180,13 @@ scenario:
         enabled: false
 
     # =========================================================================
-    # WVA-RELATED CHART VERSIONS
+    # CHART VERSIONS
+    #
+    # The WVA controller itself is installed from the upstream kustomize
+    # overlay (see wva.image.tag / wva.repoRef above), not a helm chart --
+    # this block only pins helm charts still installed by step_03.
     # =========================================================================
     chartVersions:
-      wva: 0.6.0
       prometheusAdapter: 5.2.0
 
     # =========================================================================

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -171,8 +171,9 @@ scenario:
       # Controller container image.
       # Pin `tag` to a release version for reproducibility, or set to "auto"
       # to let the version-resolver pick latest at plan time.
-      # NOTE: image tags use a leading "v" (v0.6.0), distinct from the
-      # helm chart version pinned in chartVersions.wva (which is bare 0.6.0).
+      # NOTE: the WVA controller is installed from the upstream kustomize
+      # overlay (see wva.repoRef), not a helm chart -- there is no separate
+      # `chartVersions.wva` to keep in sync.
       # Available version tags can be listed with:
       #   curl -sL "https://ghcr.io/token?scope=repository:llm-d/llm-d-workload-variant-autoscaler:pull" \
       #     | jq -r .token | xargs -I{} curl -sH "Authorization: Bearer {}" \
@@ -286,17 +287,13 @@ scenario:
         enabled: false
 
     # =========================================================================
-    # WVA-RELATED CHART VERSIONS
+    # CHART VERSIONS
     #
-    # Pins for the helm charts that step_03 installs as part of the WVA
-    # pipeline. Bump these to track upstream releases; align with what the
-    # upstream WVA guide currently calls for so the rule format and chart
-    # values stay compatible.
-    #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+    # The WVA controller itself is installed from the upstream kustomize
+    # overlay (see wva.image.tag / wva.repoRef above), not a helm chart --
+    # this block only pins helm charts still installed by step_03.
     # =========================================================================
     chartVersions:
-      # WVA controller chart (oci://ghcr.io/llm-d/workload-variant-autoscaler)
-      wva: 0.6.0
       # prometheus-adapter chart (prometheus-community/prometheus-adapter).
       # Pinned because newer releases have broken external-metric
       # compatibility with the rule format the WVA chart emits.

--- a/config/scenarios/cicd/ocp-wva.yaml
+++ b/config/scenarios/cicd/ocp-wva.yaml
@@ -169,17 +169,13 @@ scenario:
         enabled: false
 
     # =========================================================================
-    # WVA-RELATED CHART VERSIONS
+    # CHART VERSIONS
     #
-    # Pins for the helm charts that step_03 installs as part of the WVA
-    # pipeline. Bump these to track upstream releases; align with what the
-    # upstream WVA guide currently calls for so the rule format and chart
-    # values stay compatible.
-    #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+    # The WVA controller itself is installed from the upstream kustomize
+    # overlay (see wva.image.tag / wva.repoRef above), not a helm chart --
+    # this block only pins helm charts still installed by step_03.
     # =========================================================================
     chartVersions:
-      # WVA controller chart (oci://ghcr.io/llm-d/workload-variant-autoscaler)
-      wva: 0.6.0
       # prometheus-adapter chart (prometheus-community/prometheus-adapter).
       # Pinned because newer releases have broken external-metric
       # compatibility with the rule format the WVA chart emits.

--- a/config/scenarios/examples/multi-model-wva.yaml
+++ b/config/scenarios/examples/multi-model-wva.yaml
@@ -105,8 +105,10 @@ shared:
     vllmService:
       enabled: false
 
+  # The WVA controller itself is installed from the upstream kustomize
+  # overlay (see wva.image.tag / wva.repoRef above), not a helm chart --
+  # this block only pins helm charts still installed by step_03.
   chartVersions:
-    wva: 0.7.0
     prometheusAdapter: 5.2.0
 
   # --------------------------------------------------------------------------

--- a/config/scenarios/guides/workload-autoscaling.yaml
+++ b/config/scenarios/guides/workload-autoscaling.yaml
@@ -168,8 +168,9 @@ scenario:
       # Controller container image.
       # Pin `tag` to a release version for reproducibility, or set to "auto"
       # to let the version-resolver pick latest at plan time.
-      # NOTE: image tags use a leading "v" (v0.6.0), distinct from the
-      # helm chart version pinned in chartVersions.wva (which is bare 0.6.0).
+      # NOTE: the WVA controller is installed from the upstream kustomize
+      # overlay (see wva.repoRef), not a helm chart -- there is no separate
+      # `chartVersions.wva` to keep in sync.
       # Available version tags can be listed with:
       #   curl -sL "https://ghcr.io/token?scope=repository:llm-d/llm-d-workload-variant-autoscaler:pull" \
       #     | jq -r .token | xargs -I{} curl -sH "Authorization: Bearer {}" \
@@ -279,17 +280,13 @@ scenario:
         enabled: false
 
     # =========================================================================
-    # WVA-RELATED CHART VERSIONS
+    # CHART VERSIONS
     #
-    # Pins for the helm charts that step_03 installs as part of the WVA
-    # pipeline. Bump these to track upstream releases; align with what the
-    # upstream WVA guide currently calls for so the rule format and chart
-    # values stay compatible.
-    #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
+    # The WVA controller itself is installed from the upstream kustomize
+    # overlay (see wva.image.tag / wva.repoRef above), not a helm chart --
+    # this block only pins helm charts still installed by step_03.
     # =========================================================================
     chartVersions:
-      # WVA controller chart (oci://ghcr.io/llm-d/workload-variant-autoscaler)
-      wva: 0.6.0
       # prometheus-adapter chart (prometheus-community/prometheus-adapter).
       # Pinned because newer releases have broken external-metric
       # compatibility with the rule format the WVA chart emits.

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -113,7 +113,6 @@ _anchors:
   # `llm-d-router-{gateway,standalone}-dev` charts in ghcr.io/llm-d/charts).
   # Used for both the standalone and gateway router charts.
   router_chart_version:              &router_chart_version              v0.9.0
-  wva_version:                       &wva_version                       0.8.0
   vllm-openai_version:               &vllm-openai_version               v0.24.0
   llm-d-router-endpoint-picker_version: &llm-d-router-endpoint-picker_version v0.9.0
   llm-d-routing-sidecar_version:     &llm-d-routing-sidecar_version     v0.9.0
@@ -428,10 +427,6 @@ helmRepositories:
   llmDInfra:
     url: https://llm-d-incubation.github.io/llm-d-infra/
     sourceRepo: https://github.com/llm-d-incubation/llm-d-infra
-  wva:
-    name: workload-variant-autoscaler
-    url: oci://ghcr.io/llm-d/workload-variant-autoscaler
-    sourceRepo: https://github.com/llm-d/llm-d-workload-variant-autoscaler
   agentgateway:
     name: agentgateway
     url: oci://cr.agentgateway.dev/charts/
@@ -466,7 +461,6 @@ chartVersions:
   istiod: *istio_version
   llmDInfra: auto
   llmDModelservice: auto
-  wva: *wva_version
   # llm-d-router chart version (used by the standalone and gateway
   # variants). Replaces the legacy `inferencePool` (GAIE chart) entry
   # below for the EPP/router deploy.

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-07-10 18:59:33` (UTC)
-- Generated against git ref: `b26be2d5caa9a161d3d90cd5bf68908ac952f4ff`
+- Generated at: `2026-07-14 12:42:02` (UTC)
+- Generated against git ref: `624a0d5357d2c88dddb89cc9a5dc6fff0c3dcbc4`
 
 ## System Tool Dependencies
 
@@ -41,15 +41,14 @@ OCI registry at generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **agentgateway** | `v1.3.1` | tag | `config/templates/values/defaults.yaml` line 478 (`chartVersions.agentgateway`) | [agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) (`oci://cr.agentgateway.dev/charts/`) |
-| **inferencePool** | `v1.5.0` | tag | `config/templates/values/defaults.yaml` line 477 (`chartVersions.inferencePool`) | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
-| **istioBase** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 465 (`chartVersions.istioBase`) | (unknown) |
-| **istiod** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 466 (`chartVersions.istiod`) | (unknown) |
-| **llmDInfra** | `v1.4.0` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 467 (`chartVersions.llmDInfra`) | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) (`https://llm-d-incubation.github.io/llm-d-infra/`) |
-| **llmDModelservice** | `v0.4.15` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 468 (`chartVersions.llmDModelservice`) | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) (`https://llm-d-incubation.github.io/llm-d-modelservice/`) |
-| **llmDRouter** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 473 (`chartVersions.llmDRouter`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) |
-| **lws** | `0.9.0` | tag | `config/templates/values/defaults.yaml` line 479 (`chartVersions.lws`) | [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws) |
-| **wva** | `0.8.0` | tag | `config/templates/values/defaults.yaml` line 469 (`chartVersions.wva`) | [llm-d/llm-d-workload-variant-autoscaler](https://github.com/llm-d/llm-d-workload-variant-autoscaler) (`oci://ghcr.io/llm-d/workload-variant-autoscaler`) |
+| **agentgateway** | `v1.3.1` | tag | `config/templates/values/defaults.yaml` line 472 (`chartVersions.agentgateway`) | [agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) (`oci://cr.agentgateway.dev/charts/`) |
+| **inferencePool** | `v1.5.0` | tag | `config/templates/values/defaults.yaml` line 471 (`chartVersions.inferencePool`) | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
+| **istioBase** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 460 (`chartVersions.istioBase`) | (unknown) |
+| **istiod** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 461 (`chartVersions.istiod`) | (unknown) |
+| **llmDInfra** | `v1.4.0` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 462 (`chartVersions.llmDInfra`) | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) (`https://llm-d-incubation.github.io/llm-d-infra/`) |
+| **llmDModelservice** | `v0.4.15` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 463 (`chartVersions.llmDModelservice`) | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) (`https://llm-d-incubation.github.io/llm-d-modelservice/`) |
+| **llmDRouter** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 467 (`chartVersions.llmDRouter`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) |
+| **lws** | `0.9.0` | tag | `config/templates/values/defaults.yaml` line 473 (`chartVersions.lws`) | [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws) |
 
 
 ## Container Image Dependencies
@@ -60,13 +59,13 @@ generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **benchmark** | `v0.7.0` | tag | `config/templates/values/defaults.yaml` line 358 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
-| **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 406 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
-| **routerEndpointPicker** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 383 (`images.routerEndpointPicker`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) |
-| **routingSidecar** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 389 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
-| **udsTokenizer** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 395 (`images.udsTokenizer`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
-| **vllm** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 364 (`images.vllm`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
-| **vllmOpenai** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 375 (`images.vllmOpenai`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
+| **benchmark** | `v0.7.0` | tag | `config/templates/values/defaults.yaml` line 357 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
+| **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 405 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
+| **routerEndpointPicker** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 382 (`images.routerEndpointPicker`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) |
+| **routingSidecar** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 388 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
+| **udsTokenizer** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 394 (`images.udsTokenizer`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
+| **vllm** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 363 (`images.vllm`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
+| **vllmOpenai** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 374 (`images.vllmOpenai`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
 
 
 ## Python Package Dependencies (declared)
@@ -108,7 +107,7 @@ annotated with their `pyproject.toml` line.
 | **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
 | **annotated-doc** | `0.0.4` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
 | **annotated-types** | `0.7.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
-| **anyio** | `4.14.1` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
+| **anyio** | `4.14.2` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
 | **attrs** | `26.1.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
 | **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
 | **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
@@ -128,11 +127,11 @@ annotated with their `pyproject.toml` line.
 | **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
 | **fsspec** | `2026.6.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
 | **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
-| **GitPython** | `3.1.50` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
+| **GitPython** | `3.1.51` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
 | **google-api-core** | `2.31.0` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
-| **google-auth** | `2.55.2` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
+| **google-auth** | `2.56.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
 | **google-cloud-core** | `2.6.0` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
-| **google-cloud-storage** | `3.12.1` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
+| **google-cloud-storage** | `3.13.0` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
 | **google-crc32c** | `1.8.0` | version | (transitive in `.venv`) | [google-crc32c (PyPI)](https://pypi.org/project/google-crc32c/) |
 | **google-resumable-media** | `2.10.0` | version | (transitive in `.venv`) | [google-resumable-media (PyPI)](https://pypi.org/project/google-resumable-media/) |
 | **googleapis-common-protos** | `1.75.0` | version | (transitive in `.venv`) | [googleapis-common-protos (PyPI)](https://pypi.org/project/googleapis-common-protos/) |
@@ -187,7 +186,7 @@ annotated with their `pyproject.toml` line.
 | **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
 | **python-multipart** | `0.0.32` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
 | **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
-| **regex** | `2026.6.28` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
+| **regex** | `2026.7.10` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
 | **requests** | `2.34.2` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
 | **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
@@ -202,14 +201,14 @@ annotated with their `pyproject.toml` line.
 | **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
 | **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
 | **tqdm** | `4.68.4` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
-| **transformers** | `5.13.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **transformers** | `5.13.1` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
 | **typer** | `0.26.8` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
 | **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
 | **typing_extensions** | `4.16.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
 | **urllib3** | `2.7.0` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
 | **uvicorn** | `0.48.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
 | **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
-| **virtualenv** | `21.6.0` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
+| **virtualenv** | `21.6.1` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
 | **watchfiles** | `1.2.0` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
 | **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
 | **websockets** | `16.1` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |

--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -525,9 +525,10 @@ class WorkloadMonitoringStep(Step):
            (from rendered 23_wva-namespace).
         4. Per-namespace Prometheus bearer token Secret + TriggerAuthentication
            (minted dynamically via create_prometheus_auth_secret).
-        5. The WVA controller helm chart into each unique wva.namespace.
+        5. The WVA controller (upstream kustomize overlay) into each unique
+           wva.namespace.
 
-        The WVA chart itself brings its own RBAC (``templates/rbac/*``), CRD
+        The upstream overlay itself brings its own RBAC, CRD
         (``llmd.ai/variantautoscaling``), ServiceMonitor, and ConfigMaps.
         """
         pairs = wva_mod.stacks_enabling_wva(context.rendered_stacks or [])


### PR DESCRIPTION
The WVA controller install already migrated from helm to the upstream kustomize overlay (kubectl apply -k), but chartVersions.wva and helmRepositories.wva were left behind and are no longer read anywhere; the real version knobs are wva.image.tag and wva.repoRef. Left in place, this pin would silently do nothing today and break SBOM generation once the WVA helm-release workflow that publishes it is retired. Removed the dead key from defaults.yaml and all scenario configs, and pointed stale comments at the real version knobs.

Closes #1414 