### PR TITLE
Add opt-in hostPath-backed model storage with per-node download DaemonSet

### DIFF
--- a/config/scenarios/guides/epp-keda-saturation.yaml
+++ b/config/scenarios/guides/epp-keda-saturation.yaml
@@ -248,6 +248,18 @@ scenario:
     storage:
       modelPvc:
         size: 1Ti
+      hostPath:
+        # TODO: should we default to enabled: true for WVA scenarios?
+        enabled: false
+        path: /mnt/models
+        storageClassName: hostpath
+        capacity: 1Ti
+        # Target the GPU nodes where decode pods will schedule.
+        # Replace with your cluster's actual node labels.
+        nodeSelector:
+          nvidia.com/gpu.present: "true"
+        tolerations: []
+        daemonSetTimeout: 3600
 
     # =========================================================================
     # WORKLOAD / HARNESS

--- a/config/scenarios/guides/workload-autoscaling.yaml
+++ b/config/scenarios/guides/workload-autoscaling.yaml
@@ -444,6 +444,18 @@ scenario:
     storage:
       modelPvc:
         size: 1Ti
+      hostPath:
+        # TODO: should we default to enabled: true for WVA scenarios?
+        enabled: false
+        path: /mnt/models
+        storageClassName: hostpath
+        capacity: 1Ti
+        # Target the GPU nodes where decode pods will schedule.
+        # Replace with your cluster's actual node labels.
+        nodeSelector:
+          nvidia.com/gpu.present: "true"
+        tolerations: []
+        daemonSetTimeout: 3600
 
     # =========================================================================
     # WORKLOAD / HARNESS

--- a/config/templates/jinja/02_pvc_model-pvc.yaml.j2
+++ b/config/templates/jinja/02_pvc_model-pvc.yaml.j2
@@ -11,6 +11,9 @@ spec:
   resources:
     requests:
       storage: {{ storage.modelPvc.size }}
-{% if storage.modelPvc.storageClassName is defined and storage.modelPvc.storageClassName not in ["default", "auto", ""] %}
+{% if storage.hostPath is defined and storage.hostPath.enabled | default(false) %}
+  storageClassName: {{ storage.hostPath.storageClassName }}
+  volumeName: {{ storage.modelPvc.name }}-hostpath-pv
+{% elif storage.modelPvc.storageClassName is defined and storage.modelPvc.storageClassName not in ["default", "auto", ""] %}
   storageClassName: {{ storage.modelPvc.storageClassName }}
 {% endif %}

--- a/config/templates/jinja/02a_pv_model-hostpath.yaml.j2
+++ b/config/templates/jinja/02a_pv_model-hostpath.yaml.j2
@@ -1,0 +1,21 @@
+{% if storage.hostPath is defined and storage.hostPath.enabled | default(false) %}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ storage.modelPvc.name }}-hostpath-pv
+  labels:
+    app: {{ labels.app }}
+    usage: model-cache
+spec:
+  capacity:
+    storage: {{ storage.hostPath.capacity | default(storage.modelPvc.size) }}
+  accessModes:
+{% for mode in storage.modelPvc.accessModes %}
+    - {{ mode }}
+{% endfor %}
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {{ storage.hostPath.storageClassName }}
+  hostPath:
+    path: {{ storage.hostPath.path }}
+    type: DirectoryOrCreate
+{% endif %}

