### PR TITLE
fix: run the nok8s smoketest without a cluster

### DIFF
--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -54,6 +54,9 @@ export HUGGING_FACE_HUB_TOKEN=hf_...     # for gated models
 # Bring up vLLM + EPP + Envoy as local containers (step 00 runs the preflight).
 llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . standup --methods nok8s
 
+# Probe the stack over HTTP (no cluster needed); standup does not chain this one.
+llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . smoketest
+
 # Benchmark it — the harness runs as a local container against http://localhost:8081.
 llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . run
 
@@ -133,6 +136,7 @@ device and image match yourself.
 | standup step 00 | Preflight: runtime / GPU / ports / token (replaces helm/kubectl checks) |
 | standup steps 02–05 | Skipped (no namespace, PVC, model-download Job) |
 | standup step 06 | `step_06_nok8s_deploy` launches the containers, waits for `/v1/models`, records `http://localhost:<listenPort>` |
+| smoketest steps 00–01 | Cluster-free probes: `GET /v1/models` and `POST /v1/completions` against the Envoy front door, read from the rendered `34_nok8s-containers.yaml` (no pods, Service or route) |
 | run step 03 | Endpoint resolves to the local Envoy URL (no cluster query) |
 | run step 07 | `step_07_deploy_harness_local` runs the harness image locally with `--network host`; results land in `workspace/results/` via a bind-mount |
 | teardown step 06 | `step_06_nok8s_teardown` removes the containers |

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -519,8 +519,10 @@ def _execute_standup(args, logger, render_plan_errors):
     _print_standup_summary(context, result, logger)
 
     # Auto-chain smoketest after standup unless --skip-smoketest.
-    # The nok8s deploy step already curls /v1/models for readiness, so skip
-    # the chained smoketest.
+    # nok8s stays opt-out here: its deploy step already curls /v1/models for
+    # readiness, so the chained run would only add the inference probe. Run
+    # `llmdbenchmark ... smoketest` (or `experiment`, which chains it) to get
+    # that probe; it no longer needs a cluster.
     skip_smoketest = getattr(args, "skip_smoketest", False) or (
         "nok8s" in (context.deployed_methods or [])
     )

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -519,8 +519,8 @@ def _execute_standup(args, logger, render_plan_errors):
     _print_standup_summary(context, result, logger)
 
     # Auto-chain smoketest after standup unless --skip-smoketest.
-    # nok8s has no cluster/namespace for the smoketest pod and the deploy step
-    # already curls /v1/models for readiness, so skip the chained smoketest.
+    # The nok8s deploy step already curls /v1/models for readiness, so skip
+    # the chained smoketest.
     skip_smoketest = getattr(args, "skip_smoketest", False) or (
         "nok8s" in (context.deployed_methods or [])
     )
@@ -551,7 +551,8 @@ def _do_smoketest(args, logger, render_plan_errors):
         plan_info,
     )
 
