### PR TITLE
Re-export missing KEDA standup helpers + trim inert autoscaling config

### DIFF
--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -22,8 +22,9 @@
 # user-facing WVA well-lit path that the WVA make targets consume, use
 # guides/workload-autoscaling (WVA-only).
 #
-# All HPA / VariantAutoscaling knobs are listed below even when they match
-# defaults.yaml, so the full surface area is visible in one place.
+# The scaling knobs this scenario consumes (variantAutoscaling.variantCost +
+# the hpa.* block, which drive the KEDA ScaledObject) are listed below with
+# inline notes.
 #
 # Note: FMA owns the elastic vLLM tier here, so the modelservice decode and
 # prefill Deployments are explicitly disabled below (decode.enabled: false,
@@ -52,8 +53,8 @@
 #
 # How WVA tracks FMA: launcher pods carry `llm-d.ai/variant=<id>-fma` (also
 # applied at bind time via the ISC; label-based variant identification per
-# WVA repo PR #1145). Templates 27/28 retarget the VariantAutoscaling + HPA
-# at the FMA requester Deployment (`fma-requester-<id>`) when fma.enabled.
+# WVA repo PR #1145). Template 28 retargets the KEDA ScaledObject at the FMA
+# requester Deployment (`fma-requester-<id>`) when fma.enabled.
 #
 # Based on:
 #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
@@ -129,6 +130,10 @@ scenario:
 
       namespace: ""
 
+      # Ref of llm-d/llm-d used for the WVA kustomize overlay (CRD + RBAC +
+      # controller manifests). Consumed by 19_wva-kustomize.yaml.j2.
+      repoRef: "main"
+
       image:
         repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
         tag: v0.8.0
@@ -147,17 +152,17 @@ scenario:
         baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
         port: 9091
 
+      # Only variantCost is consumed (llm-d.ai/variant-cost annotation on the
+      # KEDA ScaledObject). Controller SLO/saturation tuning lives in the
+      # upstream overlay ConfigMaps; no VariantAutoscaling CR is rendered.
       variantAutoscaling:
-        enabled: true
-        minReplicas: 1
-        maxReplicas: 10
         variantCost: "10.0"
-        slo:
-          tpot: 10
-          ttft: 1000
 
+      # Drives the per-stack KEDA ScaledObject.
       hpa:
-        enabled: true
+        enabled: true                # gates the smoketest's autoscaling-aware
+                                     # replica-range check (rendering is gated
+                                     # on wva.enabled, not this)
         minReplicas: 1
         maxReplicas: 10
         targetAvgValue: 1

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -7,8 +7,9 @@
 # user-facing WVA well-lit path that the WVA make targets consume, use
 # guides/workload-autoscaling (WVA-only).
 #
-# All HPA / VariantAutoscaling knobs are listed below even when they match
-# defaults.yaml, so the full surface area is visible in one place.
+# The scaling knobs this scenario consumes (variantAutoscaling.variantCost +
+# the hpa.* block, which drive the KEDA ScaledObject) are listed below with
+# inline notes.
 #
 # Note: FMA owns the elastic vLLM tier here, so the modelservice decode and
 # prefill Deployments are explicitly disabled below (decode.enabled: false,
@@ -37,8 +38,8 @@
 #
 # How WVA tracks FMA: launcher pods carry `llm-d.ai/variant=<id>-fma` (also
 # applied at bind time via the ISC; label-based variant identification per
-# WVA repo PR #1145). Templates 27/28 retarget the VariantAutoscaling + HPA
-# at the FMA requester Deployment (`fma-requester-<id>`) when fma.enabled.
+# WVA repo PR #1145). Template 28 retargets the KEDA ScaledObject at the FMA
+# requester Deployment (`fma-requester-<id>`) when fma.enabled.
 #
 # Based on:
 #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
@@ -168,6 +169,10 @@ scenario:
       # Deployment means it won't see your HPA.
       namespace: ""
 
+      # Ref of llm-d/llm-d used for the WVA kustomize overlay (CRD + RBAC +
+      # controller manifests). Consumed by 19_wva-kustomize.yaml.j2.
+      repoRef: "main"
+
       # Controller container image.
       # Pin `tag` to a release version for reproducibility, or set to "auto"
       # to let the version-resolver pick latest at plan time.
@@ -214,45 +219,45 @@ scenario:
       # -----------------------------------------------------------------------
       # VariantAutoscaling — per-model scaling intent
       #
