### PR TITLE
fix: unhang unit tests, honor VersionResolver dry_run, parallelize

### DIFF
--- a/.github/workflows/ci-pr-benchmark.yaml
+++ b/.github/workflows/ci-pr-benchmark.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Install llmdbenchmark
         run: |
           ./install.sh -y 2>&1
-          pip install pytest
+          pip install pytest pytest-xdist
 
       - name: Run unit tests
-        run: python -m pytest tests/ -x -q
+        run: python -m pytest tests/ -x -q -n2
 
   # -- Standalone deployment (own Kind cluster) --
   benchmark-standalone:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
       # .github/workflows/ci-pr-benchmark.yaml.
       # ----------------------------------------------------------------
       - id: pytest
-        name: Unit tests (pytest tests/ -x -q)
-        entry: python -m pytest tests/ -x -q
+        name: Unit tests (pytest tests/ -x -q -n2)
+        entry: python -m pytest tests/ -x -q -n2
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/.pre-commit_requirements.txt
+++ b/.pre-commit_requirements.txt
@@ -1,3 +1,4 @@
 pre-commit
 pytest
+pytest-xdist
 git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets

--- a/llmdbenchmark/parser/version_resolver.py
+++ b/llmdbenchmark/parser/version_resolver.py
@@ -20,6 +20,7 @@ class VersionResolver:
 
     def __init__(self, logger, dry_run: bool = False):
         self.logger = logger
+        self.dry_run = dry_run
 
     @staticmethod
     def _latest_version_tag(tags: list[str]) -> str | None:
@@ -336,6 +337,16 @@ class VersionResolver:
     def resolve_all(self, values: dict) -> dict:
         """Resolve all ``"auto"`` image tags and chart versions in the values dict."""
         result = deepcopy(values)
+
+        if self.dry_run:
+            unresolved = self.has_unresolved(result)
+            if unresolved:
+                self.logger.log_warning(
+                    f"[DRY RUN] Skipping registry/helm resolution; "
+                    f"{len(unresolved)} version(s) remain 'auto': "
+                    f"{', '.join(unresolved)}"
+                )
+            return result
 
         unresolved = []
         self._resolve_image_tags(result, unresolved)

--- a/tests/test_kube_helpers_pod_failures.py
+++ b/tests/test_kube_helpers_pod_failures.py
@@ -31,6 +31,8 @@ class _Command:
     def kube(self, *args: str, **_: Any) -> _Result:
         self.calls.append(args)
         if args[:2] == ("get", "pods"):
+            if "jsonpath={.items[*].status.phase}" in args:
+                return _Result(stdout="Failed")
             return _Result(stdout=json.dumps(self.pod_list))
         return _Result()
 
@@ -72,5 +74,9 @@ def test_wait_reports_current_and_previous_container_failure() -> None:
         "Found pods in error state: inference-perf-abc/harness "
         "(CrashLoopBackOff, last terminated: OOMKilled, exit_code=137)"
     ]
-    get_call = next(call for call in cmd.calls if call[:2] == ("get", "pods"))
+    get_call = next(
+        call
+        for call in cmd.calls
+        if call[:2] == ("get", "pods") and call[-2:] == ("-o", "json")
+    )
     assert get_call[-2:] == ("-o", "json")


### PR DESCRIPTION
- test_kube_helpers_pod_failures: #1630 rewrote wait_for_pods_by_label as a poll loop; the test mock never returned a pod phase and did not mock sleep, so the loop slept in real time up to timeout=3600 and blew past the CI unit-tests job's 5-minute limit. Return a terminal phase for the phase query and select the -o json crash-state call in the assertion.

- VersionResolver: __init__ accepted dry_run but ignored it, so every --dry-run render (cli.py passes args.dry_run) still shelled out to skopeo/helm over the network. Mirror ClusterResourceResolver: in dry-run skip resolution, warn, and leave "auto" in place.

- Run unit tests with -n2 (pytest-xdist) in the pre-commit hook and CI; matches the 2-core CI runner and speeds up local runs.