### PR TITLE
config: organize scenario stacks into method sections

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -93,15 +93,28 @@ Create a scenario YAML under `config/scenarios/` that overrides only the values 
 ```yaml
 scenario:
   - name: "my-deployment"
-    model:
-      name: Qwen/Qwen3-32B
-    decode:
-      replicas: 4
-    namespace:
-      name: my-namespace
+    common:
+      model:
+        name: Qwen/Qwen3-32B
+      namespace:
+        name: my-namespace
+    modelservice:
+      enabled: true
+      decode:
+        replicas: 4
+    standalone:
+      enabled: false
+    fma:
+      enabled: false
 ```
 
 Only the keys you specify are overridden. Everything else comes from `defaults.yaml`.
+The `common` section is inherited by every standup method. Method-specific
+settings belong under `standalone`, `modelservice`, or `fma`. Legacy flat
+scenario keys remain supported for backward compatibility.
+
+`modelservice.common` is distinct from the stack-level `common` section: it
+is passed through as the modelservice Helm chart's `common` values block.
 
 **Multi-stack scenarios - the `shared:` block.** The scenario file also
 accepts an optional top-level `shared:` key that's merged into every stack
@@ -767,15 +780,26 @@ affinity:
 
 ## Scenario Organization
 
-Scenario files use comment headers to organize settings into three categories:
+Each stack is organized into four YAML sections:
 
-- **COMMON** -- settings that apply to all deployment methods (model config, namespace, decode/prefill resources, vllmCommon, monitoring, etc.)
-- **STANDALONE** -- settings that only apply when `standalone.enabled: true` (standalone image, replicas, volumes)
-- **MODELSERVICE** -- settings that only apply when `modelservice.enabled: true` (Helm chart values, gateway config, GAIE settings)
+- **`common`** -- settings inherited by every deployment method (model,
+  namespace, storage, vllmCommon, harness, images, and workDir)
+- **`standalone`** -- settings used when `standalone.enabled: true`
+- **`modelservice`** -- settings used when `modelservice.enabled: true`,
+  including decode, prefill, gateway, router, routing, httpRoute,
+  inferenceExtension, and multinode
+- **`fma`** -- settings used when `fma.enabled: true`
+
+The renderer expands `common` and method-specific sub-sections to the flat
+effective `config.yaml` consumed internally. If a scenario contains both a
+legacy flat key and its sectioned spelling, the sectioned spelling wins.
+Treatment and CLI overrides are applied afterward and therefore take highest
+precedence.
 
 Each scenario must set exactly one of `standalone.enabled: true` or `modelservice.enabled: true`. Only one deployment method can be active at a time. The CLI `-t` flag overrides the scenario value (e.g., `-t standalone` forces standalone even if the scenario says modelservice). If both are passed via CLI, a warning is logged and modelservice is used. Templates use Jinja2 conditionals to skip rendering when the corresponding flag is `false`.
 
-A fifth section header, **WORKLOAD / HARNESS**, groups the `workDir` and `harness` fields that configure benchmark execution (which harness, workload profile, and where results are stored).
+Workload settings such as `workDir` and `harness` belong under `common` because
+they apply regardless of the selected standup method.
 
 ---
 

--- a/config/scenarios/cicd/ocp.yaml
+++ b/config/scenarios/cicd/ocp.yaml
@@ -9,81 +9,79 @@
 scenario:
   - name: "ocp-cicd"
 
-    # Model
-    model:
-      name: Qwen/Qwen3-8B
-      shortName: qwen-qwen3-8b
-      path: models/Qwen/Qwen3-8B
-      huggingfaceId: Qwen/Qwen3-8B
-      # Keeping it similar to FMA launcher's vLLM (24_fma-deployment.yaml.j2)
-      maxModelLen: 40960
-      blockSize: 16
+    common:
+      # Model
+      model:
+        name: Qwen/Qwen3-8B
+        shortName: qwen-qwen3-8b
+        path: models/Qwen/Qwen3-8B
+        huggingfaceId: Qwen/Qwen3-8B
+        # Keeping it similar to FMA launcher's vLLM (24_fma-deployment.yaml.j2)
+        maxModelLen: 40960
+        blockSize: 16
 
