### PR TITLE
Some more improvements to the FMA+KEDA/WVA workflows

### DIFF
--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -133,7 +133,7 @@ jobs:
   # =========================================================================
   baseline:
     name: Baseline (EPP+KEDA, no FMA)
-    uses: ./.github/workflows/reusable-ci-nightly-benchmark.yaml  # TEMP HACK (revert before merge): local copy so it clones the fma_keda branch
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
       standup_method: 'modelservice'
@@ -170,7 +170,7 @@ jobs:
   nightly:
     name: EPP+KEDA with FMA (Warm-Start)
     needs: [baseline]
-    uses: ./.github/workflows/reusable-ci-nightly-benchmark.yaml  # TEMP HACK (revert before merge): local copy so it clones the fma_keda branch
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
       # Both methods: this scenario deploys modelservice (gateway/EPP/
@@ -211,7 +211,7 @@ jobs:
   hotstart:
     name: EPP+KEDA with FMA (Hot-Start)
     needs: [baseline]
-    uses: ./.github/workflows/reusable-ci-nightly-benchmark.yaml  # TEMP HACK (revert before merge): local copy so it clones the fma_keda branch
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
       standup_method: 'modelservice,fma'

--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -102,6 +102,11 @@ on:
         required: false
         default: 'inference-perf'
         type: 'string'
+      model:
+        description: 'Served model. Keep in sync with the scenario model.'
+        required: false
+        default: 'Qwen/Qwen3-32B'
+        type: 'string'
       workload:
         description: 'Workload profile (under workload/profiles/<harness>/)'
         required: false
@@ -128,7 +133,7 @@ jobs:
   # =========================================================================
   baseline:
     name: Baseline (EPP+KEDA, no FMA)
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    uses: ./.github/workflows/reusable-ci-nightly-benchmark.yaml  # TEMP HACK (revert before merge): local copy so it clones the fma_keda branch
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
       standup_method: 'modelservice'
@@ -165,7 +170,7 @@ jobs:
   nightly:
     name: EPP+KEDA with FMA (Warm-Start)
     needs: [baseline]
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    uses: ./.github/workflows/reusable-ci-nightly-benchmark.yaml  # TEMP HACK (revert before merge): local copy so it clones the fma_keda branch
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
       # Both methods: this scenario deploys modelservice (gateway/EPP/
@@ -206,7 +211,7 @@ jobs:
   hotstart:
     name: EPP+KEDA with FMA (Hot-Start)
     needs: [baseline]
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-ci-nightly-benchmark.yaml@main
+    uses: ./.github/workflows/reusable-ci-nightly-benchmark.yaml  # TEMP HACK (revert before merge): local copy so it clones the fma_keda branch
     with:
       scenario_dir: ${{ inputs.scenario_dir || 'cicd' }}
       standup_method: 'modelservice,fma'
@@ -248,6 +253,9 @@ jobs:
       FMA_KEDA_WARMSTART_SCENARIO: ${{ inputs.standup_scenario || 'ocp-keda-fma-warmstart' }}
       FMA_KEDA_HOTSTART_SCENARIO: ${{ inputs.hotstart_scenario || 'ocp-keda-fma-hotstart' }}
     steps:
+      - name: Checkout llm-d-benchmark (for the results-table script)
+        uses: actions/checkout@v7.0.0
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -288,249 +296,18 @@ jobs:
           [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_KEDA_WARMSTART_DIR/" || true
           [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_KEDA_HOTSTART_DIR/" || true
 
-          # PyYAML for cluster-state parsing in the timing-row computation
-          # below; ubuntu-latest doesn't have it pre-installed in the user
-          # site, but the system one does (apt-installed python3-yaml).
-          pip install --quiet pyyaml 2>/dev/null || true
-
-          # Locate, per pass:
-          #   - summary_lifecycle_metrics.json   (harness output, has latency)
-          #   - <exp_id>/keda-controller.log      (step_09a; absent for the KEDA path)
-          #   - <exp_id>/resources.yaml          (step_09a, has Pod Ready timestamps)
-          find_in_results() {
-            # $1 = pass dir, $2 = filename
-            find "$1" -path "*/results/*" -name "$2" 2>/dev/null | sort | tail -1
-          }
-          BL_SUM=$(find_in_results "$BASELINE_DIR"            "summary_lifecycle_metrics.json")
-          FW_WARMSTART_SUM=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "summary_lifecycle_metrics.json")
-          FW_HOTSTART_SUM=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "summary_lifecycle_metrics.json")
-          BL_KEDA=$(find_in_results "$BASELINE_DIR"            "keda-controller.log")
-          FW_WARMSTART_KEDA=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "keda-controller.log")
-          FW_HOTSTART_KEDA=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "keda-controller.log")
-          BL_RES=$(find_in_results "$BASELINE_DIR"            "resources.yaml")
-          FW_WARMSTART_RES=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "resources.yaml")
-          FW_HOTSTART_RES=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "resources.yaml")
-          BL_EVENTS=$(find_in_results "$BASELINE_DIR"            "events.json")
-          FW_WARMSTART_EVENTS=$(find_in_results "$FMA_KEDA_WARMSTART_DIR" "events.json")
-          FW_HOTSTART_EVENTS=$(find_in_results "$FMA_KEDA_HOTSTART_DIR"   "events.json")
-
-          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_KEDA" "$FW_WARMSTART_KEDA" "$FW_HOTSTART_KEDA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" "$BL_EVENTS" "$FW_WARMSTART_EVENTS" "$FW_HOTSTART_EVENTS" \
-            >> "$GITHUB_STEP_SUMMARY" <<'PY'
-          import json, sys, os, re, datetime
-          try:
-              import yaml
-              HAVE_YAML = True
-          except ImportError:
-              HAVE_YAML = False
-
-          (bl_sum, fw_ws_sum, fw_hs_sum,
-           bl_keda, fw_ws_keda, fw_hs_keda,
-           bl_res, fw_ws_res, fw_hs_res,
-           bl_events, fw_ws_events, fw_hs_events) = sys.argv[1:13]
-
-          def load_json(p):
-              if not p or not os.path.isfile(p):
-                  return None
-              try:
-                  with open(p) as f:
-                      return json.load(f)
-              except (json.JSONDecodeError, OSError):
-                  return None
-
-          bl = load_json(bl_sum)
-          fw_ws = load_json(fw_ws_sum)   # EPP+KEDA with FMA — warm start
-          fw_hs = load_json(fw_hs_sum)   # EPP+KEDA with FMA — hot start
-
-          def get(d, *keys, scale=1.0):
-              if d is None: return None
-              cur = d
-              for k in keys:
-                  if not isinstance(cur, dict) or k not in cur: return None
-                  cur = cur[k]
-              return cur * scale if isinstance(cur, (int, float)) else cur
-
-          def fmt(v, unit="", precision=1):
-              if v is None: return "_n/a_"
-              if isinstance(v, float): return f"{v:.{precision}f}{unit}"
-              return f"{v}{unit}"
-
-          # ----- Scale actuation timing (scaler-agnostic: pod lifecycle) -----
-          # FMA requester Deployment is scaled via a KEDAScaledObject -> HPA,
-          # so timing is measured from the captured resources.yaml (pod status)
-
-          # T_actuation: mean wall-clock from each serving container's START to
-          # its pod's Ready transition. Measuring from container start (not pod
-          # creation) excludes scheduling + image-pull + volume-mount overhead —
-          # matching FMA's httpstart, which times from container start.
-          def _iso_full(s):
-              """Parse an RFC3339 timestamp (with optional fractional seconds
-              and Z suffix) into a tz-aware datetime, or None on failure."""
-              if not s:
-                  return None
-              try:
-                  return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
-              except (ValueError, TypeError):
-                  return None
-
-          # Serving-container names whose start marks the beginning of model
-          # actuation: "vllm" for the decode baseline,
-          # "inference-server" for FMA launcher & requester pods.
-          SERVING_CONTAINERS = ("inference-server", "vllm")
-
-          def _container_started(item):
-              for cs in item.get('status', {}).get('containerStatuses', []):
-                  if cs.get('name') in SERVING_CONTAINERS:
-                      running = (cs.get('state') or {}).get('running') or {}
-                      return _iso_full(running.get('startedAt'))
-              return None
-
-          def actuation_mean(resources_path):
-              if not HAVE_YAML or not resources_path or not os.path.isfile(resources_path):
-                  return None
-              try:
-                  with open(resources_path) as f:
-                      doc = yaml.safe_load(f)
-              except (yaml.YAMLError, OSError):
-                  return None
-              if not isinstance(doc, dict):
-                  return None
-              items = doc.get('items', []) if doc.get('kind') == 'List' else []
-              durs = []
-              for item in items:
-                  if item.get('kind') != 'Pod': continue
-                  name = item.get('metadata', {}).get('name', '')
-                  if 'fma-requester' not in name and '-decode-' not in name:
-                      continue
-                  start = _container_started(item) or _iso_full(item['metadata'].get('creationTimestamp'))
-                  ready = None
-                  for c in item.get('status', {}).get('conditions', []):
-                      if c.get('type') == 'Ready' and c.get('status') == 'True':
-                          ready = _iso_full(c.get('lastTransitionTime'))
-                          break
-                  if start and ready:
-                      durs.append((ready - start).total_seconds())
-              return sum(durs)/len(durs) if durs else None
-
-          bl_actuation = actuation_mean(bl_res)
-          fw_ws_actuation = actuation_mean(fw_ws_res)
-          fw_hs_actuation = actuation_mean(fw_hs_res)
-
-          # T_scale_up: autoscaler scale-UP latency, event-anchored. t0 = each
-          # HPA SuccessfulRescale scale-up event (where "New size" increases);
-          # t1 = that replica's Ready. Only scale-UPs count, so it's robust to
-          # the end-of-run scale-down that overwrites HPA.lastScaleTime. Reads
-          # events.json (absolute timestamps) + resources.yaml (pod Ready) --
-          # all passes drive a KEDA-managed HPA that emits SuccessfulRescale.
-          # Returns None if no scale-up event is found
-          # or the scaled-up pods were already deleted by capture time.
-          def t_scale_up_mean(events_path, resources_path):
-              if not HAVE_YAML or not events_path or not os.path.isfile(events_path):
-                  return None
-              try:
-                  with open(events_path) as f:
-                      ev = json.load(f)
-              except (ValueError, OSError):
-                  return None
-              size_rx = re.compile(r'New size:\s*(\d+)')
-              def _etime(e):
-                  return e.get('lastTimestamp') or e.get('eventTime') or e.get('firstTimestamp') or ''
-              ups, prev = [], None
-              evitems = ev.get('items', []) if isinstance(ev, dict) else []
-              for e in sorted(evitems, key=_etime):
-                  if e.get('reason') != 'SuccessfulRescale':
-                      continue
-                  if (e.get('involvedObject', {}) or {}).get('kind') != 'HorizontalPodAutoscaler':
-                      continue
-                  m = size_rx.search(e.get('message', '') or '')
-                  if not m:
-                      continue
-                  n = int(m.group(1))
-                  t = _iso_full(_etime(e))
-                  if t and (prev is None or n > prev):
-                      ups.append(t)
-                  prev = n
-              if not ups:
-                  return None
-              readies = []
-              if resources_path and os.path.isfile(resources_path):
-                  try:
-                      with open(resources_path) as f:
-                          doc = yaml.safe_load(f)
-                  except (yaml.YAMLError, OSError):
-                      doc = None
-                  ritems = doc.get('items', []) if isinstance(doc, dict) and doc.get('kind') == 'List' else []
-                  for item in ritems:
-                      if item.get('kind') != 'Pod':
-                          continue
-                      name = item.get('metadata', {}).get('name', '')
-                      if 'fma-requester' not in name and '-decode-' not in name:
-                          continue
-                      for c in item.get('status', {}).get('conditions', []):
-                          if c.get('type') == 'Ready' and c.get('status') == 'True':
-                              r = _iso_full(c.get('lastTransitionTime'))
-                              if r:
-                                  readies.append(r)
-              readies.sort()
-              used = [False] * len(readies)
-              durs = []
-              for t0 in ups:
-                  for i, r in enumerate(readies):
-                      if not used[i] and r >= t0:
-                          durs.append((r - t0).total_seconds())
-                          used[i] = True
-                          break
-              return sum(durs) / len(durs) if durs else None
-
-          bl_t_scale_up = t_scale_up_mean(bl_events, bl_res)
-          fw_ws_t_scale_up = t_scale_up_mean(fw_ws_events, fw_ws_res)
-          fw_hs_t_scale_up = t_scale_up_mean(fw_hs_events, fw_hs_res)
-
-          # ----- Render the table --------------------------------------------
-          print("| Metric | Baseline (EPP+KEDA, no FMA) | EPP+KEDA with FMA Warm Start | EPP+KEDA with FMA Hot Start |")
-          print("|---|---:|---:|---:|")
-
-          rows = [
-              ("Duration (s)",    "benchmark_time_seconds", None, 0, ""),
-              ("Total requests",  "load_summary", "count",  None, 0, ""),
-              ("Successes",       "successes", "count",     None, 0, ""),
-              ("Failures",        "failures", "count",      None, 0, ""),
-              ("Avg prompt len (tokens)",  "successes", "prompt_len", "mean", None, 1, ""),
-              ("Avg output len (tokens)",  "successes", "output_len", "mean", None, 1, ""),
-              ("Throughput (req/s)",       "successes", "throughput", "requests_per_sec",     None, 1, ""),
-              ("Throughput input (tok/s)", "successes", "throughput", "input_tokens_per_sec", None, 0, ""),
-              ("Throughput output (tok/s)","successes", "throughput", "output_tokens_per_sec",None, 0, ""),
-              ("Latency mean (ms)",  "successes", "latency", "request_latency", "mean",       1000, ""),
-              ("Latency p99 (ms)",   "successes", "latency", "request_latency", "p99",        1000, ""),
-              ("TTFT mean (ms)",     "successes", "latency", "time_to_first_token", "mean",   1000, ""),
-              ("TTFT p99 (ms)",      "successes", "latency", "time_to_first_token", "p99",    1000, ""),
-              ("TPOT mean (ms)",     "successes", "latency", "time_per_output_token", "mean", 1000, ""),
-              ("TPOT p99 (ms)",      "successes", "latency", "time_per_output_token", "p99",  1000, ""),
-              ("ITL mean (ms)",      "successes", "latency", "inter_token_latency", "mean",   1000, ""),
-              ("ITL p99 (ms)",       "successes", "latency", "inter_token_latency", "p99",    1000, ""),
-          ]
-          for row in rows:
-              label = row[0]
-              keys = [k for k in row[1:-2] if k is not None]
-              scale = row[-2] or 1.0
-              unit = row[-1]
-              prec = 0 if any(s in label for s in ("Total", "Successes", "Failures", "Duration", "tok/s")) else 1
-              bl_v = get(bl, *keys, scale=scale)
-              fw_ws_v = get(fw_ws, *keys, scale=scale)
-              fw_hs_v = get(fw_hs, *keys, scale=scale)
-              print(f"| {label} | {fmt(bl_v, unit, prec)} | {fmt(fw_ws_v, unit, prec)} | {fmt(fw_hs_v, unit, prec)} |")
-
-          print(f"| T_scale_up mean (s) — HPA scale→ready | {fmt(bl_t_scale_up, '', 1)} | {fmt(fw_ws_t_scale_up, '', 1)} | {fmt(fw_hs_t_scale_up, '', 1)} |")
-          print(f"| T_actuation mean (s) — container start→ready | {fmt(bl_actuation, '', 1)} | {fmt(fw_ws_actuation, '', 1)} | {fmt(fw_hs_actuation, '', 1)} |")
-
-          if bl is None:
-              print("\n_No baseline results found._")
-          if fw_ws is None:
-              print("\n_No EPP+KEDA with FMA warm-start results found._")
-          if fw_hs is None:
-              print("\n_No EPP+KEDA with FMA hot-start results found._")
-          if not HAVE_YAML:
-              print("\n_Note: PyYAML unavailable; scale-event timing rows skipped._")
-          PY
+          python3 "$GITHUB_WORKSPACE/llmdbenchmark/analysis/scripts/fma_comparison_table.py" \
+            --baseline-dir "$BASELINE_DIR" \
+            --warmstart-dir "$FMA_KEDA_WARMSTART_DIR" \
+            --hotstart-dir "$FMA_KEDA_HOTSTART_DIR" \
+            --col-baseline "Baseline (EPP+KEDA, no FMA)" \
+            --col-warmstart "EPP+KEDA with FMA Warm Start" \
+            --col-hotstart "EPP+KEDA with FMA Hot Start" \
+            --model "${{ inputs.model || 'Qwen/Qwen3-32B' }}" \
+            --harness "${{ inputs.harness || 'inference-perf' }}" \
+            --workload "${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}" \
+            --gpu-hourly-cost 1.0 \
+            >> "$GITHUB_STEP_SUMMARY"
         shell: bash
 
       # =====================================================================

