### PR TITLE
fix: guidellm harness reports the real cause for an unsupported profile

### DIFF
--- a/tests/test_guidellm_profile_guard.py
+++ b/tests/test_guidellm_profile_guard.py
@@ -1,0 +1,135 @@
+"""Tests for the guidellm harness pre-flight profile guard.
+
+The installed guidellm (pinned via ``build/Dockerfile``) rejects an
+unsupported/unavailable ``profile`` (e.g. ``replay``, which only exists on
+guidellm's main branch and is not yet on PyPI) with a clear error -- but that
+error gets swallowed while ``guidellm benchmark --scenario ...`` parses its
+config, and what actually surfaces is a misleading
+``Error: Invalid value for --target: Field required``, sending operators off
+to debug the wrong thing.
+
+These tests pin the guard added to ``guidellm-llm-d-benchmark.sh`` that reads
+the workload's ``profile`` field and rejects an unsupported value with the
+real cause *before* guidellm ever runs. The guard shells out to Python to ask
+the installed guidellm which profiles it actually supports (rather than
+hardcoding a list), so it stays correct if the image is rebuilt with a
+guidellm commit that does support ``replay``.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+from pathlib import Path
+
+_HARNESS_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "workload"
+    / "harnesses"
+    / "guidellm-llm-d-benchmark.sh"
+)
+
+
+def _extract_guard_block() -> str:
+    """Pull the profile-guard block out of the real harness script.
+
+    Testing the exact committed block (rather than a copy pasted into the
+    test) means an edit that weakens or removes the guard fails this test.
+    """
+    content = _HARNESS_SCRIPT.read_text(encoding="utf-8")
+    start = content.index("# Guard:")
+    end = content.index("export LLMDBENCH_HARNESS_ARGS=")
+    return content[start:end]
+
+
+def _write_fake_bin(bin_dir: Path, name: str, script: str) -> None:
+    path = bin_dir / name
+    path.write_text(f"#!/usr/bin/env bash\n{script}\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _run_guard(
+    tmp_path: Path, workload_yaml: str, supported: str
+) -> subprocess.CompletedProcess:
+    """Run the extracted guard block against a fake yq/python3/guidellm.
+
+    ``supported`` is the space-separated profile list the fake python3 stub
+    prints back, standing in for guidellm's real
+    ``get_literal_vals(ProfileType | StrategyType)`` introspection.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    # Mirrors the real layout: $LLMDBENCH_RUN_WORKSPACE_DIR/profiles/guidellm/<workload>
+    profiles_dir = tmp_path / "profiles" / "guidellm"
+    profiles_dir.mkdir(parents=True)
+    workload_file = profiles_dir / "workload.yaml"
+    workload_file.write_text(workload_yaml, encoding="utf-8")
+
+    # Minimal fake yq: reads a single top-level "key: value" line.
+    _write_fake_bin(
+        bin_dir,
+        "yq",
+        """
+key="${2#.}"
+val=$(grep -E "^${key}:" "$3" | head -1 | sed -E "s/^${key}:[[:space:]]*//")
+[[ -z "$val" ]] && echo null || echo "$val"
+""",
+    )
+    _write_fake_bin(bin_dir, "python3", f'echo "{supported}"')
+    _write_fake_bin(bin_dir, "guidellm", 'echo "guidellm version: 0.6.0"')
+
+    script = _extract_guard_block() + '\necho "GUARD_PASSED"\n'
+    env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "LLMDBENCH_RUN_WORKSPACE_DIR": str(tmp_path),
+        "LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME": "workload.yaml",
+    }
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+_SUPPORTED = "async concurrent constant poisson sweep synchronous throughput"
+
+
+def test_unsupported_profile_fails_with_real_cause(tmp_path: Path) -> None:
+    result = _run_guard(tmp_path, "profile: replay\n", _SUPPORTED)
+
+    assert result.returncode == 1
+    assert "GUARD_PASSED" not in result.stdout
+    # Matches this repo's own precedent (lm-eval-llm-d-benchmark.sh): fatal
+    # errors go to stderr, not stdout.
+    assert "replay" in result.stderr
+    assert "does not support" in result.stderr
+    # The whole point: name the real cause instead of the misleading
+    # "--target: Field required" guidellm would otherwise surface.
+    assert "--target" not in result.stderr
+
+
+def test_supported_profile_passes_through(tmp_path: Path) -> None:
+    result = _run_guard(tmp_path, "profile: concurrent\n", _SUPPORTED)
+
+    assert result.returncode == 0
+    assert "GUARD_PASSED" in result.stdout
+
+
+def test_missing_profile_field_does_not_block(tmp_path: Path) -> None:
+    result = _run_guard(tmp_path, "target: http://x\n", _SUPPORTED)
+
+    assert result.returncode == 0
+    assert "GUARD_PASSED" in result.stdout
+
+
+def test_introspection_failure_fails_open(tmp_path: Path) -> None:
+    """If the installed guidellm can't be introspected for any reason, the
+    guard must not block a run it can't actually validate."""
+    result = _run_guard(tmp_path, "profile: replay\n", "")
+
+    assert result.returncode == 0
+    assert "GUARD_PASSED" in result.stdout