+      affinity:
+        enabled: true
+        nodeSelector:
+          # nvidia.com/gpu.product: NVIDIA-L40S
+          nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
+
+      # storage:
+      #   modelPvc:
+      #     storageClassName: ocs-storagecluster-cephfs
+      #   workloadPvc:
+      #     storageClassName: ocs-storagecluster-cephfs
+
+      vllmCommon:
+        priorityClassName: nightly-gpu-critical
+        flags:
+          # Disable enforce_eager so the standalone vLLM runs torch.compile +
+          # CUDA-graph capture -- otherwise Dynamo / Torch Compile / Memory
+          # Profiling metrics are all 0 (those phases are skipped under eager).
+          enforceEager: false
+          # FMA runs with prefix caching off (--no-enable-prefix-caching)
+          noPrefixCaching: true
+
+      workDir: /tmp/llmdbenchcicd-ocp/
+
+      harness:
+        name: vllm-benchmark
+        experimentProfile: sanity_random.yaml
+        # executable: llm-d-benchmark.py
+
+      images:
+        benchmark:
+          repository: ghcr.io/llm-d/llm-d-benchmark
+          tag: nightly
     # Deployment method
     modelservice:
       enabled: true
+      # gateway:
+      #   className: istio
+
+      prefill:
+        enabled: true
+        replicas: 1
+        acceleratorType:
+          labelKey: nvidia.com/gpu.product
+          # labelValue: NVIDIA-L40S
+          labelValue: NVIDIA-H100-80GB-HBM3
+
+      decode:
+        enabled: true
+        replicas: 1
+        acceleratorType:
+          labelKey: nvidia.com/gpu.product
+          # labelValue: NVIDIA-L40S
+          labelValue: NVIDIA-H100-80GB-HBM3
+
     standalone:
       enabled: false
+      acceleratorType:
+        labelKey: nvidia.com/gpu.product
+        # labelValue: NVIDIA-L40S
+        labelValue: NVIDIA-H100-80GB-HBM3
+
     fma:
       enabled: false
       iterations: 10
-
-#    gateway:
-#      className: istio
-
-    affinity:
-      enabled: true
-      nodeSelector:
-#        nvidia.com/gpu.product: NVIDIA-L40S
-        nvidia.com/gpu.product: NVIDIA-H100-80GB-HBM3
-
-    prefill:
-      enabled: true
-      replicas: 1
-      acceleratorType:
-        labelKey: nvidia.com/gpu.product
-#        labelValue: NVIDIA-L40S
-        labelValue: NVIDIA-H100-80GB-HBM3
-
-    decode:
-      enabled: true
-      replicas: 1
-      acceleratorType:
-        labelKey: nvidia.com/gpu.product
-#        labelValue: NVIDIA-L40S
-        labelValue: NVIDIA-H100-80GB-HBM3
-
-    standalone:
-      acceleratorType:
-        labelKey: nvidia.com/gpu.product
-#        labelValue: NVIDIA-L40S
-        labelValue: NVIDIA-H100-80GB-HBM3
-
-#    storage:
-#      modelPvc:
-#        storageClassName: ocs-storagecluster-cephfs
-#      workloadPvc:
-#        storageClassName: ocs-storagecluster-cephfs
-
-    vllmCommon:
-      priorityClassName: nightly-gpu-critical
-      flags:
-        # Disable enforce_eager so the standalone vLLM runs torch.compile +
-        # CUDA-graph capture -- otherwise Dynamo / Torch Compile / Memory
-        # Profiling metrics are all 0 (those phases are skipped under eager).
-        enforceEager: false
-        # FMA runs with prefix caching off (--no-enable-prefix-caching)
-        noPrefixCaching: true
-
-    workDir: /tmp/llmdbenchcicd-ocp/
-
-    harness:
-      name: vllm-benchmark
-      experimentProfile: sanity_random.yaml
-#      executable: llm-d-benchmark.py
-
-    images:
-      benchmark:
-        repository: ghcr.io/llm-d/llm-d-benchmark
-        tag: nightly
-