--- a/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
@@ -106,6 +106,11 @@ on:
         required: false
         default: 'inference-perf'
         type: 'string'
+      model:
+        description: 'Served model. Keep in sync with the scenario model.'
+        required: false
+        default: 'Qwen/Qwen3-32B'
+        type: 'string'
       workload:
         description: 'Workload profile (under workload/profiles/<harness>/)'
         required: false
@@ -252,6 +257,9 @@ jobs:
       FMA_WVA_WARMSTART_SCENARIO: ${{ inputs.standup_scenario || 'ocp-wva-fma-warmstart' }}
       FMA_WVA_HOTSTART_SCENARIO: ${{ inputs.hotstart_scenario || 'ocp-wva-fma-hotstart' }}
     steps:
+      - name: Checkout llm-d-benchmark (for the results-table script)
+        uses: actions/checkout@v7.0.0
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -292,249 +300,18 @@ jobs:
           [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_WVA_WARMSTART_DIR/" || true
           [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_WVA_HOTSTART_DIR/" || true
 
-          # PyYAML for cluster-state parsing in the timing-row computation
-          # below; ubuntu-latest doesn't have it pre-installed in the user
-          # site, but the system one does (apt-installed python3-yaml).
-          pip install --quiet pyyaml 2>/dev/null || true
-
-          # Locate, per pass:
-          #   - summary_lifecycle_metrics.json   (harness output, has latency)
-          #   - <exp_id>/wva-controller.log      (step_09a, has scale-up timestamp)
-          #   - <exp_id>/resources.yaml          (step_09a, has Pod Ready timestamps)
-          find_in_results() {
-            # $1 = pass dir, $2 = filename
-            find "$1" -path "*/results/*" -name "$2" 2>/dev/null | sort | tail -1
-          }
-          BL_SUM=$(find_in_results "$BASELINE_DIR"            "summary_lifecycle_metrics.json")
-          FW_WARMSTART_SUM=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "summary_lifecycle_metrics.json")
-          FW_HOTSTART_SUM=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "summary_lifecycle_metrics.json")
-          BL_WVA=$(find_in_results "$BASELINE_DIR"            "wva-controller.log")
-          FW_WARMSTART_WVA=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "wva-controller.log")
-          FW_HOTSTART_WVA=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "wva-controller.log")
-          BL_RES=$(find_in_results "$BASELINE_DIR"            "resources.yaml")
-          FW_WARMSTART_RES=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "resources.yaml")
-          FW_HOTSTART_RES=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "resources.yaml")
-          BL_EVENTS=$(find_in_results "$BASELINE_DIR"            "events.json")
-          FW_WARMSTART_EVENTS=$(find_in_results "$FMA_WVA_WARMSTART_DIR" "events.json")
-          FW_HOTSTART_EVENTS=$(find_in_results "$FMA_WVA_HOTSTART_DIR"   "events.json")
-
-          python3 - "$BL_SUM" "$FW_WARMSTART_SUM" "$FW_HOTSTART_SUM" "$BL_WVA" "$FW_WARMSTART_WVA" "$FW_HOTSTART_WVA" "$BL_RES" "$FW_WARMSTART_RES" "$FW_HOTSTART_RES" "$BL_EVENTS" "$FW_WARMSTART_EVENTS" "$FW_HOTSTART_EVENTS" \
-            >> "$GITHUB_STEP_SUMMARY" <<'PY'
-          import json, sys, os, re, datetime
-          try:
-              import yaml
-              HAVE_YAML = True
-          except ImportError:
-              HAVE_YAML = False
-
-          (bl_sum, fw_ws_sum, fw_hs_sum,
-           bl_wva, fw_ws_wva, fw_hs_wva,
-           bl_res, fw_ws_res, fw_hs_res,
-           bl_events, fw_ws_events, fw_hs_events) = sys.argv[1:13]
-
-          def load_json(p):
-              if not p or not os.path.isfile(p):
-                  return None
-              try:
-                  with open(p) as f:
-                      return json.load(f)
-              except (json.JSONDecodeError, OSError):
-                  return None
-
-          bl = load_json(bl_sum)
-          fw_ws = load_json(fw_ws_sum)   # WVA with FMA — warm start
-          fw_hs = load_json(fw_hs_sum)   # WVA with FMA — hot start
-
-          def get(d, *keys, scale=1.0):
-              if d is None: return None
-              cur = d
-              for k in keys:
-                  if not isinstance(cur, dict) or k not in cur: return None
-                  cur = cur[k]
-              return cur * scale if isinstance(cur, (int, float)) else cur
-
-          def fmt(v, unit="", precision=1):
-              if v is None: return "_n/a_"
-              if isinstance(v, float): return f"{v:.{precision}f}{unit}"
-              return f"{v}{unit}"
-
-          # ----- Scale actuation timing (scaler-agnostic: pod lifecycle) -----
-          # FMA requester Deployment is scaled via a KEDAScaledObject -> HPA,
-          # so timing is measured from the captured resources.yaml (pod status)
-
-          # T_actuation: mean wall-clock from each serving container's START to
-          # its pod's Ready transition. Measuring from container start (not pod
-          # creation) excludes scheduling + image-pull + volume-mount overhead —
-          # matching FMA's httpstart, which times from container start.
-          def _iso_full(s):
-              """Parse an RFC3339 timestamp (with optional fractional seconds
-              and Z suffix) into a tz-aware datetime, or None on failure."""
-              if not s:
-                  return None
-              try:
-                  return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
-              except (ValueError, TypeError):
-                  return None
-
-          # Serving-container names whose start marks the beginning of model
-          # actuation: "vllm" for the WVA/decode baseline,
-          # "inference-server" for FMA launcher & requester pods.
-          SERVING_CONTAINERS = ("inference-server", "vllm")
-
-          def _container_started(item):
-              for cs in item.get('status', {}).get('containerStatuses', []):
-                  if cs.get('name') in SERVING_CONTAINERS:
-                      running = (cs.get('state') or {}).get('running') or {}
-                      return _iso_full(running.get('startedAt'))
-              return None
-
-          def actuation_mean(resources_path):
-              if not HAVE_YAML or not resources_path or not os.path.isfile(resources_path):
-                  return None
-              try:
-                  with open(resources_path) as f:
-                      doc = yaml.safe_load(f)
-              except (yaml.YAMLError, OSError):
-                  return None
-              if not isinstance(doc, dict):
-                  return None
-              items = doc.get('items', []) if doc.get('kind') == 'List' else []
-              durs = []
-              for item in items:
-                  if item.get('kind') != 'Pod': continue
-                  name = item.get('metadata', {}).get('name', '')
-                  if 'fma-requester' not in name and '-decode-' not in name:
-                      continue
-                  start = _container_started(item) or _iso_full(item['metadata'].get('creationTimestamp'))
-                  ready = None
-                  for c in item.get('status', {}).get('conditions', []):
-                      if c.get('type') == 'Ready' and c.get('status') == 'True':
-                          ready = _iso_full(c.get('lastTransitionTime'))
-                          break
-                  if start and ready:
-                      durs.append((ready - start).total_seconds())
-              return sum(durs)/len(durs) if durs else None
-
-          bl_actuation = actuation_mean(bl_res)
-          fw_ws_actuation = actuation_mean(fw_ws_res)
-          fw_hs_actuation = actuation_mean(fw_hs_res)
-
-          # T_scale_up: autoscaler scale-UP latency, event-anchored. t0 = each
-          # HPA SuccessfulRescale scale-up event (where "New size" increases);
-          # t1 = that replica's Ready. Only scale-UPs count, so it's robust to
-          # the end-of-run scale-down that overwrites HPA.lastScaleTime. Reads
-          # events.json (absolute timestamps) + resources.yaml (pod Ready) --
-          # identical for WVA & EPP-KEDA (both drive a KEDA-managed HPA that
-          # emits SuccessfulRescale). Returns None if no scale-up event is found
-          # or the scaled-up pods were already deleted by capture time.
-          def t_scale_up_mean(events_path, resources_path):
-              if not HAVE_YAML or not events_path or not os.path.isfile(events_path):
-                  return None
-              try:
-                  with open(events_path) as f:
-                      ev = json.load(f)
-              except (ValueError, OSError):
-                  return None
-              size_rx = re.compile(r'New size:\s*(\d+)')
-              def _etime(e):
-                  return e.get('lastTimestamp') or e.get('eventTime') or e.get('firstTimestamp') or ''
-              ups, prev = [], None
-              evitems = ev.get('items', []) if isinstance(ev, dict) else []
-              for e in sorted(evitems, key=_etime):
-                  if e.get('reason') != 'SuccessfulRescale':
-                      continue
-                  if (e.get('involvedObject', {}) or {}).get('kind') != 'HorizontalPodAutoscaler':
-                      continue
-                  m = size_rx.search(e.get('message', '') or '')
-                  if not m:
-                      continue
-                  n = int(m.group(1))
-                  t = _iso_full(_etime(e))
-                  if t and (prev is None or n > prev):
-                      ups.append(t)
-                  prev = n
-              if not ups:
-                  return None
-              readies = []
-              if resources_path and os.path.isfile(resources_path):
-                  try:
-                      with open(resources_path) as f:
-                          doc = yaml.safe_load(f)
-                  except (yaml.YAMLError, OSError):
-                      doc = None
-                  ritems = doc.get('items', []) if isinstance(doc, dict) and doc.get('kind') == 'List' else []
-                  for item in ritems:
-                      if item.get('kind') != 'Pod':
-                          continue
-                      name = item.get('metadata', {}).get('name', '')
-                      if 'fma-requester' not in name and '-decode-' not in name:
-                          continue
-                      for c in item.get('status', {}).get('conditions', []):
-                          if c.get('type') == 'Ready' and c.get('status') == 'True':
-                              r = _iso_full(c.get('lastTransitionTime'))
-                              if r:
-                                  readies.append(r)
-              readies.sort()
-              used = [False] * len(readies)
-              durs = []
-              for t0 in ups:
-                  for i, r in enumerate(readies):
-                      if not used[i] and r >= t0:
-                          durs.append((r - t0).total_seconds())
-                          used[i] = True
-                          break
-              return sum(durs) / len(durs) if durs else None
-
-          bl_t_scale_up = t_scale_up_mean(bl_events, bl_res)
-          fw_ws_t_scale_up = t_scale_up_mean(fw_ws_events, fw_ws_res)
-          fw_hs_t_scale_up = t_scale_up_mean(fw_hs_events, fw_hs_res)
-
-          # ----- Render the table --------------------------------------------
-          print("| Metric | Baseline (WVA without FMA) | WVA with FMA Warm Start | WVA with FMA Hot Start |")
-          print("|---|---:|---:|---:|")
-
-          rows = [
-              ("Duration (s)",    "benchmark_time_seconds", None, 0, ""),
-              ("Total requests",  "load_summary", "count",  None, 0, ""),
-              ("Successes",       "successes", "count",     None, 0, ""),
-              ("Failures",        "failures", "count",      None, 0, ""),
-              ("Avg prompt len (tokens)",  "successes", "prompt_len", "mean", None, 1, ""),
-              ("Avg output len (tokens)",  "successes", "output_len", "mean", None, 1, ""),
-              ("Throughput (req/s)",       "successes", "throughput", "requests_per_sec",     None, 1, ""),
-              ("Throughput input (tok/s)", "successes", "throughput", "input_tokens_per_sec", None, 0, ""),
-              ("Throughput output (tok/s)","successes", "throughput", "output_tokens_per_sec",None, 0, ""),
-              ("Latency mean (ms)",  "successes", "latency", "request_latency", "mean",       1000, ""),
-              ("Latency p99 (ms)",   "successes", "latency", "request_latency", "p99",        1000, ""),
-              ("TTFT mean (ms)",     "successes", "latency", "time_to_first_token", "mean",   1000, ""),
-              ("TTFT p99 (ms)",      "successes", "latency", "time_to_first_token", "p99",    1000, ""),
-              ("TPOT mean (ms)",     "successes", "latency", "time_per_output_token", "mean", 1000, ""),
-              ("TPOT p99 (ms)",      "successes", "latency", "time_per_output_token", "p99",  1000, ""),
-              ("ITL mean (ms)",      "successes", "latency", "inter_token_latency", "mean",   1000, ""),
-              ("ITL p99 (ms)",       "successes", "latency", "inter_token_latency", "p99",    1000, ""),
-          ]
-          for row in rows:
-              label = row[0]
-              keys = [k for k in row[1:-2] if k is not None]
-              scale = row[-2] or 1.0
-              unit = row[-1]
-              prec = 0 if any(s in label for s in ("Total", "Successes", "Failures", "Duration", "tok/s")) else 1
-              bl_v = get(bl, *keys, scale=scale)
-              fw_ws_v = get(fw_ws, *keys, scale=scale)
-              fw_hs_v = get(fw_hs, *keys, scale=scale)
-              print(f"| {label} | {fmt(bl_v, unit, prec)} | {fmt(fw_ws_v, unit, prec)} | {fmt(fw_hs_v, unit, prec)} |")
-
-          print(f"| T_scale_up mean (s) — HPA scale→ready | {fmt(bl_t_scale_up, '', 1)} | {fmt(fw_ws_t_scale_up, '', 1)} | {fmt(fw_hs_t_scale_up, '', 1)} |")
-          print(f"| T_actuation mean (s) — container start→ready | {fmt(bl_actuation, '', 1)} | {fmt(fw_ws_actuation, '', 1)} | {fmt(fw_hs_actuation, '', 1)} |")
-
-          if bl is None:
-              print("\n_No baseline results found._")
-          if fw_ws is None:
-              print("\n_No WVA+FMA warm-start results found._")
-          if fw_hs is None:
-              print("\n_No WVA+FMA hot-start results found._")
-          if not HAVE_YAML:
-              print("\n_Note: PyYAML unavailable; scale-event timing rows skipped._")
-          PY
+          python3 "$GITHUB_WORKSPACE/llmdbenchmark/analysis/scripts/fma_comparison_table.py" \
+            --baseline-dir "$BASELINE_DIR" \
+            --warmstart-dir "$FMA_WVA_WARMSTART_DIR" \
+            --hotstart-dir "$FMA_WVA_HOTSTART_DIR" \
+            --col-baseline "Baseline (WVA without FMA)" \
+            --col-warmstart "WVA with FMA Warm Start" \
+            --col-hotstart "WVA with FMA Hot Start" \
+            --model "${{ inputs.model || 'Qwen/Qwen3-32B' }}" \
+            --harness "${{ inputs.harness || 'inference-perf' }}" \
+            --workload "${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}" \
+            --gpu-hourly-cost 1.0 \
+            >> "$GITHUB_STEP_SUMMARY"
         shell: bash
 
       # =====================================================================

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -642,7 +642,9 @@ jobs:
             mkdir -p ~/work/llm-d-benchmark/
             cd ~/work/llm-d-benchmark/
             echo "### llm-d-benchmark code NOT found, will clone now"
