### PR TITLE
Set VLLM_HTTP_TIMEOUT_KEEP_ALIVE=120 as default

### DIFF
--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -228,6 +228,8 @@
   value: "{{ config.vllm.workerMultiprocMethod | default(vllmCommon.workerMultiprocMethod | default('spawn')) }}"
 - name: VLLM_LOGGING_LEVEL
   value: "{{ config.vllm.loggingLevel | default(vllmCommon.loggingLevel | default('INFO')) }}"
+- name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+  value: "{{ config.vllm.httpTimeoutKeepAlive | default(120) }}"
 {% if vllmCommon.flags.allowLongMaxModelLen is defined and vllmCommon.flags.allowLongMaxModelLen -%}
 - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
   value: "{{ vllmCommon.flags.allowLongMaxModelLen }}"


### PR DESCRIPTION
The decode routing-proxy sidecar pools idle conns for 90s (IdleConnTimeout), while vLLM's uvicorn keep-alive defaults to 5s. vLLM closes the socket first; on the next turn of a multi-turn session the sidecar reuses the half-closed socket -> TCP RST -> HTTP 502 -> failed session (no retry). Raising vLLM's keep-alive above the sidecar's 90s makes the sidecar close idle conns first (clean), eliminating the reset.