### PR TITLE
fix: rename shadowed log_plain overload to log_plain_console

### DIFF
--- a/llmdbenchmark/logging/logger.py
+++ b/llmdbenchmark/logging/logger.py
@@ -170,7 +170,7 @@ class LLMDBenchmarkLogger:
             self._apply_indent(msg), extra={"emoji": emoji} if emoji else {}
         )
 
-    def log_plain(self, msg, emoji=None):
+    def log_plain_console(self, msg, emoji=None):
         """Log a plain message to console (no metadata) but full message to file."""
         self.logger.info(self._apply_indent(msg), extra={"plain": True, "emoji": emoji})
 
@@ -194,7 +194,7 @@ class LLMDBenchmarkLogger:
             handler.stream.write("\n")
             handler.flush()
 
-    def log_plain(self, msg: str) -> None:  # noqa: F811
+    def log_plain(self, msg: str) -> None:
         """Write *msg* verbatim to every handler - no timestamp or level prefix.
 
         For human-facing payloads where the log formatting would be more


### PR DESCRIPTION
Two methods named log_plain() existed on LLMDBenchmarkLogger with different behavior; the console/file-split variant was always shadowed by the verbatim-write variant defined later, triggering F811 and leaving the first implementation dead code.

Co-Authored-By: Claude

fixes #1197 