-            git clone https://github.com/llm-d/llm-d-benchmark.git
+            # TEMP HACK (revert before merge): clone the dispatched repo/branch
+            # (e.g. fma_keda) so standup runs the branch's scenarios, not main.
+            git clone -b "${{ github.ref_name }}" "https://github.com/${{ github.repository }}.git"
           fi
           cd ~/work/llm-d-benchmark/llm-d-benchmark/
           if [[ ! -f install.sh ]]; then

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -642,9 +642,7 @@ jobs:
             mkdir -p ~/work/llm-d-benchmark/
             cd ~/work/llm-d-benchmark/
             echo "### llm-d-benchmark code NOT found, will clone now"
-            # TEMP HACK (revert before merge): clone the dispatched repo/branch
-            # (e.g. fma_keda) so standup runs the branch's scenarios, not main.
-            git clone -b "${{ github.ref_name }}" "https://github.com/${{ github.repository }}.git"
+            git clone https://github.com/llm-d/llm-d-benchmark.git
           fi
           cd ~/work/llm-d-benchmark/llm-d-benchmark/
           if [[ ! -f install.sh ]]; then

--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -114,13 +114,20 @@ scenario:
       # Benchmark then scales 1->N, measuring pure HPA/KEDA behavior (identical to
       # warm-start) without model load latency.
       requester:
