### PR TITLE
Fix: EPP-KEDA ServiceMonitor metrics authentication (RBAC-only approach)

### DIFF
--- a/config/templates/jinja/29_epp-keda-saturation-epp-monitoring.yaml.j2
+++ b/config/templates/jinja/29_epp-keda-saturation-epp-monitoring.yaml.j2
@@ -2,27 +2,14 @@
    29_epp-keda-saturation-epp-monitoring.yaml.j2
 
    ServiceMonitor for Prometheus to scrape EPP metrics endpoint (port 9090).
-   Includes ClusterRole + ClusterRoleBinding to grant Prometheus read access
-   to EPP's protected /metrics endpoint (enforces TokenReview/SubjectAccessReview).
+   Includes Role + RoleBinding to grant Prometheus read access to EPP metrics.
 
    Only rendered when eppKedaSaturation.enabled is true.
    ============================================================================ #}
 {% if eppKedaSaturation is defined and eppKedaSaturation.enabled | default(false) %}
 {% set epp_ns = eppKedaSaturation.namespace | default(namespace.name, true) %}
 ---
-{# Secret containing Prometheus ServiceAccount token for metrics scraping #}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: inference-gateway-sa-metrics-reader-secret
-  namespace: {{ epp_ns }}
-  annotations:
-    kubernetes.io/description: "Token for prometheus-user-workload to scrape EPP metrics"
-type: Opaque
-data:
-  token: {{ prometheus_sa_token | b64encode }}
----
-{# Role allowing prometheus-user-workload to read the metrics token secret #}
+{# Role allowing prometheus-user-workload to find and read the router's auto-created token secret #}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -31,8 +18,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  resourceNames: ["inference-gateway-sa-metrics-reader-secret"]
-  verbs: [get]
+  verbs: [get, list]
 ---
 {# RoleBinding: prometheus-user-workload → epp-metrics-secret-reader #}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -69,7 +55,8 @@ spec:
       path: /metrics
       scheme: http
       interval: 15s
-      bearerTokenSecret:
-        name: inference-gateway-sa-metrics-reader-secret
-        key: token
+      authorization:
+        credentials:
+          name: {{ model_id_label }}-router-epp-token
+          key: token
 {% endif %}


### PR DESCRIPTION
## Problem

PR #1659 introduced `bearerTokenSecret` but has critical issues:
1. Undefined variable: `{{ prometheus_sa_token | b64encode }}`
2. Helm conflict with Secret ownership metadata
3. Creates duplicate secret instead of using router's auto-generated token

## Solution

RBAC-only approach:
- Removes problematic Secret creation
- Grants Prometheus permission via Role/RoleBinding  
- Uses `authorization.credentials` to reference existing router token
- No Helm conflicts

## Testing

✅ Full deployment tested and working:
- Standup completes without Helm conflicts
- Model serves requests properly
- ServiceMonitor scrapes metrics (852m/700m values observed)
- KEDA HPA reads metrics and triggers scaling
- Auto-scaling verified: 1 → 2 replicas at 853m/700m threshold

## Changes

Modified `config/templates/jinja/29_epp-keda-saturation-epp-monitoring.yaml.j2`:
- Removed Secret creation and undefined variable reference
- Simplified to Role + RoleBinding + ServiceMonitor
- References existing `{{ model_id_label }}-router-epp-token` via `authorization.credentials`