### PR TITLE
fix: scope nop harness service lookup to its namespace

### DIFF
--- a/config/templates/jinja/05_namespace_sa_rbac_secret.yaml.j2
+++ b/config/templates/jinja/05_namespace_sa_rbac_secret.yaml.j2
@@ -36,6 +36,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods/log"]
   verbs: ["get"]
+# Namespace-scoped: the nop harness looks up the standalone vLLM Service by
+# ClusterIP via v1.list_namespaced_service(), not the cluster-scoped
+# list_service_for_all_namespaces().
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 # Allow the metrics collector (collect_metrics.sh) to read the EPP
 # metrics-reader Secret so it can present its bearer token when scraping
 # the EPP /metrics endpoint (authn/authz filter is on by default).
@@ -80,42 +86,6 @@ roleRef:
   kind: ClusterRole
   name: system:openshift:scc:restricted
   apiGroup: rbac.authorization.k8s.io
-{% if not nonAdmin | default(false) %}
----
-# Cluster-scoped service viewer: nop harness uses
-# v1.list_service_for_all_namespaces() to find the standalone vLLM service
-# by ClusterIP. Namespace-scoped Role can't grant cluster-scope list, so
-# this ClusterRole + ClusterRoleBinding is required for the SA used by
-# the harness pod.
-#
-# Gated on --non-admin: a user without cluster-level RBAC permissions
-# cannot create these. Skipping is safe for the inference-perf, guidellm,
-# and vllm-benchmark harnesses (they target a known endpoint URL). The
-# 'nop' harness will not function in --non-admin deployments because it
-# relies on cluster-wide service listing -- pick a different harness or
-# have an admin pre-create inference-perf-service-viewer-<ns>.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: inference-perf-service-viewer-{{ namespace.name }}
-rules:
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: inference-perf-service-viewer-{{ namespace.name }}
-subjects:
-- kind: ServiceAccount
-  name: {{ serviceAccount.name }}
-  namespace: {{ namespace.name }}
-roleRef:
-  kind: ClusterRole
-  name: inference-perf-service-viewer-{{ namespace.name }}
-  apiGroup: rbac.authorization.k8s.io
-{% endif %}
 {% if huggingface.enabled %}
 ---
 apiVersion: v1

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -87,12 +87,7 @@ class RenderPlans:
         # ``--non-admin`` propagates into the Jinja render context as
         # ``nonAdmin`` so templates can gate cluster-scoped resources
         # (ClusterRole, ClusterRoleBinding, etc.) the namespaced user
