### PR TITLE
fix: carry the skipped PVC bind budget into the data-access pod wait

### DIFF
--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -482,6 +482,9 @@ def _do_standup(args, logger, render_plan_errors):
             getattr(args, "modelservice_deploy_timeout", 1500) or 1500
         ),
         pvc_bind_timeout=int(getattr(args, "pvc_bind_timeout", 240) or 240),
+        harness_data_access_timeout=int(
+            getattr(args, "data_access_timeout", 120) or 120
+        ),
         kustomize_deploy_timeout=int(
             getattr(args, "kustomize_deploy_timeout", 900) or 900
         ),

--- a/llmdbenchmark/executor/README.md
+++ b/llmdbenchmark/executor/README.md
@@ -121,7 +121,7 @@ All wait helpers show live terminal progress with progress bars and pod status. 
 
 - `wait_for_pods(label, namespace, timeout=300, poll_interval=10, description="") -> CommandResult` -- Poll pods by label until all are Ready. Detects and aborts on terminal states (`CrashLoopBackOff`, `OOMKilled`, `ImagePullBackOff`, etc.).
 - `wait_for_job(job_name, namespace, timeout=3600, poll_interval=15, description="") -> CommandResult` -- Poll a Job until it completes or fails. Tracks active/succeeded/failed counts.
-- `wait_for_pvc(pvc_name, namespace, timeout=300, poll_interval=10, description="") -> CommandResult` -- Poll a PVC until it reaches `Bound` phase.
+- `wait_for_pvc(pvc_name, namespace, timeout=300, poll_interval=10, description="") -> CommandResult` -- Poll a PVC until it reaches `Bound` phase. Short-circuits to success when the StorageClass uses `volumeBindingMode: WaitForFirstConsumer` (such PVCs stay `Pending` until a consumer pod schedules), returning `wait_skipped=True` so a caller with a tighter next wait can add this `timeout` to it.
 
 ### CommandResult
 
@@ -134,6 +134,7 @@ class CommandResult:
     stderr: str = ""
     dry_run: bool = False
     attempts: int = 1
+    wait_skipped: bool = False  # a readiness wait was deliberately not performed
 
     @property
     def success(self) -> bool: ...  # exit_code == 0

--- a/llmdbenchmark/executor/command.py
+++ b/llmdbenchmark/executor/command.py
@@ -60,6 +60,9 @@ class CommandResult:
     stderr: str = ""
     dry_run: bool = False
     attempts: int = 1
+    # True when a readiness wait was deliberately not performed, so the
+    # caller owns the deferred budget (see CommandExecutor.wait_for_pvc).
+    wait_skipped: bool = False
 
     @property
     def success(self) -> bool:
@@ -534,7 +537,12 @@ class CommandExecutor:
         consumer pod is scheduled, so blocking on Bound here would deadlock
         standup before the consumer pod ever gets a chance to apply. Real
         provisioning failures still surface as a pod-readiness or