-        replicas: 10  # ← Match maxReplicas; will be scaled down after warmup
+        replicas: 6  # ← Match maxReplicas; will be scaled down after warmup
+
+      # Standup (step 06) bound-launcher wait: how long to wait for the
+      # dual-pods-controller to bind a launcher and its vLLM to start serving
+      # (the inferenceServing/model labels appear only once serving). Hot-start
+      # loads all 6 launchers in parallel off shared storage, so give generous
+      # headroom above the 600s default to avoid a CI standup timeout.
+      boundLauncherTimeout: 1800
 
       # HOT-START CHANGE #2: Extended warmup for parallel model loading + scale-down
       # Warmup sequence:
-      #   1. Wait for Deployment to be Available (all 10 pods Ready)
+      #   1. Wait for Deployment to be Available (all 6 pods Ready)
       #   2. No additional buffer (models already loaded on all pods)
-      #   3. Scale requester Deployment down to 1 (vLLM sleeps on 9 pods)
+      #   3. Scale requester Deployment down to 1 (vLLM sleeps on 5 pods)
       #   4. Confirm sleeping vLLM instances are present
       warmupTimeout: 1200  # ← Increased: 10-20 min model load + scale-down verification
 
@@ -145,7 +152,7 @@ scenario:
 
       scaledObject:
         minReplicas: 1
-        maxReplicas: 10
+        maxReplicas: 6
         pollingInterval: 15
         kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
         queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
@@ -263,6 +270,12 @@ scenario:
     # =========================================================================
     # WORKLOAD / HARNESS
     # =========================================================================
+    # Enable metrics scraping (collect_metrics.sh in the harness):
+    # captures requester replica counts + EPP KV-cache/queue-depth gauges into
+    # results/metrics/..
+    monitoring:
+      metricsScrapeEnabled: true
+
     workDir: "/tmp/llmdbenchcicd-ocp-keda-fma-hotstart/"
 
     # Custom run-phase warmup step for hot-start scenario.
@@ -285,6 +298,8 @@ scenario:
       # run even begins, matching the hot-start job's wait_timeout: 7200.
       waitTimeout: 7200
 
+    # TEMP HACK (revert to nightly before merge): branch-built image so the
+    # in-pod collect_metrics.sh carries the requester replica-counting fix.
     images:
       benchmark:
-        tag: nightly
+        tag: fma_keda

--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -298,8 +298,6 @@ scenario:
       # run even begins, matching the hot-start job's wait_timeout: 7200.
       waitTimeout: 7200
 
-    # TEMP HACK (revert to nightly before merge): branch-built image so the
-    # in-pod collect_metrics.sh carries the requester replica-counting fix.
     images:
       benchmark:
-        tag: fma_keda
+        tag: nightly

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -139,6 +139,13 @@ scenario:
       requester:
         replicas: 1
 
+      # Standup (step 06) bound-launcher wait: how long to wait for the
+      # dual-pods-controller to bind a launcher and its vLLM to start serving
+      # (the inferenceServing/model labels appear only once serving). Raised
+      # above the 600s default because Qwen3-32B off shared storage can exceed
+      # 10 min to load and serve, tripping a CI standup timeout.
+      boundLauncherTimeout: 1800
+
       # Warmup: a deliberate wait inserted in the run phase before the
       # benchmark fires.
       warmupTimeout: 1200               # Qwen3-32B fresh vLLM load (warm start)
@@ -169,7 +176,7 @@ scenario:
 
       scaledObject:
         minReplicas: 1
-        maxReplicas: 10
+        maxReplicas: 6
         pollingInterval: 15
         kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
         queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
@@ -313,6 +320,12 @@ scenario:
     # =========================================================================
     # WORKLOAD / HARNESS
     # =========================================================================
+    # Enable metrics scraping (collect_metrics.sh in the harness):
+    # captures requester replica counts + EPP KV-cache/queue-depth gauges into
+    # results/metrics/..
+    monitoring:
+      metricsScrapeEnabled: true
+
     workDir: "/tmp/llmdbenchcicd-ocp-keda-fma-warmstart/"
 
     harness:
@@ -327,6 +340,8 @@ scenario:
       # back to this field (see cli.py harness_wait_timeout resolution).
       waitTimeout: 5400
 
+    # TEMP HACK (revert to nightly before merge): branch-built image so the
+    # in-pod collect_metrics.sh carries the requester replica-counting fix.
     images:
       benchmark:
-        tag: nightly
+        tag: fma_keda

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -340,8 +340,6 @@ scenario:
       # back to this field (see cli.py harness_wait_timeout resolution).
       waitTimeout: 5400
 
-    # TEMP HACK (revert to nightly before merge): branch-built image so the
-    # in-pod collect_metrics.sh carries the requester replica-counting fix.
     images:
       benchmark:
-        tag: fma_keda
+        tag: nightly

--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -255,10 +255,3 @@ scenario:
       # Heavy variant -- matched RPS across the baseline and FMA passes.
       experimentProfile: shared_prefix_synthetic_heavy.yaml
       waitTimeout: 5400
-
-    # TEMP HACK (revert to nightly before merge): pin the harness image to the
-    # branch-built tag so the in-pod collect_metrics.sh carries the requester
-    # replica-counting fix (the published :nightly image predates it).
-    images:
-      benchmark:
-        tag: fma_keda

--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -64,7 +64,7 @@ scenario:
 
       scaledObject:
         minReplicas: 1
-        maxReplicas: 10
+        maxReplicas: 6
         pollingInterval: 15
         kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
         queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
@@ -242,6 +242,12 @@ scenario:
     # =========================================================================
     # WORKLOAD / HARNESS
     # =========================================================================
+    # Enable metrics scraping (collect_metrics.sh in the harness):
+    # captures requester replica counts + EPP KV-cache/queue-depth gauges into
+    # results/metrics/..
+    monitoring:
+      metricsScrapeEnabled: true
+
     workDir: "/tmp/llmdbenchcicd-ocp-keda/"
 
     harness:
@@ -249,3 +255,10 @@ scenario:
       # Heavy variant -- matched RPS across the baseline and FMA passes.
       experimentProfile: shared_prefix_synthetic_heavy.yaml
       waitTimeout: 5400
+
+    # TEMP HACK (revert to nightly before merge): pin the harness image to the
+    # branch-built tag so the in-pod collect_metrics.sh carries the requester
+    # replica-counting fix (the published :nightly image predates it).
+    images:
+      benchmark:
+        tag: fma_keda

--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -302,6 +302,12 @@ scenario:
     # =========================================================================
     # WORKLOAD / HARNESS
     # =========================================================================
+    # Enable metrics scraping (collect_metrics.sh in the harness):
+    # captures requester replica counts + EPP KV-cache/queue-depth gauges into
+    # results/metrics/..
+    monitoring:
+      metricsScrapeEnabled: true
+
     workDir: "/tmp/llmdbenchcicd-ocp-wva-fma-hotstart/"
 
     # Custom run-phase warmup step for hot-start scenario.

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -438,6 +438,12 @@ scenario:
     # =========================================================================
     # WORKLOAD / HARNESS
     # =========================================================================
+    # Enable metrics scraping (collect_metrics.sh in the harness):
+    # captures requester replica counts + EPP KV-cache/queue-depth gauges into
+    # results/metrics/..
+    monitoring:
+      metricsScrapeEnabled: true
+
     workDir: "/tmp/llmdbenchcicd-ocp-wva-fma-warmstart/"
 
     harness:

--- a/config/scenarios/cicd/ocp-wva.yaml
+++ b/config/scenarios/cicd/ocp-wva.yaml
@@ -392,6 +392,12 @@ scenario:
     # =========================================================================
     # WORKLOAD / HARNESS
     # =========================================================================
+    # Enable metrics scraping (collect_metrics.sh in the harness):
+    # captures requester replica counts + EPP KV-cache/queue-depth gauges into
+    # results/metrics/..
+    monitoring:
+      metricsScrapeEnabled: true
+
     workDir: "/tmp/llmdbenchcicd-ocp-wva/"
 
     harness:

--- a/llmdbenchmark/analysis/scripts/fma_comparison_table.py
+++ b/llmdbenchmark/analysis/scripts/fma_comparison_table.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Render the FMA autoscaling comparison table (baseline vs FMA warm/hot start).
+
+Shared by the EPP+KEDA (``ci-benchmark-ocp-fma-keda``) and WVA
+(``ci-benchmark-ocp-fma-wva``) nightly workflows
+
+Per-pass artifacts consumed:
+  * ``summary_lifecycle_metrics.json``              -- harness latency/throughput
+  * ``metrics/processed/replica_status.json``       -- aggregate_ready_replicas
+                                                       (avg/max replicas)
+  * ``metrics/processed/metrics_summary.json``      -- _aggregated.metrics EPP
+                                                       KV-cache / queue-depth means
+  * ``metrics/processed/pod_startup_times.json``    -- per-pod creation->Ready
+                                                       (Avg pod startup: baseline
+                                                       decode / FMA runtime requester)
+  (the metrics/* files are present only when monitoring.metricsScrapeEnabled).
+"""
+
+import argparse
+import glob
+import json
+import os
+
+
+# ---------------------------------------------------------------------------
+# Artifact location + loading
+# ---------------------------------------------------------------------------
+def newest_run_dir(root):
+    """Return the newest run root directory."""
+    roots = sorted(
+        os.path.dirname(d)
+        for d in glob.glob(os.path.join(root, "**", "results"), recursive=True)
+        if os.path.isdir(d)
+    )
+    return roots[-1] if roots else ""
+
+
+def _find_one(run_root, filename):
+    """Newest file named ``filename`` anywhere under ``run_root``, or ""."""
+    if not run_root:
+        return ""
+    matches = sorted(
+        glob.glob(os.path.join(run_root, "**", filename), recursive=True)
+    )
+    return matches[-1] if matches else ""
+
+
+def load_json(p):
+    if not p or not os.path.isfile(p):
+        return None
+    try:
+        with open(p, encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def get(d, *keys, scale=1.0):
+    if d is None:
+        return None
+    cur = d
+    for k in keys:
+        if not isinstance(cur, dict) or k not in cur:
+            return None
+        cur = cur[k]
+    return cur * scale if isinstance(cur, (int, float)) else cur
+
+
+def fmt(v, unit="", precision=1):
+    if v is None:
+        return "_n/a_"
+    if isinstance(v, float):
+        return f"{v:.{precision}f}{unit}"
+    return f"{v}{unit}"
+
+# ---------------------------------------------------------------------------
+
+KV_CACHE_METRIC = "inference_pool_average_kv_cache_utilization"
+QUEUE_SIZE_METRIC = "inference_pool_average_queue_size"
+
+
+def replica_stats(rdir):
+    """(avg, max) ready replicas, read from process_metrics' pre-aggregated
+    ``replica_status.json`` (``aggregate_ready_replicas``)."""
+    data = load_json(_find_one(rdir, "replica_status.json"))
+    agg = (data or {}).get("aggregate_ready_replicas") or {}
+    return (agg.get("mean"), agg.get("max"))
+
+def epp_gauge_mean(rdir, metric):
+    """Mean of an EPP pool gauge, read from process_metrics' pre-aggregated
+    ``metrics_summary.json`` (``_aggregated.metrics.<metric>.mean``)."""
+    data = load_json(_find_one(rdir, "metrics_summary.json"))
+    metrics = (((data or {}).get("_aggregated") or {}).get("metrics")) or {}
+    return (metrics.get(metric) or {}).get("mean")
+
+def pod_startup_mean(rdir):
+    """Avg pod startup = pod creation → Ready, read from process_metrics'
+    pre-aggregated ``pod_startup_times.json``"""
+    data = load_json(_find_one(rdir, "pod_startup_times.json")) or {}
+    agg = data.get("requester_runtime_aggregate") or data.get("aggregate") or {}
+    return agg.get("mean")
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+ROWS = [
+    ("Duration (s)", "benchmark_time_seconds", None, 0, ""),
+    ("Total requests", "load_summary", "count", None, 0, ""),
+    ("Successes", "successes", "count", None, 0, ""),
+    ("Failures", "failures", "count", None, 0, ""),
+    ("Avg prompt len (tokens)", "successes", "prompt_len", "mean", None, 1, ""),
+    ("Avg output len (tokens)", "successes", "output_len", "mean", None, 1, ""),
+    ("Throughput (req/s)", "successes", "throughput", "requests_per_sec", None, 1, ""),
+    ("Throughput input (tok/s)", "successes", "throughput", "input_tokens_per_sec", None, 0, ""),
+    ("Throughput output (tok/s)", "successes", "throughput", "output_tokens_per_sec", None, 0, ""),
+    ("Latency mean (ms)", "successes", "latency", "request_latency", "mean", 1000, ""),
+    ("Latency p50 (ms)", "successes", "latency", "request_latency", "median", 1000, ""),
+    ("Latency p90 (ms)", "successes", "latency", "request_latency", "p90", 1000, ""),
+    ("Latency p95 (ms)", "successes", "latency", "request_latency", "p95", 1000, ""),
+    ("Latency p99 (ms)", "successes", "latency", "request_latency", "p99", 1000, ""),
+    ("TTFT mean (ms)", "successes", "latency", "time_to_first_token", "mean", 1000, ""),
+    ("TTFT p50 (ms)", "successes", "latency", "time_to_first_token", "median", 1000, ""),
+    ("TTFT p90 (ms)", "successes", "latency", "time_to_first_token", "p90", 1000, ""),
+    ("TTFT p95 (ms)", "successes", "latency", "time_to_first_token", "p95", 1000, ""),
+    ("TTFT p99 (ms)", "successes", "latency", "time_to_first_token", "p99", 1000, ""),
+    ("TPOT mean (ms)", "successes", "latency", "time_per_output_token", "mean", 1000, ""),
+    ("TPOT p50 (ms)", "successes", "latency", "time_per_output_token", "median", 1000, ""),
+    ("TPOT p90 (ms)", "successes", "latency", "time_per_output_token", "p90", 1000, ""),
+    ("TPOT p95 (ms)", "successes", "latency", "time_per_output_token", "p95", 1000, ""),
+    ("TPOT p99 (ms)", "successes", "latency", "time_per_output_token", "p99", 1000, ""),
+    ("ITL mean (ms)", "successes", "latency", "inter_token_latency", "mean", 1000, ""),
+    ("ITL p50 (ms)", "successes", "latency", "inter_token_latency", "median", 1000, ""),
+    ("ITL p90 (ms)", "successes", "latency", "inter_token_latency", "p90", 1000, ""),
+    ("ITL p95 (ms)", "successes", "latency", "inter_token_latency", "p95", 1000, ""),
+    ("ITL p99 (ms)", "successes", "latency", "inter_token_latency", "p99", 1000, ""),
+]
+
+
+def render_run_info(args, summaries):
+    """Emit a Run Info block above the table."""
+    duration = next(
+        (get(s, "benchmark_time_seconds") for s in summaries if s), None
+    )
+    total = next((get(s, "load_summary", "count") for s in summaries if s), None)
+    lines = ["### Run Info", ""]
+    if args.model:
+        lines.append(f"- **Model:** {args.model}")
+    if args.harness:
+        lines.append(f"- **Harness:** {args.harness}")
+    if args.workload:
+        lines.append(f"- **Workload:** {args.workload}")
+    if duration is not None:
+        lines.append(f"- **Duration:** {fmt(duration, 's', 0)}")
+    if total is not None:
+        lines.append(f"- **Total requests:** {fmt(total, '', 0)}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--baseline-dir", required=True)
+    ap.add_argument("--warmstart-dir", required=True)
+    ap.add_argument("--hotstart-dir", required=True)
+    ap.add_argument("--col-baseline", required=True, help="Baseline column header")
+    ap.add_argument("--col-warmstart", required=True, help="Warm-start column header")
+    ap.add_argument("--col-hotstart", required=True, help="Hot-start column header")
+    ap.add_argument("--model", default="", help="Run Info: served model")
+    ap.add_argument("--harness", default="", help="Run Info: harness name")
+    ap.add_argument("--workload", default="", help="Run Info: workload profile")
+    ap.add_argument(
+        "--gpu-hourly-cost",
+        type=float,
+        default=1.0,
+        help="Cost row multiplier: cost = avg replicas × this (default 1.0, so "
+        "Cost == avg replicas, matching the WVA benchmark doc).",
+    )
+    args = ap.parse_args()
+
+    dirs = (args.baseline_dir, args.warmstart_dir, args.hotstart_dir)
+    rdirs = [newest_run_dir(d) for d in dirs]
+    sums = [_find_one(r, "summary_lifecycle_metrics.json") for r in rdirs]
+
+    bl, fw_ws, fw_hs = (load_json(p) for p in sums)
+    summaries = [bl, fw_ws, fw_hs]
+
+    out = [render_run_info(args, summaries)]
+
+    out.append(
+        f"| Metric | {args.col_baseline} | {args.col_warmstart} | {args.col_hotstart} |"
+    )
+    out.append("|---|---:|---:|---:|")
+    for row in ROWS:
+        label = row[0]
+        keys = [k for k in row[1:-2] if k is not None]
+        scale = row[-2] or 1.0
+        unit = row[-1]
+        prec = (
+            0
+            if any(
+                s in label
+                for s in ("Total", "Successes", "Failures", "Duration", "tok/s")
+            )
+            else 1
+        )
+        vals = [get(s, *keys, scale=scale) for s in summaries]
+        out.append(
+            f"| {label} | "
+            + " | ".join(fmt(v, unit, prec) for v in vals)
+            + " |"
+        )
+
+    repl = [replica_stats(r) for r in rdirs]
+    avg_repl = [r[0] for r in repl]
+    max_repl = [r[1] for r in repl]
+    startup = [pod_startup_mean(r) for r in rdirs]
+    kv = [epp_gauge_mean(r, KV_CACHE_METRIC) for r in rdirs]
+    qd = [epp_gauge_mean(r, QUEUE_SIZE_METRIC) for r in rdirs]
+    kv_pct = [(v * 100 if v is not None and v <= 1.0 else v) for v in kv]
+    cost = [(a * args.gpu_hourly_cost if a is not None else None) for a in avg_repl]
+
+    out.append("| Avg replicas | " + " | ".join(fmt(v, "", 2) for v in avg_repl) + " |")
+    out.append("| Max replicas | " + " | ".join(fmt(v, "", 0) for v in max_repl) + " |")
+    out.append(
+        "| Avg KV cache utilization | "
+        + " | ".join(fmt(v, "%", 1) for v in kv_pct)
+        + " |"
+    )
+    out.append(
+        "| Avg queue depth (EPP) | " + " | ".join(fmt(v, "", 1) for v in qd) + " |"
+    )
+    out.append(
+        "| Avg pod startup (s) | " + " | ".join(fmt(v, "", 0) for v in startup) + " |"
+    )
+    out.append(
+        "| Cost (avg replicas × GPU/hr) | "
+        + " | ".join(fmt(v, "", 2) for v in cost)
+        + " |"
+    )
+
+    if bl is None:
+        out.append("\n_No baseline results found._")
+    if fw_ws is None:
+        out.append("\n_No warm-start results found._")
+    if fw_hs is None:
+        out.append("\n_No hot-start results found._")
+
+    print("\n".join(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/llmdbenchmark/analysis/scripts/fma_comparison_table.py
+++ b/llmdbenchmark/analysis/scripts/fma_comparison_table.py
@@ -26,22 +26,20 @@ import os
 # Artifact location + loading
 # ---------------------------------------------------------------------------
 def newest_run_dir(root):
-    """Return the newest run root directory."""
-    roots = sorted(
-        os.path.dirname(d)
-        for d in glob.glob(os.path.join(root, "**", "results"), recursive=True)
-        if os.path.isdir(d)
-    )
-    return roots[-1] if roots else ""
+    """Return the newest run directory under ``root`` (or "").
+
+    Runs are ``runner-<UTC YYYYMMDD-HHMMSS>-<id>`` dirs holding a ``results/``,
+    so the newest is simply the latest-sorting ``runner-*`` match. (Lexical, not
+    mtime: these are GCS-downloaded, so mtimes are the download time.)"""
+    runs = glob.glob(os.path.join(root, "**", "runner-*", "results"), recursive=True)
+    return os.path.dirname(sorted(runs)[-1]) if runs else ""
 
 
 def _find_one(run_root, filename):
     """Newest file named ``filename`` anywhere under ``run_root``, or ""."""
     if not run_root:
         return ""
-    matches = sorted(
-        glob.glob(os.path.join(run_root, "**", filename), recursive=True)
-    )
+    matches = sorted(glob.glob(os.path.join(run_root, "**", filename), recursive=True))
     return matches[-1] if matches else ""
 
 
@@ -73,6 +71,7 @@ def fmt(v, unit="", precision=1):
         return f"{v:.{precision}f}{unit}"
     return f"{v}{unit}"
 
+
 # ---------------------------------------------------------------------------
 
 KV_CACHE_METRIC = "inference_pool_average_kv_cache_utilization"
@@ -86,12 +85,14 @@ def replica_stats(rdir):
     agg = (data or {}).get("aggregate_ready_replicas") or {}
     return (agg.get("mean"), agg.get("max"))
 
+
 def epp_gauge_mean(rdir, metric):
     """Mean of an EPP pool gauge, read from process_metrics' pre-aggregated
     ``metrics_summary.json`` (``_aggregated.metrics.<metric>.mean``)."""
     data = load_json(_find_one(rdir, "metrics_summary.json"))
     metrics = (((data or {}).get("_aggregated") or {}).get("metrics")) or {}
     return (metrics.get(metric) or {}).get("mean")
+
 
 def pod_startup_mean(rdir):
     """Avg pod startup = pod creation → Ready, read from process_metrics'
@@ -112,37 +113,81 @@ ROWS = [
     ("Avg prompt len (tokens)", "successes", "prompt_len", "mean", None, 1, ""),
     ("Avg output len (tokens)", "successes", "output_len", "mean", None, 1, ""),
     ("Throughput (req/s)", "successes", "throughput", "requests_per_sec", None, 1, ""),
-    ("Throughput input (tok/s)", "successes", "throughput", "input_tokens_per_sec", None, 0, ""),
-    ("Throughput output (tok/s)", "successes", "throughput", "output_tokens_per_sec", None, 0, ""),
+    (
+        "Throughput input (tok/s)",
+        "successes",
+        "throughput",
+        "input_tokens_per_sec",
+        None,
+        0,
+        "",
+    ),
+    (
+        "Throughput output (tok/s)",
+        "successes",
+        "throughput",
+        "output_tokens_per_sec",
+        None,
+        0,
+        "",
+    ),
     ("Latency mean (ms)", "successes", "latency", "request_latency", "mean", 1000, ""),
-    ("Latency p50 (ms)", "successes", "latency", "request_latency", "median", 1000, ""),
-    ("Latency p90 (ms)", "successes", "latency", "request_latency", "p90", 1000, ""),
-    ("Latency p95 (ms)", "successes", "latency", "request_latency", "p95", 1000, ""),
     ("Latency p99 (ms)", "successes", "latency", "request_latency", "p99", 1000, ""),
     ("TTFT mean (ms)", "successes", "latency", "time_to_first_token", "mean", 1000, ""),
-    ("TTFT p50 (ms)", "successes", "latency", "time_to_first_token", "median", 1000, ""),
-    ("TTFT p90 (ms)", "successes", "latency", "time_to_first_token", "p90", 1000, ""),
-    ("TTFT p95 (ms)", "successes", "latency", "time_to_first_token", "p95", 1000, ""),
     ("TTFT p99 (ms)", "successes", "latency", "time_to_first_token", "p99", 1000, ""),
-    ("TPOT mean (ms)", "successes", "latency", "time_per_output_token", "mean", 1000, ""),
-    ("TPOT p50 (ms)", "successes", "latency", "time_per_output_token", "median", 1000, ""),
-    ("TPOT p90 (ms)", "successes", "latency", "time_per_output_token", "p90", 1000, ""),
-    ("TPOT p95 (ms)", "successes", "latency", "time_per_output_token", "p95", 1000, ""),
+    (
+        "TPOT mean (ms)",
+        "successes",
+        "latency",
+        "time_per_output_token",
+        "mean",
+        1000,
+        "",
+    ),
     ("TPOT p99 (ms)", "successes", "latency", "time_per_output_token", "p99", 1000, ""),
     ("ITL mean (ms)", "successes", "latency", "inter_token_latency", "mean", 1000, ""),
-    ("ITL p50 (ms)", "successes", "latency", "inter_token_latency", "median", 1000, ""),
-    ("ITL p90 (ms)", "successes", "latency", "inter_token_latency", "p90", 1000, ""),
-    ("ITL p95 (ms)", "successes", "latency", "inter_token_latency", "p95", 1000, ""),
     ("ITL p99 (ms)", "successes", "latency", "inter_token_latency", "p99", 1000, ""),
 ]
 
+# Rows that are additive across inference-perf workers (each worker's summary
+# reports only its own share), so they are multiplied by the worker count.
+_PER_WORKER_ROWS = {
+    "Total requests",
+    "Successes",
+    "Failures",
+    "Throughput (req/s)",
+    "Throughput input (tok/s)",
+    "Throughput output (tok/s)",
+}
 
-def render_run_info(args, summaries):
+
+def _num_workers(rdir, workload):
+    prof = _find_one(rdir, os.path.basename(workload)) if workload else ""
+    if prof:
+        try:
+            with open(prof, encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if s.startswith("num_workers:"):
+                        return int(s.split(":", 1)[1].strip())
+        except (OSError, ValueError):
+            pass
+    return 1
+
+
+def render_run_info(args, summaries, workers):
     """Emit a Run Info block above the table."""
-    duration = next(
-        (get(s, "benchmark_time_seconds") for s in summaries if s), None
+    duration = next((get(s, "benchmark_time_seconds") for s in summaries if s), None)
+    # Total requests summed across the inference-perf workers (per-worker count
+    # x worker count), matching the per-arm Total requests row.
+    total = next(
+        (
+            get(s, "load_summary", "count") * w
+            for s, w in zip(summaries, workers)
+            if s and get(s, "load_summary", "count") is not None
+        ),
+        None,
     )
-    total = next((get(s, "load_summary", "count") for s in summaries if s), None)
     lines = ["### Run Info", ""]
     if args.model:
         lines.append(f"- **Model:** {args.model}")
@@ -185,7 +230,8 @@ def main():
     bl, fw_ws, fw_hs = (load_json(p) for p in sums)
     summaries = [bl, fw_ws, fw_hs]
 
-    out = [render_run_info(args, summaries)]
+    workers = [_num_workers(r, args.workload) for r in rdirs]
+    out = [render_run_info(args, summaries, workers)]
 
     out.append(
         f"| Metric | {args.col_baseline} | {args.col_warmstart} | {args.col_hotstart} |"
@@ -205,10 +251,10 @@ def main():
             else 1
         )
         vals = [get(s, *keys, scale=scale) for s in summaries]
+        if label in _PER_WORKER_ROWS:
+            vals = [v * w if v is not None else None for v, w in zip(vals, workers)]
         out.append(
-            f"| {label} | "
-            + " | ".join(fmt(v, unit, prec) for v in vals)
-            + " |"
+            f"| {label} | " + " | ".join(fmt(v, unit, prec) for v in vals) + " |"
         )
 
     repl = [replica_stats(r) for r in rdirs]

--- a/workload/harnesses/collect_metrics.sh
+++ b/workload/harnesses/collect_metrics.sh
@@ -147,7 +147,12 @@ for item in data.get("items", []):
     tmpl_labels = (
         spec.get("template", {}).get("metadata", {}).get("labels", {})
     )
-    if tmpl_labels.get("llm-d.ai/inferenceServing") != "true":
+    # Its a serving replica source if either:
+    #   * its pod template is labelled inferenceServing=true OR
+    #   * it is the FMA requester Deployment (llm-d.ai/role=requester).
+    is_serving = tmpl_labels.get("llm-d.ai/inferenceServing") == "true"
+    is_fma_requester = tmpl_labels.get("llm-d.ai/role") == "requester"
+    if not (is_serving or is_fma_requester):
         continue
 
     # Filter by model if LLMDBENCH_HARNESS_STACK_NAME is set
@@ -208,7 +213,7 @@ collect_pod_startup_times() {
 
     mkdir -p "$METRICS_DIR/processed" "$METRICS_DIR/raw"
 
-    # Try modelservice labels first, fall back to standalone
+    # Serving pods (modelservice decode / FMA launcher) carry inferenceServing=true.
     local pods_json
     pods_json=$($kubectl_cmd --namespace "$namespace" get pods \
         -l llm-d.ai/inferenceServing=true \
@@ -223,6 +228,31 @@ collect_pod_startup_times() {
             --field-selector=status.phase=Running \
             -o json 2>>"$debug_log") || pods_json='{"items":[]}'
     fi
+
+    # Also capture FMA requester pods (role=requester). Their creation->Ready is
+    # the FMA "Avg pod startup": the requester's readiness gates on the bound
+    # vLLM actually serving, unlike the launcher pool.
+    local requester_json
+    requester_json=$($kubectl_cmd --namespace "$namespace" get pods \
+        -l llm-d.ai/role=requester \
+        --field-selector=status.phase=Running \
+        -o json 2>>"$debug_log") || requester_json='{"items":[]}'
+
+    pods_json=$(_MC_SERVING="$pods_json" _MC_REQUESTER="$requester_json" python3 -c '
+import json, os
+items, seen = [], set()
+for env in ("_MC_SERVING", "_MC_REQUESTER"):
+    try:
+        d = json.loads(os.environ.get(env) or "{}")
+    except json.JSONDecodeError:
+        d = {}
+    for it in d.get("items", []):
+        n = it.get("metadata", {}).get("name", "")
+        if n and n not in seen:
+            seen.add(n)
+            items.append(it)
+print(json.dumps({"items": items}))
+' 2>>"$debug_log") || pods_json='{"items":[]}'
 
     echo "$pods_json" | _ST_OUTPUT="$output_file" python3 -c '
 import json, sys, os

--- a/workload/harnesses/process_metrics.py
+++ b/workload/harnesses/process_metrics.py
@@ -378,6 +378,41 @@ def aggregate_pod_startup_stats():
     )
 
 
+def aggregate_requester_startup_stats():
+    """Aggregate creation->Ready for runtime FMA requester pods.
+
+    FMA requester pod goes Ready only when its bound vLLM is serving, so this is
+    FMA's "Avg pod startup" (time to serving)."""
+    startup_file = os.path.join(processed_dir, "pod_startup_times.json")
+    data = _load_json(startup_file) or {}
+    if not data.get("pods"):
+        return
+    ts_data = _load_json(os.path.join(processed_dir, "replica_status_timeseries.json"))
+    snaps = (ts_data or {}).get("snapshots", [])
+    run_start = snaps[0].get("timestamp") if snaps else None
+
+    values = []
+    for p in data.get("pods", []):
+        if p.get("role") != "requester":
+            continue
+        s = p.get("startup_seconds")
+        if not isinstance(s, (int, float)):
+            continue
+        ready = p.get("ready_timestamp")
+        if run_start and ready and ready < run_start:
+            continue  # standup requester -- ignore
+        values.append(s)
+    if not values:
+        return
+
+    data["requester_runtime_aggregate"] = _compute_stats(values, "s")
+    _save_json(startup_file, data)
+    print(
+        f"Requester run-time startup: {len(values)} pods, "
+        f"mean={data['requester_runtime_aggregate']['mean']:.1f}s"
+    )
+
+
 def aggregate_replica_stats():
     """Compute aggregate statistics from replica status time series."""
     ts_data = _load_json(os.path.join(processed_dir, "replica_status_timeseries.json"))
@@ -406,4 +441,5 @@ def aggregate_replica_stats():
 if __name__ == "__main__":
     aggregate_metrics()
     aggregate_pod_startup_stats()
+    aggregate_requester_startup_stats()
     aggregate_replica_stats()


### PR DESCRIPTION
1. New reusable comparison-table script — `llmdbenchmark/analysis/scripts/fma_comparison_table.py`
- Single source of truth shared by both ci-benchmark-ocp-fma-keda and ci-benchmark-ocp-fma-wva,
- Reads the three pass dirs (baseline / FMA warm-start / FMA hot-start) and emits one comparison table with configurable column headers

2. `Run Info header` above the table — **served model, harness, workload profile, run duration, and total request count**

3. Enabled metrics collection for scale/replica info
- Added `monitoring.metricsScrapeEnabled: true` to all six scenarios (ocp-keda, ocp-keda-fma-{warm,hot}start, ocp-wva, ocp-wva-fma-{warm,hot}start)

4. Autoscaling metrics in the table
- Avg replicas, Max replicas, Avg KV-cache utilization (%), Avg queue depth (EPP), Avg pod startup (s), and Cost (avg replicas × GPU/hr)

5. Scenario tuning
- KEDA replicas/maxReplicas 10 → 6 to match the WVA arm (apples-to-apples pod counts)
- `boundLauncherTimeout: 1800` on the KEDA hot/warm-start scenarios for Qwen3-32B parallel load off shared storage