-      # Should match the HPA min/max below; the VA caps what the controller
-      # is willing to compute, the HPA caps what actually gets applied.
+      # Only `variantCost` is consumed: it becomes the `llm-d.ai/variant-cost`
+      # annotation on the KEDA ScaledObject. The WVA controller reads its SLO /
+      # saturation tuning from the ConfigMaps shipped by the upstream overlay
+      # (applied in step_03), NOT from per-model fields here — this scenario
+      # renders no VariantAutoscaling CR. The replica floor/ceiling comes from
+      # the hpa.min/maxReplicas block below.
       # -----------------------------------------------------------------------
       variantAutoscaling:
-        enabled: true                # required for the VA to render at all
-        minReplicas: 1               # controller floor — never compute below this
-        maxReplicas: 10              # controller ceiling — never compute above this
         # Relative GPU cost weight used by WVA's saturation solver to decide
         # WHICH model to scale when several share GPU capacity. Higher =
         # more expensive to scale up. Common tiering: H100=10, A100=8,
         # L40S=5, MI300X=10. Tweak per stack to express your business priority.
         variantCost: "10.0"
-        # SLO targets the controller tries to keep the variant within when
-        # computing desiredReplicas. Lower numbers = more aggressive scale-up
-        # under load.
-        slo:
-          tpot: 10                   # Time-Per-Output-Token target (ms)
-          ttft: 1000                 # Time-To-First-Token target (ms)
 
       # -----------------------------------------------------------------------
-      # HorizontalPodAutoscaler — what actually changes the replica count
+      # KEDA ScaledObject — what actually changes the replica count
       #
-      # The HPA reads `wva_desired_replicas` (emitted by the WVA controller
-      # via prometheus-adapter) and scales the decode Deployment between
-      # min/max.
+      # Named `hpa` for parity with the upstream guide, but these knobs drive a
+      # KEDA ScaledObject (28_wva-scaledobject.yaml.j2), not a native HPA +
+      # prometheus-adapter. KEDA queries Prometheus for `wva_desired_replicas`
+      # (emitted by the WVA controller) and scales the decode Deployment between
+      # min/max. KEDA generates an HPA under the hood, so `behavior` applies.
       # -----------------------------------------------------------------------
       hpa:
-        enabled: true                # set false to render the VA only, no HPA
-        minReplicas: 1               # never scale below this — must be >= 1
-                                     # (HPA refuses to manage targets at 0)
-                                     # Keep aligned with variantAutoscaling.minReplicas above.
-        maxReplicas: 10              # safety ceiling — scale-up cap regardless
-                                     # of what the controller computes
-                                     # Keep aligned with variantAutoscaling.maxReplicas above.
-        targetAvgValue: 1            # target value the HPA tries to reach for
-                                     # `wva_desired_replicas` per pod.
-                                     # 1 = "match controller's desiredReplicas
-                                     # exactly". Don't change unless you
-                                     # understand HPA averaging math.
+        enabled: true                # gates the smoketest's autoscaling-aware
+                                     # replica-range check (does not affect
+                                     # rendering; the ScaledObject is gated on
+                                     # wva.enabled)
+        minReplicas: 1               # ScaledObject minReplicaCount — never scale
+                                     # below this; must be >= 1 (KEDA/HPA refuse
+                                     # to manage targets at 0)
+        maxReplicas: 10              # ScaledObject maxReplicaCount — safety
+                                     # ceiling regardless of what the controller
+                                     # computes
+        targetAvgValue: 1            # Prometheus trigger threshold for
+                                     # `wva_desired_replicas`. 1 = "match the
+                                     # controller's desiredReplicas exactly".
+                                     # Don't change unless you understand
+                                     # HPA/KEDA averaging math.
 
         # Scaling behavior — how aggressively the HPA reacts. See:
         #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior

--- a/config/scenarios/cicd/ocp-wva.yaml
+++ b/config/scenarios/cicd/ocp-wva.yaml
@@ -61,6 +61,10 @@ scenario:
       # this namespace.
       namespace: ""
 
+      # Ref of llm-d/llm-d used for the WVA kustomize overlay (CRD + RBAC +
+      # controller manifests). Consumed by 19_wva-kustomize.yaml.j2.
+      repoRef: "main"
+
       # Controller container image.
       image:
         repository: ghcr.io/llm-d/llm-d-workload-variant-autoscaler
