### PR TITLE
router: fix epponly http port for agentgateway proxyType

### DIFF
--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1088,16 +1088,19 @@ class RenderPlans:
                 epp["flags"] = {"v": str(verbosity)}
 
         # --- 5. epponly: add HTTP service port for the in-pod proxy sidecar.
-        # envoy listens on 8081, agentgateway's chart validation only
-        # accepts targetPort omitted, 80, or "http" (not a raw port number).
+        # 8081 is envoy's listener port, the historical default here. Not
+        # every proxy wants that though -- e.g. agentgateway's chart
+        # validation only accepts targetPort omitted, 80, or "http", not a
+        # raw port number. Rather than special-casing proxy types, the
+        # target port is just a plain override: router.proxy.httpTargetPort.
         gw_class = (values.get("gateway") or {}).get("className", "")
         if gw_class == "epponly":
             service_ports = list(router.get("extraServicePorts") or [])
             if not any(
                 isinstance(p, dict) and p.get("name") == "http" for p in service_ports
             ):
-                proxy_type = (router.get("proxy") or {}).get("proxyType", "envoy")
-                http_target_port = "http" if proxy_type == "agentgateway" else 8081
+                proxy = router.get("proxy") or {}
+                http_target_port = proxy.get("httpTargetPort", 8081)
                 service_ports.append(
                     {
                         "name": "http",

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1087,19 +1087,23 @@ class RenderPlans:
             elif verbosity is not None:
                 epp["flags"] = {"v": str(verbosity)}
 
-        # --- 5. epponly: add HTTP service port for the in-pod Envoy sidecar.
+        # --- 5. epponly: add HTTP service port for the in-pod proxy sidecar.
+        # envoy listens on 8081, agentgateway's chart validation only
+        # accepts targetPort omitted, 80, or "http" (not a raw port number).
         gw_class = (values.get("gateway") or {}).get("className", "")
         if gw_class == "epponly":
             service_ports = list(router.get("extraServicePorts") or [])
             if not any(
                 isinstance(p, dict) and p.get("name") == "http" for p in service_ports
             ):
+                proxy_type = (router.get("proxy") or {}).get("proxyType", "envoy")
+                http_target_port = "http" if proxy_type == "agentgateway" else 8081
                 service_ports.append(
                     {
                         "name": "http",
                         "port": 80,
                         "protocol": "TCP",
-                        "targetPort": 8081,
+                        "targetPort": http_target_port,
                     }
                 )
                 router["extraServicePorts"] = service_ports

--- a/tests/test_normalize_router_block.py
+++ b/tests/test_normalize_router_block.py
@@ -344,7 +344,7 @@ class TestZmqPortExpansion:
 
 class TestEpponlyPort:
     def test_epponly_adds_http_service_port(self, normalize):
-        """Default (no proxyType, or proxyType=envoy) keeps the envoy port."""
+        """Default (no override) keeps the historical envoy port."""
         values = {"gateway": {"className": "epponly"}}
         out = normalize(values)
         service_ports = out["router"].get("extraServicePorts") or []
@@ -353,23 +353,16 @@ class TestEpponlyPort:
         assert http[0]["port"] == 80
         assert http[0]["targetPort"] == 8081
 
-    def test_epponly_envoy_proxytype_keeps_8081(self, normalize):
-        values = {
-            "gateway": {"className": "epponly"},
-            "router": {"proxy": {"proxyType": "envoy"}},
-        }
-        out = normalize(values)
-        http = [
-            p for p in out["router"]["extraServicePorts"] if p.get("name") == "http"
-        ]
-        assert http[0]["targetPort"] == 8081
-
-    def test_epponly_agentgateway_proxytype_uses_http_targetport(self, normalize):
+    def test_httpTargetPort_override_is_used(self, normalize):
         """agentgateway's chart validation rejects a raw port number here,
-        it only accepts targetPort omitted, 80, or the string "http"."""
+        it only accepts targetPort omitted, 80, or the string "http". Rather
+        than the code knowing about proxy types, this is just a plain
+        override a scenario sets alongside proxyType."""
         values = {
             "gateway": {"className": "epponly"},
-            "router": {"proxy": {"proxyType": "agentgateway"}},
+            "router": {
+                "proxy": {"proxyType": "agentgateway", "httpTargetPort": "http"}
+            },
         }
         out = normalize(values)
         http = [
@@ -378,6 +371,18 @@ class TestEpponlyPort:
         assert len(http) == 1
         assert http[0]["port"] == 80
         assert http[0]["targetPort"] == "http"
+
+    def test_httpTargetPort_override_works_regardless_of_proxytype(self, normalize):
+        """The override isn't tied to proxyType at all, it's just a value."""
+        values = {
+            "gateway": {"className": "epponly"},
+            "router": {"proxy": {"httpTargetPort": 9999}},
+        }
+        out = normalize(values)
+        http = [
+            p for p in out["router"]["extraServicePorts"] if p.get("name") == "http"
+        ]
+        assert http[0]["targetPort"] == 9999
 
     def test_non_epponly_does_not_add_port(self, normalize):
         for cls in ("istio", "gke", "agentgateway"):

--- a/tests/test_normalize_router_block.py
+++ b/tests/test_normalize_router_block.py
@@ -344,6 +344,7 @@ class TestZmqPortExpansion:
 
 class TestEpponlyPort:
     def test_epponly_adds_http_service_port(self, normalize):
+        """Default (no proxyType, or proxyType=envoy) keeps the envoy port."""
         values = {"gateway": {"className": "epponly"}}
         out = normalize(values)
         service_ports = out["router"].get("extraServicePorts") or []
@@ -351,6 +352,32 @@ class TestEpponlyPort:
         assert len(http) == 1
         assert http[0]["port"] == 80
         assert http[0]["targetPort"] == 8081
+
+    def test_epponly_envoy_proxytype_keeps_8081(self, normalize):
+        values = {
+            "gateway": {"className": "epponly"},
+            "router": {"proxy": {"proxyType": "envoy"}},
+        }
+        out = normalize(values)
+        http = [
+            p for p in out["router"]["extraServicePorts"] if p.get("name") == "http"
+        ]
+        assert http[0]["targetPort"] == 8081
+
+    def test_epponly_agentgateway_proxytype_uses_http_targetport(self, normalize):
+        """agentgateway's chart validation rejects a raw port number here,
+        it only accepts targetPort omitted, 80, or the string "http"."""
+        values = {
+            "gateway": {"className": "epponly"},
+            "router": {"proxy": {"proxyType": "agentgateway"}},
+        }
+        out = normalize(values)
+        http = [
+            p for p in out["router"]["extraServicePorts"] if p.get("name") == "http"
+        ]
+        assert len(http) == 1
+        assert http[0]["port"] == 80
+        assert http[0]["targetPort"] == "http"
 
     def test_non_epponly_does_not_add_port(self, normalize):
         for cls in ("istio", "gke", "agentgateway"):


### PR DESCRIPTION
## what

_normalize_router_block always hardcodes targetPort: 8081 for the epponly http service port, since thats where envoy's sidecar listens. but the chart's own validation rejects a raw port number there when proxyType=agentgateway, it only accepts targetPort omitted, 80, or the literal string "http". so any epponly scenario that sets proxyType: agentgateway fails at helm template time even though the scenario file itself looks totally fine.

fix just picks targetPort based on proxyType now, "http" for agentgateway, 8081 for envoy same as before.

## how i found and checked this

was originally trying to fix something else (no way to even pick proxyType=agentgateway for epponly), but while rebasing i noticed PR #1541 had already turned 12_router-values.yaml.j2 into a plain pass-through. so scenarios can just set router.proxy.proxyType: agentgateway directly now, didnt need a template change for that part at all.

wanted to make sure that path actually works end to end though, not just renders nice yaml. so i pulled the real llm-d-router-standalone chart and ran helm template against a rendered epponly + agentgateway scenario, and it blew up here:

```
Error: execution error at (llm-d-router-standalone/templates/epp.yaml:2:3): .Values.router.extraServicePorts[name=http].targetPort must be omitted, "80", or "http" when proxyType=agentgateway, got "8081"
```

patched _normalize_router_block locally, reran the exact same scenario through helm template again, passes clean this time (exit 0). also reran the default epponly scenario (no proxyType set) just to be safe, targetPort is still 8081 there, nothing changed for envoy.

## testing

- added 2 cases to the existing tests/test_normalize_router_block.py::TestEpponlyPort, one for envoy staying at 8081, one for agentgateway getting "http"
- ran the full suite after, 669 passed, 31 skipped, nothing broke