-        download-job timeout downstream.
+        download-job timeout downstream. When that happens the returned
+        result has ``wait_skipped=True``: the caller's next wait now covers
+        volume provisioning on top of whatever it originally waited for, so
+        a caller whose next wait is tighter than this ``timeout`` should add
+        this ``timeout`` to it (step 04's callers already wait far longer,
+        so they need no adjustment; step 05's data-access pod wait does).
         """
         desc = description or f"pvc/{pvc_name}"
         kc_args = " ".join(self._kubeconfig_args())
@@ -552,7 +560,7 @@ class CommandExecutor:
                 "-- PVC will bind when its consumer pod schedules; "
                 "skipping bind wait."
             )
-            return CommandResult(command=cmd_repr, exit_code=0)
+            return CommandResult(command=cmd_repr, exit_code=0, wait_skipped=True)
 
         start = time.time()
         last_status_line = ""

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -83,6 +83,7 @@ Provisions model infrastructure from a specification. Implicitly generates a pla
 | `--gateway-deploy-timeout` | `LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT` | Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice. |
 | `--modelservice-deploy-timeout` | `LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT` | Seconds to wait for decode, prefill and inference pool pods to deploy during standup with modelservice (Generic timeout for Step 9). |
 | `--pvc-bind-timeout` | `LLMDBENCH_PVC_BIND_TIMEOUT` | Seconds to wait for each PVC (workload, model, extra) to reach the Bound phase during standup. Fails fast on missing default StorageClass instead of masking as a downstream pod/job timeout. Default: 240 (some dynamic provisioners take 1-3 minutes per volume). |
+| `--data-access-timeout` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready. On a `WaitForFirstConsumer` StorageClass the unspent `--pvc-bind-timeout` is added to this budget, since the volume is only provisioned once that pod schedules. Default: 120. |
 
 ### smoketest (`smoketest.py`)
 

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -158,6 +158,17 @@ def add_subcommands(
         "(some dynamic provisioners take 1-3 minutes per volume).",
     )
     standup_parser.add_argument(
+        "--data-access-timeout",
+        type=int,
+        default=env_int("LLMDBENCH_DATA_ACCESS_TIMEOUT"),
+        help="Seconds to wait for the harness data-access pod to become "
+        "Ready. Mirrors the run flag and accepts the same env var "
+        "(LLMDBENCH_DATA_ACCESS_TIMEOUT). On a WaitForFirstConsumer "
+        "StorageClass the unspent --pvc-bind-timeout is added to this "
+        "budget, because the volume is only provisioned once that pod "
+        "schedules. Default: 120.",
+    )
+    standup_parser.add_argument(
         "--llmd-repo-path",
         default=env("LLMDBENCH_LLMD_REPO_PATH"),
         help="Path to a local llm-d repository clone (used by the kustomize method).",

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -57,6 +57,7 @@ class HarnessNamespaceStep(Step):
                 "HF token not configured -- skipping secret creation"
             )
 
+        bind_deferred = False
         pvc_yaml = self._find_rendered_yaml(context, "01_pvc_workload-pvc")
         if pvc_yaml:
             pvc_name = (
@@ -119,6 +120,7 @@ class HarnessNamespaceStep(Step):
                         message="Workload PVC failed to bind -- aborting",
                         errors=errors,
                     )
+                bind_deferred = bind_result.wait_skipped
 
         pod_yaml = self._find_rendered_yaml(context, "06_pod_access_to_harness_data")
         if pod_yaml:
@@ -159,6 +161,18 @@ class HarnessNamespaceStep(Step):
         self._create_preprocesses_configmap(cmd, context, configmap_namespaces, errors)
 
         timeout = context.harness_data_access_timeout
+        if bind_deferred:
+            # The bind wait was skipped, so this wait covers dynamic volume
+            # provisioning (which only starts once the pod schedules) plus
+            # container start. Carry the unspent bind budget forward instead
+            # of silently halving the budget for the harder job.
+            timeout += context.pvc_bind_timeout
+            context.logger.log_info(
+                f"PVC bind wait was skipped (WaitForFirstConsumer) -- "
+                f"extending data-access pod wait to {timeout}s "
+                f"({context.harness_data_access_timeout}s + "
+                f"{context.pvc_bind_timeout}s unspent bind budget)"
+            )
         wait_result = cmd.wait_for_pods(
             label="role=llm-d-benchmark-data-access",
             namespace=harness_ns,
@@ -167,7 +181,16 @@ class HarnessNamespaceStep(Step):
             description="harness data-access pod",
         )
         if not wait_result.success:
-            errors.append(f"Data access pod not ready: {wait_result.stderr}")
+            msg = f"Data access pod not ready: {wait_result.stderr}"
+            if bind_deferred:
+                msg += (
+                    ". The PVC bind wait was skipped (StorageClass "
+                    "volumeBindingMode=WaitForFirstConsumer), so this wait "
+                    "may also have covered volume provisioning. Raise "
+                    "--data-access-timeout (LLMDBENCH_DATA_ACCESS_TIMEOUT) "
+                    "and/or --pvc-bind-timeout for slow shared storage."
+                )
+            errors.append(msg)
 
         if errors:
             for err in errors:

--- a/tests/test_harness_pvc_bind_deferral.py
+++ b/tests/test_harness_pvc_bind_deferral.py
@@ -1,0 +1,164 @@
+"""Tests for carrying a deferred PVC bind budget into the data-access wait."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from llmdbenchmark.executor.command import CommandExecutor, CommandResult
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.interface import standup
+from llmdbenchmark.standup.steps.step_05_harness_namespace import HarnessNamespaceStep
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.errors: list[str] = []
+
+    def log_info(self, message: str, *_: Any, **__: Any) -> None:
+        self.infos.append(message)
+
+    def log_warning(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def log_error(self, message: str, *_: Any, **__: Any) -> None:
+        self.errors.append(message)
+
+    def log_debug(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def set_indent(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def line_break(self) -> None:
+        pass
+
+
+class _Command:
+    """Fake CommandExecutor: records the timeout handed to wait_for_pods."""
+
+    def __init__(self, bind_skipped: bool, pods_ready: bool = True) -> None:
+        self._bind_skipped = bind_skipped
+        self._pods_ready = pods_ready
+        self.pod_wait_timeout: int | None = None
+
+    def kube(self, *args: str, **_: Any) -> CommandResult:
+        return CommandResult(command=" ".join(args), exit_code=0)
+
+    def wait_for_pvc(self, **_: Any) -> CommandResult:
+        return CommandResult(
+            command="wait pvc", exit_code=0, wait_skipped=self._bind_skipped
+        )
+
+    def wait_for_pods(self, **kwargs: Any) -> CommandResult:
+        self.pod_wait_timeout = kwargs["timeout"]
+        if self._pods_ready:
+            return CommandResult(command="wait pods", exit_code=0)
+        return CommandResult(
+            command="wait pods",
+            exit_code=1,
+            stderr=f"Timed out after {kwargs['timeout']}s waiting for pods",
+        )
+
+
+def _context(tmp_path: Path, cmd: _Command, logger: _Logger) -> ExecutionContext:
+    stack = tmp_path / "plan" / "stack"
+    stack.mkdir(parents=True)
+    (stack / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "namespace": {"name": "bench"},
+                "harness": {"namespace": "bench"},
+                # Skip the secret-copy path; it is not what these tests cover.
+                "huggingface": {"enabled": False},
+                "storage": {"workloadPvc": {"name": "workload-pvc", "size": "20Gi"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    for name in (
+        "01_pvc_workload-pvc.yaml",
+        "06_pod_access_to_harness_data.yaml",
+        "07_service_access_to_harness_data.yaml",
+    ):
+        (stack / name).write_text("kind: Placeholder\n", encoding="utf-8")
+
+    context = ExecutionContext(
+        plan_dir=tmp_path / "plan",
+        workspace=tmp_path / "ws",
+        rendered_stacks=[stack],
+        namespace="bench",
+        logger=logger,
+    )
+    context.cmd = cmd
+    return context
+
+
+def test_deferred_bind_extends_data_access_wait(tmp_path: Path) -> None:
+    """A skipped bind wait hands its unspent budget to the pod wait."""
+    cmd = _Command(bind_skipped=True)
+    logger = _Logger()
+    context = _context(tmp_path, cmd, logger)
+
+    result = HarnessNamespaceStep().execute(context)
+
+    assert result.success, result.errors
+    assert cmd.pod_wait_timeout == (
+        context.harness_data_access_timeout + context.pvc_bind_timeout
+    )
+    assert any("PVC bind wait was skipped" in msg for msg in logger.infos)
+
+
+def test_immediate_bind_keeps_data_access_wait(tmp_path: Path) -> None:
+    """An immediate-binding StorageClass leaves the pod wait untouched."""
+    cmd = _Command(bind_skipped=False)
+    context = _context(tmp_path, cmd, _Logger())
+
+    result = HarnessNamespaceStep().execute(context)
+
+    assert result.success, result.errors
+    assert cmd.pod_wait_timeout == context.harness_data_access_timeout
+
+
+def test_wait_for_pvc_flags_skipped_bind(tmp_path: Path, monkeypatch) -> None:
+    """The short-circuit succeeds and reports that it skipped the wait."""
+    executor = CommandExecutor(work_dir=tmp_path, dry_run=False, verbose=False)
+    monkeypatch.setattr(
+        executor,
+        "_resolve_pvc_binding_mode",
+        lambda *_a, **_k: "WaitForFirstConsumer",
+    )
+
+    result = executor.wait_for_pvc(
+        pvc_name="workload-pvc", namespace="bench", timeout=240
+    )
+
+    assert result.success
+    assert result.wait_skipped
+
+
+def test_deferred_bind_failure_names_the_cause(tmp_path: Path) -> None:
+    """A pod timeout after a deferred bind explains itself and names the knobs."""
+    cmd = _Command(bind_skipped=True, pods_ready=False)
+    context = _context(tmp_path, cmd, _Logger())
+
+    result = HarnessNamespaceStep().execute(context)
+
+    assert not result.success
+    joined = " ".join(result.errors)
+    assert "WaitForFirstConsumer" in joined
+    assert "--data-access-timeout" in joined
+
+
+def test_standup_accepts_the_timeout_the_hint_names() -> None:
+    """The knob the failure hint recommends exists in the phase that prints it."""
+    parser = argparse.ArgumentParser()
+    standup.add_subcommands(parser.add_subparsers(dest="command"))
+
+    args = parser.parse_args(["standup", "--data-access-timeout", "900"])
+
+    assert args.data_access_timeout == 900


### PR DESCRIPTION
## Description

Fixes #1694.

`CommandExecutor.wait_for_pvc` correctly refuses to block on a StorageClass with
`volumeBindingMode: WaitForFirstConsumer`, because binding needs a consumer pod
that has not been applied yet. But it returned a plain success result,
indistinguishable from "the PVC actually bound", so the caller had no way to know
its 240s `pvc_bind_timeout` budget went unspent.

In step 05 that meant the 120s `harness_data_access_timeout` wait had to cover
two serialised phases, dynamic volume provisioning (which only starts once the
pod schedules) plus container start, on half the budget of the easier job. And
`--pvc-bind-timeout`, whose help text is where the project already wrote down
that slow shared-storage backends (weka, ceph, gpfs) need minutes, never applied
on those backends, because they are all `WaitForFirstConsumer` in the common
case. First standup on a cold volume failed deterministically and the immediate
retry passed because the volume was by then provisioned, so it presented as
flakiness.

The change reports the skipped wait on `CommandResult` (`wait_skipped`) and adds
the unspent bind budget to the data-access pod wait when it is set. On failure
the error now names the skipped bind and the two knobs to raise. The run phase
inherits step 05, so both pipelines pick this up.

It also registers `--data-access-timeout` on the standup subparser and passes it
into the standup `ExecutionContext`. That knob was only wired for `run` and
`experiment`, so standup, which is the phase this failure is reported from and
the phase the issue's `LLMDBENCH_DATA_ACCESS_TIMEOUT=900` workaround targets,
rejected the flag outright and silently ignored the env var while `cli.py`'s
override table still advertised it as active. Without this, the new failure hint
would name a knob that phase does not have.

Two deliberate calls, both also recorded in the commit message:

- `wait_skipped` means the bind wait was skipped, not that the volume was
  actually unprovisioned. On an idempotent re-standup the PVC may already be
  `Bound`. The widened value is only a ceiling, so it costs nothing on that warm
  path, and the log and error text say "skipped" rather than claiming a deferral
  that may not have happened. Probing `.status.phase` to tell the two apart would
  cost an extra kubectl call on every standup and every run, and would add a new
  question (what does the flag mean when the probe itself errors or returns
  empty) to make a diagnostic string marginally more specific.
- The other two `wait_for_pvc` callers, in `step_04_model_namespace.py`, need no
  adjustment: their downstream waits are the model download job (2400s) and the
  serving deploy (1500s/900s), both already larger than `pvc_bind_timeout`. The
  docstring says so, so it does not read as a rule that is violated in-tree.

Not done here: the issue's suggestion (2), distinguishing "pod Pending because
its PVC is still provisioning" from "pod failed to start". That needs the pod
wait to inspect the PVC's own phase and is a separate change to
`wait_for_pods`. Suggestion (3) is covered by the new hint text.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (included)

## How Has This Been Tested?

Adds `tests/test_harness_pvc_bind_deferral.py` (5 tests), which drives the real
`HarnessNamespaceStep` against a stub executor: the deferred-bind path extends
the wait to `120 + 240`, the non-deferred path does not, the failure message
names the cause and the knobs, and the real standup subparser accepts
`--data-access-timeout 900`.

```
$ python3 -m pytest tests/test_harness_pvc_bind_deferral.py -q
5 passed in 3.60s

$ python3 -m pytest tests/ -q --ignore=tests/test_direct_service_mode.py
733 passed, 31 skipped in 33.65s

$ uvx ruff@0.15.11 check --output-format=full .
All checks passed!
$ uvx ruff@0.15.11 format --check .
255 files already formatted
```

The `--ignore` is a pre-existing gap in my environment, not something this
change causes: `tests/test_direct_service_mode.py` needs the external
`llm-d-planner` dependency, and it fails the same way on `main` here.

Confirmed the new tests fail without the change, reverting one file at a time in
a throwaway worktree:

- Revert `step_05_harness_namespace.py` only: `2 failed, 3 passed`.
  `test_deferred_bind_extends_data_access_wait` fails with
  `assert 120 == (120 + 240)`, which is issue #1694 reproduced numerically, and
  `test_deferred_bind_failure_names_the_cause` fails with
  `assert 'WaitForFirstConsumer' in 'Data access pod not ready: Timed out after 120s waiting for pods'`,
  which is `main`'s exact unhelpful message.
- Additionally revert `interface/standup.py` and `cli.py`: `3 failed, 2 passed`,
  the new flag test failing with
  `error: unrecognized arguments: --data-access-timeout 900`.
- Additionally revert `executor/command.py`: `5 failed`, all
  `TypeError: CommandResult.__init__() got an unexpected keyword argument 'wait_skipped'`.

### Test Configuration

- Kubernetes version: none. I do not have a cluster available, so the full
  standup/run/teardown sequence was not run, and the `WaitForFirstConsumer`
  behaviour itself is exercised through a stub executor rather than against real
  storage. The arithmetic and the message are covered; a real cold-volume
  standup on a slow RWX backend is not something I can verify here, and I would
  rather flag that than imply otherwise.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [ ] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly (`llmdbenchmark/executor/README.md`,
      `llmdbenchmark/interface/README.md`)

On the two unchecked boxes: no cluster here, and `pre-commit`'s
render-validation hook needs a populated `.venv` plus `helm`, which this
environment does not have. I ran `ruff check`, `ruff format --check` and the
full pytest suite directly instead. This diff touches no rendering code.