--- a/config/templates/jinja/03_download_daemonset.yaml.j2
+++ b/config/templates/jinja/03_download_daemonset.yaml.j2
@@ -1,0 +1,98 @@
+{% if storage.hostPath is defined and storage.hostPath.enabled | default(false) %}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ storage.hostPath.daemonSetName | default('download-model-ds') }}
+  namespace: {{ namespace.name }}
+  labels:
+    app: {{ labels.app }}
+    component: model-download
+spec:
+  selector:
+    matchLabels:
+      app: {{ labels.app }}
+      component: model-download
+  template:
+    metadata:
+      labels:
+        app: {{ labels.app }}
+        component: model-download
+    spec:
+      serviceAccountName: {{ serviceAccount.name }}
+      securityContext:
+        seLinuxOptions:
+          type: spc_t
+{% if storage.hostPath.nodeSelector is defined and storage.hostPath.nodeSelector %}
+      nodeSelector:
+{{ storage.hostPath.nodeSelector | toyaml | indent(8, true) }}
+{% endif %}
+{% if storage.hostPath.tolerations is defined and storage.hostPath.tolerations %}
+      tolerations:
+{{ storage.hostPath.tolerations | toyaml | indent(8, true) }}
+{% endif %}
+      containers:
+        - name: downloader
+          image: {{ images.benchmark.repository }}:{{ images.benchmark.tag }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              TARGET_DIR="{{ storage.hostPath.path }}/{{ model.path }}"
+              MARKER="${TARGET_DIR}/.download-complete"
+              if [ -f "${MARKER}" ]; then
+                echo "Model already present at ${TARGET_DIR}, skipping download."
+                exec sleep infinity
+              fi
+              echo "Downloading model to ${TARGET_DIR}..."
+              mkdir -p "${TARGET_DIR}"
+              pip install huggingface_hub
+              export PATH="${PATH}:${HOME}/.local/bin"
+{% if huggingface.enabled %}
+              hf auth login --token "${HF_TOKEN}"
+{% endif %}
+              hf download "{{ model.huggingfaceId }}" --local-dir "${TARGET_DIR}"
+              echo "Relabelling for non-spc_t readers..."
+              chcon -R -t container_file_t "{{ storage.hostPath.path }}"
+              touch "${MARKER}"
+              echo "Download complete."
+              exec sleep infinity
+          env:
+            - name: HF_HOME
+              value: /tmp/huggingface
+            - name: HOME
+              value: /tmp
+{% if huggingface.enabled %}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ huggingface.secretName }}
+                  key: {{ huggingface.tokenKey }}
+{% endif %}
+          volumeMounts:
+            - name: model-host-storage
+              mountPath: {{ storage.hostPath.path }}
+{% if vllmCommon.pullSecret is defined and vllmCommon.pullSecret %}
+      imagePullSecrets:
+        - name: {{ vllmCommon.pullSecret }}
+{% endif %}
+      restartPolicy: Always
+      volumes:
+        - name: model-host-storage
+          hostPath:
+            path: {{ storage.hostPath.path }}
+            type: DirectoryOrCreate
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ serviceAccount.name }}-hostmount-anyuid
+  namespace: {{ namespace.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ serviceAccount.name }}
+  namespace: {{ namespace.name }}
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:hostmount-anyuid
+  apiGroup: rbac.authorization.k8s.io
+{% endif %}

--- a/config/templates/jinja/04_download_job.yaml.j2
+++ b/config/templates/jinja/04_download_job.yaml.j2
@@ -1,3 +1,4 @@
+{% if not (storage.hostPath is defined and storage.hostPath.enabled | default(false)) %}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -54,3 +55,4 @@ spec:
         - name: model-cache
           persistentVolumeClaim:
             claimName: {{ storage.modelPvc.name }}
