### PR TITLE
harness: fix permissions

### DIFF
--- a/config/templates/jinja/20_harness_pod.yaml.j2
+++ b/config/templates/jinja/20_harness_pod.yaml.j2
@@ -63,6 +63,14 @@ spec:
       value: "{{ experiment_id }}"
     - name: RAYON_NUM_THREADS
       value: "{{ harness.inferencePerf.rayonNumThreads }}"
+    - name: HOME
+      value: "{{ harness.resultsDirPrefix | default('/requests') }}/.home"
+    - name: HF_HOME
+      value: "{{ harness.resultsDirPrefix | default('/requests') }}/.cache/huggingface"
+    - name: XDG_CACHE_HOME
+      value: "{{ harness.resultsDirPrefix | default('/requests') }}/.cache"
+    - name: MPLCONFIGDIR
+      value: "{{ harness.resultsDirPrefix | default('/requests') }}/.cache/matplotlib"
 {% if huggingface.enabled %}
     - name: HF_TOKEN_SECRET
       value: "{{ huggingface.secretName }}"


### PR DESCRIPTION
PR #1630 makes the harness use a random UID. This makes the cache dir non-writable and breaks under some circumstances.

This commit moves the cache onto the PVC, fixing the bug and promoting re-use across runs.