### PR TITLE
router: let epponly pick proxyType=agentgateway, not just envoy

### DIFF
--- a/config/templates/jinja/12_router-values.yaml.j2
+++ b/config/templates/jinja/12_router-values.yaml.j2
@@ -24,6 +24,9 @@
                                                   hack is gone)
      inferenceExtension.envoySidecar          -> router.proxy.{args,resources}
                                                  (standalone-chart Envoy)
+     inferenceExtension.proxyType             -> router.proxy.proxyType
+                                                 (epponly only, envoy [default]
+                                                 or agentgateway)
      inferenceExtension.extraServicePorts     -> router.extraServicePorts
      inferenceExtension.extraContainerPorts   -> router.epp.extraContainerPorts
      inferenceExtension.monitoring            -> router.monitoring
@@ -55,6 +58,7 @@
                     else images.inferenceScheduler %}
 {% set registry = _epp_image.repository.split('/')[0] %}
 {% set _epponly = (gateway.className | default('') == 'epponly') %}
+{% set _proxy_type = (inferenceExtension.proxyType | default('envoy')) | lower %}
 router:
 {# UDS tokenizer is a first-class chart feature on the llm-d-router
    charts. Toggling `inferenceExtension.sidecar.enabled` in a scenario
@@ -124,6 +128,12 @@ router:
       {{ key }}: "{{ value }}"
 {% endfor %}
 {% else %}
+{# agentgateway standalone talks to EPP over plaintext grpc, so the chart
+   fails validation unless secure-serving is off. envoy doesn't care about
+   this flag so we only set it for agentgateway. #}
+{% if _epponly and _proxy_type == 'agentgateway' %}
+      secure-serving: "false"
+{% endif %}
 {% if monitoring is defined and monitoring.metricsScrapeEnabled is defined and monitoring.metricsScrapeEnabled %}
       v: "4"
 {% else %}
@@ -188,13 +198,17 @@ router:
         # the default per-stack to keep them disjoint.
         secretName: {{ inferenceExtension.monitoring.secretName | default('inference-gateway-sa-metrics-reader-secret') }}
 
-{# Envoy sidecar config for the standalone chart (gateway.className=epponly).
-   The new chart surfaces the Envoy sidecar tunables under `router.proxy`
-   (the legacy chart used `inferenceExtension.sidecar`). #}
+{# Proxy sidecar config for the standalone chart (gateway.className=epponly).
+   The new chart surfaces this under `router.proxy`. proxyType picks envoy
+   (default, keeps old behavior) or agentgateway. envoySidecar's args/
+   resources are envoy-specific tunables and still apply on top, the
+   chart just ignores them when proxyType=agentgateway. #}
 {% if _epponly
-      and inferenceExtension.envoySidecar is defined
-      and inferenceExtension.envoySidecar %}
+      and (inferenceExtension.envoySidecar is defined and inferenceExtension.envoySidecar
+           or inferenceExtension.proxyType is defined) %}
   proxy:
+    proxyType: {{ _proxy_type }}
+{% if inferenceExtension.envoySidecar is defined and inferenceExtension.envoySidecar %}
 {% if inferenceExtension.envoySidecar.args is defined and inferenceExtension.envoySidecar.args %}
     args:
 {% for arg in inferenceExtension.envoySidecar.args %}
@@ -204,6 +218,7 @@ router:
 {% if inferenceExtension.envoySidecar.resources is defined and inferenceExtension.envoySidecar.resources %}
     resources:
 {{ inferenceExtension.envoySidecar.resources | toyaml | indent(6, true) }}
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -269,6 +269,25 @@ When `epponly` is selected, standup automatically:
    smoketest and run phase resolve to the EPP service directly instead
    of a Gateway IP.
 
+By default the sidecar in this pod is Envoy. Set `inferenceExtension.proxyType: agentgateway`
+in the scenario to use agentgateway instead:
+
+```yaml
+scenario:
+  - name: "my-stack"
+    gateway:
+      className: epponly
+
+    inferenceExtension:
+      proxyType: agentgateway   # default is "envoy"
+    # ... rest of scenario config
+```
+
+`secure-serving` gets set to `false` on the EPP automatically when
+`proxyType: agentgateway` is picked (the chart requires it, agentgateway talks
+to EPP over plaintext grpc). If a scenario also sets `inferenceExtension.flags`
+explicitly, add `secure-serving: false` there yourself.
+
 #### Restrictions
 
 - **Single-stack only.** `epponly` cannot multiplex multiple models since

--- a/tests/test_epponly_proxytype.py
+++ b/tests/test_epponly_proxytype.py
@@ -1,0 +1,127 @@
+"""Tests for router.proxy.proxyType rendering on the epponly path.
+
+epponly (the standalone router topology) used to only ever render
+Envoy sidecar settings, there was no way to pick agentgateway as the
+proxy even though the chart supports it. This checks that setting
+inferenceExtension.proxyType actually shows up in the rendered values,
+and that picking envoy or leaving it unset behaves the same as before.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_PATH = (
+    REPO_ROOT / "config" / "templates" / "jinja" / "12_router-values.yaml.j2"
+)
+DEFAULTS_PATH = REPO_ROOT / "config" / "templates" / "values" / "defaults.yaml"
+
+
+@pytest.fixture
+def renderer():
+    """Bypass __init__, we only need _render_template + the jinja filters."""
+    logger = MagicMock()
+    r = RenderPlans.__new__(RenderPlans)
+    r.logger = logger
+    r._jinja_env = None
+    return r
+
+
+@pytest.fixture
+def defaults():
+    with open(DEFAULTS_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def scenario_values(
+    defaults: dict,
+    gateway_class: str = "epponly",
+    extra_inference_extension: dict | None = None,
+) -> dict:
+    """Real defaults.yaml plus the bits a scenario would normally override."""
+    values = copy.deepcopy(defaults)
+    values["standalone"] = {"enabled": False}
+    values["kustomize"] = {"enabled": False}
+    values["gateway"]["className"] = gateway_class
+    if extra_inference_extension:
+        values["inferenceExtension"].update(extra_inference_extension)
+    return values
+
+
+def render(renderer, values: dict) -> dict:
+    rendered = renderer._render_template(TEMPLATE_PATH.read_text(), values)
+    return yaml.safe_load(rendered)
+
+
+class TestProxyTypeRendering:
+    def test_no_proxytype_set_keeps_old_behavior(self, renderer, defaults):
+        """Nothing set at all -> no proxy block, same as before this fix."""
+        out = render(renderer, scenario_values(defaults))
+        assert "proxy" not in out["router"]
+
+    def test_proxytype_agentgateway_is_rendered(self, renderer, defaults):
+        out = render(
+            renderer,
+            scenario_values(
+                defaults, extra_inference_extension={"proxyType": "agentgateway"}
+            ),
+        )
+        assert out["router"]["proxy"]["proxyType"] == "agentgateway"
+
+    def test_proxytype_agentgateway_auto_sets_secure_serving_false(
+        self, renderer, defaults
+    ):
+        """chart fails to render if secure-serving isn't false for agentgateway."""
+        out = render(
+            renderer,
+            scenario_values(
+                defaults, extra_inference_extension={"proxyType": "agentgateway"}
+            ),
+        )
+        assert out["router"]["epp"]["flags"]["secure-serving"] == "false"
+
+    def test_proxytype_envoy_explicit_still_works(self, renderer, defaults):
+        out = render(
+            renderer,
+            scenario_values(defaults, extra_inference_extension={"proxyType": "envoy"}),
+        )
+        assert out["router"]["proxy"]["proxyType"] == "envoy"
+        # envoy doesn't need secure-serving forced off
+        assert "secure-serving" not in out["router"]["epp"]["flags"]
+
+    def test_envoy_sidecar_args_still_work_alongside_proxytype(
+        self, renderer, defaults
+    ):
+        """existing envoySidecar.args/resources scenarios shouldn't break."""
+        out = render(
+            renderer,
+            scenario_values(
+                defaults,
+                extra_inference_extension={
+                    "proxyType": "envoy",
+                    "envoySidecar": {"args": ["--foo", "bar"]},
+                },
+            ),
+        )
+        assert out["router"]["proxy"]["proxyType"] == "envoy"
+        assert out["router"]["proxy"]["args"] == ["--foo", "bar"]
+
+    def test_non_epponly_ignores_proxytype(self, renderer, defaults):
+        """proxyType is an epponly-only knob, gateway-based topologies don't use it."""
+        out = render(
+            renderer,
+            scenario_values(
+                defaults,
+                gateway_class="istio",
+                extra_inference_extension={"proxyType": "agentgateway"},
+            ),
+        )
+        assert "proxy" not in out["router"]


### PR DESCRIPTION
fixes #1653

epponly (the standalone router topology) always deployed envoy as the proxy sidecar. theres no field anywhere in the templates to switch it to agentgateway, even though the chart itself already supports proxyType: [envoy, agentgateway] fine on its own.

## what changed

adds inferenceExtension.proxyType to the scenario schema, defaults to envoy so nothing existing changes. when epponly is active this gets passed through as router.proxy.proxyType.

also auto-sets epp.flags.secure-serving: "false" when agentgateway is picked and no explicit flags are set, since the chart requires that (agentgateway talks to EPP over plaintext grpc) and fails to render otherwise. if a scenario sets inferenceExtension.flags explicitly they need to add secure-serving: false themselves, documented that in standup.md.

## testing

- added tests/test_epponly_proxytype.py, 6 cases covering: nothing set keeps old behavior, agentgateway renders correctly, secure-serving gets auto set, explicit envoy still works, envoySidecar args/resources still work alongside proxyType, and non-epponly topologies ignore proxyType entirely
- ran the full existing suite, 297 passed 4 skipped, no regressions
- also verified through the real llmdbenchmark plan pipeline (not just my unit tests): built a scenario off cicd/kind.yaml with gateway.className: epponly + proxyType: agentgateway, ran plan, and confirmed the rendered 12_router-values.yaml has proxyType: agentgateway plus secure-serving: "false", while the existing router.proxy.resources values still flowed through correctly. ran the unmodified cicd/kind.yaml scenario the same way as a control, confirmed the output is byte identical to before this change (no proxy: block at all, since that scenario doesn't use epponly)

## docs

added a short section + example to docs/standup.md under the epponly part explaining the new proxyType field and the secure-serving requirement