### PR TITLE
fix: teardown leaving GAIE/EPP Helm release and Deployment behind

### DIFF
--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -37,6 +37,12 @@ class UninstallHelmStep(Step):
         }
     )
 
+    # Chart name prefixes used exclusively by modelservice deployments this
+    # tool creates (llm-d-modelservice, llm-d-router-gateway/-standalone).
+    # Used as a fallback match on full-scenario teardowns -- see
+    # _release_matches.
+    _MANAGED_CHART_PREFIXES = ("llm-d-modelservice", "llm-d-router-")
+
     def __init__(self):
         super().__init__(
             number=1,
@@ -239,10 +245,17 @@ class UninstallHelmStep(Step):
         except ValueError:
             releases = []
 
+        # Full-scenario teardowns (no --stack filter) are allowed to match
+        # releases by chart identity alone -- see _release_matches. A
+        # --stack-filtered (partial) teardown must not, since sibling
+        # stacks of this scenario can share the namespace and must be
+        # preserved.
+        full_teardown = not context.stack_filter
+
         for rel in releases:
             release_name = rel.get("name", "")
             if not release_name or not self._release_matches(
-                release_name, release, model_labels
+                release_name, release, model_labels, rel.get("chart", ""), full_teardown
             ):
                 continue
 
@@ -278,12 +291,38 @@ class UninstallHelmStep(Step):
 
     @staticmethod
     def _release_matches(
-        release_name: str, release: str, model_labels: list[str]
+        release_name: str,
+        release: str,
+        model_labels: list[str],
+        chart: str,
+        full_teardown: bool,
     ) -> bool:
-        """Check if a helm release belongs to this deployment."""
+        """Check if a helm release belongs to this deployment.
+
+        ``model_labels`` is derived from a fresh render of the scenario at
+        teardown time, which depends on ``--models``/``LLMDBENCH_MODELS``
+        being re-supplied to match what was actually deployed at standup.
+        If it's omitted or doesn't match, a release can go unmatched here
+        even though it belongs to this deployment -- silently leaving it
+        (and everything it owns, e.g. the GAIE/EPP Deployment) behind with
+        teardown still reporting success.
+
+        On a full-scenario teardown (``full_teardown``, i.e. no --stack
+        filter), we also match by chart identity: any release using one of
+        our managed charts (llm-d-modelservice, llm-d-router-*) belongs to
+        this deployment regardless of model-label mismatches, since a full
+        teardown is meant to wipe everything this tool deployed in the
+        namespace anyway. A --stack-filtered (partial) teardown must not
+        use this broader match -- sibling stacks in the same namespace can
+        use the same charts and must be preserved.
+        """
         if release and release in release_name:
             return True
-        return any(label in release_name for label in model_labels)
+        if any(label in release_name for label in model_labels):
+            return True
+        return full_teardown and chart.startswith(
+            UninstallHelmStep._MANAGED_CHART_PREFIXES
+        )
 
     def _delete_openshift_routes(
         self,

--- a/llmdbenchmark/teardown/steps/step_03_delete_resources.py
+++ b/llmdbenchmark/teardown/steps/step_03_delete_resources.py
@@ -45,6 +45,11 @@ MODELSERVICE_PATTERNS = [
     "inference-gateway-secret",
     "inference-gateway-params",
     "lmbenchmark",
+    # Catches the GAIE/EPP Deployment (named e.g. "<model>-router-epp" or
+    # the older "<model>-gaie-epp" convention) as a safety net independent
+    # of Helm release matching -- "endpoint-picker" above only matches the
+    # container image repo, not the Deployment's own object name.
+    "-epp",
 ]
 
 DEEP_RESOURCE_KINDS = [

--- a/tests/test_teardown_gaie_epp_cleanup.py
+++ b/tests/test_teardown_gaie_epp_cleanup.py
@@ -1,0 +1,101 @@
+"""Tests for GAIE/EPP cleanup during teardown.
+
+Regression coverage for: teardown reporting success while leaving the
+GAIE/EPP Helm release (and its Deployment) behind when the model label
+re-derived at teardown time doesn't match what was actually deployed at
+standup (e.g. ``--models``/``LLMDBENCH_MODELS`` wasn't re-supplied).
+
+Two independent mechanisms are covered:
+- ``UninstallHelmStep._release_matches``: Helm release matching now also
+  matches by chart identity on a full-scenario teardown (no --stack filter).
+- ``DeleteResourcesStep.MODELSERVICE_PATTERNS``: the namespace-wide safety
+  net now also matches "-epp"-suffixed resource names.
+"""
+
+from __future__ import annotations
+
+from llmdbenchmark.teardown.steps.step_01_uninstall_helm import UninstallHelmStep
+from llmdbenchmark.teardown.steps.step_03_delete_resources import (
+    DeleteResourcesStep,
+    MODELSERVICE_PATTERNS,
+)
+
+
+class TestReleaseMatchesChartFallback:
+    """UninstallHelmStep._release_matches chart-identity fallback."""
+
+    def test_model_label_match_still_works_regardless_of_full_teardown(self):
+        assert UninstallHelmStep._release_matches(
+            "qwen-qwe-04b6bb85-router",
+            "llmdbench",
+            ["qwen-qwe-04b6bb85"],
+            "llm-d-router-gateway-1.2.3",
+            full_teardown=False,
+        )
+
+    def test_release_name_match_still_works_regardless_of_full_teardown(self):
+        assert UninstallHelmStep._release_matches(
+            "llmdbench-router",
+            "llmdbench",
+            [],
+            "llm-d-router-gateway-1.2.3",
+            full_teardown=False,
+        )
+
+    def test_full_teardown_matches_by_chart_identity_despite_label_mismatch(self):
+        """The bug: teardown re-rendered with a different model, so neither
+        the release name nor model_labels match -- but it's a full-scenario
+        teardown, so the release still belongs to us by chart identity."""
+        assert UninstallHelmStep._release_matches(
+            "qwen-qwe-04b6bb85-en3-0-6b-router",
+            "llmdbench",
+            ["some-other-model-label"],
+            "llm-d-router-gateway-1.2.3",
+            full_teardown=True,
+        )
+
+    def test_full_teardown_matches_modelservice_chart_too(self):
+        assert UninstallHelmStep._release_matches(
+            "qwen-qwe-04b6bb85-en3-0-6b-ms",
+            "llmdbench",
+            ["some-other-model-label"],
+            "llm-d-modelservice-0.4.0",
+            full_teardown=True,
+        )
+
+    def test_partial_stack_teardown_does_not_use_chart_fallback(self):
+        """A --stack-filtered teardown must not sweep up sibling stacks'
+        releases just because they share a chart -- only a real name/label
+        match should count."""
+        assert not UninstallHelmStep._release_matches(
+            "sibling-model-router",
+            "llmdbench",
+            ["some-other-model-label"],
+            "llm-d-router-gateway-1.2.3",
+            full_teardown=False,
+        )
+
+    def test_unmanaged_chart_never_matches_on_label_mismatch(self):
+        assert not UninstallHelmStep._release_matches(
+            "unrelated-release",
+            "llmdbench",
+            ["some-other-model-label"],
+            "some-unrelated-chart-1.0.0",
+            full_teardown=True,
+        )
+
+
+class TestModelservicePatternsCatchesEppDeployment:
+    """DeleteResourcesStep's namespace-wide safety net for the EPP Deployment."""
+
+    def test_router_epp_deployment_name_matches(self):
+        assert DeleteResourcesStep._matches_any(
+            "deployment/qwen-qwe-04b6bb85-en3-0-6b-router-epp",
+            MODELSERVICE_PATTERNS,
+        )
+
+    def test_legacy_gaie_epp_deployment_name_matches(self):
+        assert DeleteResourcesStep._matches_any(
+            "deployment/qwen-qwe-04b6bb85-en3-0-6b-gaie-epp",
+            MODELSERVICE_PATTERNS,
+        )


### PR DESCRIPTION
Teardown re-renders the scenario fresh on every invocation, so the model_id_label used to match Helm releases depends on --models/ LLMDBENCH_MODELS being re-supplied identically to what was passed at standup. When it's omitted or doesn't match, the release owning the GAIE/EPP Deployment (<model_id_label>-router) silently goes unmatched -- zero matches means zero errors, so teardown still reports success while the release (and its Deployment/pods) are left running.

- UninstallHelmStep._release_matches now also matches by chart identity (llm-d-modelservice, llm-d-router-*) on full-scenario teardowns (no --stack filter), independent of model-label mismatches. Partial-stack teardowns keep strict name/label matching so sibling stacks sharing the namespace aren't swept up.
- DeleteResourcesStep.MODELSERVICE_PATTERNS gains an "-epp" pattern, so the namespace-wide safety net catches the EPP Deployment by name too ("endpoint-picker" only matched the container image repo, not the Deployment's own object name).

Co-Authored-By: Claude

Fixes #1234 