@@ -97,45 +101,45 @@ scenario:
       # -----------------------------------------------------------------------
       # VariantAutoscaling — per-model scaling intent
       #
-      # Should match the HPA min/max below; the VA caps what the controller
-      # is willing to compute, the HPA caps what actually gets applied.
+      # Only `variantCost` is consumed: it becomes the `llm-d.ai/variant-cost`
+      # annotation on the KEDA ScaledObject. The WVA controller reads its SLO /
+      # saturation tuning from the ConfigMaps shipped by the upstream overlay
+      # (applied in step_03), NOT from per-model fields here — this scenario
+      # renders no VariantAutoscaling CR. The replica floor/ceiling comes from
+      # the hpa.min/maxReplicas block below.
       # -----------------------------------------------------------------------
       variantAutoscaling:
-        enabled: true                # required for the VA to render at all
-        minReplicas: 1               # controller floor — never compute below this
-        maxReplicas: 10              # controller ceiling — never compute above this
         # Relative GPU cost weight used by WVA's saturation solver to decide
         # WHICH model to scale when several share GPU capacity. Higher =
         # more expensive to scale up. Common tiering: H100=10, A100=8,
         # L40S=5, MI300X=10. Tweak per stack to express your business priority.
         variantCost: "10.0"
-        # SLO targets the controller tries to keep the variant within when
-        # computing desiredReplicas. Lower numbers = more aggressive scale-up
-        # under load.
-        slo:
-          tpot: 10                   # Time-Per-Output-Token target (ms)
-          ttft: 1000                 # Time-To-First-Token target (ms)
 
       # -----------------------------------------------------------------------
-      # HorizontalPodAutoscaler — what actually changes the replica count
+      # KEDA ScaledObject — what actually changes the replica count
       #
-      # The HPA reads `wva_desired_replicas` (emitted by the WVA controller
-      # via prometheus-adapter) and scales the decode Deployment between
-      # min/max.
+      # Named `hpa` for parity with the upstream guide, but these knobs drive a
+      # KEDA ScaledObject (28_wva-scaledobject.yaml.j2), not a native HPA +
+      # prometheus-adapter. KEDA queries Prometheus for `wva_desired_replicas`
+      # (emitted by the WVA controller) and scales the decode Deployment between
+      # min/max. KEDA generates an HPA under the hood, so `behavior` applies.
       # -----------------------------------------------------------------------
       hpa:
-        enabled: true                # set false to render the VA only, no HPA
-        minReplicas: 1               # never scale below this — must be >= 1
-                                     # (HPA refuses to manage targets at 0)
-                                     # Keep aligned with variantAutoscaling.minReplicas above.
-        maxReplicas: 10              # safety ceiling — scale-up cap regardless
-                                     # of what the controller computes
-                                     # Keep aligned with variantAutoscaling.maxReplicas above.
-        targetAvgValue: 1            # target value the HPA tries to reach for
-                                     # `wva_desired_replicas` per pod.
-                                     # 1 = "match controller's desiredReplicas
-                                     # exactly". Don't change unless you
-                                     # understand HPA averaging math.
+        enabled: true                # gates the smoketest's autoscaling-aware
+                                     # replica-range check (does not affect
+                                     # rendering; the ScaledObject is gated on
+                                     # wva.enabled)
+        minReplicas: 1               # ScaledObject minReplicaCount — never scale
+                                     # below this; must be >= 1 (KEDA/HPA refuse
+                                     # to manage targets at 0)
+        maxReplicas: 10              # ScaledObject maxReplicaCount — safety
+                                     # ceiling regardless of what the controller
+                                     # computes
+        targetAvgValue: 1            # Prometheus trigger threshold for
+                                     # `wva_desired_replicas`. 1 = "match the
+                                     # controller's desiredReplicas exactly".
+                                     # Don't change unless you understand
+                                     # HPA/KEDA averaging math.
 
         # Scaling behavior — how aggressively the HPA reacts. See:
         #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior

--- a/config/scenarios/examples/multi-model-wva.yaml
+++ b/config/scenarios/examples/multi-model-wva.yaml
@@ -297,16 +297,16 @@ scenario:
       gpuMemoryUtilization: 0.85
 
     wva:
+      # Only variantCost is consumed (llm-d.ai/variant-cost annotation on the
+      # KEDA ScaledObject). Controller SLO/saturation tuning lives in the
+      # upstream overlay ConfigMaps; no VariantAutoscaling CR is rendered.
       variantAutoscaling:
