### PR TITLE
fix: reject a specification missing the keys every caller indexes

### DIFF
--- a/config/scenarios/guides/nok8s.yaml
+++ b/config/scenarios/guides/nok8s.yaml
@@ -10,9 +10,9 @@
 #     export HUGGING_FACE_HUB_TOKEN=hf_...
 #
 # Usage:
-#     llmdbenchmark --spec config/scenarios/guides/nok8s.yaml standup --methods nok8s
-#     llmdbenchmark --spec config/scenarios/guides/nok8s.yaml run
-#     llmdbenchmark --spec config/scenarios/guides/nok8s.yaml teardown --methods nok8s
+#     llmdbenchmark --spec guides/nok8s standup --methods nok8s
+#     llmdbenchmark --spec guides/nok8s run
+#     llmdbenchmark --spec guides/nok8s teardown --methods nok8s
 
 scenario:
   - name: "nok8s-single"

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -35,7 +35,7 @@ from llmdbenchmark.interface import smoketest as smoketest_interface
 from llmdbenchmark.interface import experiment as experiment_interface
 from llmdbenchmark.interface import results
 from llmdbenchmark.parser.render_specification import RenderSpecification
-from llmdbenchmark.exceptions.exceptions import TemplateError
+from llmdbenchmark.exceptions.exceptions import TemplateError, ConfigurationError
 from llmdbenchmark.parser.render_plans import RenderPlans
 from llmdbenchmark.parser.version_resolver import VersionResolver
 from llmdbenchmark.parser.cluster_resource_resolver import ClusterResourceResolver
@@ -87,10 +87,14 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
         Command.RUN.value,
     ):
         # Resolve templates, scenarios, and values into the workspace