+{% endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -319,6 +319,28 @@ storage:
     volumeMode: Filesystem
     storageClassName: *storage_class
 
+  # HostPath-backed model storage (opt-in).
+  # When enabled, a static PersistentVolume with hostPath is created and the
+  # model PVC binds to it via a matching storageClassName.  A DaemonSet
+  # downloads the model to the hostPath on every target node BEFORE the
+  # serving pods start; the regular download Job is skipped.
+  #
+  # Requirements:
+  #   - Nodes must have the hostPath directory writable.
+  #   - nodeSelector / tolerations should target the GPU nodes where
+  #     vLLM pods will schedule.
+  #   - The storageClassName does NOT need a real StorageClass object
+  #     on the cluster; static PV binding uses label matching.
+  hostPath:
+    enabled: false
+    path: /mnt/models
+    storageClassName: hostpath
+    capacity: 300Gi
+    nodeSelector: {}
+    tolerations: []
+    daemonSetTimeout: 3600
+    daemonSetName: download-model-ds
+
 # ============================================================================
 # HUGGINGFACE CONFIGURATION
 # ============================================================================

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-07-15 03:23:20` (UTC)
-- Generated against git ref: `308c9ed47837b764c43e0b5484186fe1d90c07a4`
+- Generated at: `2026-07-30 18:28:08` (UTC)
+- Generated against git ref: `99cfe78994a982ac0e1fb87d6a604a2819da8887`
 
 ## System Tool Dependencies
 
@@ -41,14 +41,14 @@ OCI registry at generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **agentgateway** | `v1.3.1` | tag | `config/templates/values/defaults.yaml` line 472 (`chartVersions.agentgateway`) | [agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) (`oci://cr.agentgateway.dev/charts/`) |
-| **inferencePool** | `v1.5.0` | tag | `config/templates/values/defaults.yaml` line 471 (`chartVersions.inferencePool`) | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
-| **istioBase** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 460 (`chartVersions.istioBase`) | (unknown) |
-| **istiod** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 461 (`chartVersions.istiod`) | (unknown) |
-| **llmDInfra** | `v1.4.0` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 462 (`chartVersions.llmDInfra`) | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) (`https://llm-d-incubation.github.io/llm-d-infra/`) |
-| **llmDModelservice** | `v0.4.15` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 463 (`chartVersions.llmDModelservice`) | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) (`https://llm-d-incubation.github.io/llm-d-modelservice/`) |
-| **llmDRouter** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 467 (`chartVersions.llmDRouter`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) |
-| **lws** | `0.9.0` | tag | `config/templates/values/defaults.yaml` line 473 (`chartVersions.lws`) | [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws) |
+| **agentgateway** | `v1.3.1` | tag | `config/templates/values/defaults.yaml` line 494 (`chartVersions.agentgateway`) | [agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) (`oci://cr.agentgateway.dev/charts/`) |
+| **inferencePool** | `v1.5.0` | tag | `config/templates/values/defaults.yaml` line 493 (`chartVersions.inferencePool`) | [kubernetes-sigs/gateway-api-inference-extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension) |
+| **istioBase** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 482 (`chartVersions.istioBase`) | (unknown) |
+| **istiod** | `1.29.2` | tag | `config/templates/values/defaults.yaml` line 483 (`chartVersions.istiod`) | (unknown) |
+| **llmDInfra** | `v1.4.0` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 484 (`chartVersions.llmDInfra`) | [llm-d-incubation/llm-d-infra](https://github.com/llm-d-incubation/llm-d-infra) (`https://llm-d-incubation.github.io/llm-d-infra/`) |
+| **llmDModelservice** | `v0.4.15` | tag (auto-resolved) | `config/templates/values/defaults.yaml` line 485 (`chartVersions.llmDModelservice`) | [llm-d-incubation/llm-d-modelservice](https://github.com/llm-d-incubation/llm-d-modelservice) (`https://llm-d-incubation.github.io/llm-d-modelservice/`) |
+| **llmDRouter** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 489 (`chartVersions.llmDRouter`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) |
+| **lws** | `0.9.0` | tag | `config/templates/values/defaults.yaml` line 495 (`chartVersions.lws`) | [kubernetes-sigs/lws](https://github.com/kubernetes-sigs/lws) |
 
 
 ## Container Image Dependencies
@@ -59,13 +59,13 @@ generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **benchmark** | `v0.7.0` | tag | `config/templates/values/defaults.yaml` line 357 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
-| **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 405 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
-| **routerEndpointPicker** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 382 (`images.routerEndpointPicker`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) |
-| **routingSidecar** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 388 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
-| **udsTokenizer** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 394 (`images.udsTokenizer`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
-| **vllm** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 363 (`images.vllm`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
-| **vllmOpenai** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 374 (`images.vllmOpenai`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
+| **benchmark** | `v0.7.0` | tag | `config/templates/values/defaults.yaml` line 379 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
+| **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 427 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
+| **routerEndpointPicker** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 404 (`images.routerEndpointPicker`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) |
+| **routingSidecar** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 410 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
+| **udsTokenizer** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 416 (`images.udsTokenizer`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
+| **vllm** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 385 (`images.vllm`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
+| **vllmOpenai** | `v0.24.0` | tag | `config/templates/values/defaults.yaml` line 396 (`images.vllmOpenai`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
 
 
 ## Python Package Dependencies (declared)
@@ -89,138 +89,3 @@ captured in the snapshot table below.
 | **PyYAML** | `(unpinned)` | (unpinned) | `pyproject.toml` line 7 | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
 | **requests** | `(unpinned)` | (unpinned) | `pyproject.toml` line 9 | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **transformers** | `(unpinned)` | (unpinned) | `pyproject.toml` line 16 | [transformers (PyPI)](https://pypi.org/project/transformers/) |
-
-
-## Python Package Dependencies (installed snapshot)
-
-Output of `pip freeze` against the project venv (`.venv`). Includes
-every transitive dependency actually installed; direct deps are
-annotated with their `pyproject.toml` line.
-
-<details>
-<summary>Click to expand the full pip-freeze snapshot</summary>
-
-| Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
-|---|---|---|---|---|
-| **aiohappyeyeballs** | `2.6.1` | version | (transitive in `.venv`) | [aiohappyeyeballs (PyPI)](https://pypi.org/project/aiohappyeyeballs/) |
-| **aiohttp** | `3.13.3` | version | (transitive in `.venv`) | [aiohttp (PyPI)](https://pypi.org/project/aiohttp/) |
-| **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
-| **annotated-doc** | `0.0.4` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
-| **annotated-types** | `0.7.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
-| **anyio** | `4.12.1` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
-| **attrs** | `25.4.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
-| **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
-| **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
-| **certifi** | `2026.2.25` | version | (transitive in `.venv`) | [certifi (PyPI)](https://pypi.org/project/certifi/) |
-| **cffi** | `2.0.0` | version | (transitive in `.venv`) | [cffi (PyPI)](https://pypi.org/project/cffi/) |
-| **cfgv** | `3.5.0` | version | (transitive in `.venv`) | [cfgv (PyPI)](https://pypi.org/project/cfgv/) |
-| **chardet** | `6.0.0.post1` | version | (transitive in `.venv`) | [chardet (PyPI)](https://pypi.org/project/chardet/) |
-| **charset-normalizer** | `3.4.4` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
-| **click** | `8.4.1` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
-| **config_explorer** | `(unknown)` | commit SHA | (transitive in `.venv`) | [config_explorer (PyPI)](https://pypi.org/project/config-explorer/) |
-| **contourpy** | `1.3.3` | version | (transitive in `.venv`) | [contourpy (PyPI)](https://pypi.org/project/contourpy/) |
-| **cryptography** | `46.0.7` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
-| **cycler** | `0.12.1` | version | (transitive in `.venv`) | [cycler (PyPI)](https://pypi.org/project/cycler/) |
-| **detect_secrets** | `76a765c2b1a8928824a3d937ebeacf88354b86bb` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
-| **distlib** | `0.4.0` | version | (transitive in `.venv`) | [distlib (PyPI)](https://pypi.org/project/distlib/) |
-| **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
-| **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
-| **fastapi** | `0.136.3` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
-| **filelock** | `3.24.3` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
-| **fonttools** | `4.61.1` | version | (transitive in `.venv`) | [fonttools (PyPI)](https://pypi.org/project/fonttools/) |
-| **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
-| **fsspec** | `2026.2.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
-| **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
-| **GitPython** | `3.1.46` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
-| **google-api-core** | `2.30.3` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
-| **google-auth** | `2.52.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
-| **google-cloud-core** | `2.6.0` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
-| **google-cloud-storage** | `3.10.1` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
-| **google-crc32c** | `1.8.0` | version | (transitive in `.venv`) | [google-crc32c (PyPI)](https://pypi.org/project/google-crc32c/) |
-| **google-resumable-media** | `2.9.0` | version | (transitive in `.venv`) | [google-resumable-media (PyPI)](https://pypi.org/project/google-resumable-media/) |
-| **googleapis-common-protos** | `1.75.0` | version | (transitive in `.venv`) | [googleapis-common-protos (PyPI)](https://pypi.org/project/googleapis-common-protos/) |
-| **h11** | `0.16.0` | version | (transitive in `.venv`) | [h11 (PyPI)](https://pypi.org/project/h11/) |
-| **hf-xet** | `1.5.1` | version | (transitive in `.venv`) | [hf-xet (PyPI)](https://pypi.org/project/hf-xet/) |
-| **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
-| **httptools** | `0.7.1` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
-| **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
-| **huggingface_hub** | `1.19.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
-| **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
-| **idna** | `3.11` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
-| **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
-| **Jinja2** | `3.1.6` | version | `pyproject.toml` line 8 (direct) | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
-| **jiter** | `0.13.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |
-| **kiwisolver** | `1.4.9` | version | (transitive in `.venv`) | [kiwisolver (PyPI)](https://pypi.org/project/kiwisolver/) |
-| **kubernetes** | `35.0.0` | version | `pyproject.toml` line 11 (direct) | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
-| **kubernetes_asyncio** | `35.0.1` | version | (transitive in `.venv`) | [kubernetes_asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
-| **llm-optimizer** | `bb82d22e8863b762e856be66e831d551d27576b1` | commit SHA | (transitive in `.venv`) | [llm-optimizer (PyPI)](https://pypi.org/project/llm-optimizer/) |
-| **llmdbenchmark** | `editable` | editable | (transitive in `.venv`) | [llmdbenchmark (PyPI)](https://pypi.org/project/llmdbenchmark/) |
-| **markdown-it-py** | `4.0.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
-| **MarkupSafe** | `3.0.3` | version | (transitive in `.venv`) | [MarkupSafe (PyPI)](https://pypi.org/project/markupsafe/) |
-| **matplotlib** | `3.10.8` | version | (transitive in `.venv`) | [matplotlib (PyPI)](https://pypi.org/project/matplotlib/) |
-| **mdurl** | `0.1.2` | version | (transitive in `.venv`) | [mdurl (PyPI)](https://pypi.org/project/mdurl/) |
-| **multidict** | `6.7.1` | version | (transitive in `.venv`) | [multidict (PyPI)](https://pypi.org/project/multidict/) |
-| **nodeenv** | `1.10.0` | version | (transitive in `.venv`) | [nodeenv (PyPI)](https://pypi.org/project/nodeenv/) |
-| **numpy** | `2.4.2` | version | (transitive in `.venv`) | [numpy (PyPI)](https://pypi.org/project/numpy/) |
-| **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
-| **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
-| **ollama** | `0.6.2` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
-| **openai** | `2.24.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
-| **packaging** | `26.0` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
-| **pandas** | `3.0.3` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
-| **pillow** | `12.1.1` | version | (transitive in `.venv`) | [pillow (PyPI)](https://pypi.org/project/pillow/) |
-| **planner** | `f51812bebca30e0291ec541bd2ef2acf0572e8a4` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
-| **platformdirs** | `4.9.6` | version | (transitive in `.venv`) | [platformdirs (PyPI)](https://pypi.org/project/platformdirs/) |
-| **pluggy** | `1.6.0` | version | (transitive in `.venv`) | [pluggy (PyPI)](https://pypi.org/project/pluggy/) |
-| **pre_commit** | `4.6.0` | version | (transitive in `.venv`) | [pre_commit (PyPI)](https://pypi.org/project/pre-commit/) |
-| **propcache** | `0.4.1` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
-| **proto-plus** | `1.28.0` | version | (transitive in `.venv`) | [proto-plus (PyPI)](https://pypi.org/project/proto-plus/) |
-| **protobuf** | `7.34.1` | version | (transitive in `.venv`) | [protobuf (PyPI)](https://pypi.org/project/protobuf/) |
-| **psutil** | `7.2.2` | version | (transitive in `.venv`) | [psutil (PyPI)](https://pypi.org/project/psutil/) |
-| **psycopg2-binary** | `2.9.12` | version | (transitive in `.venv`) | [psycopg2-binary (PyPI)](https://pypi.org/project/psycopg2-binary/) |
-| **pyasn1** | `0.6.3` | version | (transitive in `.venv`) | [pyasn1 (PyPI)](https://pypi.org/project/pyasn1/) |
-| **pyasn1_modules** | `0.4.2` | version | (transitive in `.venv`) | [pyasn1_modules (PyPI)](https://pypi.org/project/pyasn1-modules/) |
-| **pycparser** | `3.0` | version | (transitive in `.venv`) | [pycparser (PyPI)](https://pypi.org/project/pycparser/) |
-| **pydantic** | `2.13.4` | version | `pyproject.toml` line 17 (direct) | [pydantic (PyPI)](https://pypi.org/project/pydantic/) |
-| **pydantic-settings** | `2.14.1` | version | (transitive in `.venv`) | [pydantic-settings (PyPI)](https://pypi.org/project/pydantic-settings/) |
-| **pydantic_core** | `2.46.4` | version | (transitive in `.venv`) | [pydantic_core (PyPI)](https://pypi.org/project/pydantic-core/) |
-| **Pygments** | `2.19.2` | version | (transitive in `.venv`) | [Pygments (PyPI)](https://pypi.org/project/pygments/) |
-| **PyJWT** | `2.12.1` | version | (transitive in `.venv`) | [PyJWT (PyPI)](https://pypi.org/project/pyjwt/) |
-| **pykube-ng** | `23.6.0` | version | `pyproject.toml` line 12 (direct) | [pykube-ng (PyPI)](https://pypi.org/project/pykube-ng/) |
-| **pyparsing** | `3.3.2` | version | (transitive in `.venv`) | [pyparsing (PyPI)](https://pypi.org/project/pyparsing/) |
-| **pytest** | `9.0.3` | version | (transitive in `.venv`) | [pytest (PyPI)](https://pypi.org/project/pytest/) |
-| **python-dateutil** | `2.9.0.post0` | version | (transitive in `.venv`) | [python-dateutil (PyPI)](https://pypi.org/project/python-dateutil/) |
-| **python-discovery** | `1.2.2` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
-| **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
-| **python-multipart** | `0.0.29` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
-| **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
-| **regex** | `2026.2.19` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
-| **requests** | `2.34.2` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
-| **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
-| **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
-| **rich** | `14.3.3` | version | (transitive in `.venv`) | [rich (PyPI)](https://pypi.org/project/rich/) |
-| **safetensors** | `0.7.0` | version | (transitive in `.venv`) | [safetensors (PyPI)](https://pypi.org/project/safetensors/) |
-| **scipy** | `1.17.1` | version | (transitive in `.venv`) | [scipy (PyPI)](https://pypi.org/project/scipy/) |
-| **shellingham** | `1.5.4` | version | (transitive in `.venv`) | [shellingham (PyPI)](https://pypi.org/project/shellingham/) |
-| **six** | `1.17.0` | version | (transitive in `.venv`) | [six (PyPI)](https://pypi.org/project/six/) |
-| **smmap** | `5.0.2` | version | (transitive in `.venv`) | [smmap (PyPI)](https://pypi.org/project/smmap/) |
-| **sniffio** | `1.3.1` | version | (transitive in `.venv`) | [sniffio (PyPI)](https://pypi.org/project/sniffio/) |
-| **starlette** | `1.0.0` | version | (transitive in `.venv`) | [starlette (PyPI)](https://pypi.org/project/starlette/) |
-| **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
-| **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
-| **tqdm** | `4.67.3` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
-| **transformers** | `5.12.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
-| **typer** | `0.24.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
-| **typer-slim** | `0.24.0` | version | (transitive in `.venv`) | [typer-slim (PyPI)](https://pypi.org/project/typer-slim/) |
-| **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
-| **typing_extensions** | `4.15.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
-| **urllib3** | `2.6.3` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
-| **uvicorn** | `0.48.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
-| **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
-| **virtualenv** | `21.2.4` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
-| **watchfiles** | `1.1.1` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
-| **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
-| **websockets** | `16.0` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
-| **yarl** | `1.22.0` | version | (transitive in `.venv`) | [yarl (PyPI)](https://pypi.org/project/yarl/) |
-
-</details>

--- a/llmdbenchmark/executor/command.py
+++ b/llmdbenchmark/executor/command.py
@@ -518,6 +518,91 @@ class CommandExecutor:
 
             time.sleep(poll_interval)
 
+    def wait_for_daemonset(
+        self,
+        ds_name: str,
+        namespace: str,
+        timeout: int = 3600,
+        poll_interval: int = 15,
+        description: str = "",
+    ) -> CommandResult:
+        """Poll a DaemonSet until all pods are ready, showing live progress.
+
+        Succeeds when status.numberReady >= status.desiredNumberScheduled
+        and desiredNumberScheduled > 0.
+        """
+        desc = description or f"daemonset/{ds_name}"
+        kc_args = " ".join(self._kubeconfig_args())
+        cmd_repr = (
+            f"{self._kube_bin} {kc_args} rollout status daemonset/{ds_name} "
+            f"--namespace {namespace} --timeout={timeout}s"
+        ).replace("  ", " ")
+
+        if self.dry_run:
+            return self._handle_dry_run(cmd_repr, int(time.time() * 1e9))
+
+        start = time.time()
+        last_status_line = ""
+
+        while True:
+            elapsed = time.time() - start
+
+            if elapsed > timeout:
+                self._clear_progress_line(last_status_line)
+                self.logger.log_error(
+                    f"⏱️  Timed out waiting for {desc} after {timeout}s"
+                )
+                return CommandResult(
+                    command=cmd_repr,
+                    exit_code=1,
+                    stderr=f"Timed out after {timeout}s waiting for {desc}",
+                )
+
+            ds_status = self._get_daemonset_status(ds_name, namespace)
+
+            if ds_status is None:
+                status_line = self._format_progress(
+                    desc,
+                    elapsed,
+                    timeout,
+                    "daemonset not found -- waiting...",
+                    0,
+                    1,
+                )
+                self._print_progress(status_line, last_status_line)
+                last_status_line = status_line
+                time.sleep(poll_interval)
+                continue
+
+            desired = ds_status.get("desiredNumberScheduled", 0)
+            ready = ds_status.get("numberReady", 0)
+            available = ds_status.get("numberAvailable", 0)
+            updated = ds_status.get("updatedNumberScheduled", 0)
+
+            if desired > 0 and ready >= desired:
+                self._clear_progress_line(last_status_line)
+                self.logger.log_info(
+                    f"✅ {desc}: {ready}/{desired} Ready ({self._fmt_elapsed(elapsed)})"
+                )
+                return CommandResult(command=cmd_repr, exit_code=0)
+
+            parts = (
+                f"desired={desired} ready={ready} "
+                f"available={available} updated={updated}"
+            )
+            status_line = self._format_progress(
+                desc,
+                elapsed,
+                timeout,
+                parts,
+                ready,
+                max(1, desired),
+            )
+            self._print_progress(status_line, last_status_line)
+            last_status_line = status_line
+
+            time.sleep(poll_interval)
+
     def wait_for_pvc(
         self,
         pvc_name: str,
@@ -767,6 +852,37 @@ class CommandExecutor:
                 "get",
                 "job",
                 job_name,
+                "--namespace",
+                namespace,
+                "-o",
+                "json",
+            ]
+        )
+        try:
+            result = subprocess.run(
+                " ".join(parts),
+                shell=True,
+                capture_output=True,
+                text=True,
+                check=False,
+                executable="/bin/bash",
+            )
+            if result.returncode != 0:
+                return None
+            data = json.loads(result.stdout)
+            return data.get("status", {})
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _get_daemonset_status(self, ds_name: str, namespace: str) -> dict | None:
+        """Query DaemonSet status via kubectl/oc get daemonset -o json."""
+        parts = [self._kube_bin]
+        parts.extend(self._kubeconfig_args())
+        parts.extend(
+            [
+                "get",
+                "daemonset",
+                ds_name,
                 "--namespace",
                 namespace,
                 "-o",

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -83,20 +83,37 @@ class ModelNamespaceStep(Step):
             self._warn_on_undersized_model_pvc(context, pvc_stacks)
 
         for stack_path in pvc_stacks:
+            stack_cfg = self._load_stack_config(stack_path)
+            if self._is_hostpath_enabled(stack_cfg):
+                self._apply_hostpath_pv(cmd, context, errors, stack_path)
             self._create_model_pvc(cmd, context, errors, stack_path)
             self._create_extra_pvc(cmd, context, errors, stack_path)
 
         self._add_context_secret(cmd, context, errors, plan_config)
 
         if pvc_stacks:
-            # Two-phase parallel download (only for stacks that need it):
-            #   Phase 1 - apply every download Job back-to-back; they all
-            #             start running concurrently in the cluster.
-            #   Phase 2 - wait on each in turn. Subsequent waits return
-            #             nearly instantly once their Job is already done,
-            #             so total wall time ~ max(individual), not sum.
-            launched = []
+            # Separate stacks into hostPath (DaemonSet) vs regular (Job) flows.
+            hostpath_stacks: list[Path] = []
+            regular_stacks: list[Path] = []
             for stack_path in pvc_stacks:
+                stack_cfg = self._load_stack_config(stack_path)
+                if self._is_hostpath_enabled(stack_cfg):
+                    hostpath_stacks.append(stack_path)
+                else:
+                    regular_stacks.append(stack_path)
+
+            # hostPath flow: apply DaemonSets for per-node downloads.
+            ds_launched: list[tuple[Path, str]] = []
+            for stack_path in hostpath_stacks:
+                ds_name = self._apply_download_daemonset(
+                    cmd, context, errors, stack_path
+                )
+                if ds_name:
+                    ds_launched.append((stack_path, ds_name))
+
+            # Regular flow: two-phase parallel download Jobs.
+            launched = []
+            for stack_path in regular_stacks:
                 applied = self._apply_download_job(cmd, context, errors, stack_path)
                 if applied is not None:
                     job_name, download_yaml = applied
@@ -106,6 +123,11 @@ class ModelNamespaceStep(Step):
                 context.logger.log_info(
                     f"📦 Launched {len(launched)} model downloads in parallel; "
                     "waiting for completion..."
+                )
+
+            for stack_path, ds_name in ds_launched:
+                self._wait_for_download_daemonset(
+                    cmd, context, errors, stack_path, ds_name
                 )
 
             for stack_path, job_name, download_yaml in launched:
@@ -228,6 +250,13 @@ class ModelNamespaceStep(Step):
         standalone_enabled = plan_config.get("standalone", {}).get("enabled", False)
 
         return uri_protocol == "pvc" or standalone_enabled
+
+    @staticmethod
+    def _is_hostpath_enabled(plan_config: dict | None) -> bool:
+        """Return True when hostPath-backed model storage is enabled."""
+        if not plan_config:
+            return False
+        return plan_config.get("storage", {}).get("hostPath", {}).get("enabled", False)
 
     def _apply_namespace_resources(
         self, cmd: CommandExecutor, context: ExecutionContext, errors: list
@@ -524,6 +553,93 @@ class ModelNamespaceStep(Step):
                     f"{max_retries} attempts: {wait_result.stderr}"
                 )
 
+    def _apply_hostpath_pv(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        errors: list,
+        stack_path: Path,
+    ) -> None:
+        """Apply the static hostPath PV for a stack."""
+        pv_yaml = self._find_yaml(stack_path, "02a_pv_model-hostpath")
+        if not pv_yaml or not self._has_yaml_content(pv_yaml):
+            return
+
+        result = cmd.kube("apply", "-f", str(pv_yaml))
+        if not result.success and "AlreadyExists" not in result.stderr:
+            errors.append(f"Failed to create hostPath PV: {result.stderr}")
+
+    def _apply_download_daemonset(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        errors: list,
+        stack_path: Path,
+    ) -> str | None:
+        """Apply the model download DaemonSet for hostPath mode.
+
+        Returns the DaemonSet name on success, or None on failure.
+        """
+        ds_yaml = self._find_yaml(stack_path, "03_download_daemonset")
+        if not ds_yaml or not self._has_yaml_content(ds_yaml):
+            return None
+
+        plan_config = self._load_stack_config(stack_path)
+        ds_name = (
+            plan_config.get("storage", {})
+            .get("hostPath", {})
+            .get("daemonSetName", "download-model-ds")
+        )
+
+        cmd.kube(
+            "delete",
+            "daemonset",
+            ds_name,
+            "--namespace",
+            context.require_namespace(),
+            "--ignore-not-found",
+        )
+
+        result = cmd.kube("apply", "-f", str(ds_yaml))
+        if not result.success:
+            errors.append(
+                f"Failed to apply download DaemonSet {ds_name}: {result.stderr}"
+            )
+            return None
+
+        return ds_name
+
+    def _wait_for_download_daemonset(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        errors: list,
+        stack_path: Path,
+        ds_name: str,
+    ) -> None:
+        """Wait for the download DaemonSet to be fully ready."""
+        plan_config = self._load_stack_config(stack_path)
+        timeout = int(
+            plan_config.get("storage", {})
+            .get("hostPath", {})
+            .get("daemonSetTimeout", 3600)
+        )
+
+        wait_result = cmd.wait_for_daemonset(
+            ds_name=ds_name,
+            namespace=context.require_namespace(),
+            timeout=timeout,
+            poll_interval=15,
+            description=f"model download DaemonSet {ds_name}",
+        )
+        if not wait_result.success:
+            errors.append(
+                f"Download DaemonSet {ds_name} did not become ready: "
+                f"{wait_result.stderr}"
+            )
+        else:
+            context.logger.log_info(f"✅ Model download DaemonSet {ds_name} completed")
+
     def _cleanup_download_pods(
         self,
         cmd: CommandExecutor,
@@ -583,6 +699,13 @@ class ModelNamespaceStep(Step):
 
         storage = plan_config.get("storage", {})
 
+        hostpath_enabled = self._is_hostpath_enabled(plan_config)
+        hostpath_sc = (
+            storage.get("hostPath", {}).get("storageClassName", "")
+            if hostpath_enabled
+            else ""
+        )
+
         storage_classes_to_check: set[str] = set()
         for pvc_key in ("modelPvc", "workloadPvc", "extraPvc"):
             pvc = storage.get(pvc_key, {})
@@ -590,6 +713,15 @@ class ModelNamespaceStep(Step):
 
             if pvc_key == "extraPvc" and not pvc.get("name"):
                 continue  # extraPvc disabled
+
+            # When hostPath is enabled, the modelPvc's storageClassName is
+            # a synthetic label for static PV binding, not a real SC object.
+            if pvc_key == "modelPvc" and hostpath_enabled:
+                context.logger.log_info(
+                    f'StorageClass "{hostpath_sc}" is a synthetic hostPath '
+                    "binding label -- skipping cluster validation"
+                )
+                continue
 
             if sc:
                 storage_classes_to_check.add(sc)

--- a/llmdbenchmark/teardown/steps/step_03_delete_resources.py
+++ b/llmdbenchmark/teardown/steps/step_03_delete_resources.py
@@ -9,7 +9,7 @@ from llmdbenchmark.executor.command import CommandExecutor
 
 
 NORMAL_RESOURCE_LIST = (
-    "leaderworkerset,deployment,statefulset,httproute,service,"
+    "daemonset,leaderworkerset,deployment,statefulset,httproute,service,"
     "gateway,gatewayparameters,"
     "inferencepool,inferencemodel,configmap,ingress,pod,job"
 )
@@ -27,6 +27,7 @@ SYSTEM_EXCLUDES = {
 STANDALONE_PATTERNS = [
     "standalone",
     "download-model",
+    "download-model-ds",
     "testinference",
     "lmbenchmark",
 ]
@@ -63,6 +64,7 @@ DEEP_RESOURCE_KINDS = [
     "inferencepool",
     "httproute",
     "configmap",
+    "daemonset",
     "job",
     "role",
     "rolebinding",
@@ -194,6 +196,18 @@ class DeleteResourcesStep(Step):
                     context.logger.log_info(
                         f"  Deleted {len(existing)} {kind}(s) in {ns}"
                     )
+
+        # Clean up cluster-scoped hostPath PVs created by the benchmark.
+        pv_result = cmd.kube(
+            "delete",
+            "pv",
+            "-l",
+            "usage=model-cache",
+            "--ignore-not-found",
+            check=False,
+        )
+        if pv_result.success and pv_result.stdout.strip():
+            context.logger.log_info("  Deleted hostPath PV(s)")
 
     def _normal_clean(
         self,
@@ -344,6 +358,18 @@ class DeleteResourcesStep(Step):
             context.logger.log_info(
                 f"  Deleted {deleted_count}/{len(filtered)} resources in {ns}"
             )
+
+        # Clean up cluster-scoped hostPath PVs created by the benchmark.
+        pv_result = cmd.kube(
+            "delete",
+            "pv",
+            "-l",
+            "usage=model-cache",
+            "--ignore-not-found",
+            check=False,
+        )
+        if pv_result.success and pv_result.stdout.strip():
+            context.logger.log_info("  Deleted hostPath PV(s)")
 
     def _prune_unsupported(
         self, cmd: CommandExecutor, resource_list: str, namespace: str


### PR DESCRIPTION
When `storage.hostPath.enabled: true` is set in a scenario, the benchmark creates a static PV backed by a node-local directory and binds the model PVC to it. A DaemonSet downloads the model to every target node (replacing the single download Job), so serving pods always find weights on local disk regardless of scheduling.

Resolves [#1433](https://github.com/llm-d/llm-d-workload-variant-autoscaler/issues/1433)