--- a/config/scenarios/examples/fma.yaml
+++ b/config/scenarios/examples/fma.yaml
@@ -12,11 +12,37 @@
 
 scenario:
   - name: "fma-example"
-    model:
-      name: meta-llama/Llama-3.1-8B-Instruct
-      shortName: llama-3.1-8b
-      path: models/meta-llama/Llama-3.1-8B-Instruct
-      huggingfaceId: meta-llama/Llama-3.1-8B-Instruct
+
+    common:
+      model:
+        name: meta-llama/Llama-3.1-8B-Instruct
+        shortName: llama-3.1-8b
+        path: models/meta-llama/Llama-3.1-8B-Instruct
+        huggingfaceId: meta-llama/Llama-3.1-8B-Instruct
+
+      workDir: "~/data/fma"
+
+      harness:
+        name: nop
+        profile: nop.yaml
+        executable: llm-d-benchmark.py
+        experimentProfile: nop.yaml
+        condaEnvName: nop-env
+        waitTimeout: 3600
+        loadParallelism: 1
+        podLabel: llmdbench-harness-fma
+        debug: false
+        resources:
+          cpu: 16
+          memory: 32Gi
+        output: local
+        inferencePerf:
+          rayonNumThreads: 4
+
+      images:
+        benchmark:
+          repository: ghcr.io/llm-d/llm-d-benchmark
+          tag: nightly
 
     modelservice:
       enabled: false
@@ -26,28 +52,3 @@ scenario:
     fma:
       enabled: true
       iterations: 1