-        enabled: true
-        minReplicas: 1
-        maxReplicas: 10
         variantCost: "10.0"
-        slo:
-          tpot: 10
-          ttft: 1000
+      # Drives the per-stack KEDA ScaledObject.
       hpa:
-        enabled: true
+        enabled: true                # gates the smoketest's autoscaling-aware
+                                     # replica-range check (rendering is gated
+                                     # on wva.enabled, not this)
         minReplicas: 1
         maxReplicas: 10
         targetAvgValue: 1
@@ -351,16 +351,16 @@ scenario:
       gpuMemoryUtilization: 0.85
 
     wva:
+      # Only variantCost is consumed (llm-d.ai/variant-cost annotation on the
+      # KEDA ScaledObject). Controller SLO/saturation tuning lives in the
+      # upstream overlay ConfigMaps; no VariantAutoscaling CR is rendered.
       variantAutoscaling:
-        enabled: true
-        minReplicas: 1
-        maxReplicas: 10
         variantCost: "10.0"
-        slo:
-          tpot: 10
-          ttft: 1000
+      # Drives the per-stack KEDA ScaledObject.
       hpa:
-        enabled: true
+        enabled: true                # gates the smoketest's autoscaling-aware
+                                     # replica-range check (rendering is gated
+                                     # on wva.enabled, not this)
         minReplicas: 1
         maxReplicas: 10
         targetAvgValue: 1

--- a/config/scenarios/guides/workload-autoscaling.yaml
+++ b/config/scenarios/guides/workload-autoscaling.yaml
@@ -2,9 +2,10 @@
 #
 # Same base configuration as `inference-scheduling.yaml` (Qwen3-32B, 2 decode
 # pods, modelservice deployment) but with the Workload Variant Autoscaler
-# (WVA) explicitly enabled. All HPA / VariantAutoscaling knobs are listed
-# below even when they match defaults.yaml, so users can see the full
-# surface area in one place and tweak it per-scenario.
+# (WVA) explicitly enabled. The scaling knobs this scenario actually consumes
+# (variantAutoscaling.variantCost + the hpa.* block, which drive the KEDA
+# ScaledObject) are listed below with inline notes; the WVA controller's own
+# tuning lives in the upstream overlay's ConfigMaps, not here.
 #
 # Based on:
 #   https://github.com/llm-d/llm-d/blob/main/guides/workload-autoscaling/README.wva.md
@@ -211,45 +212,50 @@ scenario:
       # -----------------------------------------------------------------------
       # VariantAutoscaling — per-model scaling intent
       #
-      # Should match the HPA min/max below; the VA caps what the controller
-      # is willing to compute, the HPA caps what actually gets applied.
+      # Only `variantCost` is consumed by this benchmark's rendering: it becomes
+      # the `llm-d.ai/variant-cost` annotation on the KEDA ScaledObject
+      # (28_wva-scaledobject.yaml.j2). The WVA controller reads its own tuning
+      # (SLOs, saturation thresholds, opt interval) from the ConfigMaps shipped
+      # by the upstream overlay applied in step_03 (`manager-config` /
+      # `saturation-scaling-config`), NOT from per-model fields here — this
+      # scenario does not render a VariantAutoscaling CR. To change SLO-driven
+      # behavior on-cluster, patch those controller ConfigMaps. The replica
+      # floor/ceiling the controller actually respects is the hpa.min/maxReplicas
+      # block below (which drives the ScaledObject's min/maxReplicaCount).
       # -----------------------------------------------------------------------
       variantAutoscaling:
-        enabled: true                # required for the VA to render at all
-        minReplicas: 1               # controller floor — never compute below this
-        maxReplicas: 10              # controller ceiling — never compute above this
         # Relative GPU cost weight used by WVA's saturation solver to decide
         # WHICH model to scale when several share GPU capacity. Higher =
         # more expensive to scale up. Common tiering: H100=10, A100=8,
         # L40S=5, MI300X=10. Tweak per stack to express your business priority.
         variantCost: "10.0"
-        # SLO targets the controller tries to keep the variant within when
-        # computing desiredReplicas. Lower numbers = more aggressive scale-up
-        # under load.
-        slo:
-          tpot: 10                   # Time-Per-Output-Token target (ms)
-          ttft: 1000                 # Time-To-First-Token target (ms)
 
       # -----------------------------------------------------------------------
