### PR TITLE
docs(nok8s): document what can be validated without a GPU

### DIFF
--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -46,6 +46,47 @@ Verify GPU-in-container before you start:
 docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi
 ```
 
+## Without a GPU
+
+Serving a model needs the accelerator, but *validating the plumbing* does not.
+Rendering and `--dry-run` never touch a device or a cluster, so a plain laptop
+can still check that a nok8s scenario renders and that the container commands
+are the ones you expect. Verified on macOS (Darwin 25.3, Python 3.13, `docker`
+present and usable, no GPU, no cluster, no `helm`/`yq`/`kind`):
+
+```bash
+llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . plan
+llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . --dry-run standup --methods nok8s
+llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . --dry-run run
+llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . --dry-run teardown --methods nok8s
+```
+
+| What | Without a GPU |
+|------|---------------|
+| `pytest tests/ -q -n2` | **Works** (739 passed, 31 skipped). `tests/test_nok8s_plan.py` covers template rendering, per-accelerator device flags, per-replica pinning, and the preflight |
+| `plan` | **Works** -- renders all 36 artifacts, including `31/32/33/34_nok8s-*` |
+| `--dry-run standup --methods nok8s` | **Works** (12/12 steps) -- step 06 logs each `docker run` it *would* execute, and records `http://localhost:8081` |
+| `--dry-run run` | **Works** -- endpoint resolves locally with no cluster query, profiles render, the harness `docker run` is logged |
+| `--dry-run teardown --methods nok8s` | **Works** -- logs one `docker rm -f` per container |
+| `teardown --methods nok8s` (live) | **Works** -- `docker rm -f` is idempotent, so it is safe with nothing running |
+| `standup` (live) | **Fails at step 06.** It emits `docker run -d --name vllm-0 --gpus all ...`, which a GPU-less docker rejects: `could not select device driver "" with capabilities: [[gpu]]` |
+| `run` / `smoketest` (live) | **Fails** -- nothing is serving the model |
+
+Two caveats before you read a green dry-run as "my host is fine":
+
+- **`--dry-run` skips the step 00 preflight.** It logs what it *would* verify
+  and returns success. It proves the plan and the command strings, not the host.
+- **Run live, step 00 passes anyway on a GPU-less host** with a working
+  container runtime: only a missing or broken runtime is fatal, so the missing
+  accelerator is a warning, not an error:
+  ```
+  WARNING  'nvidia-smi' found no nvidia accelerator; vLLM needs the device + driver present, ...
+  WARNING  $HUGGING_FACE_HUB_TOKEN is not set; gated Hugging Face models will fail to download ...
+  INFO     nok8s preflight passed (runtime=docker).
+  ```
+  The port-in-use check shells out to `ss -ltn`, so on a host without `ss`
+  (macOS) it silently reports nothing rather than warning.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION

## Description

`docs/nok8s.md`'s Prerequisites table requires a Linux host with NVIDIA GPU(s)
and a working `nvidia-smi`, then says nothing about what is possible without one.
The most common new contributor is on a laptop with no GPU and no cluster, so
today the doc reads as "come back when you have an H100" even though most of the
nok8s path is verifiable offline.

This adds a "Without a GPU" section between Prerequisites and Usage: the four
commands that work, a table of what works and what does not, and the two caveats
that make a green dry-run misleading. Every row is grounded in a run on a macOS
host (Darwin 25.3, Python 3.13, `docker` present and usable, no GPU, no cluster,
no `helm`/`yq`/`kind`), not inferred from reading the code.

The two caveats are the part worth reviewing:

- `--dry-run` **skips** the step 00 preflight entirely
  (`step_00_ensure_infra.py:139-150` logs what it would verify and returns
  success), so a green dry-run says nothing about your host.
- Run live, step 00 **passes** on a GPU-less host: only a missing or broken
  container runtime is fatal, an absent accelerator is a warning. So "preflight
  passed" is not evidence you can serve. The section says this outright rather
  than letting a reader infer the opposite.

There is also a one-line note that the port-in-use check shells out to `ss -ltn`
and therefore silently reports nothing on a host without `ss` (macOS).
`step_00_ensure_infra.py:220` gates on `res.success`, so the "host ports already
in use" warning can never fire off Linux. Not a bug on the supported Linux path,
but it means preflight is quieter than it looks on a dev laptop, and a reader
following this section is on exactly such a laptop.

Documentation only. No behaviour change and nothing new to maintain beyond the
counts, which the existing pytest and render hooks already exercise on every
commit.

## Type of change

- [x] This change requires a documentation update (it is the documentation update)

Not a bug fix, not a new feature, not breaking.

## How Has This Been Tested?

Every claim in the new section was produced by running the thing, on the host
described in the section:

- `pytest tests/ -q -n2`: `the full unit suite passes in 20.29s` on this branch.
- `plan`: `Success: 36, Errors: 0`, including `31_nok8s-epp-config.yaml`,
  `32_nok8s-epp-endpoints.yaml`, `33_nok8s-envoy.yaml`, `34_nok8s-containers.yaml`.
- `--dry-run standup --methods nok8s`: `Steps: 12/12 passed, 10 skipped`,
  `Mode: dry-run`, endpoint `http://localhost:8081`, and each `docker run` it
  would execute is logged.
- `--dry-run run`: completes, resolves the local endpoint with no cluster query,
  renders profiles, logs the harness `docker run`.
- `--dry-run teardown --methods nok8s`: three `docker rm -f` lines, completes.
- `teardown --methods nok8s` live, with nothing running: succeeds and is
  idempotent.
- Step 00 preflight live, driven through the real `EnsureInfraStep` and real
  `CommandExecutor`: two warnings (no nvidia accelerator, no
  `$HUGGING_FACE_HUB_TOKEN`) and `nok8s preflight passed (runtime=docker)`. This
  is the source of the second caveat.
- The `--gpus all` rejection is quoted from an actual run rather than inferred:
  `docker run --rm --gpus all hello-world` gives
  `could not select device driver "" with capabilities: [[gpu]]`.

A live `standup` was deliberately not run: it pulls roughly 10 GB before failing
at the same `--gpus all` rejection shown above.

`pre-commit run --files docs/nok8s.md`: unit tests Passed, render-changed Passed,
detect-secrets Passed. Byte-compile, ruff-check, ruff-format and SBOM all skipped
with "no files to check", correct for a docs-only change.

The section adds no links, so the markdown link checker has nothing new to
resolve.

### Test Configuration

- Kubernetes version: none. That is the point of the section.
- macOS 15 (Darwin 25.3.0) / Python 3.13.7 / Docker 29.1.5, no GPU, no cluster,
  `helm`/`helmfile`/`yq`/`kind`/`podman` absent. Installed with
  `python3 -m venv` plus `pip install -e .`; `./install.sh` was not run, since it
  brew-installs helm and kubectl globally.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` ->
      `./setup/teardown.sh` sequence completed successfully. Not run, and the
      section is explicit that it cannot be on this host. Every sub-command that
      does work here was run, and the ones that do not are listed as failing with
      the exact error.
- [x] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly

Fixes #1706
