### PR TITLE
fix: Downgrade Ruff based on Community

### DIFF
--- a/.github/workflows/ci-pr-lint-and-format.yaml
+++ b/.github/workflows/ci-pr-lint-and-format.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Run Ruff Lint Check
         uses: astral-sh/ruff-action@v3
         with:
-          version: "0.16.0"
+          version: "0.15.11"
           args: "check --output-format=full"
 
       # 2. Run Formatting Check (Fails if code isn't formatted, but won't modify any files)
       - name: Run Ruff Format Check
         uses: astral-sh/ruff-action@v3
         with:
-          version: "0.16.0"
+          version: "0.15.11"
           args: "format --check --diff"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,7 +146,7 @@ repos:
   # * Add the --all-files arg to lint/format all files in the repo.
   # ----------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.15.11
     hooks:
       # Run the linter
       - id: ruff-check


### PR DESCRIPTION
# Summary

- Downgrade `ruff` to original v0.15 since `v0.16` introduces way too many rules too catch currently...we will eventually move forward when we can