-      # HorizontalPodAutoscaler — what actually changes the replica count
+      # KEDA ScaledObject — what actually changes the replica count
       #
-      # The HPA reads `wva_desired_replicas` (emitted by the WVA controller
-      # via prometheus-adapter) and scales the decode Deployment between
-      # min/max.
+      # Despite the `hpa` name (retained for parity with defaults.yaml and the
+      # upstream guide), these knobs now drive a KEDA ScaledObject
+      # (28_wva-scaledobject.yaml.j2), not a native HPA + prometheus-adapter.
+      # KEDA queries Prometheus for `wva_desired_replicas` (emitted by the WVA
+      # controller) and scales the decode Deployment between min/max. KEDA
+      # generates an HPA under the hood, so `behavior` still applies.
       # -----------------------------------------------------------------------
       hpa:
-        enabled: true                # set false to render the VA only, no HPA
-        minReplicas: 1               # never scale below this — must be >= 1
-                                     # (HPA refuses to manage targets at 0)
-                                     # Keep aligned with variantAutoscaling.minReplicas above.
-        maxReplicas: 10              # safety ceiling — scale-up cap regardless
-                                     # of what the controller computes
-                                     # Keep aligned with variantAutoscaling.maxReplicas above.
-        targetAvgValue: 1            # target value the HPA tries to reach for
-                                     # `wva_desired_replicas` per pod.
-                                     # 1 = "match controller's desiredReplicas
-                                     # exactly". Don't change unless you
-                                     # understand HPA averaging math.
+        enabled: true                # gates the smoketest's autoscaling-aware
+                                     # replica-range check (does not affect
+                                     # rendering; the ScaledObject is gated on
+                                     # wva.enabled)
+        minReplicas: 1               # ScaledObject minReplicaCount — never scale
+                                     # below this; must be >= 1 (KEDA/HPA refuse
+                                     # to manage targets at 0)
+        maxReplicas: 10              # ScaledObject maxReplicaCount — safety
+                                     # ceiling regardless of what the controller
+                                     # computes
+        targetAvgValue: 1            # Prometheus trigger threshold for
+                                     # `wva_desired_replicas`. 1 = "match the
+                                     # controller's desiredReplicas exactly".
+                                     # Don't change unless you understand
+                                     # HPA/KEDA averaging math.
 
         # Scaling behavior — how aggressively the HPA reacts. See:
         #   https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1433,8 +1433,8 @@ extraObjects: []
 #
 # Installed in *namespaced* mode: the controller watches only the namespace
 # it is deployed in. One controller per unique wva.namespace across rendered
-# stacks. VariantAutoscaling + HPA are rendered per-stack so a single
-# controller can manage multiple models in the same namespace.
+# stacks. A KEDA ScaledObject is rendered per-stack (28_wva-scaledobject.yaml.j2)
+# so a single controller can manage multiple models in the same namespace.
 # ============================================================================
 wva:
   enabled: false
@@ -1458,13 +1458,17 @@ wva:
   prometheus:
     baseUrl: https://thanos-querier.openshift-monitoring.svc.cluster.local
     port: 9091
+  # Only variantCost is consumed by rendering (llm-d.ai/variant-cost annotation
+  # on the KEDA ScaledObject). The controller's SLO / saturation tuning comes
+  # from the upstream overlay's ConfigMaps, not from per-model fields here --
+  # no VariantAutoscaling CR is rendered.
   variantAutoscaling:
-    enabled: true
     variantCost: "10.0"
-    slo:
-      tpot: 10
-      ttft: 1000
+  # Drives the per-stack KEDA ScaledObject (min/maxReplicaCount, trigger
+  # threshold, HPA behavior). Named "hpa" for parity with the upstream guide.
   hpa:
+    # Gates the smoketest's autoscaling-aware replica-range check. Does not
+    # affect rendering -- the ScaledObject is gated on wva.enabled.
     enabled: true
     minReplicas: 1
     maxReplicas: 16

--- a/llmdbenchmark/run/steps/step_02a_fma_warmup_hotstart.py
+++ b/llmdbenchmark/run/steps/step_02a_fma_warmup_hotstart.py
@@ -106,13 +106,11 @@ class FMAWarmupHotStartStep(Step):
         # actually enforces the requester Deployment's replica count during the
         # benchmark. Scaling below it would just get bounced back up on the next
         # HPA sync, defeating the "sleep until the benchmark scales up" intent.