--- a/workload/harnesses/guidellm-llm-d-benchmark.sh
+++ b/workload/harnesses/guidellm-llm-d-benchmark.sh
@@ -3,6 +3,28 @@
 echo Using experiment result dir: "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
 pushd "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" > /dev/null  2>&1
+
+# Guard: an unsupported/unavailable "profile" value (e.g. "replay", which is
+# only on guidellm main and not yet in a PyPI release) is rejected by
+# guidellm's own CLI validation, but that error gets swallowed during argument
+# parsing and resurfaces as a misleading "Missing field '--target': Field
+# required", sending operators off to debug the wrong thing. Check the
+# requested profile against what the installed guidellm actually supports
+# before invoking it, so the real cause is reported up front.
+requested_profile=$(yq -r '.profile' ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME})
+if [[ -n "$requested_profile" ]] && [[ "$requested_profile" != "null" ]]; then
+  supported_profiles=$(python3 -c "
+from guidellm.benchmark import ProfileType
+from guidellm.scheduler import StrategyType
+from guidellm.utils.typing import get_literal_vals
+print(' '.join(sorted(get_literal_vals(ProfileType | StrategyType))))
+" 2>/dev/null)
+  if [[ -n "$supported_profiles" ]] && [[ " $supported_profiles " != *" $requested_profile "* ]]; then
+    echo "ERROR: workload profile '${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}' requests profile '${requested_profile}', which the installed guidellm ($(guidellm --version 2>/dev/null)) does not support. Supported profiles: ${supported_profiles}. If '${requested_profile}' is a newer guidellm feature (e.g. 'replay'), the benchmark image's guidellm pin needs to be updated to a version/commit that supports it." >&2
+    exit 1
+  fi
+fi
+
 export LLMDBENCH_HARNESS_ARGS="--target $(cat ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} | yq -r .target) --scenario ${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/guidellm/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME} --output-path ${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}/results.json --disable-progress"
 
 # Start metrics collection in background if enabled


### PR DESCRIPTION
## Description

Fixes #1510, specifically the misleading-error half of it (see the note at the end about the image pin).

`profile: replay`, and any other profile the installed guidellm doesn't know, fails inside guidellm's own argument parsing. The real error gets swallowed and resurfaces as something unrelated. Operators see:

```
Error: Missing field '--target': Field required
```

when the actual cause is:

```
Invalid value for --profile: Input should be 'synchronous', 'concurrent', 'throughput', 'constant' or 'poisson'
```

so they go and debug `--target`, which is fine.

This adds a pre-flight check to `guidellm-llm-d-benchmark.sh` that reads the workload's `profile` field and asks the installed guidellm which profiles it actually supports (a small `python3 -c` introspection of `ProfileType | StrategyType`) before guidellm is invoked. An unsupported profile now fails fast naming the real cause and the installed guidellm version. If the introspection fails for any reason it fails open, so the guard never blocks a run it couldn't validate, and a workload with no `profile` field is unaffected. The error goes to stderr, matching the precedent in `lm-eval-llm-d-benchmark.sh`.

On why the guard doesn't just pass `--profile` and let guidellm validate it: guidellm's `--profile` does validate against `click.Choice(STRATEGY_PROFILE_CHOICES)`, but this harness hands the whole workload file over via `--scenario` and never passes `--profile`, so that built-in validation never runs. Reproducing the check in shell keeps the change inside one harness script and avoids depending on `--scenario`/`--profile` precedence that isn't documented.

Out of scope: bumping the guidellm pin so `profile: replay` actually works. `replay` currently only exists on guidellm's main branch (e.g. `73d91f311bd9`). `build/Dockerfile` does install from a git commit rather than a PyPI release, so pinning a newer commit is technically possible today, but whether to ship an unreleased guidellm is a maintainer call rather than something this fix should decide.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `tests/test_guidellm_profile_guard.py`, which extracts the guard block from the shipped script itself (rather than a copy, so the test can't drift from the script) and runs it against fake `yq`, `python3`, and `guidellm` stubs. Four cases: unsupported profile fails with the real cause, supported profile passes through, a missing `profile` field doesn't block, and introspection failure fails open.

```
$ python3 -m pytest tests/test_guidellm_profile_guard.py -q
4 passed
```

Confirmed the tests actually fail without the change by reverting `workload/harnesses/guidellm-llm-d-benchmark.sh` to `main` and re-running: all four fail. Also ran `bash -n` on the script (syntax OK) and `ruff check` on the new test (clean).

### Test Configuration

- Kubernetes version: none. This change is confined to a harness shell script and a unit test that stubs out `yq`/`python3`/`guidellm`, so no cluster is involved in exercising it. I don't have a cluster available, so the full standup/run/teardown sequence was not run. Flagging that rather than claiming it.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [ ] I confirm that `pre-commit run` was run and all checks passed
- [ ] I have updated the documentation accordingly

On the two unchecked boxes: no cluster available here for the standup/run/teardown sequence, and `pre-commit` isn't installed in this environment, so I ran `ruff check` and `pytest` directly instead. Happy to have CI confirm both. No documentation change seemed warranted for an error-message fix, but say the word if you'd like the profile constraint written down somewhere.