-        # can't create. Currently consumed by
-        # ``05_namespace_sa_rbac_secret.yaml.j2`` to skip the
-        # ``inference-perf-service-viewer`` pair -- those are only
-        # required by the ``nop`` harness's cluster-wide service
-        # discovery, so dropping them is safe for the mainstream
-        # harnesses (inference-perf, guidellm, vllm-benchmark).
+        # can't create.
         self.cli_non_admin: bool = bool(cli_non_admin)
 
         self.logger = logger or get_logger(

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -237,16 +237,6 @@ class ModelNamespaceStep(Step):
         if not ns_yaml:
             return
 
-        if context.non_admin:
-            # The render pipeline elides ClusterRole/ClusterRoleBinding when
-            # --non-admin is set; surface that here so it's not silent and
-            # so the 'nop' harness mismatch is callable out in the log.
-            context.logger.log_info(
-                "--non-admin: skipped ClusterRole/ClusterRoleBinding "
-                "'inference-perf-service-viewer' (only the 'nop' harness "
-                "needs them; use inference-perf / guidellm / vllm-benchmark)"
-            )
-
         result = cmd.kube("apply", "-f", str(ns_yaml))
         if not result.success:
             errors.append(f"Failed to apply namespace resources: {result.stderr}")

--- a/tests/test_nop_find_service_by_cluster_ip.py
+++ b/tests/test_nop_find_service_by_cluster_ip.py
@@ -1,0 +1,59 @@
+"""Regression test for find_service_by_cluster_ip namespace scoping.
+
+The 'nop' harness looks up the standalone vLLM Service by ClusterIP. It must
+call the namespace-scoped list_namespaced_service(), not the cluster-scoped
+list_service_for_all_namespaces() -- the harness SA is only granted a
+namespaced Role, so the cluster-scoped call 403s on RBAC-strict clusters
+(GKE/CKS). See issue #1278.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# nop_functions.py uses bare imports that assume workload/harnesses is on the
+# path, which is how it runs in the harness container. Mirror that here.
+_HARNESS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "workload", "harnesses")
+)
+if _HARNESS_DIR not in sys.path:
+    sys.path.insert(0, _HARNESS_DIR)
+
+import nop_functions as nf  # noqa: E402
+
+
+def _fake_service(name, namespace, cluster_ip):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name, namespace=namespace),
+        spec=SimpleNamespace(cluster_ip=cluster_ip),
+    )
+
+
+class TestFindServiceByClusterIp:
+    def test_calls_list_namespaced_service_not_all_namespaces(self):
+        v1 = MagicMock()
+        v1.list_namespaced_service.return_value = SimpleNamespace(items=[])
+
+        nf.find_service_by_cluster_ip(v1, "my-ns", "10.0.0.1")
+
+        v1.list_namespaced_service.assert_called_once_with(namespace="my-ns")
+        v1.list_service_for_all_namespaces.assert_not_called()
+
+    def test_finds_matching_service_in_namespace(self):
+        svc = _fake_service("vllm-svc", "my-ns", "10.0.0.5")
+        v1 = MagicMock()
+        v1.list_namespaced_service.return_value = SimpleNamespace(items=[svc])
+
+        found = nf.find_service_by_cluster_ip(v1, "my-ns", "10.0.0.5")
+
+        assert found is svc
+
+    def test_returns_none_when_no_match(self):
+        svc = _fake_service("other-svc", "my-ns", "10.0.0.9")
+        v1 = MagicMock()
+        v1.list_namespaced_service.return_value = SimpleNamespace(items=[svc])
+
+        found = nf.find_service_by_cluster_ip(v1, "my-ns", "10.0.0.5")
+
+        assert found is None

--- a/workload/harnesses/nop_functions.py
+++ b/workload/harnesses/nop_functions.py
@@ -934,9 +934,9 @@ def wake(base_url: str, timeout: float, wait: float):
             raise RuntimeError(f"Server failed sleeping status after {elapsed} secs.")
 
 
-def find_service_by_cluster_ip(v1: client.CoreV1Api, ip: str):
-    """find a clusterip service giving an ip"""
-    services = v1.list_service_for_all_namespaces().items
+def find_service_by_cluster_ip(v1: client.CoreV1Api, namespace: str, ip: str):
+    """find a clusterip service giving an ip, scoped to a namespace"""
+    services = v1.list_namespaced_service(namespace=namespace).items
     for svc in services:
         if svc.spec.cluster_ip == ip:
             return svc
@@ -1876,7 +1876,7 @@ def benchmark_nop(  # pylint: disable=too-many-arguments,too-many-positional-arg
         raise RuntimeError(f"Unable to extract hostname from {endpoint_url}.")
 
     # it should be IP
-    svc = find_service_by_cluster_ip(v1, cluster_ip)
+    svc = find_service_by_cluster_ip(v1, namespace, cluster_ip)
     if not svc:
         raise RuntimeError(f"No service found with ClusterIP {cluster_ip}")
 


### PR DESCRIPTION
Fixes #1278.

The standalone `nop` harness looks up the standalone vLLM `Service` by ClusterIP via `find_service_by_cluster_ip()`, which called the kubernetes client's `list_service_for_all_namespaces()`. That requires a cluster-scoped `list` grant, which RBAC-strict clusters like GKE/CKS reject:

```
services is forbidden: User "system:serviceaccount:<ns>:inference-perf-runner"
cannot list resource "services" in API group "" at the cluster scope
```

`benchmark_nop()` already knows the target namespace (`LLMDBENCH_VLLM_COMMON_NAMESPACE`), so there's no need for a cluster-wide list. This switches the lookup to `list_namespaced_service()` scoped to that namespace instead of widening RBAC to grant cluster scope.

I grepped the repo for every call site of `list_service_for_all_namespaces` (only the one in `find_service_by_cluster_ip`) and every caller of `find_service_by_cluster_ip` (only `benchmark_nop`), so this is the single fix point.

Since the harness no longer needs cluster-scope, this also drops the `inference-perf-service-viewer` `ClusterRole`/`ClusterRoleBinding` pair the RBAC template had been granting for exactly this call, folding a plain namespaced `services` `get`/`list` rule into the existing `inference-perf-job-creator` `Role` instead. That pair was also gated behind `--non-admin` (skipped for namespaced-only users) -- since it's gone, the associated `--non-admin` warning log and stale comments referencing it are removed too. This is strictly a reduction in granted privilege (least privilege), and it also makes the `nop` harness usable in `--non-admin` deployments, which it previously was not.

Added `tests/test_nop_find_service_by_cluster_ip.py` with the kubernetes client mocked, asserting `find_service_by_cluster_ip()` calls `list_namespaced_service(namespace=...)` and never `list_service_for_all_namespaces()`.
