### PR TITLE
feat(keda): extend prometheus bearer token TTL from 60min to 24h

### DIFF
--- a/llmdbenchmark/standup/keda_prometheus_auth.py
+++ b/llmdbenchmark/standup/keda_prometheus_auth.py
@@ -115,6 +115,7 @@ def create_prometheus_auth_secret(
     sa_name: str = "wva-prometheus-auth",
     ta_template_stem: str = "21_keda-triggerauthentication",
     errors: list | None = None,
+    token_duration: str = "24h",
 ) -> None:
     """Create a per-namespace Prometheus bearer token Secret + TriggerAuthentication.
 
@@ -133,6 +134,8 @@ def create_prometheus_auth_secret(
         ta_template_stem: Template filename stem to locate the TA YAML
             (default: "21_keda-triggerauthentication").
         errors: List to append error messages to (optional).
+        token_duration: Requested lifetime of the issued token
+            (default: "24h"). Use Kubernetes duration format (e.g., "1h", "24h", "168h").
     """
     if errors is None:
         errors = []
@@ -150,6 +153,7 @@ def create_prometheus_auth_secret(
         sa_name,
         "-n",
         target_namespace,
+        f"--duration={token_duration}",
         check=False,
     )
     if not token_result.success:


### PR DESCRIPTION
## Summary
Extends KEDA Prometheus bearer token TTL from 60 minutes to 24 hours to support longer-running benchmarks and tests.

## Problem
- Current token expires after 60 minutes (hardcoded Kubernetes default)
- Multi-hour benchmark runs fail with auth errors when token expires
- No way to customize token lifetime for different test scenarios

## Solution
- Add `--duration=24h` flag to `kubectl create token` command in `create_prometheus_auth_secret()`
- Add optional `token_duration` parameter (default: "24h") for flexibility
- Backward compatible: existing callers work without modification

## Testing
- Manual verification: `kubectl create token` with `--duration=24h` produces JWT with 86400s (24h) TTL
- Verified JWT contains correct exp/iat claims
- Pre-commit checks: ✓ byte-compile, ✓ pytest, ✓ scenario render, ✓ secrets check, ✓ lint, ✓ format

## Changes
- Modified: `llmdbenchmark/standup/keda_prometheus_auth.py`
  - Added `token_duration: str = "24h"` parameter
  - Added `f"--duration={token_duration}"` flag to kubectl create token command

## Impact
| Aspect | Before | After |
|--------|--------|-------|
| Token TTL | 60 min | 24 hours |
| Max test duration | ~59 min | ~23.9 hours |
| Configurability | None | Optional param |
| Backward compat | — | ✅ Yes |

## Future Enhancement
Token duration could be made configurable in scenario YAML:
```yaml
keda:
  tokenDuration: "168h"  # 1 week for very long tests
```