### PR TITLE
fix(wva): suffix WVA-owned ClusterRole names with the WVA namespace

### DIFF
--- a/config/templates/jinja/19_wva-kustomize.yaml.j2
+++ b/config/templates/jinja/19_wva-kustomize.yaml.j2
@@ -12,16 +12,26 @@
    ============================================================================ #}
 {% if wva is defined and wva.enabled | default(false) %}
 {% set _wva_ns = wva.namespace | default(namespace.name, true) %}
-{# ClusterRoleBindings produced by the upstream overlay. Per-tenant uniqueness
-   is added by suffixing metadata.name with the WVA namespace; roleRef.name
-   stays at the upstream default because the ClusterRole is shared. #}
-{% set _cluster_role_bindings = [
-  'wva-epp-metrics-reader-role-binding',
+{# ClusterRoleBindings that reference OpenShift's built-in cluster-monitoring-view
+   ClusterRole. Only metadata.name is suffixed; roleRef stays as-is since that
+   ClusterRole is genuinely shared cluster infrastructure, not WVA-owned. #}
+{% set _builtin_role_bindings = [
   'wva-manager-cluster-monitoring-view',
-  'wva-manager-rolebinding',
-  'wva-metrics-auth-rolebinding',
-  'wva-metrics-reader-rolebinding',
   'wva-prometheus-cluster-monitoring-view',
+] %}
+{# ClusterRoleBindings that reference a WVA-owned ClusterRole. Both the
+   ClusterRole and its binding are suffixed with the WVA namespace, since the
+   upstream overlay leaves the ClusterRole name bare/shared — on a multi-tenant
+   cluster this means every namespace's install collides on the same
+   cluster-scoped ClusterRole name, and one tenant's teardown deletes the
+   RBAC that every other tenant's controller depends on (hit this in practice
+   on pokprod001: 7+ unrelated installs all bound to the same bare
+   `wva-manager-role`). #}
+{% set _wva_owned_role_bindings = [
+  {'binding': 'wva-epp-metrics-reader-role-binding', 'role': 'wva-epp-metrics-reader-role'},
+  {'binding': 'wva-manager-rolebinding', 'role': 'wva-manager-role'},
+  {'binding': 'wva-metrics-auth-rolebinding', 'role': 'wva-metrics-auth-role'},
+  {'binding': 'wva-metrics-reader-rolebinding', 'role': 'wva-metrics-reader'},
 ] %}
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -50,7 +60,7 @@ patches:
 # Suffix each ClusterRoleBinding's metadata.name with the WVA namespace so
 # concurrent WVA installs in different namespaces don't fight over these
 # cluster-scoped binding names
-{% for _crb in _cluster_role_bindings %}
+{% for _crb in _builtin_role_bindings %}
 - target:
     kind: ClusterRoleBinding
     name: {{ _crb }}
@@ -58,5 +68,28 @@ patches:
     - op: replace
       path: /metadata/name
       value: {{ _crb }}-{{ _wva_ns }}
+{% endfor %}
+
+# WVA-owned ClusterRoles + their bindings: suffix BOTH the ClusterRole and the
+# binding (and repoint roleRef.name at the suffixed ClusterRole) so this
+# install never shares cluster-scoped RBAC with any other tenant.
+{% for _pair in _wva_owned_role_bindings %}
+- target:
+    kind: ClusterRole
+    name: {{ _pair.role }}
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: {{ _pair.role }}-{{ _wva_ns }}
+- target:
+    kind: ClusterRoleBinding
+    name: {{ _pair.binding }}
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: {{ _pair.binding }}-{{ _wva_ns }}
+    - op: replace
+      path: /roleRef/name
+      value: {{ _pair.role }}-{{ _wva_ns }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary

The `wva-config` guide's kustomize overlay (rendered via `config/templates/jinja/19_wva-kustomize.yaml.j2`) suffixes each `ClusterRoleBinding`'s name with the WVA namespace, but leaves the underlying `ClusterRole` names bare (`wva-manager-role`, `wva-metrics-auth-role`, `wva-metrics-reader`, `wva-epp-metrics-reader-role`). Since `ClusterRole`s are cluster-scoped, every namespace's WVA install ends up bound to the *same* object.

On a shared cluster this means one tenant's teardown deletes the `ClusterRole` that every other tenant's controller depends on, breaking their RBAC (list/watch failures on Deployments/HPAs/InferencePools → the controller silently stops managing anything, logging `"no active VariantAutoscalings found"`). Observed in practice on a real shared cluster: 7+ unrelated namespace installs all bound to the same bare `wva-manager-role` — any one of them tearing down broke RBAC for all the others.

This affects every `guides/*` scenario with `wva.enabled: true`, not just one — verified with `llmdbenchmark plan` (no cluster mutation) against both `guides/wva-sat2-tp1` (custom scenario) and the stock `guides/workload-autoscaling` (`kustomize.enabled: false` path); both render through this same template and both show the collision on the unpatched template.

## Fix

Also suffix the 4 WVA-owned `ClusterRole` names with the WVA namespace, and repoint each binding's `roleRef.name` to match, so no install shares cluster-scoped RBAC with any other tenant.

## Test plan

- [x] `llmdbenchmark plan -p <namespace>` against `guides/workload-autoscaling` — confirmed rendered `19_wva-kustomize.yaml` now includes `ClusterRole` rename patches + matching `roleRef.name` repoints for all 4 WVA-owned roles (previously only `ClusterRoleBinding` names were suffixed).
- [x] Applied the resulting manifests to a live namespace on a shared cluster; controller found and managed its `VariantAutoscaling` correctly with the namespaced role names.
- [x] Confirmed via `kustomize build` that a `replacements`-based approach inside the base overlay (this repo, or `llm-d-workload-variant-autoscaler`) cannot work generically — the target namespace is only known at the outermost caller, which for this harness is this template.