-
-    workDir: "~/data/fma"
-
-    harness:
-      name: nop
-      profile: nop.yaml
-      executable: llm-d-benchmark.py
-      experimentProfile: nop.yaml
-      condaEnvName: nop-env
-      waitTimeout: 3600
-      loadParallelism: 1
-      podLabel: llmdbench-harness-fma
-      debug: false
-      resources:
-        cpu: 16
-        memory: 32Gi
-      output: local
-      inferencePerf:
-        rayonNumThreads: 4
-
-    images:
-      benchmark:
-        repository: ghcr.io/llm-d/llm-d-benchmark
-        tag: nightly
-

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1746,7 +1746,13 @@ def _extract_workspace_from_scenario(
 
         scenarios = scenario_data.get("scenario", [])
         if scenarios and isinstance(scenarios, list):
-            return scenarios[0].get("workDir")
+            first_stack = scenarios[0]
+            if not isinstance(first_stack, dict):
+                return None
+            common = first_stack.get("common")
+            if isinstance(common, dict) and common.get("workDir") is not None:
+                return common["workDir"]
+            return first_stack.get("workDir")
     except Exception:  # noqa: BLE001 -- best-effort; fall through to temp dir
         pass
     return None

--- a/llmdbenchmark/parser/README.md
+++ b/llmdbenchmark/parser/README.md
@@ -67,9 +67,9 @@ Templates are loaded from `.j2` files in the template directory. Files prefixed 
 
 For each stack in the scenario:
 
-1. Merge defaults with the optional top-level `shared:` block (scenario-wide
-   settings applied to every stack), then with stack-specific overrides:
-   `defaults -> shared -> stack`.
+1. Expand each scenario layer's stack-level `common:` section, then merge
+   defaults with the optional top-level `shared:` block and stack-specific
+   overrides: `defaults -> shared -> stack`.
 2. Hoist scenario-nested modelservice sections to the top level (see
    [Modelservice-nested sections](#modelservice-nested-sections)).
 3. Apply setup overrides (from DoE experiment treatments) if present.
@@ -84,12 +84,39 @@ For each stack in the scenario:
 9. Write `config.yaml` with the fully-resolved config (JSON round-trip strips YAML anchors).
 10. Validate all generated YAML files for syntax.
 
+#### Sectioned scenario stacks
+
+Each scenario stack may group shared values under `common` and method-specific
+values under `standalone`, `modelservice`, and `fma`:
+
+```yaml
+scenario:
+  - name: example
+    common:
+      model: { name: Qwen/Qwen3-8B }
+      storage: { modelPvc: { size: 200Gi } }
+      vllmCommon: { inferencePort: 8000 }
+    standalone: { enabled: false }
+    modelservice:
+      enabled: true
+      prefill: { enabled: true, replicas: 1 }
+      decode: { enabled: true, replicas: 2 }
+    fma: { enabled: false }
+```
+
+`common` is expanded before defaults and scenario layers are merged, so all
+standup methods inherit the same model, storage, and runtime configuration.
+Legacy flat stack keys remain supported. When both spellings are present, the
+sectioned value wins. The top-level `common` in defaults is a separate internal
+value passed to the modelservice chart; scenario authors set that value as
+`modelservice.common`.
+
 #### Modelservice-nested sections
 
-`gateway`, `router`, `routing`, and `httpRoute` are consumed only on the
-modelservice deploy path (standalone / kustomize / fma never read them). A
-scenario may express them either flat at the top level, or nested under
-`modelservice:` to document that scope:
+`common`, `gateway`, `router`, `routing`, `httpRoute`, `inferenceExtension`,
+`prefill`, `decode`, and `multinode` are consumed on the modelservice deploy
+path. A scenario may express them either flat at the stack level for backward
+compatibility, or nested under `modelservice:` to document that scope:
 
 ```yaml
 modelservice:
@@ -100,6 +127,8 @@ modelservice:
     epp: { replicas: 2 }
   httpRoute:
     requestTimeout: "300s"
+  prefill: { enabled: true, replicas: 1 }
+  decode: { enabled: true, replicas: 2 }
 ```
 
 `RenderPlans._hoist_modelservice_sections` lifts any nested block back to the

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -917,6 +917,28 @@ class RenderPlans:
             cur = cur[part]
         cur[path[-1]] = value
 
+    def _expand_stack_common(self, values: dict) -> dict:
+        """Expand a scenario layer's ``common`` section to the config root.
+
+        Scenario stacks group settings shared by every standup method under
+        ``common``.  The renderer and templates still consume one flattened
+        effective config, so expand that authoring structure before merging
+        the layer with defaults.  Expanding the scenario layer (rather than
+        the merged config) is important because defaults.yaml has its own
+        top-level ``common`` value that is passed to the modelservice chart.
+
+        A nested value wins over the legacy flat spelling when both are
+        present, matching the precedence used for modelservice-nested
+        sections.  The input is never mutated.
+        """
+        result = deepcopy(values)
+        common = result.pop("common", None)
+        if common is None:
+            return result
+        if not isinstance(common, dict):
+            raise TypeError("'common' must be a mapping when present")
+        return self.deep_merge(result, common)
+
     # Sections a scenario may nest under `modelservice:` for clarity. They
     # are consumed only on the modelservice path (see step_08_deploy_router
     # and the modelservice-guarded templates), but every template, resolver
@@ -924,10 +946,20 @@ class RenderPlans:
     # to the top level before any resolver runs. Nesting is purely a
     # scenario-authoring convenience; the flat top-level spelling keeps
     # working unchanged.
-    _MODELSERVICE_HOISTED = ("gateway", "router", "routing", "httpRoute")
+    _MODELSERVICE_HOISTED = (
+        "common",
+        "gateway",
+        "router",
+        "routing",
+        "httpRoute",
+        "inferenceExtension",
+        "prefill",
+        "decode",
+        "multinode",
+    )
 
     def _hoist_modelservice_sections(self, values: dict) -> dict:
-        """Lift ``modelservice.{gateway,router,routing,httpRoute}`` to the top level.
+        """Lift method-specific ``modelservice`` sections to the top level.
 
         Scenarios may nest these under ``modelservice:`` to document that
         they only apply on the modelservice deploy path. Templates,
@@ -1454,15 +1486,18 @@ class RenderPlans:
         deferring to template time keeps the label computation in exactly
         one place.
         """
-        shared_standalone = (shared or {}).get("standalone", {}).get("enabled")
+        normalized_shared = self._expand_stack_common(shared or {})
+        shared_standalone = (normalized_shared.get("standalone") or {}).get("enabled")
         siblings: list[dict] = []
         for stack in stacks:
             if not isinstance(stack, dict):
                 continue
-            model_name = (stack.get("model") or {}).get("name", "")
+            normalized_stack = self._expand_stack_common(stack)
+            sibling_config = self.deep_merge(normalized_shared, normalized_stack)
+            model_name = (sibling_config.get("model") or {}).get("name", "")
             # Stack-level standalone.enabled wins; otherwise shared-level;
             # otherwise None (undetermined -> treat as non-standalone).
-            stack_standalone = (stack.get("standalone") or {}).get("enabled")
+            stack_standalone = (normalized_stack.get("standalone") or {}).get("enabled")
             is_standalone = bool(
                 stack_standalone if stack_standalone is not None else shared_standalone
             )
@@ -1542,15 +1577,18 @@ class RenderPlans:
         stack_errors = StackErrors()
         result.stacks[stack_name] = stack_errors
 
-        stack_config = {k: v for k, v in stack.items() if k != "name"}
+        stack_config = self._expand_stack_common(
+            {k: v for k, v in stack.items() if k != "name"}
+        )
+        shared_config = self._expand_stack_common(shared or {})
         # Merge order: defaults -> shared (scenario-wide) -> stack -> CLI/setup
         # overrides. Per-stack always wins so a stack can opt out of any
         # shared value by setting it explicitly.
-        merged_values = self.deep_merge(defaults, shared or {})
+        merged_values = self.deep_merge(defaults, shared_config)
         merged_values = self.deep_merge(merged_values, stack_config)
 
-        # Hoist scenario-nested modelservice.{gateway,router,routing} to the
-        # top level BEFORE setup overrides are merged. Templates, resolvers
+        # Hoist scenario-nested modelservice-only sections to the top level
+        # BEFORE setup overrides are merged. Templates, resolvers
         # and standup steps read these as top-level keys, and DoE treatment /
         # CLI overrides target the top-level dotted paths (e.g.
         # `router.epp.pluginsConfigFile`). Hoisting first preserves the
@@ -1726,6 +1764,18 @@ class RenderPlans:
             result.global_errors.append(msg)
             return result
 
+        for index, stack in enumerate(stacks, 1):
+            if not isinstance(stack, dict):
+                msg = f"Stack {index} must be a mapping"
+                self.logger.log_error(msg)
+                result.global_errors.append(msg)
+                return result
+            if "common" in stack and not isinstance(stack["common"], dict):
+                msg = f"Stack {index} 'common' section must be a mapping"
+                self.logger.log_error(msg)
+                result.global_errors.append(msg)
+                return result
+
         # Validate --stack filter against known stack names BEFORE rendering
         # anything, so typos fail with a clear error at the start of the
         # pipeline rather than silently passing through render and dying
@@ -1753,6 +1803,11 @@ class RenderPlans:
         shared = scenario.get("shared") or {}
         if not isinstance(shared, dict):
             msg = "'shared' must be a mapping when present"
+            self.logger.log_error(msg)
+            result.global_errors.append(msg)
+            return result
+        if "common" in shared and not isinstance(shared["common"], dict):
+            msg = "'shared.common' must be a mapping when present"
             self.logger.log_error(msg)
             result.global_errors.append(msg)
             return result

--- a/tests/test_hoist_modelservice_sections.py
+++ b/tests/test_hoist_modelservice_sections.py
@@ -1,14 +1,13 @@
 """Tests for `RenderPlans._hoist_modelservice_sections`.
 
-Scenarios may nest `gateway`, `routing`, `router`, and `httpRoute` under
-`modelservice:` to document that they only apply on the modelservice deploy
-path. Every template, resolver, and standup step reads these as TOP-LEVEL
-keys, so the renderer hoists them back to the top level before the resolver
-chain runs.
+Scenarios may nest method-specific sections under `modelservice:` to document
+their scope. Every template, resolver, and standup step reads these as
+TOP-LEVEL keys, so the renderer hoists them back to the top level before the
+resolver chain runs.
 
 The contract this module pins:
 
-- Nested `modelservice.{gateway,routing,router,httpRoute}` are lifted to the
+- Nested modelservice-only sections are lifted to the
   top level and removed from `modelservice` (single home in the resolved config).
 - The nested block deep-merges ON TOP OF whatever top-level block exists
   (defaults.yaml base, or a flat scenario override) -- nested wins, and
@@ -46,6 +45,10 @@ class TestHoist:
                 "routing": {"connector": "nixlv2"},
                 "router": {"epp": {"replicas": 2}},
                 "httpRoute": {"requestTimeout": "300s"},
+                "prefill": {"replicas": 2},
+                "decode": {"replicas": 4},
+                "inferenceExtension": {"enabled": True},
+                "multinode": {"enabled": True},
             },
         }
         out = renderer._hoist_modelservice_sections(values)
@@ -55,6 +58,10 @@ class TestHoist:
         assert out["routing"] == {"connector": "nixlv2"}
         assert out["router"] == {"epp": {"replicas": 2}}
         assert out["httpRoute"] == {"requestTimeout": "300s"}
+        assert out["prefill"] == {"replicas": 2}
+        assert out["decode"] == {"replicas": 4}
+        assert out["inferenceExtension"] == {"enabled": True}
+        assert out["multinode"] == {"enabled": True}
 
         # Removed from modelservice; the toggle survives.
         assert out["modelservice"] == {"enabled": True}

--- a/tests/test_scenario_sections.py
+++ b/tests/test_scenario_sections.py
@@ -1,0 +1,188 @@
+"""Regression tests for the sectioned scenario stack layout.
+
+Issue #1064 defines four author-facing sections inside each stack:
+``common``, ``standalone``, ``modelservice``, and ``fma``.  The renderer
+normalizes those sections to the legacy flat effective config consumed by
+resolvers and templates.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+import pytest
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+
+def _renderer() -> RenderPlans:
+    renderer = RenderPlans.__new__(RenderPlans)
+    renderer.logger = MagicMock()
+    return renderer
+
+
+class TestExpandStackCommon:
+    def test_common_fields_are_expanded_without_mutating_input(self) -> None:
+        renderer = _renderer()
+        values = {
+            "modelservice": {"enabled": True},
+            "common": {
+                "model": {"name": "org/model"},
+                "storage": {"modelPvc": {"size": "200Gi"}},
+                "vllmCommon": {"inferencePort": 9000},
+            },
+        }
+        before = deepcopy(values)
+
+        result = renderer._expand_stack_common(values)
+
+        assert result == {
+            "modelservice": {"enabled": True},
+            "model": {"name": "org/model"},
+            "storage": {"modelPvc": {"size": "200Gi"}},
+            "vllmCommon": {"inferencePort": 9000},
+        }
+        assert values == before
+
+    def test_common_spelling_wins_over_legacy_flat_spelling(self) -> None:
+        renderer = _renderer()
+        result = renderer._expand_stack_common(
+            {
+                "model": {"name": "legacy", "maxModelLen": 4096},
+                "common": {"model": {"name": "sectioned"}},
+            }
+        )
+
+        assert result["model"] == {
+            "name": "sectioned",
+            "maxModelLen": 4096,
+        }
+
+    def test_non_mapping_common_is_rejected(self) -> None:
+        renderer = _renderer()
+
+        with pytest.raises(TypeError, match="'common' must be a mapping when present"):
+            renderer._expand_stack_common({"common": "invalid"})
+
+
+class TestSectionNormalization:
+    def test_common_and_modelservice_sections_form_effective_config(self) -> None:
+        renderer = _renderer()
+        defaults = {
+            # This is the modelservice chart's `common`, not stack.common.
+            "common": {"chartDefault": True},
+            "model": {"name": "default/model", "maxModelLen": 4096},
+            "storage": {"modelPvc": {"size": "1Ti"}},
+            "prefill": {"enabled": False, "replicas": 1},
+            "decode": {"enabled": True, "replicas": 1},
+            "modelservice": {"enabled": True, "uriProtocol": "pvc"},
+        }
+        stack = {
+            "common": {
+                "model": {"name": "org/model"},
+                "storage": {"modelPvc": {"size": "200Gi"}},
+            },
+            "modelservice": {
+                "enabled": True,
+                "common": {"customCA": True},
+                "prefill": {"enabled": True, "replicas": 2},
+                "decode": {"replicas": 4},
+                "inferenceExtension": {"enabled": True},
+            },
+            "standalone": {"enabled": False},
+            "fma": {"enabled": False},
+        }
+
+        scenario_layer = renderer._expand_stack_common(stack)
+        effective = renderer.deep_merge(defaults, scenario_layer)
+        effective = renderer._hoist_modelservice_sections(effective)
+
+        assert effective["model"] == {
+            "name": "org/model",
+            "maxModelLen": 4096,
+        }
+        assert effective["storage"]["modelPvc"]["size"] == "200Gi"
+        assert effective["common"] == {
+            "chartDefault": True,
+            "customCA": True,
+        }
+        assert effective["prefill"] == {"enabled": True, "replicas": 2}
+        assert effective["decode"] == {"enabled": True, "replicas": 4}
+        assert effective["inferenceExtension"] == {"enabled": True}
+        assert effective["modelservice"] == {
+            "enabled": True,
+            "uriProtocol": "pvc",
+        }
+
+    def test_sibling_summary_reads_model_from_common(self) -> None:
+        renderer = _renderer()
+        siblings = renderer._build_sibling_stacks(
+            [
+                {
+                    "name": "pool-a",
+                    "common": {"model": {"name": "org/model-a"}},
+                    "standalone": {"enabled": True},
+                },
+                {
+                    "name": "pool-b",
+                    "common": {"model": {"name": "org/model-b"}},
+                    "modelservice": {"enabled": True},
+                },
+            ]
+        )
+
+        assert siblings == [
+            {"name": "pool-a", "modelName": "org/model-a", "standalone": True},
+            {"name": "pool-b", "modelName": "org/model-b", "standalone": False},
+        ]
+
+
+def test_non_mapping_stack_common_fails_before_rendering(tmp_path: Path) -> None:
+    defaults = tmp_path / "defaults.yaml"
+    scenario = tmp_path / "scenario.yaml"
+    templates = tmp_path / "templates"
+    defaults.write_text("{}\n", encoding="utf-8")
+    scenario.write_text(
+        yaml.safe_dump(
+            {"scenario": [{"name": "bad-stack", "common": "not-a-mapping"}]}
+        ),
+        encoding="utf-8",
+    )
+    templates.mkdir()
+    logger = MagicMock()
+
+    result = RenderPlans(
+        template_dir=templates,
+        defaults_file=defaults,
+        scenarios_file=scenario,
+        output_dir=tmp_path / "out",
+        logger=logger,
+    ).eval()
+
+    assert result.global_errors == ["Stack 1 'common' section must be a mapping"]
+
+
+def test_sectioned_fma_example_renders_effective_config(tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    output_dir = tmp_path / "out"
+
+    result = RenderPlans(
+        template_dir=project_root / "config/templates/jinja",
+        defaults_file=project_root / "config/templates/values/defaults.yaml",
+        scenarios_file=project_root / "config/scenarios/examples/fma.yaml",
+        output_dir=output_dir,
+        logger=MagicMock(),
+    ).eval()
+
+    assert not result.has_errors, result.to_dict()
+    config_path = next(output_dir.rglob("config.yaml"))
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["model"]["name"] == "meta-llama/Llama-3.1-8B-Instruct"
+    assert config["workDir"] == "~/data/fma"
+    assert config["harness"]["name"] == "nop"
+    assert config["modelservice"]["enabled"] is False
+    assert config["standalone"]["enabled"] is False
+    assert config["fma"]["enabled"] is True


### PR DESCRIPTION
## Summary

Reorganize scenario stacks into the four well-defined sections proposed in #1064: `common`, `standalone`, `modelservice`, and `fma`.

Common settings are expanded into the effective configuration inherited by every standup method, while method-specific modelservice settings can be nested under `modelservice`. The resolved `config.yaml` remains flat for existing templates and execution steps.

## Motivation

Fixes #1064.

Scenario stacks currently mix shared settings such as `model`, `storage`, and `vllmCommon` with method-specific settings such as `prefill`, `decode`, and `inferenceExtension`. This makes the scope of each field unclear and forces scenario files to rely on comment headers instead of an explicit YAML structure.

## What changed

- Added normalization for per-stack `common` sections before defaults, shared settings, and stack overrides are merged.
- Extended modelservice nesting to support `common`, `prefill`, `decode`, `inferenceExtension`, and `multinode` in addition to the existing gateway/router sections.
- Preserved override precedence: defaults < shared < stack < treatment/CLI.
- Added clear validation errors when `stack.common` or `shared.common` is not a mapping.
- Updated early workspace discovery to read `common.workDir`.
- Reorganized the FMA example and OCP CI scenario using the sectioned layout.
- Documented the new structure and backward-compatible flat spelling.
- Added regression coverage for common inheritance, method-specific normalization, multi-stack sibling metadata, invalid structures, and end-to-end scenario rendering.

## Testing

- `python -m pytest tests -q`
  - 674 passed, 31 skipped.
- `python -m pytest tests/test_scenario_sections.py tests/test_hoist_modelservice_sections.py tests/test_config_schema.py -q`
  - 62 passed.
- `pre-commit run`
  - Byte compilation, full unit tests, changed-scenario dry-run rendering, secret scan, Ruff lint, and Ruff format all passed.
- Rendered both migrated scenarios and compared their effective `config.yaml` dictionaries with the versions from upstream `main`.
  - `config/scenarios/examples/fma.yaml`: identical.
  - `config/scenarios/cicd/ocp.yaml`: identical.
- `git diff --check`

## Backward Compatibility

Legacy flat scenario keys remain supported and render unchanged. If both a legacy flat key and its sectioned spelling are present in the same scenario layer, the sectioned value wins. Treatment and CLI overrides continue to take final precedence.

The modelservice Helm chart's own `common` values can be written as `modelservice.common`, avoiding ambiguity with the stack-level `common` section.

## Checklist

- [x] My changes follow the style guidelines of this project.
- [x] I have performed a self-review of my changes.
- [x] I confirm that `pre-commit run` was run and all checks passed.
- [x] I have updated the documentation accordingly.