-        # variantAutoscaling.minReplicas only bounds what the WVA controller
-        # *computes*; fall back to it (then 1) when the HPA floor is unset.
+        # Falls back to 1 when the HPA floor is unset.
         min_replicas = int(
             self._resolve(
                 plan_config,
                 "wva.hpa.minReplicas",
-                "wva.variantAutoscaling.minReplicas",
                 default=1,
             )
         )

--- a/llmdbenchmark/standup/wva.py
+++ b/llmdbenchmark/standup/wva.py
@@ -22,6 +22,8 @@ import yaml
 from llmdbenchmark.executor.command import CommandExecutor
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.standup.keda_prometheus_auth import (
+    verify_keda_installed,  # noqa: F401  (re-exported for step_03)
+    extract_prometheus_ca_cert,  # noqa: F401  (re-exported for step_03)
     create_prometheus_auth_secret as _create_prometheus_auth_secret,
     apply_namespace_label,
     _find_yaml,


### PR DESCRIPTION
**Summary**

Two related fixes to the Workload Variant Autoscaler (WVA) path:

1. _Bug fix_: WVA standup crashed at step 03 with module `llmdbenchmark.standup.wva` has no attribute `verify_keda_installed`.
2. _Cleanup_: the WVA scenario config exposed a set of variantAutoscaling / hpa knobs that are no longer consumed by rendering, with comments describing an obsolete (native HPA + prometheus-adapter) architecture. Trimmed to the fields that actually take effect and corrected the comments to reflect the current KEDA ScaledObject path.

**Changes**

`llmdbenchmark/standup/wva.py`
- Re-export verify_keda_installed and extract_prometheus_ca_cert from keda_prometheus_auth, matching what step_03 calls (and mirroring keda_saturation.py).

`WVA config (defaults.yaml + all WVA scenarios)`
- variantAutoscaling: keep only variantCost (the one live field → llm-d.ai/variant-cost annotation on the ScaledObject). Remove enabled, minReplicas, maxReplicas, and slo.{tpot,ttft} — no template or step reads them.
- hpa: remove dead fields but keep enabled (still read by smoketests/base.py to gate the autoscaling-aware replica-range check) and the live minReplicas / maxReplicas / targetAvgValue / behavior that drive the ScaledObject's minReplicaCount / maxReplicaCount / trigger threshold / advanced.horizontalPodAutoscalerConfig.behavior.
- Comments reworded: the block drives a KEDA ScaledObject (28_wva-scaledobject.yaml.j2), not a native HPA + prometheus-adapter. The hpa key name is retained for parity with the upstream WVA guide (KEDA also generates a real HPA under the hood). Also fixed stale references to a non-existent "template 27" and to a rendered VariantAutoscaling CR.

**Files touched:**
- `config/templates/values/defaults.yaml`
- `config/scenarios/guides/workload-autoscaling.yaml`
- `config/scenarios/cicd/ocp-wva.yaml`
- `config/scenarios/cicd/ocp-wva-fma-hotstart.yaml`
- `config/scenarios/cicd/ocp-wva-fma-warmstart.yaml`
- `config/scenarios/examples/multi-model-wva.yaml`

**Behavior impact**

- Standup: WVA-enabled scenarios get past step 03 (verified the module now resolves both attributes).
- Rendering: unchanged. Every removed field already had a | default(...) in 28_wva-scaledobject.yaml.j2, and only variantCost + the retained hpa.* fields were ever consumed. hpa.enabled is preserved so the smoketest's range check is unaffected.
- No VariantAutoscaling CR was rendered before or after; the removed SLO/replica knobs were already inert in this repo.

**Testing**

- Pre-commit passed byte-compile, unit tests (pytest tests/), and the changed-scenario dry-run render for all 5 WVA scenarios ([OK] each).
- Validated all 6 YAML files parse and that every WVA block now has variantAutoscaling == {variantCost} with hpa.enabled: true and the live hpa fields intact.

**Notes for reviewers**

- The hpa config key is intentionally not renamed to scaledObject. It maps 1:1 onto KEDA's horizontalPodAutoscalerConfig, KEDA generates a real HPA under the hood (which teardown/smoketests/state-capture correctly inspect via kubectl … hpa), and the name keeps parity with the upstream WVA guide. Renaming would be breaking for existing scenarios and DoE sweeps for a cosmetic gain.