### PR TITLE
agent: Benchmarking Agent MVP, first slice (Agent Core)

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ The analysis pipeline generates per-request distribution plots, cross-treatment 
 - [Lifecycle](docs/lifecycle.md)
 - [Run](docs/run.md)
 - [Agentic evaluation (eval-containers)](docs/agentic_eval.md)
+- [Benchmarking Agent (Agent Core)](docs/benchmarking-agent.md)
 - [Running eval-containers on OpenShift](docs/openshift-setup.md)
 - [Standup](docs/standup.md)
 - [Kustomize deploy method](docs/kustomize.md)

--- a/docs/benchmarking-agent.md
+++ b/docs/benchmarking-agent.md
@@ -1,0 +1,252 @@
+# Benchmarking Agent (Agent Core)
+
+`llmdbenchmark/agent/` is the first slice of a Benchmarking Agent MVP for
+Run-Only Benchmark Sessions, tracked in
+[#1058](https://github.com/llm-d/llm-d-benchmark/issues/1058). It is a
+library-level Python package: four pure functions plus one versioned YAML
+map. There is no CLI subcommand, no FastAPI service, no database, and no
+Kubernetes client anywhere in the package. Everything it produces is a
+plain Python object, a `dict`, or a file the caller writes -- submitting a
+rendered manifest to a real cluster, watching it, and collecting its
+results is out of scope for this slice and is left to whatever already
+does that today (`llmdbenchmark run`, or a caller's own client).
+
+## Why a separate package
+
+The Agent Core exists to answer three questions offline, without a
+cluster: given a Workload Intent, what should be run; given Execution
+Facts, what would that run look like as a command and a Job manifest; and
+given the benchmark-report v0.2 output of a run, did it clear a set of
+SLO Gates. None of that requires touching `llmdbenchmark.cli`,
+`llmdbenchmark.standup`, or the global `config` singleton, and importing
+those modules pulls in `planner` (installed only by `install.sh`, not a
+declared dependency), so the package deliberately imports nothing from
+that chain.
+
+## Inputs
+
+### Structured Recommendation Facts
+
+`RecommendationFacts` has exactly two fields: `workload_intent` (one of
+`Interactive Chat`, `Long-Context Generation`, `Batch Throughput`, the PRD
+values verbatim) and `prefix_reuse` (bool, default `False`). Nothing else
+is in scope of mapping -- this is deliberate: `RecommendationOverrides` and
+`ExecutionFacts` are separate models so that neither an override nor an
+endpoint detail can silently change which Recommendation Map row is
+selected.
+
+### Recommendation Overrides
+
+`specification`, `harness`, `workload_profile`, `slo_gate_percentile`
+(`p95` default, `p99` available). Any override degrades Recommendation
+Confidence by one step, because an overridden field is no longer
+attested by the Recommendation Map's own fit.
+
+### Execution Facts
+
+Everything needed to render a run command and a Job manifest:
+`benchmark_session_id`, `endpoint_url`, `model`, `namespace`,
+`benchmark_runner_image` (required, no default -- no harness image in this
+repository is documented to contain the `llmdbenchmark` CLI, so the
+caller must confront that explicitly), `benchmark_workspace_volume`
+(PVC claim name and mount path), `benchmark_runner_auth` (a service
+account name; `None` means the namespace default), `benchmark_secret_references`
+(env or file references, never a value), `benchmark_monitoring_override`.
+
+`ExecutionFacts` is never a parameter of `recommend()`. This is enforced
+by the function's signature, not by a runtime check.
+
+### Benchmark Secret References
+
+A `BenchmarkSecretReference` is a discriminated union of
+`SecretEnvReference` (`secret_name`, `secret_key`, `env_var`) and
+`SecretFileReference` (`secret_name`, `mount_path`). Neither variant has a
+field that can hold a secret value, so constructing one with a `value` or
+`password` key is a `pydantic.ValidationError`, not something a filter has
+to catch downstream.
+
+## The four artifacts
+
+Calling `recommend()`, `render_run_command()`,
+`render_benchmark_job_manifest()`, and (optionally) `score_slo_goodput()`
+in sequence produces everything `write_agent_session_workspace()` writes
+to `<session_root>/<Benchmark Session ID>/`:
+
+- `recommendation.yaml` -- the `RecommendationOutput`: selected
+  specification/harness/workload profile, Recommendation ID,
+  Recommendation Map Version, Recommendation Confidence, rationale,
+  expected artifacts, and the Agent Static Validation diagnostics.
+- `run-command.txt` / `run-command.json` -- the Agent-Rendered Run
+  Command, as a copy-pasteable string and as an argv list.
+- `benchmark-job.yaml` -- the `batch/v1` Job manifest.
+- `slo-goodput.yaml` -- only written when a `SloGoodput` is supplied.
+
+`session_root` has no default. The PRD is explicit that it is not the
+workspace root, but does not name a path, so the caller supplies one.
+
+## Worked example: Interactive Chat
+
+```python
+from pathlib import Path
+
+from llmdbenchmark.agent import (
+    ExecutionFacts,
+    RecommendationFacts,
+    WorkloadIntent,
+    WorkspaceVolume,
+    recommend,
+    render_benchmark_job_manifest,
+    render_run_command,
+    write_agent_session_workspace,
+)
+
+recommendation = recommend(RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT))
+
+execution_facts = ExecutionFacts(
+    benchmark_session_id="chat-001",
+    endpoint_url="http://qwen-endpoint.default.svc.cluster.local",
+    model="Qwen/Qwen3-0.6B",
+    namespace="benchmarks",
+    benchmark_runner_image="ghcr.io/example/llmdbenchmark-runner:0.7.0",
+    benchmark_workspace_volume=WorkspaceVolume(claim_name="benchmark-workspace"),
+)
+
+run_command = render_run_command(recommendation, execution_facts)
+manifest = render_benchmark_job_manifest(recommendation, execution_facts, run_command)
+
+write_agent_session_workspace(
+    Path("/var/lib/agent-sessions"), execution_facts, recommendation, run_command, manifest
+)
+```
+
+`recommendation.selected` is
+`{specification: "guides/optimized-baseline", harness: "inference-perf",
+workload_profile: "chatbot_synthetic.yaml", slo_gate_percentile: "p95"}`.
+The rendered command is:
+
+```
+llmdbenchmark --spec guides/optimized-baseline --workspace /workspace run \
+  --namespace benchmarks --endpoint-url http://qwen-endpoint.default.svc.cluster.local \
+  --model Qwen/Qwen3-0.6B --harness inference-perf --workload chatbot_synthetic.yaml --analyze
+```
+
+`--spec` and `--workspace` come before `run` because both are root-level
+flags (`llmdbenchmark/cli.py:1783-1787`), matching the repository's own
+example at `llmdbenchmark/cli.py:1076-1080`. `--analyze` is always
+emitted: the in-container analyzer already writes benchmark-report v0.2
+files regardless, but `--analyze` also gates step 12
+(`step_12_analyze_results.py:27-31`), which re-converts locally and adds
+the cross-treatment CSV -- it is not, contrary to an earlier draft of this
+feature's PRD, what causes v0.2 reports to exist at all. `--monitoring`
+is added only when `benchmark_monitoring_override` is set; its absence is
+already the code default (`interface/run.py:203-207`).
+
+The manifest carries both identities as separate label values --
+`llmdbenchmark.llm-d.ai/benchmark-session-id` and
+`llmdbenchmark.llm-d.ai/recommendation-id` -- plus a
+`llmdbenchmark.llm-d.ai/workload-intent` label (slugified, since
+`Interactive Chat` is not a legal label value) and the verbatim string as
+an annotation. The container's `args` is `run_command.argv[1:]`, the same
+list sliced, so the two artifacts cannot drift apart. There is no
+`ttlSecondsAfterFinished` on the Job: that omission is Benchmark Artifact
+Retention, so a completed run's results are not garbage collected before
+anyone looks at them.
+
+## The `inference-scheduling` rename
+
+The PRD's Recommendation Map default names an `inference-scheduling`
+guide. That specification does not exist in this repository; it was
+renamed upstream to `optimized-baseline`
+(`README.md:104`, `util/test-scenarios.sh:91`). `recommendation_map.yaml`
+resolves both the Interactive Chat and Batch Throughput rows to
+`guides/optimized-baseline` and records the rename in a comment. If a
+maintainer wants the literal name `inference-scheduling` to resolve, the
+fix is an alias specification file under `config/specification/`, not a
+change to this package.
+
+## Recommendation Confidence
+
+`recommendation_confidence` (`high` / `medium` / `low`) describes how well
+a Recommendation Map row fits the Structured Recommendation Facts. It is
+not an estimate of the probability that a run passes its SLO Gates --
+those are two independent questions, and only `score_slo_goodput()`
+answers the second one, and only when the caller supplies gates.
+
+## SLO Gates: no built-in thresholds
+
+`score_slo_goodput()` takes a list of `SloGate` (`metric`, `threshold`,
+`units`) supplied by the caller. **No threshold value exists anywhere in
+this repository** -- not in the schema, not in a workload profile, not in
+a scenario file -- and the PRD names neither a metric set nor a number.
+Shipping an invented default was judged the single highest-probability
+rejection trigger for this PR, so this slice ships none:
+`score_slo_goodput()` scores nothing until a caller supplies gates.
+
+**Open question for maintainers:** what is the default gate set (which
+`SloMetric` members, at what threshold, at what percentile) per Workload
+Intent? Until that is decided, callers must supply their own.
+
+Scoring reads only `results.request_performance.aggregate` from
+benchmark-report v0.2 (via `import_benchmark_report`, never the committed
+`br_v0_2_json_schema.json`, which is missing `SessionPerformance` and
+several `Units` members and would reject valid reports). Every level of
+that path may be absent in a real report, so a missing percentile or a
+missing `aggregate.throughput` produces a diagnostic (`missing_percentile`,
+`missing_throughput`), never an interpolated or derived number. Reports
+whose `version` field is absent, `"0.2.1"`, or anything else produce
+`missing_report_version`, `version_superset`, or
+`unsupported_report_version` respectively; `"0.2.1"` is accepted and
+scored as an additive superset of `"0.2"` because nothing in the
+converter pipeline currently emits it and rejecting it outright seemed
+more likely to surprise a future caller than accepting it.
+
+**This is gate-at-percentile plus the passing reports' throughput, not
+per-request SLO attainment.** benchmark-report v0.2 stores aggregates
+only; true per-request goodput would need `per_request_lifecycle_metrics.json`,
+which is out of scope for this slice. `slo_goodput_output_token_rate` is
+the maximum `output_token_rate.mean` among the reports that passed all
+gates -- one function's choice of aggregation, not something the PRD
+specifies, and flagged here as a second open question.
+
+## Run-Only Benchmark RBAC (documented, not rendered)
+
+This slice does not render a `Role`/`RoleBinding`. The permission set a
+Run-Only Benchmark Session actually needs, namespace-scoped:
+
+- `configmaps`: `get`, `list`, `create`, `patch` -- even in run-only mode,
+  `_store_run_parameters_configmap` applies the
+  `llm-d-benchmark-run-parameters` ConfigMap unless `--dry-run`
+  (`llmdbenchmark/cli.py:1171-1273`).
+- `pods`, `pods/log`, `pods/exec` -- the harness workload today is a bare
+  `Pod` (`config/templates/jinja/20_harness_pod.yaml.j2`); the future Job
+  wraps the same container.
+- `jobs` -- to submit and watch the `batch/v1` Job this package renders.
+
+**Open question for maintainers:** do you want this rendered as YAML in a
+later slice, or is documentation-only sufficient for the MVP?
+
+## What this slice deliberately does not do
+
+- No Load Sweeps, Token-Shape Sweeps, or Run-Treatment Sweep generation.
+  The override key needed to vary load is harness-specific (`load.stages[N].rate`
+  for inference-perf, `rate` for guidellm, `max-concurrency` for
+  vllm-benchmark) and a wrong key silently no-ops through
+  `profile_renderer.apply_overrides`. No field on any model in this slice
+  names a sweep, so a later slice can add one without a migration.
+- No rendered Run-Treatment RBAC YAML (see above).
+- No Kubernetes API calls of any kind. `import llmdbenchmark.agent` never
+  puts `kubernetes` in `sys.modules`.
+- No CLI subcommand. There is no `Command` enum entry and no
+  `llmdbenchmark/interface/agent.py`.
+- No numeric SLO thresholds (see above).
+
+## Testing
+
+`tests/test_agent_recommend.py`, `tests/test_agent_render.py`, and
+`tests/test_agent_score.py` are offline, exercise only the public API, and
+pass under `python -m pytest tests/test_agent_*.py -q`. They do not
+exercise a live cluster, a GPU, or a model endpoint, and none of that is
+claimed. `python -m pytest tests/ -x -q` does not currently complete on
+this checkout for reasons unrelated to this package
+(`tests/test_kube_helpers_pod_failures.py` hangs after #1630); this PR
+does not attempt to fix that.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -46,11 +46,11 @@ accurate to the current codebase.
   - [Custom Jinja2 Templates](#custom-jinja2-templates)
 - [8. How to Add a Smoketest Validator](#8-how-to-add-a-smoketest-validator)
 - [9. How to Add a New Experiment](#9-how-to-add-a-new-experiment)
-- [10. Agent Core](#10-agent-core)
   - [Experiment YAML Format](#experiment-yaml-format)
   - [Setup Treatments vs Run Treatments](#setup-treatments-vs-run-treatments)
   - [How to Reference Scenario Overrides](#how-to-reference-scenario-overrides)
   - [Running an Experiment](#running-an-experiment)
+- [10. Agent Core](#10-agent-core)
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -46,6 +46,7 @@ accurate to the current codebase.
   - [Custom Jinja2 Templates](#custom-jinja2-templates)
 - [8. How to Add a Smoketest Validator](#8-how-to-add-a-smoketest-validator)
 - [9. How to Add a New Experiment](#9-how-to-add-a-new-experiment)
+- [10. Agent Core](#10-agent-core)
   - [Experiment YAML Format](#experiment-yaml-format)
   - [Setup Treatments vs Run Treatments](#setup-treatments-vs-run-treatments)
   - [How to Reference Scenario Overrides](#how-to-reference-scenario-overrides)
@@ -1351,3 +1352,43 @@ The experiment orchestrator (`_execute_experiment` in `llmdbenchmark/cli.py`):
 Options:
 - `--stop-on-error`: Abort on first failure (default: continue to next treatment)
 - `--skip-teardown`: Leave stacks running for debugging
+
+---
+
+## 10. Agent Core
+
+`llmdbenchmark/agent/` is a leaf package: four pure functions plus one
+versioned YAML map. It has no runtime state, no CLI surface, and no
+Kubernetes client -- unlike every other extension point in this guide, it
+is not a step, an analysis module, or a subcommand. See
+[docs/benchmarking-agent.md](benchmarking-agent.md) for the full model
+reference and a worked example.
+
+The package's only repository imports are
+`llmdbenchmark.utilities.os.filesystem.resolve_specification_file` and
+`llmdbenchmark.analysis.benchmark_report.import_benchmark_report`, so it
+cannot pull in `planner` or drag any standup/run machinery along with it.
+Four entry points cover the whole surface:
+
+- `recommend(facts, overrides=None, *, map_path=None, base_dir=None)` --
+  selects a row from `recommendation_map.yaml` for a Workload Intent, runs
+  Agent Static Validation against the local `config/specification/` and
+  `workload/profiles/` trees, and returns a `RecommendationOutput`. It does
+  not take Execution Facts: endpoint details must never influence
+  Recommendation Map selection.
+- `render_run_command(recommendation, execution_facts)` /
+  `render_benchmark_job_manifest(recommendation, execution_facts,
+  run_command)` -- render the Agent-Rendered Run Command and a plain
+  `batch/v1` Job dict. Neither function renders a Jinja template or touches
+  `config/`.
+- `score_slo_goodput(agent_analysis_input, gates, ...)` -- scores
+  benchmark-report v0.2 files against caller-supplied SLO Gates. It ships
+  with no default thresholds.
+- `write_agent_session_workspace(...)` -- the package's only I/O, writing
+  the four Agent Session Workspace files under a caller-supplied session
+  root.
+
+If you extend this package, keep the leaf-package property: do not import
+`llmdbenchmark.cli`, any `*/steps/*` module, or `llmdbenchmark.executor.*`
+from it, and do not add a Recommendation Map rule whose harness is missing
+from `llmdbenchmark.analysis._WRITER_NAMES`.

--- a/llmdbenchmark/agent/__init__.py
+++ b/llmdbenchmark/agent/__init__.py
@@ -1,0 +1,64 @@
+"""Agent Core: a leaf package of pure functions that recommend a benchmark
+configuration for a Workload Intent, render a run command and Benchmark Job
+Manifest for it, and score benchmark-report v0.2 output against
+caller-supplied SLO Gates.
+
+This package has no Kubernetes client, no CLI surface, and no runtime
+state. Its only repository imports are
+``llmdbenchmark.utilities.os.filesystem.resolve_specification_file`` and
+``llmdbenchmark.analysis.benchmark_report.import_benchmark_report``.
+"""
+
+from llmdbenchmark.agent.facts import (
+    AgentRenderedRunCommand,
+    BenchmarkSecretReference,
+    Diagnostic,
+    ExecutionFacts,
+    GatePercentile,
+    GateResult,
+    RecommendationConfidence,
+    RecommendationFacts,
+    RecommendationOutput,
+    RecommendationOverrides,
+    SecretEnvReference,
+    SecretFileReference,
+    SelectedConfiguration,
+    SloGate,
+    SloGoodput,
+    SloGoodputReport,
+    SloMetric,
+    WorkloadIntent,
+    WorkspaceVolume,
+)
+from llmdbenchmark.agent.recommend import recommend
+from llmdbenchmark.agent.render import render_benchmark_job_manifest, render_run_command
+from llmdbenchmark.agent.score import discover_agent_analysis_input, score_slo_goodput
+from llmdbenchmark.agent.workspace import write_agent_session_workspace
+
+__all__ = [
+    "AgentRenderedRunCommand",
+    "BenchmarkSecretReference",
+    "Diagnostic",
+    "ExecutionFacts",
+    "GatePercentile",
+    "GateResult",
+    "RecommendationConfidence",
+    "RecommendationFacts",
+    "RecommendationOutput",
+    "RecommendationOverrides",
+    "SecretEnvReference",
+    "SecretFileReference",
+    "SelectedConfiguration",
+    "SloGate",
+    "SloGoodput",
+    "SloGoodputReport",
+    "SloMetric",
+    "WorkloadIntent",
+    "WorkspaceVolume",
+    "discover_agent_analysis_input",
+    "recommend",
+    "render_benchmark_job_manifest",
+    "render_run_command",
+    "score_slo_goodput",
+    "write_agent_session_workspace",
+]

--- a/llmdbenchmark/agent/facts.py
+++ b/llmdbenchmark/agent/facts.py
@@ -1,0 +1,298 @@
+"""Pydantic models for the Agent Core: Structured Recommendation Facts,
+Execution Facts, and the artifacts the Agent Core reads and writes.
+
+Every model here is pure data -- there is no runtime state in this package,
+so everything is pydantic rather than a dataclass. Input models (facts,
+overrides, execution facts) are ``extra="forbid"`` so a typo is a
+``ValidationError`` rather than a silently-ignored key. Artifact-reader
+models are ``extra="ignore"`` so a later slice can add a field without
+breaking an older reader.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Discriminator, Field
+
+# Mirrors llmdbenchmark/parser/config_schema.py:29-33 STRICT_CONFIG.
+STRICT = ConfigDict(
+    extra="forbid",
+    validate_assignment=True,
+    str_strip_whitespace=True,
+)
+
+# For artifacts this package writes and later reads back: unknown fields
+# from a newer writer must not break an older reader.
+READER = ConfigDict(
+    extra="ignore",
+    str_strip_whitespace=True,
+)
+
+# 51 chars max so "llmdbench-agent-<id>" (17 chars of prefix) stays inside
+# the 63-char RFC1123 limit.
+_SESSION_ID_PATTERN = r"^[a-z0-9]([-a-z0-9]{0,49}[a-z0-9])?$"
+
+
+###############################################################################
+# Workload Intents and gate percentile
+###############################################################################
+
+
+class WorkloadIntent(StrEnum):
+    """The three PRD Workload Intents a Recommendation Map row can select on."""
+
+    INTERACTIVE_CHAT = "Interactive Chat"
+    LONG_CONTEXT_GENERATION = "Long-Context Generation"
+    BATCH_THROUGHPUT = "Batch Throughput"
+
+
+class GatePercentile(StrEnum):
+    """The SLO Gate Percentile a caller (or an override) may select."""
+
+    P95 = "p95"
+    P99 = "p99"
+
+
+class RecommendationConfidence(StrEnum):
+    """How well a Recommendation Map row fits the request.
+
+    This describes Recommendation Map fit only. It is not an estimate of the
+    probability that a run will pass its SLO Gates.
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class SloMetric(StrEnum):
+    """The benchmark-report v0.2 aggregate latency leaf names an SLO Gate
+    may reference. ``time_per_output_token`` and ``inter_token_latency`` are
+    kept as separate members because the schema documents that they are not
+    interchangeable across tools (schema_v0_2.py:319-333)."""
+
+    TIME_TO_FIRST_TOKEN = "time_to_first_token"
+    INTER_TOKEN_LATENCY = "inter_token_latency"
+    TIME_PER_OUTPUT_TOKEN = "time_per_output_token"
+    NORMALIZED_TIME_PER_OUTPUT_TOKEN = "normalized_time_per_output_token"
+    REQUEST_LATENCY = "request_latency"
+
+
+###############################################################################
+# Structured Recommendation Facts / Recommendation Overrides
+###############################################################################
+
+
+class RecommendationFacts(BaseModel):
+    """Structured Recommendation Facts: the inputs that select a
+    Recommendation Map row. Deliberately minimal -- Execution Facts are a
+    separate model so that endpoint details can never influence mapping."""
+
+    model_config = STRICT
+
+    workload_intent: WorkloadIntent
+    prefix_reuse: bool = False
+
+
+class RecommendationOverrides(BaseModel):
+    """Caller overrides to the mapped Recommendation Output fields."""
+
+    model_config = STRICT
+
+    specification: str | None = None
+    harness: str | None = None
+    workload_profile: str | None = None
+    slo_gate_percentile: GatePercentile | None = None
+
+
+###############################################################################
+# Execution Facts
+###############################################################################
+
+
+class WorkspaceVolume(BaseModel):
+    """The Benchmark Workspace Volume: a PVC claim name and mount path."""
+
+    model_config = STRICT
+
+    claim_name: str
+    mount_path: str = "/workspace"
+
+
+class SecretEnvReference(BaseModel):
+    """A Benchmark Secret Reference materialized as a container env var."""
+
+    model_config = STRICT
+
+    kind: Literal["env"]
+    secret_name: str
+    secret_key: str
+    env_var: str
+
+
+class SecretFileReference(BaseModel):
+    """A Benchmark Secret Reference materialized as a mounted file."""
+
+    model_config = STRICT
+
+    kind: Literal["file"]
+    secret_name: str
+    mount_path: str
+
+
+# No field on either member can hold a secret value, so a raw credential
+# raises ValidationError at construction rather than needing to be stripped
+# from every downstream output.
+BenchmarkSecretReference = Annotated[
+    Union[SecretEnvReference, SecretFileReference],
+    Discriminator("kind"),
+]
+
+
+class ExecutionFacts(BaseModel):
+    """Execution Facts: everything needed to render a run command and a
+    Benchmark Job Manifest. Kept separate from Recommendation Facts so that
+    endpoint details cannot influence Recommendation Map selection."""
+
+    model_config = STRICT
+
+    benchmark_session_id: str = Field(pattern=_SESSION_ID_PATTERN)
+    endpoint_url: str
+    model: str
+    namespace: str
+    # Required, no default: no harness image is documented to contain the
+    # llmdbenchmark CLI.
+    benchmark_runner_image: str
+    benchmark_workspace_volume: WorkspaceVolume
+    # None means the namespace default service account.
+    benchmark_runner_auth: str | None = None
+    benchmark_secret_references: list[BenchmarkSecretReference] = Field(
+        default_factory=list
+    )
+    benchmark_monitoring_override: bool = False
+
+
+###############################################################################
+# Diagnostics
+###############################################################################
+
+
+class Diagnostic(BaseModel):
+    """A non-fatal finding from Agent Static Validation or SLO scoring."""
+
+    model_config = STRICT
+
+    severity: Literal["error", "warning", "info"]
+    code: str
+    message: str
+    subject: str
+
+
+###############################################################################
+# Recommendation Output
+###############################################################################
+
+
+class SelectedConfiguration(BaseModel):
+    """The specification/harness/profile/percentile a recommendation selected."""
+
+    model_config = READER
+
+    specification: str
+    harness: str
+    workload_profile: str
+    slo_gate_percentile: GatePercentile
+
+
+class RecommendationOutput(BaseModel):
+    """The result of ``recommend()``: a Recommendation Map row applied to
+    Structured Recommendation Facts, with any Recommendation Overrides
+    folded in and Agent Static Validation diagnostics attached."""
+
+    model_config = READER
+
+    agent_artifact_version: Literal["1"] = "1"
+    recommendation_id: str
+    recommendation_map_version: str
+    workload_intent: WorkloadIntent
+    selected: SelectedConfiguration
+    rationale: str
+    recommendation_confidence: RecommendationConfidence
+    expected_artifacts: list[str]
+    diagnostics: list[Diagnostic]
+
+
+###############################################################################
+# Agent-Rendered Run Command
+###############################################################################
+
+
+class AgentRenderedRunCommand(BaseModel):
+    """The Agent-Rendered Run Command: an argv list plus its deterministic,
+    copy-pasteable rendering."""
+
+    model_config = READER
+
+    argv: list[str]
+    rendered: str
+
+
+###############################################################################
+# SLO Goodput
+###############################################################################
+
+
+class SloGate(BaseModel):
+    """A caller-supplied SLO Gate. No defaults: no threshold value exists
+    anywhere in this repository, and the PRD names neither a metric set nor
+    a number."""
+
+    model_config = STRICT
+
+    metric: SloMetric
+    threshold: float
+    units: str
+
+
+class GateResult(BaseModel):
+    """The outcome of a single SLO Gate against a single report."""
+
+    model_config = READER
+
+    metric: SloMetric
+    threshold: float
+    threshold_units: str
+    observed: float | None
+    observed_units: str | None
+    passed: bool | None
+
+
+class SloGoodputReport(BaseModel):
+    """SLO Goodput scoring for a single benchmark-report v0.2 file."""
+
+    model_config = READER
+
+    report_path: str
+    stage: int | None
+    rate_qps: float | None
+    concurrency: Any | None
+    verdict: Literal["pass", "fail", "indeterminate"]
+    gate_results: list[GateResult]
+    output_token_rate_mean: float | None
+    request_rate_mean: float | None
+
+
+class SloGoodput(BaseModel):
+    """SLO Goodput: gate-at-percentile plus the passing reports' throughput.
+    This is not per-request SLO attainment -- benchmark-report v0.2 stores
+    aggregates only."""
+
+    model_config = READER
+
+    agent_artifact_version: Literal["1"] = "1"
+    slo_gate_percentile: GatePercentile
+    reports: list[SloGoodputReport]
+    slo_scoring_diagnostics: list[Diagnostic]
+    slo_goodput_output_token_rate: float | None

--- a/llmdbenchmark/agent/facts.py
+++ b/llmdbenchmark/agent/facts.py
@@ -14,7 +14,14 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, field_validator
+
+from llmdbenchmark.analysis.benchmark_report.base import UNITS_GEN_LATENCY, UNITS_TIME
+
+# The only units score.py's normalization table (score.py:_SECONDS_PER_UNIT,
+# _SECONDS_PER_TOKEN_PER_UNIT) knows how to compare against an observed
+# aggregate value.
+_SLO_GATE_UNITS = {str(u) for u in (*UNITS_TIME, *UNITS_GEN_LATENCY)}
 
 # Mirrors llmdbenchmark/parser/config_schema.py:29-33 STRICT_CONFIG.
 STRICT = ConfigDict(
@@ -30,9 +37,10 @@ READER = ConfigDict(
     str_strip_whitespace=True,
 )
 
-# 51 chars max so "llmdbench-agent-<id>" (17 chars of prefix) stays inside
-# the 63-char RFC1123 limit.
-_SESSION_ID_PATTERN = r"^[a-z0-9]([-a-z0-9]{0,49}[a-z0-9])?$"
+# 47 chars max so "llmdbench-agent-<id>" (16 chars of prefix, see
+# render.py's render_benchmark_job_manifest) stays inside the 63-char
+# RFC1123 limit: 16 + 47 = 63.
+_SESSION_ID_PATTERN = r"^[a-z0-9]([-a-z0-9]{0,45}[a-z0-9])?$"
 
 
 ###############################################################################
@@ -254,6 +262,13 @@ class SloGate(BaseModel):
     metric: SloMetric
     threshold: float
     units: str
+
+    @field_validator("units")
+    @classmethod
+    def _units_must_be_scorable(cls, value: str) -> str:
+        if value not in _SLO_GATE_UNITS:
+            raise ValueError(f"units {value!r} is not one of {sorted(_SLO_GATE_UNITS)}")
+        return value
 
 
 class GateResult(BaseModel):

--- a/llmdbenchmark/agent/recommend.py
+++ b/llmdbenchmark/agent/recommend.py
@@ -1,0 +1,223 @@
+"""The Recommendation Map loader, ``recommend()``, and Agent Static
+Validation.
+
+``recommend()`` intentionally takes no Execution Facts parameter -- endpoint
+details cannot influence Recommendation Map selection (see
+``llmdbenchmark.agent.facts.ExecutionFacts``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.agent.facts import (
+    Diagnostic,
+    GatePercentile,
+    RecommendationConfidence,
+    RecommendationFacts,
+    RecommendationOutput,
+    RecommendationOverrides,
+    SelectedConfiguration,
+)
+from llmdbenchmark.utilities.os.filesystem import resolve_specification_file
+
+_DEFAULT_MAP_PATH = Path(__file__).resolve().parent / "recommendation_map.yaml"
+# llmdbenchmark/agent/recommend.py -> parents[2] = repository root, matching
+# the package-relative assumption step_05_render_profiles.py:65 already makes.
+_DEFAULT_BASE_DIR = Path(__file__).resolve().parents[2]
+
+
+class RecommendationMap:
+    """A loaded, validated Recommendation Map."""
+
+    def __init__(self, version: str, rules: list[dict]):
+        self.version = version
+        self.rules = rules
+
+    @classmethod
+    def load(cls, map_path: Path | None = None) -> "RecommendationMap":
+        path = map_path or _DEFAULT_MAP_PATH
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        return cls(version=data["recommendation_map_version"], rules=data["rules"])
+
+    def find(self, facts: RecommendationFacts) -> dict | None:
+        for rule in self.rules:
+            if (
+                rule["workload_intent"] == str(facts.workload_intent)
+                and rule.get("prefix_reuse", False) == facts.prefix_reuse
+            ):
+                return rule
+        return None
+
+
+def _recommendation_id(
+    facts: RecommendationFacts,
+    overrides: RecommendationOverrides,
+    map_version: str,
+) -> str:
+    payload = {
+        "recommendation_map_version": map_version,
+        "recommendation_facts": facts.model_dump(mode="json", exclude_none=True),
+        "recommendation_overrides": overrides.model_dump(
+            mode="json", exclude_none=True
+        ),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return f"rec-{digest[:12]}"
+
+
+def _profile_exists(profiles_dir: Path, profile: str) -> bool:
+    """The <name>-then-<name>.in rule from
+    step_05_render_profiles.py:260-280 (``_resolve_source_file``)."""
+    return (profiles_dir / profile).exists() or (
+        profiles_dir / f"{profile}.in"
+    ).exists()
+
+
+def _validate(
+    rule: dict,
+    base_dir: Path,
+) -> tuple[list[Diagnostic], str, bool]:
+    """Agent Static Validation: local filesystem only, zero Kubernetes
+    calls. Returns diagnostics, the selected workload profile (after any
+    Batch Throughput fallback), and whether the fallback fired."""
+    diagnostics: list[Diagnostic] = []
+
+    specification = rule["specification"]
+    try:
+        resolve_specification_file(specification, base_dir=base_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        diagnostics.append(
+            Diagnostic(
+                severity="error",
+                code="specification_not_found",
+                message=str(exc),
+                subject=specification,
+            )
+        )
+
+    harness = rule["harness"]
+    harness_dir = base_dir / "workload" / "profiles" / harness
+    if not harness_dir.is_dir():
+        diagnostics.append(
+            Diagnostic(
+                severity="error",
+                code="harness_not_found",
+                message=f"Harness directory not found: {harness_dir}",
+                subject=harness,
+            )
+        )
+
+    profile = rule["workload_profile"]
+    fallback_profile = rule.get("fallback_workload_profile")
+    fallback_used = False
+    if harness_dir.is_dir() and not _profile_exists(harness_dir, profile):
+        if fallback_profile and _profile_exists(harness_dir, fallback_profile):
+            diagnostics.append(
+                Diagnostic(
+                    severity="warning",
+                    code="workload_profile_fallback",
+                    message=(
+                        f"Workload profile '{profile}' not found under "
+                        f"{harness_dir}; falling back to '{fallback_profile}'."
+                    ),
+                    subject=profile,
+                )
+            )
+            profile = fallback_profile
+            fallback_used = True
+        else:
+            diagnostics.append(
+                Diagnostic(
+                    severity="error",
+                    code="workload_profile_not_found",
+                    message=(
+                        f"Workload profile '{profile}' not found under {harness_dir}."
+                    ),
+                    subject=profile,
+                )
+            )
+
+    return diagnostics, profile, fallback_used
+
+
+def recommend(
+    facts: RecommendationFacts,
+    overrides: RecommendationOverrides | None = None,
+    *,
+    map_path: Path | None = None,
+    base_dir: Path | None = None,
+) -> RecommendationOutput:
+    """Select a Recommendation Map row for the given Structured
+    Recommendation Facts, apply any Recommendation Overrides, run Agent
+    Static Validation against local repository assets, and return a
+    Recommendation Output."""
+    overrides = overrides or RecommendationOverrides()
+    resolved_base_dir = base_dir or _DEFAULT_BASE_DIR
+
+    recommendation_map = RecommendationMap.load(map_path)
+    rule = recommendation_map.find(facts)
+    if rule is None:
+        raise ValueError(
+            f"No Recommendation Map rule for workload_intent="
+            f"{facts.workload_intent!r}, prefix_reuse={facts.prefix_reuse!r}"
+        )
+
+    diagnostics, profile, fallback_used = _validate(rule, resolved_base_dir)
+
+    confidence = RecommendationConfidence(rule["recommendation_confidence"])
+    degraded = False
+
+    specification = overrides.specification
+    if specification is None:
+        specification = rule["specification"]
+    else:
+        degraded = True
+
+    harness = overrides.harness
+    if harness is None:
+        harness = rule["harness"]
+    else:
+        degraded = True
+
+    if overrides.workload_profile is not None:
+        profile = overrides.workload_profile
+        degraded = True
+
+    slo_gate_percentile = overrides.slo_gate_percentile or GatePercentile.P95
+    if overrides.slo_gate_percentile is not None:
+        degraded = True
+
+    if fallback_used:
+        confidence = RecommendationConfidence.LOW
+    elif degraded and confidence == RecommendationConfidence.HIGH:
+        confidence = RecommendationConfidence.MEDIUM
+    elif degraded and confidence == RecommendationConfidence.MEDIUM:
+        confidence = RecommendationConfidence.LOW
+
+    recommendation_id = _recommendation_id(facts, overrides, recommendation_map.version)
+
+    return RecommendationOutput(
+        recommendation_id=recommendation_id,
+        recommendation_map_version=recommendation_map.version,
+        workload_intent=facts.workload_intent,
+        selected=SelectedConfiguration(
+            specification=specification,
+            harness=harness,
+            workload_profile=profile,
+            slo_gate_percentile=slo_gate_percentile,
+        ),
+        rationale=rule.get("rationale", ""),
+        recommendation_confidence=confidence,
+        expected_artifacts=[
+            "<mount_path>/latest/results/*/benchmark_report_v0.2,_*.yaml"
+        ],
+        diagnostics=diagnostics,
+    )

--- a/llmdbenchmark/agent/recommend.py
+++ b/llmdbenchmark/agent/recommend.py
@@ -45,14 +45,26 @@ class RecommendationMap:
             data = yaml.safe_load(handle)
         return cls(version=data["recommendation_map_version"], rules=data["rules"])
 
-    def find(self, facts: RecommendationFacts) -> dict | None:
+    def find(self, facts: RecommendationFacts) -> tuple[dict | None, bool]:
+        """Return the matching row and whether ``prefix_reuse`` had to be
+        ignored to find it. Only Interactive Chat carries a dedicated
+        ``prefix_reuse: true`` row; a caller who sets ``prefix_reuse=True``
+        globally for another intent falls back to that intent's
+        ``prefix_reuse: false`` row rather than getting a ``ValueError``
+        from an otherwise diagnostics-not-exceptions function."""
         for rule in self.rules:
             if (
                 rule["workload_intent"] == str(facts.workload_intent)
                 and rule.get("prefix_reuse", False) == facts.prefix_reuse
             ):
-                return rule
-        return None
+                return rule, False
+        if facts.prefix_reuse:
+            for rule in self.rules:
+                if rule["workload_intent"] == str(
+                    facts.workload_intent
+                ) and not rule.get("prefix_reuse", False):
+                    return rule, True
+        return None, False
 
 
 def _recommendation_id(
@@ -82,15 +94,21 @@ def _profile_exists(profiles_dir: Path, profile: str) -> bool:
 
 
 def _validate(
-    rule: dict,
+    specification: str,
+    harness: str,
+    profile: str,
+    fallback_profile: str | None,
     base_dir: Path,
 ) -> tuple[list[Diagnostic], str, bool]:
     """Agent Static Validation: local filesystem only, zero Kubernetes
-    calls. Returns diagnostics, the selected workload profile (after any
-    Batch Throughput fallback), and whether the fallback fired."""
+    calls. Validates the specification/harness/workload_profile that were
+    actually selected -- after Recommendation Overrides are folded in, not
+    the raw Recommendation Map row -- so a bogus override is caught rather
+    than silently passed through to the rendered run command. Returns
+    diagnostics, the selected workload profile (after any Batch Throughput
+    fallback), and whether the fallback fired."""
     diagnostics: list[Diagnostic] = []
 
-    specification = rule["specification"]
     try:
         resolve_specification_file(specification, base_dir=base_dir)
     except (FileNotFoundError, ValueError) as exc:
@@ -103,7 +121,6 @@ def _validate(
             )
         )
 
-    harness = rule["harness"]
     harness_dir = base_dir / "workload" / "profiles" / harness
     if not harness_dir.is_dir():
         diagnostics.append(
@@ -115,8 +132,6 @@ def _validate(
             )
         )
 
-    profile = rule["workload_profile"]
-    fallback_profile = rule.get("fallback_workload_profile")
     fallback_used = False
     if harness_dir.is_dir() and not _profile_exists(harness_dir, profile):
         if fallback_profile and _profile_exists(harness_dir, fallback_profile):
@@ -163,14 +178,26 @@ def recommend(
     resolved_base_dir = base_dir or _DEFAULT_BASE_DIR
 
     recommendation_map = RecommendationMap.load(map_path)
-    rule = recommendation_map.find(facts)
+    rule, prefix_reuse_ignored = recommendation_map.find(facts)
     if rule is None:
         raise ValueError(
             f"No Recommendation Map rule for workload_intent="
             f"{facts.workload_intent!r}, prefix_reuse={facts.prefix_reuse!r}"
         )
 
-    diagnostics, profile, fallback_used = _validate(rule, resolved_base_dir)
+    diagnostics: list[Diagnostic] = []
+    if prefix_reuse_ignored:
+        diagnostics.append(
+            Diagnostic(
+                severity="info",
+                code="prefix_reuse_not_supported",
+                message=(
+                    f"No Recommendation Map rule distinguishes prefix_reuse "
+                    f"for {facts.workload_intent!r}; scored as prefix_reuse=False."
+                ),
+                subject="prefix_reuse",
+            )
+        )
 
     confidence = RecommendationConfidence(rule["recommendation_confidence"])
     degraded = False
@@ -189,7 +216,16 @@ def recommend(
 
     if overrides.workload_profile is not None:
         profile = overrides.workload_profile
+        fallback_profile = None
         degraded = True
+    else:
+        profile = rule["workload_profile"]
+        fallback_profile = rule.get("fallback_workload_profile")
+
+    validation_diagnostics, profile, fallback_used = _validate(
+        specification, harness, profile, fallback_profile, resolved_base_dir
+    )
+    diagnostics.extend(validation_diagnostics)
 
     slo_gate_percentile = overrides.slo_gate_percentile or GatePercentile.P95
     if overrides.slo_gate_percentile is not None:

--- a/llmdbenchmark/agent/recommendation_map.yaml
+++ b/llmdbenchmark/agent/recommendation_map.yaml
@@ -1,0 +1,55 @@
+# Recommendation Map for the Agent Core.
+#
+# recommendation_map_version is an explicit semver, never a file hash, so
+# that Recommendation ID determinism is documented rather than incidental.
+#
+# The PRD names an `inference-scheduling` guide. It does not exist: the spec
+# was renamed upstream to optimized-baseline. See README.md:104 ("optimized
+# baseline guide (formerly inference-scheduling)") and util/test-scenarios.sh:91.
+recommendation_map_version: "0.1.0"
+
+rules:
+  - workload_intent: "Interactive Chat"
+    prefix_reuse: false
+    specification: "guides/optimized-baseline"
+    harness: "inference-perf"
+    workload_profile: "chatbot_synthetic.yaml"
+    recommendation_confidence: "high"
+    rationale: >-
+      Interactive Chat is a synthetic chatbot-shaped load against the
+      optimized baseline guide, scored by inference-perf.
+
+  - workload_intent: "Interactive Chat"
+    prefix_reuse: true
+    specification: "guides/optimized-baseline"
+    harness: "inference-perf"
+    workload_profile: "shared_prefix_synthetic.yaml"
+    recommendation_confidence: "high"
+    rationale: >-
+      Prefix reuse is best exercised with the shared-prefix synthetic
+      profile so repeated system-prompt prefixes are actually present in
+      the load.
+
+  - workload_intent: "Long-Context Generation"
+    prefix_reuse: false
+    specification: "guides/pd-disaggregation"
+    harness: "inference-perf"
+    workload_profile: "summarization_synthetic.yaml"
+    recommendation_confidence: "medium"
+    rationale: >-
+      Long inputs and long outputs are the pd-disaggregation guide's target
+      shape; --harness and --workload are rendered explicitly because the
+      guide's scenario otherwise defaults to vllm-benchmark and
+      random_concurrent.yaml.
+
+  - workload_intent: "Batch Throughput"
+    prefix_reuse: false
+    specification: "guides/optimized-baseline"
+    harness: "guidellm"
+    workload_profile: "summarization_synthetic.yaml"
+    fallback_workload_profile: "sanity_concurrent.yaml"
+    recommendation_confidence: "medium"
+    rationale: >-
+      Batch Throughput is scored with guidellm's rate ladder against a
+      summarization-shaped profile; sanity_concurrent.yaml is the fallback
+      when the primary profile is not present on disk.

--- a/llmdbenchmark/agent/render.py
+++ b/llmdbenchmark/agent/render.py
@@ -1,0 +1,177 @@
+"""Rendering the Agent-Rendered Run Command and the Benchmark Job Manifest.
+
+Neither function calls Kubernetes. Both are pure: given a Recommendation
+Output and Execution Facts, they produce data structures a caller may
+submit, dump, or inspect.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Any
+
+from llmdbenchmark.agent.facts import (
+    AgentRenderedRunCommand,
+    ExecutionFacts,
+    RecommendationOutput,
+    SecretEnvReference,
+    SecretFileReference,
+)
+
+_LABEL_PREFIX = "llmdbenchmark.llm-d.ai"
+
+
+def _slugify(value: str) -> str:
+    """Legal Kubernetes label value: lowercase, alphanumerics and
+    ``-_.``. ``Interactive Chat`` contains a space and is not a legal
+    label value on its own."""
+    slug = re.sub(r"[^a-z0-9._-]+", "-", value.lower()).strip("-")
+    return slug or "unknown"
+
+
+def _argv(
+    recommendation: RecommendationOutput,
+    execution_facts: ExecutionFacts,
+) -> list[str]:
+    """The single owner of canonical argv ordering. ``--spec`` and
+    ``--workspace`` precede ``run`` because both are root flags
+    (cli.py:1783-1787, cli.py:1770-1810), matching the repo's own
+    copy-paste block at cli.py:1076-1080."""
+    selected = recommendation.selected
+    argv = [
+        "llmdbenchmark",
+        "--spec",
+        selected.specification,
+        "--workspace",
+        execution_facts.benchmark_workspace_volume.mount_path,
+        "run",
+        "--namespace",
+        execution_facts.namespace,
+        "--endpoint-url",
+        execution_facts.endpoint_url,
+        "--model",
+        execution_facts.model,
+        "--harness",
+        selected.harness,
+        "--workload",
+        selected.workload_profile,
+        "--analyze",
+    ]
+    if execution_facts.benchmark_monitoring_override:
+        argv.append("--monitoring")
+    return argv
+
+
+def render_run_command(
+    recommendation: RecommendationOutput,
+    execution_facts: ExecutionFacts,
+) -> AgentRenderedRunCommand:
+    """Render the Agent-Rendered Run Command."""
+    argv = _argv(recommendation, execution_facts)
+    return AgentRenderedRunCommand(argv=argv, rendered=shlex.join(argv))
+
+
+def render_benchmark_job_manifest(
+    recommendation: RecommendationOutput,
+    execution_facts: ExecutionFacts,
+    run_command: AgentRenderedRunCommand,
+) -> dict[str, Any]:
+    """Render the Benchmark Job Manifest: a plain ``batch/v1`` Job dict.
+
+    ``ttlSecondsAfterFinished`` is deliberately absent -- that omission is
+    Benchmark Artifact Retention, so results are not silently garbage
+    collected before an operator can inspect them.
+    """
+    name = f"llmdbench-agent-{execution_facts.benchmark_session_id}"
+    workspace = execution_facts.benchmark_workspace_volume
+
+    volumes: list[dict[str, Any]] = [
+        {
+            "name": "benchmark-workspace",
+            "persistentVolumeClaim": {"claimName": workspace.claim_name},
+        }
+    ]
+    volume_mounts: list[dict[str, Any]] = [
+        {"name": "benchmark-workspace", "mountPath": workspace.mount_path}
+    ]
+    env: list[dict[str, Any]] = []
+
+    for index, secret_ref in enumerate(execution_facts.benchmark_secret_references):
+        if isinstance(secret_ref, SecretEnvReference):
+            env.append(
+                {
+                    "name": secret_ref.env_var,
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": secret_ref.secret_name,
+                            "key": secret_ref.secret_key,
+                        }
+                    },
+                }
+            )
+        elif isinstance(secret_ref, SecretFileReference):
+            volume_name = f"benchmark-secret-{index}"
+            volumes.append(
+                {
+                    "name": volume_name,
+                    "secret": {"secretName": secret_ref.secret_name},
+                }
+            )
+            volume_mounts.append(
+                {
+                    "name": volume_name,
+                    "mountPath": secret_ref.mount_path,
+                    "readOnly": True,
+                }
+            )
+
+    container: dict[str, Any] = {
+        "name": "benchmark-runner",
+        "image": execution_facts.benchmark_runner_image,
+        "command": ["llmdbenchmark"],
+        "args": run_command.argv[1:],
+        "volumeMounts": volume_mounts,
+    }
+    if env:
+        container["env"] = env
+
+    pod_spec: dict[str, Any] = {
+        "restartPolicy": "Never",
+        "containers": [container],
+        "volumes": volumes,
+    }
+    if execution_facts.benchmark_runner_auth:
+        pod_spec["serviceAccountName"] = execution_facts.benchmark_runner_auth
+
+    manifest: dict[str, Any] = {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": name,
+            "namespace": execution_facts.namespace,
+            "labels": {
+                f"{_LABEL_PREFIX}/benchmark-session-id": (
+                    execution_facts.benchmark_session_id
+                ),
+                f"{_LABEL_PREFIX}/recommendation-id": recommendation.recommendation_id,
+                f"{_LABEL_PREFIX}/harness": recommendation.selected.harness,
+                f"{_LABEL_PREFIX}/workload-intent": _slugify(
+                    str(recommendation.workload_intent)
+                ),
+            },
+            "annotations": {
+                f"{_LABEL_PREFIX}/recommendation-map-version": (
+                    recommendation.recommendation_map_version
+                ),
+                f"{_LABEL_PREFIX}/specification": recommendation.selected.specification,
+                f"{_LABEL_PREFIX}/workload-intent": str(recommendation.workload_intent),
+                f"{_LABEL_PREFIX}/agent-rendered-run-command": run_command.rendered,
+            },
+        },
+        "spec": {
+            "backoffLimit": 0,
+            "template": {"spec": pod_spec},
+        },
+    }
+    return manifest

--- a/llmdbenchmark/agent/score.py
+++ b/llmdbenchmark/agent/score.py
@@ -1,0 +1,333 @@
+"""SLO Goodput scoring: gate-at-percentile plus the passing reports'
+throughput. This is not per-request SLO attainment -- benchmark-report
+v0.2 stores aggregates only, and the per-request source is out of scope
+for this slice.
+
+Reading is confined to ``results.request_performance.aggregate`` and
+traverses defensively at every level -- every field in that chain may be
+absent in a real report.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+from llmdbenchmark.agent.facts import (
+    Diagnostic,
+    GatePercentile,
+    GateResult,
+    SloGate,
+    SloGoodput,
+    SloGoodputReport,
+)
+from pydantic import ValidationError
+
+from llmdbenchmark.analysis.benchmark_report import import_benchmark_report
+from llmdbenchmark.analysis.benchmark_report.base import UNITS_GEN_LATENCY, UNITS_TIME
+
+# ms -> s, ms/token -> s/token; anything else is not a guessed conversion.
+_SECONDS_PER_UNIT = {
+    "s": 1.0,
+    "ms": 0.001,
+}
+_SECONDS_PER_TOKEN_PER_UNIT = {
+    "s/token": 1.0,
+    "ms/token": 0.001,
+}
+
+# Result-file glob for benchmark-report v0.2 (the comma is load-bearing --
+# analysis/__init__.py:105-108, cross_treatment.py:197). v0.1 siblings are
+# ignored.
+_AGENT_ANALYSIS_INPUT_GLOB = "**/benchmark_report_v0.2,_*.yaml"
+
+
+def discover_agent_analysis_input(results_dir: Path) -> list[Path]:
+    """Glob a results tree for benchmark-report v0.2 files (the Agent
+    Analysis Input), ignoring the v0.1 siblings written alongside them."""
+    return sorted(Path(results_dir).glob(_AGENT_ANALYSIS_INPUT_GLOB))
+
+
+def _normalize(value: float, units: str, allowed: dict[str, float]) -> float | None:
+    factor = allowed.get(units)
+    if factor is None:
+        return None
+    return value * factor
+
+
+def _score_gate(
+    gate: SloGate,
+    aggregate,
+    percentile: GatePercentile,
+    diagnostics: list[Diagnostic],
+    report_path: str,
+) -> GateResult:
+    latency = getattr(aggregate, "latency", None) if aggregate else None
+    stat = getattr(latency, gate.metric.value, None) if latency else None
+
+    if stat is None:
+        diagnostics.append(
+            Diagnostic(
+                severity="warning",
+                code="missing_percentile",
+                message=(
+                    f"{report_path}: metric '{gate.metric.value}' not present "
+                    f"in aggregate.latency"
+                ),
+                subject=gate.metric.value,
+            )
+        )
+        return GateResult(
+            metric=gate.metric,
+            threshold=gate.threshold,
+            threshold_units=gate.units,
+            observed=None,
+            observed_units=None,
+            passed=None,
+        )
+
+    observed = getattr(stat, percentile.value, None)
+    if observed is None:
+        diagnostics.append(
+            Diagnostic(
+                severity="warning",
+                code="missing_percentile",
+                message=(
+                    f"{report_path}: '{gate.metric.value}' has no "
+                    f"'{percentile.value}' value"
+                ),
+                subject=gate.metric.value,
+            )
+        )
+        return GateResult(
+            metric=gate.metric,
+            threshold=gate.threshold,
+            threshold_units=gate.units,
+            observed=None,
+            observed_units=stat.units.value,
+            passed=None,
+        )
+
+    if stat.units.value in UNITS_TIME:
+        allowed = _SECONDS_PER_UNIT
+    elif stat.units.value in UNITS_GEN_LATENCY:
+        allowed = _SECONDS_PER_TOKEN_PER_UNIT
+    else:
+        allowed = {}
+
+    normalized_observed = _normalize(observed, stat.units.value, allowed)
+    normalized_threshold = _normalize(gate.threshold, gate.units, allowed)
+    if normalized_observed is None or normalized_threshold is None:
+        diagnostics.append(
+            Diagnostic(
+                severity="warning",
+                code="unknown_units",
+                message=(
+                    f"{report_path}: cannot compare units "
+                    f"'{stat.units.value}' (observed) with '{gate.units}' "
+                    f"(gate) for '{gate.metric.value}'"
+                ),
+                subject=gate.metric.value,
+            )
+        )
+        return GateResult(
+            metric=gate.metric,
+            threshold=gate.threshold,
+            threshold_units=gate.units,
+            observed=observed,
+            observed_units=stat.units.value,
+            passed=None,
+        )
+
+    return GateResult(
+        metric=gate.metric,
+        threshold=gate.threshold,
+        threshold_units=gate.units,
+        observed=observed,
+        observed_units=stat.units.value,
+        passed=normalized_observed <= normalized_threshold,
+    )
+
+
+def _score_report(
+    path: Path,
+    gates: Sequence[SloGate],
+    percentile: GatePercentile,
+    max_failure_ratio: float | None,
+) -> tuple[SloGoodputReport, list[Diagnostic]]:
+    diagnostics: list[Diagnostic] = []
+    report_str = str(path)
+
+    try:
+        report = import_benchmark_report(report_str)
+    except ValidationError as exc:
+        # ValidationError is a ValueError subclass, so it must be caught
+        # ahead of the plain-ValueError version-dispatch branch below.
+        message = str(exc)
+        code = "unknown_units" if "units" in message.lower() else "invalid_report"
+        diagnostics.append(
+            Diagnostic(severity="error", code=code, message=message, subject=report_str)
+        )
+        return (
+            SloGoodputReport(
+                report_path=report_str,
+                stage=None,
+                rate_qps=None,
+                concurrency=None,
+                verdict="indeterminate",
+                gate_results=[],
+                output_token_rate_mean=None,
+                request_rate_mean=None,
+            ),
+            diagnostics,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        code = (
+            "missing_report_version"
+            if "Unsupported schema version: None" in message
+            else "unsupported_report_version"
+        )
+        diagnostics.append(
+            Diagnostic(severity="error", code=code, message=message, subject=report_str)
+        )
+        return (
+            SloGoodputReport(
+                report_path=report_str,
+                stage=None,
+                rate_qps=None,
+                concurrency=None,
+                verdict="indeterminate",
+                gate_results=[],
+                output_token_rate_mean=None,
+                request_rate_mean=None,
+            ),
+            diagnostics,
+        )
+
+    if getattr(report, "version", None) == "0.2.1":
+        diagnostics.append(
+            Diagnostic(
+                severity="info",
+                code="version_superset",
+                message=f"{report_str}: scored as a v0.2.1 additive superset of v0.2",
+                subject=report_str,
+            )
+        )
+
+    standardized = None
+    if report.scenario and report.scenario.load:
+        standardized = report.scenario.load.standardized
+    stage = standardized.stage if standardized else None
+    rate_qps = standardized.rate_qps if standardized else None
+    concurrency = standardized.concurrency if standardized else None
+
+    aggregate = None
+    if report.results and report.results.request_performance:
+        aggregate = report.results.request_performance.aggregate
+
+    if aggregate is None:
+        diagnostics.append(
+            Diagnostic(
+                severity="warning",
+                code="missing_percentile",
+                message=f"{report_str}: results.request_performance.aggregate is absent",
+                subject=report_str,
+            )
+        )
+
+    gate_results = [
+        _score_gate(gate, aggregate, percentile, diagnostics, report_str)
+        for gate in gates
+    ]
+
+    verdict = "pass"
+    if any(g.passed is False for g in gate_results):
+        verdict = "fail"
+    elif any(g.passed is None for g in gate_results):
+        verdict = "indeterminate"
+
+    requests = getattr(aggregate, "requests", None) if aggregate else None
+    if max_failure_ratio is not None:
+        if requests is not None and requests.total and requests.failures is not None:
+            failure_ratio = requests.failures / requests.total
+            if failure_ratio > max_failure_ratio:
+                verdict = "fail"
+        else:
+            diagnostics.append(
+                Diagnostic(
+                    severity="warning",
+                    code="missing_percentile",
+                    message=(
+                        f"{report_str}: cannot evaluate max_failure_ratio, "
+                        f"requests.{{total,failures}} missing"
+                    ),
+                    subject=report_str,
+                )
+            )
+
+    throughput = getattr(aggregate, "throughput", None) if aggregate else None
+    output_token_rate_mean = None
+    request_rate_mean = None
+    if throughput is not None:
+        if throughput.output_token_rate is not None:
+            output_token_rate_mean = throughput.output_token_rate.mean
+        if throughput.request_rate is not None:
+            request_rate_mean = throughput.request_rate.mean
+    elif aggregate is not None:
+        diagnostics.append(
+            Diagnostic(
+                severity="warning",
+                code="missing_throughput",
+                message=f"{report_str}: aggregate.throughput is absent",
+                subject=report_str,
+            )
+        )
+
+    return (
+        SloGoodputReport(
+            report_path=report_str,
+            stage=stage,
+            rate_qps=rate_qps,
+            concurrency=concurrency,
+            verdict=verdict,
+            gate_results=gate_results,
+            output_token_rate_mean=output_token_rate_mean,
+            request_rate_mean=request_rate_mean,
+        ),
+        diagnostics,
+    )
+
+
+def score_slo_goodput(
+    agent_analysis_input: Sequence[Path],
+    gates: Sequence[SloGate],
+    *,
+    slo_gate_percentile: GatePercentile = GatePercentile.P95,
+    max_failure_ratio: float | None = None,
+) -> SloGoodput:
+    """Score each Agent Analysis Input report against the given SLO Gates
+    at the given SLO Gate Percentile."""
+    reports: list[SloGoodputReport] = []
+    all_diagnostics: list[Diagnostic] = []
+
+    for path in agent_analysis_input:
+        report, diagnostics = _score_report(
+            Path(path), gates, slo_gate_percentile, max_failure_ratio
+        )
+        reports.append(report)
+        all_diagnostics.extend(diagnostics)
+
+    passing_rates = [
+        r.output_token_rate_mean
+        for r in reports
+        if r.verdict == "pass" and r.output_token_rate_mean is not None
+    ]
+    slo_goodput_output_token_rate = max(passing_rates) if passing_rates else None
+
+    return SloGoodput(
+        slo_gate_percentile=slo_gate_percentile,
+        reports=reports,
+        slo_scoring_diagnostics=all_diagnostics,
+        slo_goodput_output_token_rate=slo_goodput_output_token_rate,
+    )

--- a/llmdbenchmark/agent/score.py
+++ b/llmdbenchmark/agent/score.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
+from pydantic import ValidationError
+
 from llmdbenchmark.agent.facts import (
     Diagnostic,
     GatePercentile,
@@ -21,8 +23,6 @@ from llmdbenchmark.agent.facts import (
     SloGoodput,
     SloGoodputReport,
 )
-from pydantic import ValidationError
-
 from llmdbenchmark.analysis.benchmark_report import import_benchmark_report
 from llmdbenchmark.analysis.benchmark_report.base import UNITS_GEN_LATENCY, UNITS_TIME
 
@@ -160,6 +160,34 @@ def _score_report(
 
     try:
         report = import_benchmark_report(report_str)
+    except (OSError, AttributeError) as exc:
+        # A missing/unreadable path (FileNotFoundError, IsADirectoryError,
+        # PermissionError -- all OSError) or a YAML document whose top
+        # level isn't a mapping (AttributeError from core.py's dict-style
+        # access): routine on a stale or mid-write artifact, never a
+        # reason to kill the whole scoring run.
+        message = str(exc) or repr(exc)
+        diagnostics.append(
+            Diagnostic(
+                severity="error",
+                code="unreadable_report",
+                message=f"{report_str}: {message}",
+                subject=report_str,
+            )
+        )
+        return (
+            SloGoodputReport(
+                report_path=report_str,
+                stage=None,
+                rate_qps=None,
+                concurrency=None,
+                verdict="indeterminate",
+                gate_results=[],
+                output_token_rate_mean=None,
+                request_rate_mean=None,
+            ),
+            diagnostics,
+        )
     except ValidationError as exc:
         # ValidationError is a ValueError subclass, so it must be caught
         # ahead of the plain-ValueError version-dispatch branch below.
@@ -205,6 +233,38 @@ def _score_report(
             diagnostics,
         )
 
+    if getattr(report, "version", None) not in ("0.2", "0.2.1"):
+        # load_benchmark_report happily loads a v0.1 report (it predates
+        # the "standardized"/"aggregate" shape this module reads); a v0.1
+        # file sitting next to its v0.2 sibling on disk must yield the
+        # same diagnostic as any other unsupported version, not an
+        # AttributeError three lines down.
+        message = (
+            f"{report_str}: unsupported report version "
+            f"{getattr(report, 'version', None)!r} (only 0.2/0.2.1 are scored)"
+        )
+        diagnostics.append(
+            Diagnostic(
+                severity="error",
+                code="unsupported_report_version",
+                message=message,
+                subject=report_str,
+            )
+        )
+        return (
+            SloGoodputReport(
+                report_path=report_str,
+                stage=None,
+                rate_qps=None,
+                concurrency=None,
+                verdict="indeterminate",
+                gate_results=[],
+                output_token_rate_mean=None,
+                request_rate_mean=None,
+            ),
+            diagnostics,
+        )
+
     if getattr(report, "version", None) == "0.2.1":
         diagnostics.append(
             Diagnostic(
@@ -230,7 +290,7 @@ def _score_report(
         diagnostics.append(
             Diagnostic(
                 severity="warning",
-                code="missing_percentile",
+                code="missing_aggregate",
                 message=f"{report_str}: results.request_performance.aggregate is absent",
                 subject=report_str,
             )
@@ -241,11 +301,26 @@ def _score_report(
         for gate in gates
     ]
 
-    verdict = "pass"
-    if any(g.passed is False for g in gate_results):
+    if not gates:
+        # No SLO Gates supplied is the documented out-of-the-box state (the
+        # map ships no thresholds), but "pass" with nothing evaluated is
+        # the worst failure mode for a gating tool: it reads as every SLO
+        # having been met. Score as indeterminate instead.
+        verdict = "indeterminate"
+        diagnostics.append(
+            Diagnostic(
+                severity="info",
+                code="no_gates_supplied",
+                message=f"{report_str}: no SLO Gates supplied; SLO Goodput not evaluated",
+                subject=report_str,
+            )
+        )
+    elif any(g.passed is False for g in gate_results):
         verdict = "fail"
     elif any(g.passed is None for g in gate_results):
         verdict = "indeterminate"
+    else:
+        verdict = "pass"
 
     requests = getattr(aggregate, "requests", None) if aggregate else None
     if max_failure_ratio is not None:
@@ -257,7 +332,7 @@ def _score_report(
             diagnostics.append(
                 Diagnostic(
                     severity="warning",
-                    code="missing_percentile",
+                    code="missing_failure_ratio",
                     message=(
                         f"{report_str}: cannot evaluate max_failure_ratio, "
                         f"requests.{{total,failures}} missing"

--- a/llmdbenchmark/agent/workspace.py
+++ b/llmdbenchmark/agent/workspace.py
@@ -1,0 +1,60 @@
+"""The Agent Session Workspace: the only I/O in this package.
+
+Follows the mkdir-on-access convention of
+``llmdbenchmark.executor.context.ExecutionContext.run_dir()`` without
+importing ``ExecutionContext`` or the global ``config`` singleton -- the
+Agent Core has no cluster and no run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.agent.facts import (
+    AgentRenderedRunCommand,
+    ExecutionFacts,
+    RecommendationOutput,
+    SloGoodput,
+)
+
+
+def write_agent_session_workspace(
+    session_root: Path,
+    execution_facts: ExecutionFacts,
+    recommendation: RecommendationOutput,
+    run_command: AgentRenderedRunCommand,
+    benchmark_job_manifest: dict,
+    slo_goodput: SloGoodput | None = None,
+) -> Path:
+    """Write the Agent Session Workspace under
+    ``<session_root>/<Benchmark Session ID>/`` and return that directory."""
+    session_dir = Path(session_root) / execution_facts.benchmark_session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    (session_dir / "recommendation.yaml").write_text(
+        yaml.safe_dump(
+            recommendation.model_dump(mode="json"),
+            sort_keys=True,
+            default_flow_style=False,
+        )
+    )
+    (session_dir / "run-command.txt").write_text(run_command.rendered + "\n")
+    (session_dir / "run-command.json").write_text(
+        json.dumps(run_command.argv, indent=2, sort_keys=False) + "\n"
+    )
+    (session_dir / "benchmark-job.yaml").write_text(
+        yaml.safe_dump(benchmark_job_manifest, sort_keys=True, default_flow_style=False)
+    )
+    if slo_goodput is not None:
+        (session_dir / "slo-goodput.yaml").write_text(
+            yaml.safe_dump(
+                slo_goodput.model_dump(mode="json"),
+                sort_keys=True,
+                default_flow_style=False,
+            )
+        )
+
+    return session_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ exclude = ["templates*", "specification*"]
     "benchmark_report/*.yaml",
     "benchmark_report/*.json",
 ]
+"llmdbenchmark.agent" = ["*.yaml"]
 
 [project.urls]
 Homepage = "https://llm-d.ai"

--- a/tests/test_agent_recommend.py
+++ b/tests/test_agent_recommend.py
@@ -16,6 +16,7 @@ Validates that:
 from __future__ import annotations
 
 import inspect
+import subprocess
 import sys
 from pathlib import Path
 
@@ -185,6 +186,15 @@ class TestExecutionFactsValidation:
         with pytest.raises(ValidationError):
             ExecutionFacts(**self._kwargs(benchmark_session_id="a" * 52))
 
+    def test_47_char_session_id_allowed_and_yields_legal_job_name(self):
+        # 16-char "llmdbench-agent-" prefix + 47 == 63, the RFC1123 cap.
+        facts = ExecutionFacts(**self._kwargs(benchmark_session_id="a" * 47))
+        assert len(f"llmdbench-agent-{facts.benchmark_session_id}") == 63
+
+    def test_48_char_session_id_raises(self):
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**self._kwargs(benchmark_session_id="a" * 48))
+
 
 def test_secret_reference_with_raw_value_raises():
     with pytest.raises(ValidationError):
@@ -215,6 +225,53 @@ def test_batch_throughput_falls_back_when_primary_profile_missing(tmp_path):
     assert result.recommendation_confidence == "low"
 
 
+def test_prefix_reuse_on_an_intent_without_a_dedicated_row_falls_back():
+    """Long-Context Generation and Batch Throughput have no
+    prefix_reuse=true row; setting prefix_reuse=True globally must not
+    crash the sole entry point on an otherwise-legal input."""
+    result = recommend(
+        RecommendationFacts(
+            workload_intent=WorkloadIntent.LONG_CONTEXT_GENERATION, prefix_reuse=True
+        )
+    )
+    assert result.selected.workload_profile == "summarization_synthetic.yaml"
+    assert any(d.code == "prefix_reuse_not_supported" for d in result.diagnostics)
+
+
+def test_bogus_overrides_are_validated_not_bypassed():
+    """Agent Static Validation must check the post-override selection, not
+    the raw Recommendation Map row: a bogus override must surface as a
+    diagnostic, never as an empty diagnostics list."""
+    result = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT),
+        RecommendationOverrides(
+            specification="does/not-exist",
+            harness="nope",
+            workload_profile="ghost.yaml",
+        ),
+    )
+    codes = {d.code for d in result.diagnostics}
+    assert "specification_not_found" in codes
+    assert "harness_not_found" in codes
+    assert result.selected.specification == "does/not-exist"
+    assert result.selected.harness == "nope"
+
+
 def test_importing_agent_leaves_no_planner_or_kubernetes_in_sys_modules():
-    assert "planner" not in sys.modules
-    assert "kubernetes" not in sys.modules
+    """A process-global ``sys.modules`` assertion cannot run in-process:
+    pytest collection imports every test module up front, and sibling
+    modules (test_smoketest_inference.py, test_cluster_resource_resolver.py)
+    install a ``planner`` stub / import ``kubernetes`` before this test
+    body ever runs. Check it in a fresh subprocess instead."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import llmdbenchmark.agent; "
+            "assert 'planner' not in sys.modules; "
+            "assert 'kubernetes' not in sys.modules",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_agent_recommend.py
+++ b/tests/test_agent_recommend.py
@@ -1,0 +1,220 @@
+"""Tests for llmdbenchmark.agent recommendation behavior.
+
+Validates that:
+- each Workload Intent maps to the expected specification/harness/profile
+- every Recommendation Map rule's assets actually resolve on disk (the
+  regression that would have caught the inference-scheduling rename)
+- every rule's harness is scorable (present in analysis._WRITER_NAMES)
+- Recommendation ID is deterministic and changes with overrides / map version
+- recommend() takes no ExecutionFacts parameter (story 40, by signature)
+- ExecutionFacts validation rejects missing/invalid fields
+- a raw credential in a Benchmark Secret Reference raises ValidationError
+- the Batch Throughput fallback fires when the primary profile is absent
+- importing the package pulls in neither planner nor kubernetes
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from llmdbenchmark.agent import (
+    ExecutionFacts,
+    RecommendationFacts,
+    RecommendationOverrides,
+    SecretEnvReference,
+    WorkloadIntent,
+    WorkspaceVolume,
+    recommend,
+)
+from llmdbenchmark.agent.recommend import RecommendationMap, _recommendation_id
+from llmdbenchmark.analysis import _WRITER_NAMES
+from llmdbenchmark.utilities.os.filesystem import resolve_specification_file
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_interactive_chat_maps_to_chatbot_profile():
+    result = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+    )
+    assert result.selected.specification == "guides/optimized-baseline"
+    assert result.selected.harness == "inference-perf"
+    assert result.selected.workload_profile == "chatbot_synthetic.yaml"
+    assert result.diagnostics == []
+
+
+def test_interactive_chat_with_prefix_reuse_maps_to_shared_prefix_profile():
+    result = recommend(
+        RecommendationFacts(
+            workload_intent=WorkloadIntent.INTERACTIVE_CHAT, prefix_reuse=True
+        )
+    )
+    assert result.selected.workload_profile == "shared_prefix_synthetic.yaml"
+
+
+def test_long_context_generation_maps_to_pd_disaggregation():
+    result = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.LONG_CONTEXT_GENERATION)
+    )
+    assert result.selected.specification == "guides/pd-disaggregation"
+    assert result.selected.harness == "inference-perf"
+    assert result.selected.workload_profile == "summarization_synthetic.yaml"
+
+
+def test_batch_throughput_maps_to_guidellm():
+    result = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.BATCH_THROUGHPUT)
+    )
+    assert result.selected.harness == "guidellm"
+    assert result.selected.workload_profile == "summarization_synthetic.yaml"
+
+
+class TestMapIntegrity:
+    """Every Recommendation Map rule's assets must resolve against the real
+    repository tree, not just against a fixture."""
+
+    map_data = RecommendationMap.load()
+
+    def test_every_specification_resolves(self):
+        for rule in self.map_data.rules:
+            resolve_specification_file(rule["specification"], base_dir=PROJECT_ROOT)
+
+    def test_every_profile_resolves(self):
+        for rule in self.map_data.rules:
+            harness_dir = PROJECT_ROOT / "workload" / "profiles" / rule["harness"]
+            profile = rule["workload_profile"]
+            assert (harness_dir / profile).exists() or (
+                harness_dir / f"{profile}.in"
+            ).exists(), f"{rule['harness']}/{profile} not found"
+
+    def test_fallback_profile_resolves(self):
+        for rule in self.map_data.rules:
+            fallback = rule.get("fallback_workload_profile")
+            if fallback is None:
+                continue
+            harness_dir = PROJECT_ROOT / "workload" / "profiles" / rule["harness"]
+            assert (harness_dir / fallback).exists() or (
+                harness_dir / f"{fallback}.in"
+            ).exists(), f"{rule['harness']}/{fallback} not found"
+
+    def test_every_harness_is_scorable(self):
+        for rule in self.map_data.rules:
+            assert rule["harness"] in _WRITER_NAMES
+
+
+class TestRecommendationId:
+    def test_stable_across_repeated_calls(self):
+        facts = RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+        a = recommend(facts)
+        b = recommend(facts)
+        assert a.recommendation_id == b.recommendation_id
+
+    def test_changes_with_override(self):
+        facts = RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+        a = recommend(facts)
+        b = recommend(facts, RecommendationOverrides(harness="guidellm"))
+        assert a.recommendation_id != b.recommendation_id
+
+    def test_changes_with_map_version(self):
+        facts = RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+        overrides = RecommendationOverrides()
+        one = _recommendation_id(facts, overrides, "0.1.0")
+        two = _recommendation_id(facts, overrides, "0.2.0")
+        assert one != two
+
+    def test_recommend_has_no_execution_facts_parameter(self):
+        """Story 40: recommend()'s signature must never gain an
+        ExecutionFacts parameter, so endpoint details cannot influence
+        Recommendation Map selection."""
+        params = inspect.signature(recommend).parameters
+        assert "execution_facts" not in params
+        assert set(params) == {"facts", "overrides", "map_path", "base_dir"}
+
+
+class TestExecutionFactsValidation:
+    def _kwargs(self, **overrides):
+        base = dict(
+            benchmark_session_id="sess-1",
+            endpoint_url="http://endpoint",
+            model="a-model",
+            namespace="ns",
+            benchmark_runner_image="img:tag",
+            benchmark_workspace_volume=WorkspaceVolume(claim_name="pvc"),
+        )
+        base.update(overrides)
+        return base
+
+    def test_missing_endpoint_url_raises(self):
+        kwargs = self._kwargs()
+        del kwargs["endpoint_url"]
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**kwargs)
+
+    def test_missing_model_raises(self):
+        kwargs = self._kwargs()
+        del kwargs["model"]
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**kwargs)
+
+    def test_missing_namespace_raises(self):
+        kwargs = self._kwargs()
+        del kwargs["namespace"]
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**kwargs)
+
+    def test_missing_runner_image_raises(self):
+        kwargs = self._kwargs()
+        del kwargs["benchmark_runner_image"]
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**kwargs)
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**self._kwargs(bogus_field="x"))
+
+    def test_uppercase_session_id_raises(self):
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**self._kwargs(benchmark_session_id="ABC"))
+
+    def test_52_char_session_id_raises(self):
+        with pytest.raises(ValidationError):
+            ExecutionFacts(**self._kwargs(benchmark_session_id="a" * 52))
+
+
+def test_secret_reference_with_raw_value_raises():
+    with pytest.raises(ValidationError):
+        SecretEnvReference(
+            kind="env",
+            secret_name="s",
+            secret_key="k",
+            env_var="E",
+            value="do-not-store-me",
+        )
+
+
+def test_batch_throughput_falls_back_when_primary_profile_missing(tmp_path):
+    # Mirror the repo layout minus the Batch Throughput primary profile.
+    guidellm_dir = tmp_path / "workload" / "profiles" / "guidellm"
+    guidellm_dir.mkdir(parents=True)
+    (guidellm_dir / "sanity_concurrent.yaml.in").write_text("profile: concurrent\n")
+    spec_dir = tmp_path / "config" / "specification" / "guides"
+    spec_dir.mkdir(parents=True)
+    (spec_dir / "optimized-baseline.yaml.j2").write_text("base_dir: {}\n")
+
+    result = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.BATCH_THROUGHPUT),
+        base_dir=tmp_path,
+    )
+    assert result.selected.workload_profile == "sanity_concurrent.yaml"
+    assert any(d.code == "workload_profile_fallback" for d in result.diagnostics)
+    assert result.recommendation_confidence == "low"
+
+
+def test_importing_agent_leaves_no_planner_or_kubernetes_in_sys_modules():
+    assert "planner" not in sys.modules
+    assert "kubernetes" not in sys.modules

--- a/tests/test_agent_render.py
+++ b/tests/test_agent_render.py
@@ -1,0 +1,232 @@
+"""Tests for llmdbenchmark.agent rendering behavior.
+
+Validates that:
+- the Agent-Rendered Run Command argv matches the pinned canonical ordering
+- every run-flag token in argv is a real flag defined in interface/run.py
+- --analyze is always present; --monitoring only under the override
+- rendering is deterministic (byte-identical argv and manifest dump)
+- the Benchmark Job Manifest carries both identities, no ttlSecondsAfterFinished,
+  no hostPath/kubeconfig, and args identical to the run command's own argv slice
+- Benchmark Secret References render as references only, never raw values
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.agent import (
+    ExecutionFacts,
+    RecommendationFacts,
+    SecretEnvReference,
+    SecretFileReference,
+    WorkloadIntent,
+    WorkspaceVolume,
+    recommend,
+    render_benchmark_job_manifest,
+    render_run_command,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+RUN_PY = PROJECT_ROOT / "llmdbenchmark" / "interface" / "run.py"
+
+
+def _real_run_flags() -> set[str]:
+    return set(re.findall(r'"(--[a-z-]+)"', RUN_PY.read_text()))
+
+
+def _execution_facts(**overrides) -> ExecutionFacts:
+    base = dict(
+        benchmark_session_id="sess-1",
+        endpoint_url="http://endpoint",
+        model="a-model",
+        namespace="ns",
+        benchmark_runner_image="img:tag",
+        benchmark_workspace_volume=WorkspaceVolume(claim_name="pvc"),
+    )
+    base.update(overrides)
+    return ExecutionFacts(**base)
+
+
+def test_argv_pinned_ordering():
+    recommendation = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+    )
+    execution_facts = _execution_facts()
+    run_command = render_run_command(recommendation, execution_facts)
+    assert run_command.argv == [
+        "llmdbenchmark",
+        "--spec",
+        "guides/optimized-baseline",
+        "--workspace",
+        "/workspace",
+        "run",
+        "--namespace",
+        "ns",
+        "--endpoint-url",
+        "http://endpoint",
+        "--model",
+        "a-model",
+        "--harness",
+        "inference-perf",
+        "--workload",
+        "chatbot_synthetic.yaml",
+        "--analyze",
+    ]
+
+
+def test_run_flags_are_a_subset_of_real_run_py_flags():
+    recommendation = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.BATCH_THROUGHPUT)
+    )
+    execution_facts = _execution_facts(benchmark_monitoring_override=True)
+    run_command = render_run_command(recommendation, execution_facts)
+
+    # argv[5] is "run"; everything before it is root-level (--spec, --workspace).
+    run_flags_used = {tok for tok in run_command.argv[6:] if tok.startswith("--")}
+    assert run_flags_used <= _real_run_flags()
+
+
+def test_analyze_always_present_monitoring_only_on_override():
+    recommendation = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+    )
+
+    default_command = render_run_command(recommendation, _execution_facts())
+    assert "--analyze" in default_command.argv
+    assert "--monitoring" not in default_command.argv
+    assert "--config" not in default_command.argv
+    assert "--generate-config" not in default_command.argv
+    assert default_command.argv.count("--endpoint-url") == 1
+    assert default_command.argv.count("--model") == 1
+
+    monitored_command = render_run_command(
+        recommendation, _execution_facts(benchmark_monitoring_override=True)
+    )
+    assert monitored_command.argv.count("--monitoring") == 1
+
+
+def test_rendering_is_deterministic():
+    recommendation = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+    )
+    execution_facts = _execution_facts()
+    first = render_run_command(recommendation, execution_facts)
+    second = render_run_command(recommendation, execution_facts)
+    assert first.argv == second.argv
+    assert first.rendered == second.rendered
+
+    manifest_one = render_benchmark_job_manifest(recommendation, execution_facts, first)
+    manifest_two = render_benchmark_job_manifest(
+        recommendation, execution_facts, second
+    )
+    dump_one = yaml.safe_dump(manifest_one, sort_keys=True, default_flow_style=False)
+    dump_two = yaml.safe_dump(manifest_two, sort_keys=True, default_flow_style=False)
+    assert dump_one == dump_two
+
+
+class TestBenchmarkJobManifest:
+    def _manifest(self, **execution_overrides):
+        recommendation = recommend(
+            RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+        )
+        execution_facts = _execution_facts(**execution_overrides)
+        run_command = render_run_command(recommendation, execution_facts)
+        manifest = render_benchmark_job_manifest(
+            recommendation, execution_facts, run_command
+        )
+        return recommendation, execution_facts, run_command, manifest
+
+    def test_kind_and_api_version(self):
+        _, _, _, manifest = self._manifest()
+        assert manifest["apiVersion"] == "batch/v1"
+        assert manifest["kind"] == "Job"
+
+    def test_name_is_legal_rfc1123(self):
+        _, _, _, manifest = self._manifest()
+        name = manifest["metadata"]["name"]
+        assert len(name) <= 63
+        assert re.match(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", name)
+
+    def test_both_identities_present_and_distinct(self):
+        recommendation, _, _, manifest = self._manifest()
+        labels = manifest["metadata"]["labels"]
+        session_id = labels["llmdbenchmark.llm-d.ai/benchmark-session-id"]
+        recommendation_id = labels["llmdbenchmark.llm-d.ai/recommendation-id"]
+        assert session_id == "sess-1"
+        assert recommendation_id == recommendation.recommendation_id
+        assert session_id != recommendation_id
+
+    def test_workload_intent_slugified_label_verbatim_annotation(self):
+        _, _, _, manifest = self._manifest()
+        assert (
+            manifest["metadata"]["labels"]["llmdbenchmark.llm-d.ai/workload-intent"]
+            == "interactive-chat"
+        )
+        assert (
+            manifest["metadata"]["annotations"][
+                "llmdbenchmark.llm-d.ai/workload-intent"
+            ]
+            == "Interactive Chat"
+        )
+
+    def test_container_image_and_args_match_run_command_slice(self):
+        _, _, run_command, manifest = self._manifest()
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["image"] == "img:tag"
+        assert container["args"] == run_command.argv[1:]
+
+    def test_pvc_volume_mounted_at_mount_path(self):
+        _, _, _, manifest = self._manifest()
+        pod_spec = manifest["spec"]["template"]["spec"]
+        pvc_volumes = [v for v in pod_spec["volumes"] if "persistentVolumeClaim" in v]
+        assert len(pvc_volumes) == 1
+        assert pvc_volumes[0]["persistentVolumeClaim"]["claimName"] == "pvc"
+        mount = pod_spec["containers"][0]["volumeMounts"][0]
+        assert mount["mountPath"] == "/workspace"
+
+    def test_service_account_only_when_supplied(self):
+        _, _, _, manifest_without = self._manifest()
+        assert "serviceAccountName" not in manifest_without["spec"]["template"]["spec"]
+
+        _, _, _, manifest_with = self._manifest(benchmark_runner_auth="runner-sa")
+        assert (
+            manifest_with["spec"]["template"]["spec"]["serviceAccountName"]
+            == "runner-sa"
+        )
+
+    def test_no_hostpath_no_kubeconfig_no_ttl(self):
+        _, _, _, manifest = self._manifest()
+        dumped = yaml.safe_dump(manifest)
+        assert "hostPath" not in dumped
+        assert "kubeconfig" not in dumped
+        assert "ttlSecondsAfterFinished" not in dumped
+
+    def test_secret_references_render_by_reference_only(self):
+        sentinel = "sentinel-secret-name-xyz"
+        _, _, _, manifest = self._manifest(
+            benchmark_secret_references=[
+                SecretEnvReference(
+                    kind="env", secret_name=sentinel, secret_key="key", env_var="TOKEN"
+                ),
+                SecretFileReference(
+                    kind="file", secret_name="file-secret", mount_path="/etc/creds"
+                ),
+            ]
+        )
+        dumped = yaml.safe_dump(manifest)
+        assert sentinel in dumped
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["env"][0]["valueFrom"]["secretKeyRef"]["name"] == sentinel
+        secret_volumes = [
+            v for v in manifest["spec"]["template"]["spec"]["volumes"] if "secret" in v
+        ]
+        assert len(secret_volumes) == 1
+        assert secret_volumes[0]["secret"]["secretName"] == "file-secret"
+
+    def test_recommendation_output_dump_has_no_secret_material(self):
+        recommendation, _, _, _ = self._manifest()
+        dumped = yaml.safe_dump(recommendation.model_dump(mode="json"))
+        assert "secret" not in dumped.lower()

--- a/tests/test_agent_render.py
+++ b/tests/test_agent_render.py
@@ -150,6 +150,14 @@ class TestBenchmarkJobManifest:
         assert len(name) <= 63
         assert re.match(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", name)
 
+    def test_name_is_legal_rfc1123_at_max_session_id_length(self):
+        # The longest benchmark_session_id ExecutionFacts allows must not
+        # push metadata.name past the 63-char RFC1123 limit.
+        _, _, _, manifest = self._manifest(benchmark_session_id="a" * 47)
+        name = manifest["metadata"]["name"]
+        assert len(name) == 63
+        assert re.match(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", name)
+
     def test_both_identities_present_and_distinct(self):
         recommendation, _, _, manifest = self._manifest()
         labels = manifest["metadata"]["labels"]

--- a/tests/test_agent_score.py
+++ b/tests/test_agent_score.py
@@ -239,6 +239,55 @@ def test_missing_throughput_yields_diagnostic(tmp_path):
     assert any(d.code == "missing_throughput" for d in result.slo_scoring_diagnostics)
 
 
+def test_v01_report_yields_diagnostic_not_exception():
+    v01_report = (
+        PROJECT_ROOT
+        / "llmdbenchmark"
+        / "analysis"
+        / "benchmark_report"
+        / "br_v0_1_example.yaml"
+    )
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([v01_report], [gate])
+    assert result.reports[0].verdict == "indeterminate"
+    assert any(
+        d.code == "unsupported_report_version" for d in result.slo_scoring_diagnostics
+    )
+
+
+def test_missing_path_yields_diagnostic_not_exception(tmp_path):
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([tmp_path / "does-not-exist.yaml"], [gate])
+    assert result.reports[0].verdict == "indeterminate"
+    assert any(d.code == "unreadable_report" for d in result.slo_scoring_diagnostics)
+
+
+def test_directory_path_yields_diagnostic_not_exception(tmp_path):
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([tmp_path], [gate])
+    assert result.reports[0].verdict == "indeterminate"
+    assert any(d.code == "unreadable_report" for d in result.slo_scoring_diagnostics)
+
+
+def test_scalar_yaml_document_yields_diagnostic_not_exception(tmp_path):
+    path = tmp_path / "scalar.yaml"
+    path.write_text("just a string\n")
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([path], [gate])
+    assert result.reports[0].verdict == "indeterminate"
+    assert any(d.code == "unreadable_report" for d in result.slo_scoring_diagnostics)
+
+
+def test_empty_gates_is_indeterminate_not_pass():
+    """The out-of-the-box, no-gates-supplied state must never stamp a
+    report 'pass' -- that would publish an SLO Goodput number with zero
+    SLO evaluated."""
+    result = score_slo_goodput([EXAMPLE_REPORT], [])
+    assert result.reports[0].verdict == "indeterminate"
+    assert any(d.code == "no_gates_supplied" for d in result.slo_scoring_diagnostics)
+    assert result.slo_goodput_output_token_rate is None
+
+
 def test_discover_agent_analysis_input_ignores_v01_sibling(tmp_path):
     treatment_dir = tmp_path / "treatment_0"
     treatment_dir.mkdir()

--- a/tests/test_agent_score.py
+++ b/tests/test_agent_score.py
@@ -1,0 +1,321 @@
+"""Tests for llmdbenchmark.agent SLO Goodput scoring.
+
+Validates that:
+- a passing/failing gate against the shipped br_v0_2_example.yaml fixture
+  is scored correctly, including throughput for a passing report
+- a metric with no value at the selected percentile yields missing_percentile
+  and an indeterminate verdict, never an interpolated value
+- p99 reads p99, not p95
+- unit normalization (ms <-> s, ms/token <-> s/token) is direction-correct,
+  and an unrecognized unit yields unknown_units rather than a guess
+- version handling distinguishes missing / unsupported / 0.2.1-superset
+- a 100%-failure report fails a max_failure_ratio gate
+- discover_agent_analysis_input ignores the v0.1 sibling
+- multiple reports label by stage and aggregate goodput throughput as a max
+- write_agent_session_workspace produces exactly the expected files, all
+  re-parseable, byte-identical on a second call
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.agent import (
+    ExecutionFacts,
+    RecommendationFacts,
+    SloGate,
+    SloMetric,
+    WorkloadIntent,
+    WorkspaceVolume,
+    discover_agent_analysis_input,
+    recommend,
+    render_benchmark_job_manifest,
+    render_run_command,
+    score_slo_goodput,
+    write_agent_session_workspace,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_REPORT = (
+    PROJECT_ROOT
+    / "llmdbenchmark"
+    / "analysis"
+    / "benchmark_report"
+    / "br_v0_2_example.yaml"
+)
+
+
+def _write_report(tmp_path: Path, name: str, data: dict) -> Path:
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def test_ttft_gate_fails_below_observed():
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.02, units="s")
+    result = score_slo_goodput([EXAMPLE_REPORT], [gate])
+    report = result.reports[0]
+    assert report.verdict == "fail"
+    gate_result = report.gate_results[0]
+    assert gate_result.metric == SloMetric.TIME_TO_FIRST_TOKEN
+    assert round(gate_result.observed, 4) == 0.0452
+    assert gate_result.threshold == 0.02
+
+
+def test_ttft_gate_passes_and_reports_throughput():
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([EXAMPLE_REPORT], [gate])
+    report = result.reports[0]
+    assert report.verdict == "pass"
+    assert report.output_token_rate_mean == 2262.448
+
+
+def test_itl_gate_yields_missing_percentile():
+    gate = SloGate(metric=SloMetric.INTER_TOKEN_LATENCY, threshold=0.1, units="s")
+    result = score_slo_goodput([EXAMPLE_REPORT], [gate])
+    report = result.reports[0]
+    assert report.verdict == "indeterminate"
+    assert report.gate_results[0].observed is None
+    assert any(d.code == "missing_percentile" for d in result.slo_scoring_diagnostics)
+
+
+def test_p99_gate_reads_p99_not_p95():
+    gate_p95 = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=1.0, units="s")
+    gate_p99 = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=1.0, units="s")
+    from llmdbenchmark.agent import GatePercentile
+
+    p95_result = score_slo_goodput(
+        [EXAMPLE_REPORT], [gate_p95], slo_gate_percentile=GatePercentile.P95
+    )
+    p99_result = score_slo_goodput(
+        [EXAMPLE_REPORT], [gate_p99], slo_gate_percentile=GatePercentile.P99
+    )
+    assert p95_result.reports[0].gate_results[0].observed != (
+        p99_result.reports[0].gate_results[0].observed
+    )
+
+
+def test_ms_units_scaled_report_scores_identically_to_seconds(tmp_path):
+    example = yaml.safe_load(EXAMPLE_REPORT.read_text())
+    ttft = example["results"]["request_performance"]["aggregate"]["latency"][
+        "time_to_first_token"
+    ]
+    ttft["units"] = "ms"
+    for key, value in list(ttft.items()):
+        if key != "units" and isinstance(value, (int, float)):
+            ttft[key] = value * 1000
+
+    path = _write_report(tmp_path, "ms_report.yaml", example)
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    seconds_result = score_slo_goodput([EXAMPLE_REPORT], [gate])
+    ms_result = score_slo_goodput([path], [gate])
+    assert seconds_result.reports[0].verdict == ms_result.reports[0].verdict == "pass"
+
+
+def test_near_boundary_ms_conversion_direction(tmp_path):
+    example = yaml.safe_load(EXAMPLE_REPORT.read_text())
+    ttft = example["results"]["request_performance"]["aggregate"]["latency"][
+        "time_to_first_token"
+    ]
+    ttft["units"] = "ms"
+    ttft["p95"] = 250.0
+    path = _write_report(tmp_path, "boundary_report.yaml", example)
+
+    fails = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.2, units="s")
+    passes = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.3, units="s")
+    fail_result = score_slo_goodput([path], [fails])
+    pass_result = score_slo_goodput([path], [passes])
+    assert fail_result.reports[0].verdict == "fail"
+    assert pass_result.reports[0].verdict == "pass"
+
+
+def test_unrecognized_units_yields_unknown_units(tmp_path):
+    example = yaml.safe_load(EXAMPLE_REPORT.read_text())
+    example["results"]["request_performance"]["aggregate"]["latency"][
+        "time_to_first_token"
+    ]["units"] = "seconds"
+    path = _write_report(tmp_path, "bad_units.yaml", example)
+
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([path], [gate])
+    assert result.reports[0].verdict == "indeterminate"
+    assert any(d.code == "unknown_units" for d in result.slo_scoring_diagnostics)
+
+
+def test_minimal_v02_document_yields_diagnostics_not_exception(tmp_path):
+    path = _write_report(
+        tmp_path, "minimal.yaml", {"version": "0.2", "run": {"uid": "u"}, "results": {}}
+    )
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([path], [gate])
+    assert result.reports[0].verdict == "indeterminate"
+    assert result.slo_scoring_diagnostics
+
+
+def test_full_failure_report_fails_max_failure_ratio_gate(tmp_path):
+    path = _write_report(
+        tmp_path,
+        "all_failed.yaml",
+        {
+            "version": "0.2",
+            "run": {"uid": "u"},
+            "results": {
+                "request_performance": {
+                    "aggregate": {"requests": {"total": 100, "failures": 100}}
+                }
+            },
+        },
+    )
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([path], [gate], max_failure_ratio=0.5)
+    assert result.reports[0].verdict == "fail"
+
+
+def test_version_missing_vs_unsupported_vs_superset(tmp_path):
+    example = yaml.safe_load(EXAMPLE_REPORT.read_text())
+
+    no_version = dict(example)
+    del no_version["version"]
+    missing_path = _write_report(tmp_path, "no_version.yaml", no_version)
+
+    superset = dict(example)
+    superset["version"] = "0.2.1"
+    superset_path = _write_report(tmp_path, "superset.yaml", superset)
+
+    unsupported = dict(example)
+    unsupported["version"] = "0.3"
+    unsupported_path = _write_report(tmp_path, "unsupported.yaml", unsupported)
+
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+
+    missing_result = score_slo_goodput([missing_path], [gate])
+    assert any(
+        d.code == "missing_report_version"
+        for d in missing_result.slo_scoring_diagnostics
+    )
+
+    superset_result = score_slo_goodput([superset_path], [gate])
+    assert any(
+        d.code == "version_superset" for d in superset_result.slo_scoring_diagnostics
+    )
+    assert superset_result.reports[0].verdict == "pass"
+
+    unsupported_result = score_slo_goodput([unsupported_path], [gate])
+    assert any(
+        d.code == "unsupported_report_version"
+        for d in unsupported_result.slo_scoring_diagnostics
+    )
+
+
+def test_missing_throughput_yields_diagnostic(tmp_path):
+    path = _write_report(
+        tmp_path,
+        "no_throughput.yaml",
+        {
+            "version": "0.2",
+            "run": {"uid": "u"},
+            "results": {
+                "request_performance": {
+                    "aggregate": {
+                        "requests": {"total": 10, "failures": 0},
+                        "latency": {
+                            "time_to_first_token": {
+                                "units": "s",
+                                "mean": 0.01,
+                                "p95": 0.02,
+                            }
+                        },
+                    }
+                }
+            },
+        },
+    )
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([path], [gate])
+    assert result.reports[0].output_token_rate_mean is None
+    assert any(d.code == "missing_throughput" for d in result.slo_scoring_diagnostics)
+
+
+def test_discover_agent_analysis_input_ignores_v01_sibling(tmp_path):
+    treatment_dir = tmp_path / "treatment_0"
+    treatment_dir.mkdir()
+    v02 = treatment_dir / "benchmark_report_v0.2,_stage_0.yaml"
+    v02.write_text("version: '0.2'\n")
+    (treatment_dir / "benchmark_report,_stage_0.yaml").write_text("version: '0.1'\n")
+
+    discovered = discover_agent_analysis_input(tmp_path)
+    assert discovered == [v02]
+
+
+def test_multiple_reports_labeled_by_stage_and_max_passing_throughput(tmp_path):
+    example = yaml.safe_load(EXAMPLE_REPORT.read_text())
+    high_rate = copy.deepcopy(example)
+    high_rate["scenario"]["load"]["standardized"]["stage"] = 1
+    high_rate["results"]["request_performance"]["aggregate"]["throughput"][
+        "output_token_rate"
+    ]["mean"] = 3000.0
+    low_rate = copy.deepcopy(example)
+    low_rate["scenario"]["load"]["standardized"]["stage"] = 2
+    low_rate["results"]["request_performance"]["aggregate"]["throughput"][
+        "output_token_rate"
+    ]["mean"] = 1000.0
+
+    high_path = _write_report(tmp_path, "stage1.yaml", high_rate)
+    low_path = _write_report(tmp_path, "stage2.yaml", low_rate)
+
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    result = score_slo_goodput([high_path, low_path], [gate])
+    stages = {r.stage for r in result.reports}
+    assert stages == {1, 2}
+    assert result.slo_goodput_output_token_rate == 3000.0
+
+
+def test_write_agent_session_workspace_creates_expected_files_deterministically(
+    tmp_path,
+):
+    recommendation = recommend(
+        RecommendationFacts(workload_intent=WorkloadIntent.INTERACTIVE_CHAT)
+    )
+    execution_facts = ExecutionFacts(
+        benchmark_session_id="sess-workspace",
+        endpoint_url="http://endpoint",
+        model="a-model",
+        namespace="ns",
+        benchmark_runner_image="img:tag",
+        benchmark_workspace_volume=WorkspaceVolume(claim_name="pvc"),
+    )
+    run_command = render_run_command(recommendation, execution_facts)
+    manifest = render_benchmark_job_manifest(
+        recommendation, execution_facts, run_command
+    )
+
+    gate = SloGate(metric=SloMetric.TIME_TO_FIRST_TOKEN, threshold=0.1, units="s")
+    slo_goodput = score_slo_goodput([EXAMPLE_REPORT], [gate])
+
+    first = write_agent_session_workspace(
+        tmp_path, execution_facts, recommendation, run_command, manifest, slo_goodput
+    )
+    expected_names = {
+        "recommendation.yaml",
+        "run-command.txt",
+        "run-command.json",
+        "benchmark-job.yaml",
+        "slo-goodput.yaml",
+    }
+    assert {p.name for p in first.iterdir()} == expected_names
+
+    for name in ("recommendation.yaml", "slo-goodput.yaml"):
+        parsed = yaml.safe_load((first / name).read_text())
+        assert parsed["agent_artifact_version"] == "1"
+    benchmark_job = yaml.safe_load((first / "benchmark-job.yaml").read_text())
+    assert benchmark_job["kind"] == "Job"
+
+    contents_first = {p.name: p.read_bytes() for p in first.iterdir()}
+    second = write_agent_session_workspace(
+        tmp_path, execution_facts, recommendation, run_command, manifest, slo_goodput
+    )
+    contents_second = {p.name: p.read_bytes() for p in second.iterdir()}
+    assert contents_first == contents_second


### PR DESCRIPTION
## Description

A first slice of the Benchmarking Agent MVP described in #1058. Opening as a **draft**, because the load-bearing question is one only you can answer: **is this work claimable by an outside contributor, or is it already being built internally?** #1058 has no assignee, labels, or comments, so I couldn't tell from the outside. If it's spoken for, say so and I'll close this. The reconnaissance was useful to me either way.

Fixes # (issue): #1058, partially. Scope below.

`llmdbenchmark/agent/` is a leaf package. It imports nothing from this repo except `llmdbenchmark.analysis.benchmark_report` and `llmdbenchmark.utilities.os.filesystem`, so a clean `import llmdbenchmark.agent` pulls in neither `kubernetes` nor `planner`. Four pure functions plus one I/O wrapper:

- `recommend()` selects a benchmark configuration from `recommendation_map.yaml` (semver 0.1.0) for a Workload Intent, folds in Recommendation Overrides, runs Agent Static Validation, and returns diagnostics rather than raising.
- `render_run_command()` renders the Agent-Rendered Run Command against the existing `llmdbenchmark` CLI, with `--analyze` always on.
- `render_benchmark_job_manifest()` renders the Kubernetes Benchmark Job Manifest, with an explicit Benchmark Runner Image and Benchmark Workspace Volume.
- `score_slo_goodput()` reads benchmark-report v0.2 through the existing loaders and scores SLO Goodput against caller-supplied gates.
- `write_agent_session_workspace()` is the only I/O in the package. It writes the durable Agent Session Workspace artifacts.

Per the PRD, this slice does not submit or watch Kubernetes Jobs. It produces inspectable files.

Deliberately out of scope, and I'd rather state these up front than have them discovered:

- **No default numeric SLO thresholds.** Gates are caller-supplied and the map ships none. No threshold value exists anywhere in this repo and the PRD doesn't name any, so inventing them looked like the fastest route to arguing about numbers instead of structure. See question 1 below.
- **No sweeps** (Load, Token-Shape, Run-Treatment; stories 23 to 25). The override key is harness-specific, so a sweep can silently no-op through `apply_overrides`. That needs a decision before it's worth building.
- **No rendered RBAC** (story 36). `docs/benchmarking-agent.md` documents the permission set instead.
- **No CLI surface.** No `Command` enum entry, no `interface/agent.py`, no touch to `cli.py`. Library-only, partly so this doesn't collide with the argparse rework in #932.
- **No changes under `config/`**, so the per-spec render loop in `ci-pr-plan-rendering-validation.yaml` is untouched.
- **No new dependencies.** pydantic and PyYAML are already in `pyproject.toml`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

`ruff check` and `ruff format --check` at the CI-pinned 0.15.11 (installed fresh to match) come back clean across the package, tests and docs.

```
$ python3 -m pytest tests/test_agent_recommend.py tests/test_agent_score.py tests/test_agent_render.py -q
60 passed

$ python3 -m pytest tests/ -q --ignore=tests/test_results_store.py --ignore=tests/test_kube_helpers_pod_failures.py
748 passed, 31 skipped
```

The two ignores are modules that hang in this environment, and neither is anything this branch touches.

Every new test was checked to actually fail without the implementation, by restoring the pre-change files and re-running. Eight of them fail against the old code and pass against this one. The tests are offline, exercise only the public API, and add no fixtures or `conftest.py`.

Seven defects turned up in self-review before this was opened. All are fixed and each has a test:

1. A `sys.modules` assertion that would have made this the first CI failure under `pytest -x`, since pytest's collection imports sibling modules first. Now checked in a subprocess.
2. An `AttributeError` on a v0.1 report, which sits beside v0.2 files in a real results tree.
3. Unhandled crashes on a missing path, a directory, and a scalar-YAML document, in a function documented as never raising.
4. `verdict="pass"` when no gates were supplied, which is the documented default state. Now `indeterminate` with a diagnostic.
5. A 51-character session-id pattern against a 16-character job-name prefix, producing a 67-character `metadata.name` past the RFC1123 limit of 63.
6. Agent Static Validation running before overrides were folded in, so a nonexistent override validated clean.
7. `find()` raising `ValueError` for `prefix_reuse=True` on an intent without a dedicated row.

### Test Configuration

- Kubernetes version: none. This slice makes no Kubernetes API calls by design. It renders a manifest as data and never applies it, so nothing here needs a cluster to exercise. I don't have one available, which is why the standup box below is unchecked.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [x] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly

The standup box is unchecked because I have no cluster here. Since the package issues no cluster calls I don't think that sequence exercises this code, but I'd rather leave it unticked than claim it.

## Questions

Beyond the claimable question at the top, these are the things I couldn't settle from the repository itself:

1. Which latency metrics, and what numeric thresholds, constitute the SLO gate per Workload Intent? Nothing in the repo carries a threshold value.
2. Is SLO Goodput a per-treatment pass/fail plus a throughput number, or a derived SLO-conforming request rate? And when a run emits several per-stage v0.2 reports, should they be aggregated or scored individually?
3. Accept benchmark-report v0.2.1 as an additive superset, or hard-reject anything where version is not 0.2?
4. Should the PRD's `inference-scheduling` specification be honoured literally via an alias, or is `guides/optimized-baseline` the intended target? I assumed the latter and recorded it in a comment rather than adding a one-entry alias table.
5. Is Run-Only Benchmark RBAC meant to be a rendered Role/RoleBinding, or a documented permission set?
6. The PRD cites an existing domain glossary and ADRs. I couldn't find either in this repository. Where do they live?