-    if not namespace:
+    container_only = "nok8s" in deployed_methods
+    if not namespace and not container_only:
         raise PhaseError(
             "No namespace specified. Set 'namespace.name' in your scenario "
             "YAML, defaults.yaml, or pass --namespace on the CLI."
@@ -572,6 +573,8 @@ def _do_smoketest(args, logger, render_plan_errors):
         harness_namespace=harness_ns,
         model_name=plan_info.get("model_name"),
         logger=logger,
+        container_only=container_only,
+        container_runtime=plan_info.get("nok8s_runtime", "docker"),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 

--- a/llmdbenchmark/smoketests/README.md
+++ b/llmdbenchmark/smoketests/README.md
@@ -160,6 +160,7 @@ The stack name is the `-name` field from the scenario YAML (e.g., `pd-disaggrega
 smoketests/
 +-- __init__.py            -- get_validator() registry lookup
 +-- base.py                -- BaseSmoketest: health checks, inference test, validate_role_pods
++-- nok8s.py               -- cluster-free HTTP probes used by base.py for container_only stacks
 +-- report.py              -- SmoketestReport / CheckResult tracking
 +-- steps/
 |   +-- __init__.py        -- get_smoketest_steps() registry

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -7,6 +7,10 @@ from pathlib import Path
 
 from llmdbenchmark.executor.command import CommandExecutor
 from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.smoketests.nok8s import (
+    health_check as nok8s_health_check,
+    inference_test as nok8s_inference_test,
+)
 from llmdbenchmark.smoketests.report import CheckResult, SmoketestReport
 from llmdbenchmark.utilities.endpoint import (
     _build_overrides,
@@ -177,6 +181,10 @@ class BaseSmoketest:
         service endpoint, pod IPs, and OpenShift route.
         """
         report = SmoketestReport()
+        # nok8s deploys plain containers: no Service, no pods, no route to
+        # check. Probe the container endpoint over HTTP instead.
+        if context.container_only:
+            return nok8s_health_check(context, stack_path)
         cmd = context.require_cmd()
         namespace = context.require_namespace()
         plan_config = _load_config(stack_path)
@@ -593,6 +601,9 @@ class BaseSmoketest:
     ) -> SmoketestReport:
         """Run a sample inference request and report pass/fail."""
         report = SmoketestReport()
+        # nok8s has no ephemeral curl pod to exec from: POST directly.
+        if context.container_only:
+            return nok8s_inference_test(context, stack_path)
         cmd = context.require_cmd()
         namespace = context.require_namespace()
         plan_config = _load_config(stack_path)

--- a/llmdbenchmark/smoketests/nok8s.py
+++ b/llmdbenchmark/smoketests/nok8s.py
@@ -12,12 +12,37 @@ from pathlib import Path
 
 import requests
 import yaml
+from requests.adapters import HTTPAdapter, Retry
 
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.smoketests.report import CheckResult, SmoketestReport
 
 _SPEC_PREFIX = "34_nok8s-containers"
-_TIMEOUT = 15
+_MODELS_TIMEOUT = 15
+# A first generation on a cold or CPU-served model is not always quick; match
+# the cluster path, whose BaseSmoketest._curl_post defaults to 120s.
+_COMPLETION_TIMEOUT = 120
+# Envoy answers 502/503/504 while EPP has not yet picked an endpoint, the same
+# transient window BaseSmoketest._try_completions retries on.
+_RETRY_TOTAL = 3
+_RETRY_BACKOFF = 2
+
+
+def _session() -> requests.Session:
+    """A session that retries the transient statuses the cluster path retries."""
+    adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=_RETRY_TOTAL,
+            backoff_factor=_RETRY_BACKOFF,
+            status_forcelist=(502, 503, 504),
+            allowed_methods=frozenset({"GET", "POST"}),
+            raise_on_status=False,
+        )
+    )
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
 
 
 def _read_spec(stack_path: Path) -> tuple[str, str, str]:
@@ -52,7 +77,8 @@ def health_check(context: ExecutionContext, stack_path: Path) -> SmoketestReport
 
     context.logger.log_info(f"Checking {url}...")
     try:
-        resp = requests.get(url, timeout=_TIMEOUT)
+        with _session() as session:
+            resp = session.get(url, timeout=_MODELS_TIMEOUT)
     except requests.RequestException as e:
         report.add(
             CheckResult(
@@ -78,11 +104,13 @@ def health_check(context: ExecutionContext, stack_path: Path) -> SmoketestReport
     try:
         body = resp.json()
     except ValueError:
+        body = None
+    if not isinstance(body, dict):
         report.add(
             CheckResult(
                 "nok8s_models_endpoint",
                 False,
-                message=f"{url} returned a non-JSON body: {resp.text[:200]}",
+                message=f"{url} did not return a JSON object: {resp.text[:200]}",
             )
         )
         return report
@@ -91,7 +119,12 @@ def health_check(context: ExecutionContext, stack_path: Path) -> SmoketestReport
         CheckResult("nok8s_models_endpoint", True, message=f"{url} returned 200")
     )
 
-    served = [d.get("id") for d in body.get("data", []) if isinstance(d, dict)]
+    data = body.get("data")
+    served = (
+        [d.get("id") for d in data if isinstance(d, dict)]
+        if isinstance(data, list)
+        else []
+    )
     if model in served:
         report.add(
             CheckResult("nok8s_model_served", True, message=f"{model} is served")
@@ -124,7 +157,8 @@ def inference_test(context: ExecutionContext, stack_path: Path) -> SmoketestRepo
 
     context.logger.log_info(f"Running sample inference against {url}...")
     try:
-        resp = requests.post(url, json=payload, timeout=_TIMEOUT)
+        with _session() as session:
+            resp = session.post(url, json=payload, timeout=_COMPLETION_TIMEOUT)
     except requests.RequestException as e:
         report.add(
             CheckResult("nok8s_inference", False, message=f"{url} unreachable: {e}")
@@ -144,19 +178,23 @@ def inference_test(context: ExecutionContext, stack_path: Path) -> SmoketestRepo
         return report
 
     try:
-        choices = resp.json().get("choices") or []
+        body = resp.json()
     except ValueError:
+        body = None
+    if not isinstance(body, dict):
         report.add(
             CheckResult(
                 "nok8s_inference",
                 False,
-                message=f"{url} returned a non-JSON body: {resp.text[:200]}",
+                message=f"{url} did not return a JSON object: {resp.text[:200]}",
             )
         )
         return report
 
-    text = choices[0].get("text", "") if choices else ""
-    if not text:
+    choices = body.get("choices")
+    first = choices[0] if isinstance(choices, list) and choices else None
+    text = first.get("text") if isinstance(first, dict) else None
+    if not isinstance(text, str) or not text:
         report.add(
             CheckResult(
                 "nok8s_inference",

--- a/llmdbenchmark/smoketests/nok8s.py
+++ b/llmdbenchmark/smoketests/nok8s.py
@@ -1,0 +1,173 @@
+"""Cluster-free smoketest probes for the no-Kubernetes (nok8s) deployment.
+
+The stack is plain containers on the host, so there is no Service IP, no pod
+to exec into and no route to look up.  These two probes talk straight to the
+Envoy front door over HTTP, using the same rendered
+``34_nok8s-containers.yaml`` launch spec ``step_06_nok8s_deploy`` deployed
+from, so the endpoint probed and the model asserted provably match what was
+launched.
+"""
+
+from pathlib import Path
+
+import requests
+import yaml
+
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.smoketests.report import CheckResult, SmoketestReport
+
+_SPEC_PREFIX = "34_nok8s-containers"
+_TIMEOUT = 15
+
+
+def _read_spec(stack_path: Path) -> tuple[str, str, str]:
+    """Return (endpoint, model, error) from the rendered nok8s launch spec."""
+    for spec_file in sorted(stack_path.glob(f"{_SPEC_PREFIX}*")):
+        spec = yaml.safe_load(spec_file.read_text(encoding="utf-8")) or {}
+        endpoint = str(spec.get("endpoint") or "").rstrip("/")
+        model = str(spec.get("model") or "")
+        if not endpoint or not model:
+            return "", "", f"{spec_file} is missing 'endpoint' and/or 'model'"
+        return endpoint, model, ""
+    return "", "", f"No {_SPEC_PREFIX}*.yaml found in {stack_path}"
+
+
+def _spec_failure(name: str, error: str) -> SmoketestReport:
+    report = SmoketestReport()
+    report.add(CheckResult(name, False, message=error))
+    return report
+
+
+def health_check(context: ExecutionContext, stack_path: Path) -> SmoketestReport:
+    """Probe ``/v1/models`` on the nok8s Envoy front door."""
+    report = SmoketestReport()
+    endpoint, model, error = _read_spec(stack_path)
+    if error:
+        return _spec_failure("nok8s_container_spec", error)
+
+    url = f"{endpoint}/v1/models"
+    if context.dry_run:
+        context.logger.log_info(f"[dry-run] would GET {url} expecting model {model}")
+        return report
+
+    context.logger.log_info(f"Checking {url}...")
+    try:
+        resp = requests.get(url, timeout=_TIMEOUT)
+    except requests.RequestException as e:
+        report.add(
+            CheckResult(
+                "nok8s_models_endpoint",
+                False,
+                message=f"{url} unreachable: {e}",
+            )
+        )
+        return report
+
+    if resp.status_code != 200:
+        report.add(
+            CheckResult(
+                "nok8s_models_endpoint",
+                False,
+                expected="200",
+                actual=str(resp.status_code),
+                message=f"{url} returned HTTP {resp.status_code}: {resp.text[:200]}",
+            )
+        )
+        return report
+
+    try:
+        body = resp.json()
+    except ValueError:
+        report.add(
+            CheckResult(
+                "nok8s_models_endpoint",
+                False,
+                message=f"{url} returned a non-JSON body: {resp.text[:200]}",
+            )
+        )
+        return report
+
+    report.add(
+        CheckResult("nok8s_models_endpoint", True, message=f"{url} returned 200")
+    )
+
+    served = [d.get("id") for d in body.get("data", []) if isinstance(d, dict)]
+    if model in served:
+        report.add(
+            CheckResult("nok8s_model_served", True, message=f"{model} is served")
+        )
+    else:
+        report.add(
+            CheckResult(
+                "nok8s_model_served",
+                False,
+                expected=model,
+                actual=", ".join(str(s) for s in served) or "(none)",
+                message=f"{model} not served, {url} lists: {served}",
+            )
+        )
+    return report
+
+
+def inference_test(context: ExecutionContext, stack_path: Path) -> SmoketestReport:
+    """Send one completion request through the nok8s Envoy front door."""
+    report = SmoketestReport()
+    endpoint, model, error = _read_spec(stack_path)
+    if error:
+        return _spec_failure("nok8s_container_spec", error)
+
+    url = f"{endpoint}/v1/completions"
+    payload = {"model": model, "prompt": "Hello", "max_tokens": 16}
+    if context.dry_run:
+        context.logger.log_info(f"[dry-run] would POST {payload} to {url}")
+        return report
+
+    context.logger.log_info(f"Running sample inference against {url}...")
+    try:
+        resp = requests.post(url, json=payload, timeout=_TIMEOUT)
+    except requests.RequestException as e:
+        report.add(
+            CheckResult("nok8s_inference", False, message=f"{url} unreachable: {e}")
+        )
+        return report
+
+    if resp.status_code != 200:
+        report.add(
+            CheckResult(
+                "nok8s_inference",
+                False,
+                expected="200",
+                actual=str(resp.status_code),
+                message=f"{url} returned HTTP {resp.status_code}: {resp.text[:200]}",
+            )
+        )
+        return report
+
+    try:
+        choices = resp.json().get("choices") or []
+    except ValueError:
+        report.add(
+            CheckResult(
+                "nok8s_inference",
+                False,
+                message=f"{url} returned a non-JSON body: {resp.text[:200]}",
+            )
+        )
+        return report
+
+    text = choices[0].get("text", "") if choices else ""
+    if not text:
+        report.add(
+            CheckResult(
+                "nok8s_inference",
+                False,
+                message=f"{url} returned no generated text: {resp.text[:200]}",
+            )
+        )
+        return report
+
+    context.logger.log_info(f"Generated: {text[:120]}")
+    report.add(
+        CheckResult("nok8s_inference", True, message=f"{model} responded via {url}")
+    )
+    return report

--- a/llmdbenchmark/smoketests/steps/step_01_inference_test.py
+++ b/llmdbenchmark/smoketests/steps/step_01_inference_test.py
@@ -37,8 +37,10 @@ class InferenceTestStep(Step):
         validator = get_validator(stack_name)
         report = validator.run_inference_test(context, stack_path)
 
-        # Clean up ephemeral curl pods left behind by health + inference checks
-        if not context.dry_run:
+        # Clean up ephemeral curl pods left behind by health + inference checks.
+        # nok8s never creates one (and has no cluster to talk to), but it does
+        # carry a namespace, so the container_only guard is load-bearing.
+        if not context.dry_run and not context.container_only:
             namespace = context.harness_namespace or context.namespace
             if namespace:
                 cmd = context.require_cmd()

--- a/tests/test_nok8s_smoketest.py
+++ b/tests/test_nok8s_smoketest.py
@@ -50,6 +50,9 @@ class _Responses:
     def __init__(self):
         self.models = (200, {"data": [{"id": MODEL}]})
         self.completions = (200, {"choices": [{"text": " world"}]})
+        # One-shot reply served before `models`, for the retry test.
+        self.models_once = None
+        self.model_hits = 0
 
 
 def _make_handler(responses: _Responses):
@@ -66,7 +69,9 @@ def _make_handler(responses: _Responses):
 
         def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
             if self.path == "/v1/models":
-                self._reply(*responses.models)
+                responses.model_hits += 1
+                once, responses.models_once = responses.models_once, None
+                self._reply(*(once or responses.models))
             else:
                 self._reply(404, {"error": "not found"})
 
@@ -84,12 +89,20 @@ def _make_handler(responses: _Responses):
     return Handler
 
 
+@pytest.fixture(autouse=True)
+def _no_retry_backoff(monkeypatch):
+    """Keep the suite quick; the retry budget has its own explicit test."""
+    monkeypatch.setattr(nok8s, "_RETRY_TOTAL", 0)
+    monkeypatch.setattr(nok8s, "_RETRY_BACKOFF", 0)
+
+
 @pytest.fixture
 def server():
     """A running stub server; yields (responses, port)."""
     responses = _Responses()
     httpd = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(responses))
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    # Short poll interval: shutdown() otherwise costs 0.5s per test.
+    thread = threading.Thread(target=httpd.serve_forever, args=(0.02,), daemon=True)
     thread.start()
     try:
         yield responses, httpd.server_address[1]
@@ -159,12 +172,25 @@ class TestHealthCheck:
         errors = "".join(report.errors())
         assert MODEL in errors and "some/other-model" in errors
 
-    def test_non_json_body_fails(self, server, tmp_path):
+    @pytest.mark.parametrize(
+        "body",
+        [b"<html>gateway</html>", b"null", b'["a"]'],
+        ids=["html", "null", "list"],
+    )
+    def test_body_that_is_not_a_json_object_fails(self, server, tmp_path, body):
         responses, port = server
-        responses.models = (200, b"<html>gateway</html>")
+        responses.models = (200, body)
         report = nok8s.health_check(_context(), _stack_dir(tmp_path, port))
         assert not report.passed
-        assert "non-JSON" in "".join(report.errors())
+        assert "did not return a JSON object" in "".join(report.errors())
+
+    def test_transient_503_is_retried(self, server, tmp_path, monkeypatch):
+        responses, port = server
+        monkeypatch.setattr(nok8s, "_RETRY_TOTAL", 2)
+        responses.models_once = (503, {"error": "warming up"})
+        report = nok8s.health_check(_context(), _stack_dir(tmp_path, port))
+        assert report.passed, report.errors()
+        assert responses.model_hits == 2
 
     def test_missing_spec_file_fails(self, tmp_path):
         empty = tmp_path / "nok8s-single"
@@ -199,12 +225,25 @@ class TestInferenceTest:
         assert not report.passed
         assert "500" in "".join(report.errors())
 
-    def test_empty_choices_fails(self, server, tmp_path):
+    @pytest.mark.parametrize(
+        "body",
+        [{"choices": []}, {"choices": ["abc"]}, {"choices": [{"text": ""}]}, {}],
+        ids=["empty", "strings", "blank-text", "no-choices"],
+    )
+    def test_missing_generated_text_fails(self, server, tmp_path, body):
         responses, port = server
-        responses.completions = (200, {"choices": []})
+        responses.completions = (200, body)
         report = nok8s.inference_test(_context(), _stack_dir(tmp_path, port))
         assert not report.passed
         assert "no generated text" in "".join(report.errors())
+
+    @pytest.mark.parametrize("body", [b"null", b'["a"]'], ids=["null", "list"])
+    def test_body_that_is_not_a_json_object_fails(self, server, tmp_path, body):
+        responses, port = server
+        responses.completions = (200, body)
+        report = nok8s.inference_test(_context(), _stack_dir(tmp_path, port))
+        assert not report.passed
+        assert "did not return a JSON object" in "".join(report.errors())
 
     def test_unreachable_endpoint_fails(self, tmp_path):
         report = nok8s.inference_test(_context(), _stack_dir(tmp_path, _closed_port()))
@@ -281,5 +320,15 @@ def test_do_smoketest_sets_container_only(monkeypatch, tmp_path):
     cli._do_smoketest(args, MagicMock(), types.SimpleNamespace(rendered_paths=[]))
 
     assert captured["context"].container_only is True
-    # resolve_cluster() short-circuits on container_only, so no kubeconfig.
-    assert captured["context"].resolve_cluster() is None
+
+    # resolve_cluster() must short-circuit on container_only instead of
+    # reaching the kubeconfig-loading resolver (which is what issue #1698
+    # tripped over). Fail loudly if it ever gets there.
+    import llmdbenchmark.utilities.cluster as cluster_mod
+
+    monkeypatch.setattr(
+        cluster_mod,
+        "resolve_cluster",
+        lambda ctx: pytest.fail("smoketest must not resolve a cluster for nok8s"),
+    )
+    captured["context"].resolve_cluster()

--- a/tests/test_nok8s_smoketest.py
+++ b/tests/test_nok8s_smoketest.py
@@ -1,0 +1,285 @@
+"""Tests for the cluster-free (nok8s) smoketest probes.
+
+Issue #1698: `llmdbenchmark ... smoketest` on a nok8s scenario died before
+step 00 with a kubeconfig error, because `_do_smoketest` never set
+`container_only`, and even past that the validators were cluster-shaped
+(Service IP discovery, pod readiness, `oc get route`).
+
+These tests drive the probes against a real stdlib HTTP server on an
+ephemeral loopback port, so the request path (socket, status code, JSON
+body) is exercised for real rather than mocked. The failure paths matter
+most: a probe that silently passes when the endpoint is down is worse than
+no probe.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import threading
+import types
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub planner so we can import smoketest modules (see
+# test_smoketest_inference.py for the same pattern + rationale).
+if "planner" not in sys.modules:
+    planner_stub = types.ModuleType("planner")
+    capacity_stub = types.ModuleType("planner.capacity_planner")
+    capacity_stub.__getattr__ = lambda name: lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules["planner"] = planner_stub
+    sys.modules["planner.capacity_planner"] = capacity_stub
+
+from llmdbenchmark.smoketests import nok8s  # noqa: E402
+
+MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+
+# ---------------------------------------------------------------------------
+# A configurable OpenAI-shaped stub server
+# ---------------------------------------------------------------------------
+
+
+class _Responses:
+    """Per-test response config, mutated by the tests before each request."""
+
+    def __init__(self):
+        self.models = (200, {"data": [{"id": MODEL}]})
+        self.completions = (200, {"choices": [{"text": " world"}]})
+
+
+def _make_handler(responses: _Responses):
+    class Handler(BaseHTTPRequestHandler):
+        def _reply(self, status, body):
+            payload = (
+                body if isinstance(body, bytes) else json.dumps(body).encode("utf-8")
+            )
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+            if self.path == "/v1/models":
+                self._reply(*responses.models)
+            else:
+                self._reply(404, {"error": "not found"})
+
+        def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler API
+            length = int(self.headers.get("Content-Length", 0))
+            self.rfile.read(length)
+            if self.path == "/v1/completions":
+                self._reply(*responses.completions)
+            else:
+                self._reply(404, {"error": "not found"})
+
+        def log_message(self, *args):  # silence the stub's stderr noise
+            pass
+
+    return Handler
+
+
+@pytest.fixture
+def server():
+    """A running stub server; yields (responses, port)."""
+    responses = _Responses()
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(responses))
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield responses, httpd.server_address[1]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def _closed_port() -> int:
+    """Bind and immediately release a port so nothing is listening on it."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _stack_dir(tmp_path: Path, port: int, *, model: str = MODEL) -> Path:
+    """A stack dir holding a real 34_nok8s-containers.yaml launch spec."""
+    stack = tmp_path / "nok8s-single"
+    stack.mkdir()
+    (stack / "34_nok8s-containers.yaml").write_text(
+        f'runtime: docker\nmodel: {model}\nendpoint: "http://127.0.0.1:{port}"\n',
+        encoding="utf-8",
+    )
+    return stack
+
+
+def _context(dry_run: bool = False):
+    ctx = MagicMock()
+    ctx.container_only = True
+    ctx.dry_run = dry_run
+    ctx.logger = MagicMock()
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# health_check
+# ---------------------------------------------------------------------------
+
+
+class TestHealthCheck:
+    def test_happy_path(self, server, tmp_path):
+        _responses, port = server
+        report = nok8s.health_check(_context(), _stack_dir(tmp_path, port))
+        assert report.passed, report.errors()
+        assert {c.name for c in report.checks} == {
+            "nok8s_models_endpoint",
+            "nok8s_model_served",
+        }
+
+    def test_unreachable_endpoint_fails(self, tmp_path):
+        report = nok8s.health_check(_context(), _stack_dir(tmp_path, _closed_port()))
+        assert not report.passed
+        assert "unreachable" in "".join(report.errors())
+
+    def test_non_200_fails(self, server, tmp_path):
+        responses, port = server
+        responses.models = (503, {"error": "unavailable"})
+        report = nok8s.health_check(_context(), _stack_dir(tmp_path, port))
+        assert not report.passed
+        assert "503" in "".join(report.errors())
+
+    def test_different_model_fails_and_names_expected(self, server, tmp_path):
+        responses, port = server
+        responses.models = (200, {"data": [{"id": "some/other-model"}]})
+        report = nok8s.health_check(_context(), _stack_dir(tmp_path, port))
+        assert not report.passed
+        errors = "".join(report.errors())
+        assert MODEL in errors and "some/other-model" in errors
+
+    def test_non_json_body_fails(self, server, tmp_path):
+        responses, port = server
+        responses.models = (200, b"<html>gateway</html>")
+        report = nok8s.health_check(_context(), _stack_dir(tmp_path, port))
+        assert not report.passed
+        assert "non-JSON" in "".join(report.errors())
+
+    def test_missing_spec_file_fails(self, tmp_path):
+        empty = tmp_path / "nok8s-single"
+        empty.mkdir()
+        report = nok8s.health_check(_context(), empty)
+        assert not report.passed
+        assert "34_nok8s-containers" in "".join(report.errors())
+
+    def test_dry_run_issues_no_http(self, tmp_path):
+        # Port is closed: a real request would fail, so a pass proves no I/O.
+        stack = _stack_dir(tmp_path, _closed_port())
+        report = nok8s.health_check(_context(dry_run=True), stack)
+        assert report.passed
+        assert report.total == 0
+
+
+# ---------------------------------------------------------------------------
+# inference_test
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceTest:
+    def test_happy_path(self, server, tmp_path):
+        _responses, port = server
+        report = nok8s.inference_test(_context(), _stack_dir(tmp_path, port))
+        assert report.passed, report.errors()
+
+    def test_server_error_fails(self, server, tmp_path):
+        responses, port = server
+        responses.completions = (500, {"error": "boom"})
+        report = nok8s.inference_test(_context(), _stack_dir(tmp_path, port))
+        assert not report.passed
+        assert "500" in "".join(report.errors())
+
+    def test_empty_choices_fails(self, server, tmp_path):
+        responses, port = server
+        responses.completions = (200, {"choices": []})
+        report = nok8s.inference_test(_context(), _stack_dir(tmp_path, port))
+        assert not report.passed
+        assert "no generated text" in "".join(report.errors())
+
+    def test_unreachable_endpoint_fails(self, tmp_path):
+        report = nok8s.inference_test(_context(), _stack_dir(tmp_path, _closed_port()))
+        assert not report.passed
+        assert "unreachable" in "".join(report.errors())
+
+    def test_dry_run_issues_no_http(self, tmp_path):
+        stack = _stack_dir(tmp_path, _closed_port())
+        report = nok8s.inference_test(_context(dry_run=True), stack)
+        assert report.passed
+        assert report.total == 0
+
+
+# ---------------------------------------------------------------------------
+# The base validator must route container_only deployments to the probes
+# instead of the cluster-shaped path (which calls require_cmd() first).
+# ---------------------------------------------------------------------------
+
+
+class TestBaseRoutesContainerOnly:
+    def _validator(self):
+        from llmdbenchmark.smoketests.base import BaseSmoketest
+
+        return BaseSmoketest.__new__(BaseSmoketest)
+
+    def test_health_checks_do_not_touch_the_cluster(self, server, tmp_path):
+        _responses, port = server
+        ctx = _context()
+        ctx.require_cmd.side_effect = AssertionError("must not require kubectl")
+        ctx.require_namespace.side_effect = AssertionError("must not need namespace")
+        report = self._validator().run_health_checks(ctx, _stack_dir(tmp_path, port))
+        assert report.passed, report.errors()
+
+    def test_inference_does_not_touch_the_cluster(self, server, tmp_path):
+        _responses, port = server
+        ctx = _context()
+        ctx.require_cmd.side_effect = AssertionError("must not require kubectl")
+        ctx.require_namespace.side_effect = AssertionError("must not need namespace")
+        report = self._validator().run_inference_test(ctx, _stack_dir(tmp_path, port))
+        assert report.passed, report.errors()
+
+
+# ---------------------------------------------------------------------------
+# cli._do_smoketest must set container_only so resolve_cluster() short-circuits
+# instead of raising "Failed to load Kubernetes configuration".
+# ---------------------------------------------------------------------------
+
+
+def test_do_smoketest_sets_container_only(monkeypatch, tmp_path):
+    from llmdbenchmark import cli
+
+    monkeypatch.setattr(cli.config, "plan_dir", tmp_path, raising=False)
+    monkeypatch.setattr(cli.config, "workspace", tmp_path, raising=False)
+    monkeypatch.setattr(cli, "_load_all_stacks_info", lambda paths: [{}])
+    monkeypatch.setattr(cli, "_resolve_deploy_methods", lambda *a, **kw: ["nok8s"])
+    monkeypatch.setattr(cli, "_parse_namespaces", lambda *a, **kw: ("llmdbench", None))
+
+    captured = {}
+
+    class _Result:
+        has_errors = False
+
+    class _Executor:
+        def __init__(self, **kwargs):
+            captured["context"] = kwargs["context"]
+
+        def execute(self, step_spec=None):
+            return _Result()
+
+    monkeypatch.setattr(cli, "StepExecutor", _Executor)
+    monkeypatch.setattr(cli, "get_smoketest_steps", lambda: [])
+
+    args = types.SimpleNamespace()
+    cli._do_smoketest(args, MagicMock(), types.SimpleNamespace(rendered_paths=[]))
+
+    assert captured["context"].container_only is True
+    # resolve_cluster() short-circuits on container_only, so no kubeconfig.
+    assert captured["context"].resolve_cluster() is None


### PR DESCRIPTION
## Description

Fixes #1698.

`llmdbenchmark ... smoketest` on a no-Kubernetes scenario died before step 00 with
"Failed to load Kubernetes configuration", contradicting docs/nok8s.md, which says
no cluster access is required. Two layers were broken.

`_do_smoketest` was the only phase builder that never computed `container_only`, so
`resolve_cluster()` took the Kubernetes branch and the phase exited 1 before any step
ran. It also enforced a namespace unconditionally, which standup, teardown and run all
relax for nok8s. Fixing the phase builder rather than the subcommand dispatcher also
repairs `experiment`, which calls `_do_smoketest` with no nok8s guard.

Even past that, the validators were cluster-shaped by construction: `require_cmd()`
plus `require_namespace()`, Service IP discovery, pod readiness waits, pod IPs and an
`oc get route` lookup, none of which exist in a nok8s deployment.
`BaseSmoketest.run_health_checks` and `run_inference_test` now branch on
`container_only` to two HTTP probes that read the same rendered
`34_nok8s-containers.yaml` launch spec step 06 deployed from, so the endpoint probed
and the model asserted match what was actually launched. No validator subclass
overrides either method, so the single base branch covers every stack. Step 01's
kubectl-based ephemeral pod cleanup is skipped for the same reason.

The probes fail loudly on an unreachable endpoint, a non-200, a non-JSON body, a
malformed body shape, a model the server does not list, and an empty completion, and
issue no request at all under `--dry-run`.

Three deliberate calls:

- Separate timeouts. GET /v1/models gets 15s, POST /v1/completions gets 120s, matching
  `BaseSmoketest._curl_post`'s existing default. A 16-token generation on a cold or
  `accelerator: cpu` stack is not reliably sub-15s, and a single 15s budget would have
  turned that into a false failure.
- A retry budget. Both probes go through a `requests.Session` with a urllib3 Retry
  adapter (total=3, backoff_factor=2, 502/503/504, `raise_on_status=False`).
  base.py already records that the old no-retry cluster behaviour "made every transient
  warmup race a hard smoketest failure", and the first draft of these probes had
  reintroduced exactly that. Reusing base.py's `_is_retryable`/`_compute_backoff` was
  not possible, since base.py imports nok8s.py at module level and importing back would
  be circular. `raise_on_status=False` preserves the existing
  "returned HTTP 503: <body>" diagnostic instead of surfacing a RetryError.
- The `standup` phase still does not chain the smoketest for nok8s. Changing which
  phases auto-chain is a separate behavioural decision for maintainers, and I cannot
  validate it on a host with no GPU. The skip is now documented in docs/nok8s.md and
  explained honestly in the code comment rather than by a stale rationale.

Not done here: a `/v1/chat/completions` fallback. The nok8s stack launches
`vllm serve <model>` from the same rendered spec the probe reads, and vLLM's OpenAI
server always registers `/v1/completions`. The cluster path's fallback exists because
it probes arbitrary user-supplied routes; nok8s cannot produce that configuration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (included)

## How Has This Been Tested?

Adds `tests/test_nok8s_smoketest.py` (23 tests) driving the real code against a stdlib
stub server on an ephemeral loopback port.

```
$ python3 -m pytest tests/ -x -q -n2
762 passed, 31 skipped in 27.56s
```

Baseline on main is 739; the branch adds 23.

Revert check, with the three production files reset to main and the tests kept:

```
FAILED tests/test_nok8s_smoketest.py::TestBaseRoutesContainerOnly::test_health_checks_do_not_touch_the_cluster
FAILED tests/test_nok8s_smoketest.py::TestBaseRoutesContainerOnly::test_inference_does_not_touch_the_cluster
FAILED tests/test_nok8s_smoketest.py::test_do_smoketest_sets_container_only
3 failed, 20 passed in 1.82s
```

Two mutation checks on the new logic: emptying the Retry `status_forcelist` fails
`test_transient_503_is_retried`, and deleting the `container_only` short-circuit in
`ExecutionContext.resolve_cluster` fails `test_do_smoketest_sets_container_only`.

Exercised through the real CLI with `KUBECONFIG=/nonexistent`, no `--dry-run` and no
mocking: healthy gives exit 0; wrong model, null body, array body, empty choices,
string choices, null completion body, persistent 503 and no server at all each give
exit 1 with the correct diagnostic and no traceback; 503-once-then-200 gives exit 0,
which is the retry budget working. `--dry-run` issues zero I/O.

`pre-commit run --files` on the 5 changed files: py-compile, pytest, render-changed-
scenarios, detect-secrets, ruff-check and ruff-format all Passed. The SBOM hook
self-skipped on its file filter.

### Test Configuration

- Kubernetes version: none, which is the point of this change. A live nok8s standup
  was not verifiable here, since vLLM needs `--gpus all` and this host has no GPU. The
  probes are exercised against a stub server speaking the same OpenAI-shaped contract,
  not against a real vLLM.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [x] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly (`docs/nok8s.md`,
      `llmdbenchmark/smoketests/README.md`)

No cluster and no GPU here, so the standup/run/teardown sequence was not run.