-        specification_as_dict = RenderSpecification(
-            specification_file=args.specification_file,
-            base_dir=args.base_dir,
-        ).eval()
+        try:
+            specification_as_dict = RenderSpecification(
+                specification_file=args.specification_file,
+                base_dir=args.base_dir,
+            ).eval()
+        except ConfigurationError as e:
+            logger.log_error(f"Invalid specification: {e}")
+            sys.exit(1)
 
         logger.log_info(
             "Specification file rendered and validated successfully.",

--- a/llmdbenchmark/parser/render_specification.py
+++ b/llmdbenchmark/parser/render_specification.py
@@ -17,6 +17,11 @@ from llmdbenchmark.utilities.os.filesystem import (
 from llmdbenchmark.logging.logger import get_logger
 from llmdbenchmark.exceptions.exceptions import TemplateError, ConfigurationError
 
+# Keys every consumer of the returned config dict indexes unconditionally as
+# `<key>["path"]` (see cli.py dispatch_cli and _render_plans_for_experiment).
+# Missing any of them is a config mistake, not a runtime KeyError.
+_REQUIRED_KEYS = ("template_dir", "values_file", "scenario_file")
+
 
 class RenderSpecification:  # pylint: disable=too-few-public-methods
     """
@@ -92,6 +97,35 @@ class RenderSpecification:  # pylint: disable=too-few-public-methods
                 context={"yaml_error": str(exc)},
             ) from exc
 
+    def _check_required(self, config_dict: Any) -> None:
+        """Validate that the specification defines every required key as `{path: ...}`."""
+        node = config_dict if isinstance(config_dict, dict) else {}
+        missing = [
+            key
+            for key in _REQUIRED_KEYS
+            if not isinstance(node.get(key), dict) or "path" not in node[key]
+        ]
+        if not missing:
+            return
+
+        if "scenario" in node:
+            hint = (
+                "this looks like a scenario file, not a specification; pass a "
+                "specification instead, for example --spec guides/nok8s"
+            )
+        else:
+            hint = (
+                "specifications live under config/specification/ and must define "
+                "each required key as '<key>:' followed by 'path: <location>'"
+            )
+
+        raise ConfigurationError(
+            message=f"Specification is missing required keys: {', '.join(missing)}",
+            step="Validate required specification keys",
+            config_file=f"{self.specification_file.stem}.yaml",
+            context={"hint": hint},
+        )
+
     def _precheck(self, node: Any, prefix: str = "") -> None:
         """Recursively validate filesystem paths referenced in the config."""
         if isinstance(node, dict):
@@ -148,6 +182,7 @@ class RenderSpecification:  # pylint: disable=too-few-public-methods
         """Render, parse, and validate the specification. Returns the config dict."""
         rendered_yaml = self._render()
         config_dict = self._parse(rendered_yaml)
+        self._check_required(config_dict)
         self._precheck(config_dict)
 
         _json_dump = json.dumps(config_dict, indent=2)

--- a/tests/test_specification_required_keys.py
+++ b/tests/test_specification_required_keys.py
@@ -1,0 +1,58 @@
+"""Specification required-key validation.
+
+A file that merely parses as YAML is not a specification. Passing a scenario
+file to --spec used to sail through validation and blow up later with a raw
+KeyError on 'template_dir'; it must fail with an actionable message instead.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmdbenchmark.config import config
+from llmdbenchmark.exceptions.exceptions import ConfigurationError
+from llmdbenchmark.parser.render_specification import RenderSpecification
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCENARIO = REPO_ROOT / "config" / "scenarios" / "guides" / "nok8s.yaml"
+SPECIFICATION = REPO_ROOT / "config" / "specification" / "guides" / "nok8s.yaml.j2"
+
+
+def _workspace(tmp_path: Path) -> None:
+    config.plan_dir = tmp_path
+    config.log_dir = tmp_path
+
+
+def test_scenario_passed_as_specification_is_rejected(tmp_path: Path) -> None:
+    _workspace(tmp_path)
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        RenderSpecification(specification_file=SCENARIO).eval()
+
+    rendered = str(excinfo.value)
+    for key in ("template_dir", "values_file", "scenario_file"):
+        assert key in rendered
+    assert "--spec guides/nok8s" in rendered
+
+
+def test_empty_specification_is_rejected(tmp_path: Path) -> None:
+    _workspace(tmp_path)
+
+    empty = tmp_path / "empty.yaml.j2"
+    empty.write_text("# nothing here\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError):
+        RenderSpecification(specification_file=empty).eval()
+
+
+def test_real_specification_still_validates(tmp_path: Path) -> None:
+    _workspace(tmp_path)
+
+    specification = RenderSpecification(
+        specification_file=SPECIFICATION, base_dir=REPO_ROOT
+    ).eval()
+
+    for key in ("template_dir", "values_file", "scenario_file"):
+        assert Path(specification[key]["path"]).exists()


### PR DESCRIPTION

## Description

`config/scenarios/guides/nok8s.yaml` documents its own usage as
`llmdbenchmark --spec config/scenarios/guides/nok8s.yaml standup --methods nok8s`.
That points `--spec` at a scenario file, not a specification, and running it
verbatim dies with a raw traceback:

```
INFO - Specification file rendered and validated successfully.
Traceback (most recent call last):
  ...
  File ".../llmdbenchmark/cli.py", line 112, in dispatch_cli
    template_dir=specification_as_dict["template_dir"]["path"],
KeyError: 'template_dir'
```

Two separable things are wrong, and this fixes both.

**1. The scenario header (`c4508ad`).** `nok8s.yaml` is the only scenario in the
repo whose header points `--spec` at itself. Every other guide scenario documents
the resolvable short form, for example
`config/scenarios/guides/optimized-baseline-sglang.yaml:19` uses
`--spec guides/optimized-baseline-sglang`. The header now uses `--spec guides/nok8s`
to match. `docs/nok8s.md:55` was already correct and is untouched.

**2. The missing guard (`51278d9`).** `RenderSpecification` logged "rendered and
validated successfully" for any file that merely parsed as YAML. `_precheck` only
walks the keys that happen to be present and asserts their path-shaped leaves
exist on disk, so nothing ever required a key. Both consumers then index
`template_dir` / `values_file` / `scenario_file` as `["path"]` with no guard, so
any wrong file surfaced as a `KeyError` traceback.

The check goes into the `RenderSpecification` entry method rather than into
`dispatch_cli`, because that is the choke point shared by both call sites:
`cli.py:91` (plan/standup/smoketest/teardown/run) and `cli.py:1290`
(`_render_plans_for_experiment`). It runs before the "validated successfully" log
so that log stops lying. `dispatch_cli` catches the resulting `ConfigurationError`
and reports it the same way it already reports template and cluster-config
failures: one `log_error` line, exit 1.

The hint names the likely mistake, and calls out the scenario-file case
specifically since it is the easy one to make.

Fixes #1697

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (the scenario file's own usage
      header, included here)

## How Has This Been Tested?

New tests, `tests/test_specification_required_keys.py` (3 cases): a scenario file
passed to `--spec` is rejected with all three key names and the corrected
invocation in the message; an empty file is rejected; the real
`config/specification/guides/nok8s.yaml.j2` still validates and its three paths
still resolve on disk.

Revert check: with `llmdbenchmark/` reset to `main` and the new test file kept,
2 of the 3 cases fail (`Failed: DID NOT RAISE ConfigurationError`). The third is
the regression guard and is expected to pass either way.

Full unit suite, the same command CI runs
(`.github/workflows/ci-pr-benchmark.yaml:30`):

```
$ python -m pytest tests/ -x -q -n2
742 passed, 31 skipped in 20.89s
```

(739 on `main`, plus the 3 new cases.)

Manual, on the branch. Before, this was a traceback; now:

```
$ llmdbenchmark --spec config/scenarios/guides/nok8s.yaml --base-dir . plan
ERROR - ❌ Invalid specification: [Validate required specification keys] Specification
is missing required keys: template_dir, values_file, scenario_file (Context: hint=this
looks like a scenario file, not a specification; pass a specification instead, for
example --spec guides/nok8s, config_file=nok8s.yaml)
$ echo $?
1
```

And the newly documented form works:

```
$ llmdbenchmark --spec guides/nok8s --base-dir . plan
INFO - ✅ Rendered: 34_nok8s-containers.yaml
INFO - Success: 36, Errors: 0
```

`pre-commit run --files <the 4 changed files>`: byte-compile Passed, unit tests
Passed, render-changed Passed, detect-secrets Passed, ruff-check Passed,
ruff-format Passed. SBOM skipped (no files in its trigger set).

### Test Configuration

- Kubernetes version: none. This path is reached before any cluster contact, and
  the nok8s method does not use a cluster at all. Reproduced and verified on
  macOS 15 (Darwin 25.3.0) / Python 3.13.7 / Docker 29.1.5, no cluster, no GPU.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh`
      sequence completed successfully. Not run: no GPU and no cluster on this host,
      so a live standup cannot get past pulling the model. The change is in
      specification validation, which runs before any deploy step, and the happy
      path is covered by the existing suite plus a live `plan` on the real nok8s
      specification.
- [x] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly
