### PR TITLE
fix(nightly): refresh persistent llm-d checkout to origin/main

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -621,7 +621,10 @@ jobs:
             echo "### llm-d code NOT found, will clone now"
             git clone https://github.com/llm-d/llm-d.git
           else
-            echo "### llm-d code is already present. Will then delete llm-d-benchmark"
+            echo "### llm-d code is already present. Refreshing to origin/main and deleting llm-d-benchmark"
+            # Refresh the persistent checkout so it doesn't run against stale guide config.
+            git -C ~/work/llm-d/llm-d fetch --prune origin
+            git -C ~/work/llm-d/llm-d reset --hard origin/main
             pip uninstall -y llmdbenchmark || true
             rm -rf ~/work/llm-d-benchmark/
           fi


### PR DESCRIPTION
## Problem

The [nightly workflow](https://github.com/llm-d/llm-d/actions/runs/29491570080/job/87598737271) for XPU failed because there is outdated llm-d repo on the self-hosted github runner. 

## Fix

When the checkout already exists, `git fetch --prune origin` + `git reset --hard origin/main` so every run uses current guide config.