### PR TITLE
fix: vllm 0.24.0 does not log vllmstart line, setting standalone nop baseline vllm args to match FMA launcher vllm

### DIFF
--- a/config/scenarios/cicd/ocp.yaml
+++ b/config/scenarios/cicd/ocp.yaml
@@ -15,6 +15,9 @@ scenario:
       shortName: qwen-qwen3-8b
       path: models/Qwen/Qwen3-8B
       huggingfaceId: Qwen/Qwen3-8B
+      # Keeping it similar to FMA launcher's vLLM (24_fma-deployment.yaml.j2)
+      maxModelLen: 40960
+      blockSize: 16
 
     # Deployment method
     modelservice:
@@ -64,6 +67,13 @@ scenario:
 
     vllmCommon:
       priorityClassName: nightly-gpu-critical
+      flags:
+        # Disable enforce_eager so the standalone vLLM runs torch.compile +
+        # CUDA-graph capture -- otherwise Dynamo / Torch Compile / Memory
+        # Profiling metrics are all 0 (those phases are skipped under eager).
+        enforceEager: false
+        # FMA runs with prefix caching off (--no-enable-prefix-caching)
+        noPrefixCaching: true
 
     workDir: /tmp/llmdbenchcicd-ocp/
 

--- a/workload/harnesses/nop_functions.py
+++ b/workload/harnesses/nop_functions.py
@@ -1246,7 +1246,10 @@ def parse_logs(  # pylint: disable=too-many-locals,too-many-branches,too-many-st
 
     # Strings to be searched on logging ouput in order to extract values
 
-    plugins_init = "plugins/__init__.py"
+    # vLLM start marker for vLLM >= 0.24: Older vLLM logged "plugins/__init__.py"
+    # during startup, but v0.24 dropped that line; "non-default args:" is the
+    # earliest APIServer line (api_utils.py) and marks the server-process start.
+    vllm_start_marker = "non-default args:"
     available_routes = "Available routes are:"
 
     server_non_default_args = "non-default args:"
@@ -1294,7 +1297,7 @@ def parse_logs(  # pylint: disable=too-many-locals,too-many-branches,too-many-st
     for log in logs:
         line = log.line.strip()
 
-        if metrics.vllm_start_timestamp == 0.0 and plugins_init in line:
+        if metrics.vllm_start_timestamp == 0.0 and vllm_start_marker in line:
             metrics.vllm_start_timestamp = log.timestamp.astimezone(
                 timezone.utc
             ).timestamp()


### PR DESCRIPTION
Noticed a lot of 0s in standalone baseline metrics in the nightly: https://github.com/llm-d/llm-d-benchmark/actions/runs/29378818786