### PR TITLE
fix: scope nok8s container names, ports and workspace per stack

### DIFF
--- a/config/templates/jinja/33_nok8s-envoy.yaml.j2
+++ b/config/templates/jinja/33_nok8s-envoy.yaml.j2
@@ -8,7 +8,7 @@ admin:
   address:
     socket_address:
       address: 127.0.0.1
-      port_value: 19000
+      port_value: {{ nok8s.envoy.adminPort }}
 
 static_resources:
   listeners:

--- a/config/templates/jinja/34_nok8s-containers.yaml.j2
+++ b/config/templates/jinja/34_nok8s-containers.yaml.j2
@@ -18,7 +18,7 @@ readiness:
   envoyPort: {{ nok8s.envoy.listenPort }}
 containers:
 {% for i in range(nok8s.vllm.replicas) %}
-  - name: vllm-{{ i }}
+  - name: vllm-{{ i }}{{ nok8s.nameSuffix }}
     kind: vllm
     image: "{{ nok8s.vllm.image }}:{{ nok8s.vllm.tag }}"
     hostPort: {{ nok8s.vllm.hostPort + i }}
@@ -32,7 +32,7 @@ containers:
     replicaIndex: {{ i }}
     extraArgs: [{% for a in nok8s.vllm.extraArgs %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 {% endfor %}
-  - name: epp
+  - name: epp{{ nok8s.nameSuffix }}
     kind: epp
     image: "{{ nok8s.epp.image }}:{{ nok8s.epp.tag }}"
     grpcPort: {{ nok8s.epp.grpcPort }}
@@ -41,7 +41,7 @@ containers:
     poolName: {{ nok8s.epp.poolName }}
     poolNamespace: {{ nok8s.epp.poolNamespace }}
     configMountDir: {{ nok8s.epp.configMountDir }}
-  - name: envoy
+  - name: envoy{{ nok8s.nameSuffix }}
     kind: envoy
     image: "{{ nok8s.envoy.image }}:{{ nok8s.envoy.tag }}"
     listenPort: {{ nok8s.envoy.listenPort }}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1421,7 +1421,8 @@ nok8s:
   # Appended to every container name (vllm-N, epp, envoy). Filled in
   # automatically with "-<stack>" when a scenario has more than one stack, so
   # sibling stacks on one host don't share (and delete) each other's
-  # containers. An explicit value is preserved; single-stack scenarios keep
+  # containers. An explicit value is preserved, but two stacks resolving to
+  # the same container name is a render error; single-stack scenarios keep
   # the bare names.
   nameSuffix: ""
 

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1414,8 +1414,16 @@ nok8s:
   # can pull gated models from Hugging Face.
   hfTokenEnv: HUGGING_FACE_HUB_TOKEN
   # Host directory where rendered EPP/Envoy configs are staged and bind-mounted
-  # from (avoids sudo writes to /etc).
+  # from (avoids sudo writes to /etc). A scenario with more than one stack
+  # gets a per-stack subdirectory appended so stacks never overwrite each
+  # other's staged configs.
   workspaceHostDir: "~/.llmdbench/nok8s"
+  # Appended to every container name (vllm-N, epp, envoy). Filled in
+  # automatically with "-<stack>" when a scenario has more than one stack, so
+  # sibling stacks on one host don't share (and delete) each other's
+  # containers. An explicit value is preserved; single-stack scenarios keep
+  # the bare names.
+  nameSuffix: ""
 
   # vLLM inference worker(s)
   vllm:
@@ -1459,6 +1467,9 @@ nok8s:
     image: docker.io/envoyproxy/envoy
     tag: distroless-v1.33.2
     listenPort: 8081
+    # Envoy admin interface. Envoy runs with --network host, so two stacks on
+    # one host need distinct admin ports as well as distinct listenPorts.
+    adminPort: 19000
     configMountPath: /etc/envoy/envoy.yaml
 
 # ============================================================================

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -129,7 +129,8 @@ single-GPU example. Key fields (full defaults in
 | `nok8s.workspaceHostDir` | Host dir where EPP/Envoy configs are staged + bind-mounted |
 | `nok8s.vllm.{image,tag,hostPort,tensorParallel,accelerator,gpus,deviceArgs,shmSize,replicas,extraArgs}` | vLLM worker(s); worker *i* is published on `hostPort + i` (see Accelerators for `accelerator`/`deviceArgs`) |
 | `nok8s.epp.{image,tag,grpcPort,grpcHealthPort,metricsPort}` | Endpoint Picker |
-| `nok8s.envoy.{image,tag,listenPort}` | Envoy front door (the run target) |
+| `nok8s.envoy.{image,tag,listenPort,adminPort}` | Envoy front door (the run target); `adminPort` is the admin interface, bound on the host (`--network host`) |
+| `nok8s.nameSuffix` | Appended to every container name. Filled automatically with `-<stack>` in a multi-stack scenario (see below); leave empty for one stack |
 | `model.{name,huggingfaceId}` | Set both; standup uses `name`, run reads `huggingfaceId` |
 
 Sizing (fp16, single GPU): ~16 GB → 7–8B · ~24 GB → 8B · ~40 GB → 14B ·
@@ -169,6 +170,60 @@ nok8s:
 Step 00 probes the accelerator when it can (`nvidia-smi`/`rocm-smi`/`xpu-smi`/
 `hl-smi`); `cpu`/`spyre`/custom are not probed (a note is logged) — ensure the
 device and image match yourself.
+
+## Several stacks on one host
+
+A scenario with more than one stack runs every stack's containers on the same
+host, with no namespace to keep them apart, so each stack needs its own
+identity. Two things are automatic and one is on you:
+
+- **Container names** get a `-<stack name>` suffix, e.g. `vllm-0-chat`,
+  `epp-chat`, `envoy-chat`. Without this, stack B's idempotency sweep
+  (`docker rm -f epp`) deletes stack A's running router.
+- **`nok8s.workspaceHostDir`** gains a per-stack sub-directory, so the staged
+  EPP/Envoy configs never overwrite each other.
+- **Host ports are yours to assign.** They are never derived, because guessing
+  would silently bind ports you did not ask for. Two nok8s stacks claiming the
+  same port is a render error that names the port and the owning stack, and
+  standup stops before any container starts.
+
+A single-stack scenario is unaffected: names stay `vllm-0` / `epp` / `envoy`
+and the workspace stays `~/.llmdbench/nok8s`.
+
+Give every stack after the first a distinct set of six ports (more, with
+`replicas > 1`: worker *i* takes `hostPort + i`):
+
+```yaml
+scenario:
+  - name: chat
+    nok8s:
+      enabled: true
+      # ... first stack keeps the defaults: 8000, 8081, 19000, 9002/9003/9090
+
+  - name: code
+    nok8s:
+      enabled: true
+      vllm:
+        hostPort: 8100
+      epp:
+        grpcPort: 9102
+        grpcHealthPort: 9103
+        metricsPort: 9190
+      envoy:
+        listenPort: 8181
+        adminPort: 19100
+```
+
+Each stack gets its own Envoy front door, so benchmark them one at a time and
+point the run phase at that stack's `listenPort`:
+
+```bash
+llmdbenchmark --spec my-scenario.yaml run --stack chat --endpoint-url http://localhost:8081
+llmdbenchmark --spec my-scenario.yaml run --stack code --endpoint-url http://localhost:8181
+```
+
+`--endpoint-url` is required here: without it the run phase uses the first
+stack's endpoint for every stack.
 
 ## How it maps to the pipeline
 
@@ -220,7 +275,8 @@ auto-pinning and puts you in control).
 
 - **Preflight fails on runtime** — install docker/podman or set `nok8s.runtime`.
 - **vLLM container exits at load** — usually a too-large model for VRAM or a bad
-  HF token; check `docker logs vllm-0`. Lower the model size or add
+  HF token; check `docker logs vllm-0` (`docker logs vllm-0-<stack>` in a
+  multi-stack scenario). Lower the model size or add
   `--max-model-len`/`--gpu-memory-utilization` via `nok8s.vllm.extraArgs`.
 - **Envoy 503** — a worker isn't up; confirm `curl http://localhost:8000/v1/models`.
 - **podman + GPU** — ensure the CDI spec exists: `nvidia-ctk cdi list` should show

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -175,36 +175,50 @@ device and image match yourself.
 
 A scenario with more than one stack runs every stack's containers on the same
 host, with no namespace to keep them apart, so each stack needs its own
-identity. Two things are automatic and one is on you:
+identity. Two things are automatic and two are on you:
 
 - **Container names** get a `-<stack name>` suffix, e.g. `vllm-0-chat`,
   `epp-chat`, `envoy-chat`. Without this, stack B's idempotency sweep
-  (`docker rm -f epp`) deletes stack A's running router.
+  (`docker rm -f epp`) deletes stack A's running router. Two stacks that
+  still end up with the same container name (names differing only by
+  punctuation, or a shared explicit `nok8s.nameSuffix`) are a render error.
 - **`nok8s.workspaceHostDir`** gains a per-stack sub-directory, so the staged
   EPP/Envoy configs never overwrite each other.
 - **Host ports are yours to assign.** They are never derived, because guessing
   would silently bind ports you did not ask for. Two nok8s stacks claiming the
   same port is a render error that names the port and the owning stack, and
   standup stops before any container starts.
+- **Accelerators are yours to divide.** A worker with `replicas: 1` gets
+  `--gpus all`, so two such stacks both claim every device and the second one
+  runs out of memory. Give each stack its own devices (preflight warns when
+  more than one stack is left unpinned). Total demand is the sum of
+  `replicas x tensorParallel` over all stacks.
 
 A single-stack scenario is unaffected: names stay `vllm-0` / `epp` / `envoy`
-and the workspace stays `~/.llmdbench/nok8s`.
+and the workspace stays `~/.llmdbench/nok8s`. Converting an existing one? Run
+`teardown` first (or `docker rm -f vllm-0 epp envoy`): the unsuffixed
+containers from the single-stack run are no longer matched by the suffixed
+names, so teardown will not remove them and they keep holding their ports and
+device memory.
 
 Give every stack after the first a distinct set of six ports (more, with
-`replicas > 1`: worker *i* takes `hostPort + i`):
+`replicas > 1`: worker *i* takes `hostPort + i`) and its own devices:
 
 ```yaml
 scenario:
   - name: chat
     nok8s:
       enabled: true
-      # ... first stack keeps the defaults: 8000, 8081, 19000, 9002/9003/9090
+      vllm:
+        gpus: "device=0"        # podman: nok8s.vllm.deviceArgs
+      # ... first stack keeps the default ports: 8000, 8081, 19000, 9002/9003/9090
 
   - name: code
     nok8s:
       enabled: true
       vllm:
         hostPort: 8100
+        gpus: "device=1"
       epp:
         grpcPort: 9102
         grpcHealthPort: 9103
@@ -214,16 +228,18 @@ scenario:
         adminPort: 19100
 ```
 
-Each stack gets its own Envoy front door, so benchmark them one at a time and
-point the run phase at that stack's `listenPort`:
+Each stack gets its own Envoy front door, so there is no scenario-wide
+endpoint: benchmark them one at a time with `--stack`, which resolves that
+stack's `listenPort`.
 
 ```bash
-llmdbenchmark --spec my-scenario.yaml run --stack chat --endpoint-url http://localhost:8081
-llmdbenchmark --spec my-scenario.yaml run --stack code --endpoint-url http://localhost:8181
+llmdbenchmark --spec my-scenario.yaml run --stack chat   # -> http://localhost:8081
+llmdbenchmark --spec my-scenario.yaml run --stack code   # -> http://localhost:8181
 ```
 
-`--endpoint-url` is required here: without it the run phase uses the first
-stack's endpoint for every stack.
+`run` without `--stack` (or an explicit `--endpoint-url`) fails on a
+multi-stack nok8s scenario rather than benchmarking the first stack's Envoy
+and filing the results under every stack's name.
 
 ## How it maps to the pipeline
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -346,6 +346,32 @@ def _load_all_stacks_info(rendered_paths):
     return stacks_info
 
 
+def _nok8s_endpoint_url(all_stacks_info, stack_filter=None):
+    """Default the nok8s run target to the local Envoy front door.
+
+    Each nok8s stack has its own Envoy, so there is no scenario-wide
+    endpoint: picking one stack's port and benchmarking every stack through
+    it files stack A's traffic under stack B's name. Refuse instead, unless
+    --stack narrows the run to a single nok8s stack (then use that stack's
+    port) or the caller passed --endpoint-url.
+    """
+    stacks = [s for s in all_stacks_info if s.get("nok8s_enabled")]
+    if stack_filter:
+        stacks = [s for s in stacks if s.get("stack_name") in stack_filter]
+    if len(stacks) > 1:
+        raise PhaseError(
+            "This scenario has "
+            + str(len(stacks))
+            + " nok8s stacks, each with its own Envoy port, so there is no "
+            "single endpoint to benchmark. Run them one at a time with "
+            "'--stack <name>', or pass '--endpoint-url "
+            "http://localhost:<that stack's nok8s.envoy.listenPort>'. Stacks: "
+            + ", ".join(f"{s['stack_name']} ({s['nok8s_listen_port']})" for s in stacks)
+        )
+    port = (stacks[0] if stacks else {}).get("nok8s_listen_port", 8081)
+    return f"http://localhost:{port}"
+
+
 def _load_plan_info(rendered_paths):
     """Read key configuration from the first rendered plan config.yaml.
 
@@ -862,7 +888,9 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
     # so the run is fully cluster-free (flips is_run_only_mode, skipping k8s
     # endpoint discovery and namespace validation).
     if container_only and not endpoint_url:
-        endpoint_url = f"http://localhost:{plan_info.get('nok8s_listen_port', 8081)}"
+        endpoint_url = _nok8s_endpoint_url(
+            all_stacks_info, _parse_stack_filter(getattr(args, "stack", None))
+        )
     is_run_only = bool(endpoint_url or run_config_file)
 
     if not namespace and not is_run_only:

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -104,6 +104,9 @@ class RenderPlans:
         # _resolve_model fires once per RenderPlans instance, not N times
         # in a multi-stack scenario.
         self._cli_model_multi_stack_warned: bool = False
+        # host port -> stack that claimed it, accumulated across the
+        # sequentially rendered nok8s stacks. See _validate_nok8s_host_ports.
+        self._nok8s_port_claims: dict[int, str] = {}
 
         # ``--non-admin`` propagates into the Jinja render context as
         # ``nonAdmin`` so templates can gate cluster-scoped resources
@@ -1015,6 +1018,87 @@ class RenderPlans:
                 self._set_nested(values, path, f"{default}-{label}")
 
         return values
+
+    # nok8s host ports that must be unique across every nok8s stack on the
+    # host: config path -> whether the value is a base for `vllm.replicas`
+    # consecutive ports.
+    _NOK8S_HOST_PORTS: tuple[tuple[tuple[str, ...], bool], ...] = (
+        (("nok8s", "vllm", "hostPort"), True),
+        (("nok8s", "envoy", "listenPort"), False),
+        (("nok8s", "envoy", "adminPort"), False),
+        (("nok8s", "epp", "grpcPort"), False),
+        (("nok8s", "epp", "grpcHealthPort"), False),
+        (("nok8s", "epp", "metricsPort"), False),
+    )
+
+    def _resolve_nok8s_stack_scope(
+        self, values: dict, stack_name: str, total_stacks: int = 1
+    ) -> dict:
+        """Scope nok8s container names and the staged config dir to the stack.
+
+        nok8s containers live on one host with no namespace to separate
+        them, so every identity that a sibling stack also uses has to be
+        qualified. The stack name is unique by construction (it is the plan
+        sub-directory), so it is the qualifier: container names get a
+        ``-<stack>`` suffix and ``workspaceHostDir`` gets a ``/<stack>``
+        sub-directory.
+
+        Skipped for single-stack scenarios (matching
+        ``_resolve_per_stack_identity``) so the shipped names ``vllm-0`` /
+        ``epp`` / ``envoy`` and ``~/.llmdbench/nok8s`` stay stable.
+
+        Host ports are NOT derived here: binding a port the author never
+        wrote is worse than refusing to render. See
+        ``_validate_nok8s_host_ports``.
+        """
+        if total_stacks < 2 or not values.get("nok8s", {}).get("enabled"):
+            return values
+
+        # docker/podman container names allow [a-zA-Z0-9_.-] only.
+        slug = re.sub(r"[^A-Za-z0-9_.-]", "-", stack_name)
+        if not slug:
+            return values
+
+        nok8s = values["nok8s"]
+        if not nok8s.get("nameSuffix"):
+            nok8s["nameSuffix"] = f"-{slug}"
+        # Unconditional: an explicitly shared workspace dir still has to be
+        # partitioned, otherwise stack B overwrites stack A's staged configs.
+        workspace = str(nok8s.get("workspaceHostDir") or "~/.llmdbench/nok8s")
+        nok8s["workspaceHostDir"] = f"{workspace.rstrip('/')}/{slug}"
+
+        return values
+
+    def _validate_nok8s_host_ports(self, values: dict, stack_name: str) -> list[str]:
+        """Reject two nok8s stacks claiming the same host port.
+
+        Every nok8s container publishes on (or, for EPP/Envoy, binds with
+        ``--network host``) a fixed host port, so sibling stacks silently
+        fight over them. Claims are accumulated across stacks, which render
+        sequentially, and a clash is a render error: the CLI aborts before
+        any container is launched.
+        """
+        if not values.get("nok8s", {}).get("enabled"):
+            return []
+
+        errors: list[str] = []
+        replicas = int(values.get("nok8s", {}).get("vllm", {}).get("replicas", 1) or 1)
+        for path, is_base in self._NOK8S_HOST_PORTS:
+            base = self._get_nested(values, path)
+            if not isinstance(base, int):
+                continue
+            key = ".".join(path)
+            for port in range(base, base + (replicas if is_base else 1)):
+                owner = self._nok8s_port_claims.setdefault(port, stack_name)
+                if owner != stack_name:
+                    errors.append(
+                        f"[{stack_name}] nok8s host port {port} ({key}) is already "
+                        f"used by stack '{owner}'. Every nok8s stack on a host needs "
+                        f"its own ports; give this stack distinct "
+                        f"nok8s.vllm.hostPort, nok8s.envoy.listenPort, "
+                        f"nok8s.envoy.adminPort and nok8s.epp.* values."
+                    )
+        return errors
 
     @staticmethod
     def _get_nested(root: dict, path: tuple[str, ...]) -> Any:
@@ -1932,6 +2016,9 @@ class RenderPlans:
         merged_values = self._resolve_per_stack_identity(
             merged_values, total_stacks=total_stacks
         )
+        merged_values = self._resolve_nok8s_stack_scope(
+            merged_values, stack_name=stack_name, total_stacks=total_stacks
+        )
         merged_values = self._resolve_inference_pool_host(merged_values)
         merged_values = self._normalize_direct_service_mode(merged_values)
         merged_values = self._normalize_router_block(merged_values)
@@ -1977,6 +2064,10 @@ class RenderPlans:
             stack_name=stack_name,
         )
         for msg in kustomize_errors:
+            self.logger.log_error(msg)
+            stack_errors.render_errors.append(msg)
+
+        for msg in self._validate_nok8s_host_ports(merged_values, stack_name):
             self.logger.log_error(msg)
             stack_errors.render_errors.append(msg)
 
@@ -2176,6 +2267,7 @@ class RenderPlans:
             sibling_stacks
         )
 
+        self._nok8s_port_claims = {}
         for i, stack in enumerate(stacks, 1):
             self._process_stack(
                 stack=stack,

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1052,7 +1052,7 @@ class RenderPlans:
 
         Host ports are NOT derived here: binding a port the author never
         wrote is worse than refusing to render. See
-        ``_validate_nok8s_host_ports``.
+        ``_validate_nok8s_host_claims``.
         """
         if total_stacks < 2 or not values.get("nok8s", {}).get("enabled"):
             return values

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -104,9 +104,11 @@ class RenderPlans:
         # _resolve_model fires once per RenderPlans instance, not N times
         # in a multi-stack scenario.
         self._cli_model_multi_stack_warned: bool = False
-        # host port -> stack that claimed it, accumulated across the
-        # sequentially rendered nok8s stacks. See _validate_nok8s_host_ports.
-        self._nok8s_port_claims: dict[int, str] = {}
+        # host port -> (stack, config key) and container name -> stack that
+        # claimed them, accumulated across the sequentially rendered nok8s
+        # stacks. See _validate_nok8s_host_claims.
+        self._nok8s_port_claims: dict[int, tuple[str, str]] = {}
+        self._nok8s_name_claims: dict[str, str] = {}
 
         # ``--non-admin`` propagates into the Jinja render context as
         # ``nonAdmin`` so templates can gate cluster-scoped resources
@@ -1038,10 +1040,11 @@ class RenderPlans:
 
         nok8s containers live on one host with no namespace to separate
         them, so every identity that a sibling stack also uses has to be
-        qualified. The stack name is unique by construction (it is the plan
-        sub-directory), so it is the qualifier: container names get a
+        qualified. The stack name is the qualifier: container names get a
         ``-<stack>`` suffix and ``workspaceHostDir`` gets a ``/<stack>``
-        sub-directory.
+        sub-directory. The suffix is only a default (two names can slug to
+        one string, and an explicit ``nameSuffix`` wins), so the resolved
+        names are checked in ``_validate_nok8s_host_claims``.
 
         Skipped for single-stack scenarios (matching
         ``_resolve_per_stack_identity``) so the shipped names ``vllm-0`` /
@@ -1069,12 +1072,14 @@ class RenderPlans:
 
         return values
 
-    def _validate_nok8s_host_ports(self, values: dict, stack_name: str) -> list[str]:
-        """Reject two nok8s stacks claiming the same host port.
+    def _validate_nok8s_host_claims(self, values: dict, stack_name: str) -> list[str]:
+        """Reject two nok8s stacks claiming the same container name or host port.
 
-        Every nok8s container publishes on (or, for EPP/Envoy, binds with
-        ``--network host``) a fixed host port, so sibling stacks silently
-        fight over them. Claims are accumulated across stacks, which render
+        The host has one flat container namespace and one set of ports, so
+        sibling stacks silently fight over both: a shared name means one
+        stack's idempotency sweep (``rm -f``) deletes the other's running
+        containers, a shared port means whichever container starts second
+        dies. Claims are accumulated across stacks, which render
         sequentially, and a clash is a render error: the CLI aborts before
         any container is launched.
         """
@@ -1082,14 +1087,43 @@ class RenderPlans:
             return []
 
         errors: list[str] = []
-        replicas = int(values.get("nok8s", {}).get("vllm", {}).get("replicas", 1) or 1)
+        nok8s = values["nok8s"]
+        replicas = nok8s.get("vllm", {}).get("replicas", 1)
+        if not isinstance(replicas, int) or replicas < 1:
+            # A bad value is already reported by the template render; this
+            # validator only has to not crash on it.
+            replicas = 1
+
+        # Names exactly as 34_nok8s-containers.yaml.j2 builds them. The
+        # suffix is normally derived from the stack name, but two stack
+        # names can slug to the same string and an explicit
+        # ``nok8s.nameSuffix`` can be shared outright, so the resolved name
+        # is what gets checked.
+        suffix = str(nok8s.get("nameSuffix") or "")
+        names = [f"vllm-{i}{suffix}" for i in range(replicas)]
+        names += [f"epp{suffix}", f"envoy{suffix}"]
+        for name in names:
+            owner = self._nok8s_name_claims.setdefault(name, stack_name)
+            if owner != stack_name:
+                errors.append(
+                    f"[{stack_name}] nok8s container name '{name}' is already "
+                    f"used by stack '{owner}'. Standing up this stack would "
+                    f"delete that stack's containers; give the stacks names "
+                    f"that differ by more than punctuation, or set a distinct "
+                    f"nok8s.nameSuffix on each."
+                )
+
         for path, is_base in self._NOK8S_HOST_PORTS:
             base = self._get_nested(values, path)
+            if isinstance(base, str) and base.isdigit():
+                base = int(base)
             if not isinstance(base, int):
                 continue
             key = ".".join(path)
             for port in range(base, base + (replicas if is_base else 1)):
-                owner = self._nok8s_port_claims.setdefault(port, stack_name)
+                owner, owner_key = self._nok8s_port_claims.setdefault(
+                    port, (stack_name, key)
+                )
                 if owner != stack_name:
                     errors.append(
                         f"[{stack_name}] nok8s host port {port} ({key}) is already "
@@ -1097,6 +1131,12 @@ class RenderPlans:
                         f"its own ports; give this stack distinct "
                         f"nok8s.vllm.hostPort, nok8s.envoy.listenPort, "
                         f"nok8s.envoy.adminPort and nok8s.epp.* values."
+                    )
+                elif owner_key != key:
+                    errors.append(
+                        f"[{stack_name}] nok8s host port {port} is claimed by both "
+                        f"{owner_key} and {key}. Each nok8s container binds its own "
+                        f"host port; the second one to start would fail to bind."
                     )
         return errors
 
@@ -2067,7 +2107,7 @@ class RenderPlans:
             self.logger.log_error(msg)
             stack_errors.render_errors.append(msg)
 
-        for msg in self._validate_nok8s_host_ports(merged_values, stack_name):
+        for msg in self._validate_nok8s_host_claims(merged_values, stack_name):
             self.logger.log_error(msg)
             stack_errors.render_errors.append(msg)
 
@@ -2268,6 +2308,7 @@ class RenderPlans:
         )
 
         self._nok8s_port_claims = {}
+        self._nok8s_name_claims = {}
         for i, stack in enumerate(stacks, 1):
             self._process_stack(
                 stack=stack,

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -128,13 +128,30 @@ class EnsureInfraStep(Step):
         nok8s = plan_config.get("nok8s", {})
         accelerator = str(nok8s.get("vllm", {}).get("accelerator", "nvidia")).lower()
         hf_env = nok8s.get("hfTokenEnv", "HUGGING_FACE_HUB_TOKEN")
-        ports = [
-            nok8s.get("vllm", {}).get("hostPort", 8000),
-            nok8s.get("envoy", {}).get("listenPort", 8081),
-            nok8s.get("epp", {}).get("grpcPort", 9002),
-            nok8s.get("epp", {}).get("grpcHealthPort", 9003),
-            nok8s.get("epp", {}).get("metricsPort", 9090),
-        ]
+        # Every nok8s stack in the plan lands on this host, so the port and
+        # GPU checks cover all of them, not just the first.
+        stacks = [
+            cfg
+            for cfg in (
+                (self._load_stack_config(p).get("nok8s") or {})
+                for p in (context.rendered_stacks or [])
+            )
+            if cfg.get("enabled")
+        ] or [nok8s]
+        ports = sorted(
+            {
+                port
+                for cfg in stacks
+                for port in (
+                    cfg.get("vllm", {}).get("hostPort", 8000),
+                    cfg.get("envoy", {}).get("listenPort", 8081),
+                    cfg.get("envoy", {}).get("adminPort", 19000),
+                    cfg.get("epp", {}).get("grpcPort", 9002),
+                    cfg.get("epp", {}).get("grpcHealthPort", 9003),
+                    cfg.get("epp", {}).get("metricsPort", 9090),
+                )
+            }
+        )
 
         if context.dry_run:
             context.logger.log_info(
@@ -205,10 +222,11 @@ class EnsureInfraStep(Step):
 
         # 2b. GPU capacity: replicas x tensorParallel must fit the host's GPUs.
         #     Only checkable for nvidia (nvidia-smi -L enumerates devices).
-        vllm = nok8s.get("vllm", {})
-        replicas = int(vllm.get("replicas", 1) or 1)
-        tp = int(vllm.get("tensorParallel", 1) or 1)
-        needed = replicas * tp
+        needed = sum(
+            int(cfg.get("vllm", {}).get("replicas", 1) or 1)
+            * int(cfg.get("vllm", {}).get("tensorParallel", 1) or 1)
+            for cfg in stacks
+        )
         if accelerator == "nvidia" and needed > 1:
             res_gpu = cmd.execute("nvidia-smi -L", check=False, force=True, silent=True)
             if res_gpu.success and res_gpu.stdout:
@@ -217,10 +235,27 @@ class EnsureInfraStep(Step):
                 )
                 if count and needed > count:
                     warnings.append(
-                        f"nok8s.vllm needs {needed} GPUs (replicas {replicas} x "
-                        f"tensorParallel {tp}) but only {count} detected -- workers "
-                        f"will contend for devices or fail to start."
+                        f"nok8s.vllm needs {needed} GPUs (replicas x tensorParallel "
+                        f"over {len(stacks)} stack(s)) but only {count} detected -- "
+                        f"workers will contend for devices or fail to start."
                     )
+
+        # 2c. A worker with replicas: 1 and no explicit device selection gets
+        #     the whole accelerator ("--gpus all"), so two such stacks claim
+        #     the same devices and the second one runs out of memory.
+        unpinned = [
+            cfg
+            for cfg in stacks
+            if int(cfg.get("vllm", {}).get("replicas", 1) or 1) == 1
+            and str(cfg.get("vllm", {}).get("gpus", "all")) == "all"
+            and not cfg.get("vllm", {}).get("deviceArgs")
+        ]
+        if accelerator != "cpu" and len(unpinned) > 1:
+            warnings.append(
+                f"{len(unpinned)} nok8s stacks each take every accelerator on this "
+                f"host; give them distinct devices with nok8s.vllm.gpus (docker) or "
+                f"nok8s.vllm.deviceArgs, or they will fight over memory."
+            )
 
         # 3. Hugging Face token (warning).
         if not os.environ.get(hf_env):

--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -100,7 +100,11 @@ class NoK8sDeployStep(Step):
         if not context.dry_run:
             ready_err = self._wait_ready(cmd, runtime, spec, context)
             if ready_err:
-                self._dump_logs(cmd, runtime, "envoy", context)
+                envoy = next(
+                    (c["name"] for c in containers if c.get("kind") == "envoy"), None
+                )
+                if envoy:
+                    self._dump_logs(cmd, runtime, envoy, context)
                 return self._fail(stack_path, ready_err, [ready_err])
 
         return StepResult(

--- a/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
+++ b/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
@@ -43,9 +43,25 @@ class NoK8sTeardownStep(Step):
             runtime = spec.get("runtime", runtime)
             names = [c["name"] for c in spec.get("containers", [])]
 
-        # Fallback to the well-known names if the spec is unavailable.
-        if not names:
+        # Fallback to the well-known names if the spec is unavailable, but
+        # only for a single-stack plan. With siblings around, those names
+        # belong to whichever stack rendered without a suffix, so removing
+        # them here would tear down another stack's containers.
+        if not names and len(context.rendered_stacks or []) <= 1:
             names = ["envoy", "epp", "vllm-0"]
+
+        if not names:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=True,
+                message=(
+                    "No nok8s container spec for this stack and the plan has "
+                    "sibling stacks; removed nothing to avoid deleting their "
+                    "containers"
+                ),
+                stack_name=stack_path.name if stack_path else None,
+            )
 
         for name in names:
             cmd.execute(f"{runtime} rm -f {name}", check=False)

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -257,17 +257,24 @@ SECOND_STACK_PORTS = {
 }
 
 
-def _two_stack_scenario(tmp_path: Path, distinct_ports: bool) -> Path:
+def _two_stack_scenario(
+    tmp_path: Path,
+    distinct_ports: bool,
+    names: tuple[str, str] = ("nok8s-single", "nok8s-second"),
+    both_nok8s: dict | None = None,
+) -> Path:
     """Duplicate the shipped single-stack nok8s scenario into a two-stack one."""
     import copy
 
     doc = yaml.safe_load(NOK8S_SCENARIO.read_text(encoding="utf-8"))
     first = doc["scenario"][0]
     second = copy.deepcopy(first)
-    second["name"] = "nok8s-second"
+    first["name"], second["name"] = names
     if distinct_ports:
         for (section, key), port in SECOND_STACK_PORTS.items():
             second["nok8s"].setdefault(section, {})[key] = port
+    for stack in (first, second):
+        stack["nok8s"].update(copy.deepcopy(both_nok8s or {}))
     doc["scenario"] = [first, second]
 
     path = tmp_path / f"two-stack-{'ok' if distinct_ports else 'clash'}.yaml"
@@ -341,6 +348,93 @@ def test_nok8s_port_collision_is_a_render_error(tmp_path: Path) -> None:
     ), errors
     # The clashing stack is not rendered, so nothing downstream can launch it.
     assert [Path(p).name for p in result.rendered_paths] == ["nok8s-single"]
+
+
+def test_nok8s_container_name_collision_is_a_render_error(tmp_path: Path) -> None:
+    """Stack names that differ only by punctuation slug to one container name."""
+    result = _render_scenario(
+        tmp_path, _two_stack_scenario(tmp_path, True, names=("chat one", "chat-one"))
+    )
+    assert result.has_errors
+
+    errors = result.stacks["chat-one"].render_errors
+    assert any("epp-chat-one" in e and "chat one" in e for e in errors), errors
+    assert [Path(p).name for p in result.rendered_paths] == ["chat one"]
+
+
+def test_shared_nok8s_name_suffix_is_a_render_error(tmp_path: Path) -> None:
+    """An explicit nameSuffix on both stacks puts them back on one identity."""
+    result = _render_scenario(
+        tmp_path,
+        _two_stack_scenario(tmp_path, True, both_nok8s={"nameSuffix": "-shared"}),
+    )
+    assert result.has_errors
+
+    errors = result.stacks["nok8s-second"].render_errors
+    assert any("envoy-shared" in e and "nok8s-single" in e for e in errors), errors
+
+
+def _validator() -> RenderPlans:
+    return RenderPlans(
+        template_dir=TEMPLATE_DIR,
+        defaults_file=DEFAULTS_FILE,
+        scenarios_file=NOK8S_SCENARIO,
+        output_dir=Path("/tmp/unused-nok8s-plan"),
+        logger=_Logger(),
+    )
+
+
+def test_nok8s_one_stack_claiming_a_port_twice_is_a_render_error() -> None:
+    """Envoy on the worker's port would fail to bind, silently, at standup."""
+    errors = _validator()._validate_nok8s_host_claims(
+        {
+            "nok8s": {
+                "enabled": True,
+                "vllm": {"hostPort": 8000},
+                "envoy": {"listenPort": 8000},
+            }
+        },
+        "solo",
+    )
+    assert any(
+        "8000" in e and "nok8s.vllm.hostPort" in e and "nok8s.envoy.listenPort" in e
+        for e in errors
+    ), errors
+
+
+def test_nok8s_claims_validator_survives_a_non_int_replicas() -> None:
+    """A bad replicas value is the template's error to report, not a traceback."""
+    assert (
+        _validator()._validate_nok8s_host_claims(
+            {
+                "nok8s": {
+                    "enabled": True,
+                    "vllm": {"replicas": "auto", "hostPort": 8000},
+                }
+            },
+            "solo",
+        )
+        == []
+    )
+
+
+def test_nok8s_run_endpoint_needs_one_stack() -> None:
+    """The run phase refuses to benchmark every stack through stack 1's Envoy."""
+    from llmdbenchmark.cli import PhaseError, _nok8s_endpoint_url
+
+    stacks = [
+        {"stack_name": "chat", "nok8s_enabled": True, "nok8s_listen_port": 8081},
+        {"stack_name": "code", "nok8s_enabled": True, "nok8s_listen_port": 8181},
+    ]
+
+    assert _nok8s_endpoint_url(stacks[:1]) == "http://localhost:8081"
+    assert _nok8s_endpoint_url(stacks, ["code"]) == "http://localhost:8181"
+    try:
+        _nok8s_endpoint_url(stacks)
+    except PhaseError as e:
+        assert "--stack" in str(e) and "8181" in str(e)
+    else:
+        raise AssertionError("expected a PhaseError for a multi-stack nok8s run")
 
 
 class _RecordingCmd:

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -242,3 +242,162 @@ def test_resolve_deploy_method_forces_nok8s() -> None:
     assert out["nok8s"]["enabled"] is True
     assert out["standalone"]["enabled"] is False
     assert out["modelservice"]["enabled"] is False
+
+
+# ---------------------------------------------------------------------- #
+# Multiple nok8s stacks on one host (issue #1699)
+# ---------------------------------------------------------------------- #
+SECOND_STACK_PORTS = {
+    ("vllm", "hostPort"): 8100,
+    ("epp", "grpcPort"): 9102,
+    ("epp", "grpcHealthPort"): 9103,
+    ("epp", "metricsPort"): 9190,
+    ("envoy", "listenPort"): 8181,
+    ("envoy", "adminPort"): 19100,
+}
+
+
+def _two_stack_scenario(tmp_path: Path, distinct_ports: bool) -> Path:
+    """Duplicate the shipped single-stack nok8s scenario into a two-stack one."""
+    import copy
+
+    doc = yaml.safe_load(NOK8S_SCENARIO.read_text(encoding="utf-8"))
+    first = doc["scenario"][0]
+    second = copy.deepcopy(first)
+    second["name"] = "nok8s-second"
+    if distinct_ports:
+        for (section, key), port in SECOND_STACK_PORTS.items():
+            second["nok8s"].setdefault(section, {})[key] = port
+    doc["scenario"] = [first, second]
+
+    path = tmp_path / f"two-stack-{'ok' if distinct_ports else 'clash'}.yaml"
+    path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    return path
+
+
+def _render_scenario(tmp_path: Path, scenario_file: Path, out_name: str = "plan"):
+    return RenderPlans(
+        template_dir=TEMPLATE_DIR,
+        defaults_file=DEFAULTS_FILE,
+        scenarios_file=scenario_file,
+        output_dir=tmp_path / out_name,
+        logger=_Logger(),
+    ).eval()
+
+
+def _spec_of(stack_dir: Path) -> dict:
+    return yaml.safe_load(
+        next(stack_dir.glob("34_nok8s-containers*")).read_text(encoding="utf-8")
+    )
+
+
+def test_multi_stack_nok8s_identities_are_disjoint(tmp_path: Path) -> None:
+    """Two nok8s stacks must not share names, workspace, endpoint or admin port."""
+    result = _render_scenario(tmp_path, _two_stack_scenario(tmp_path, True))
+    assert not result.has_errors, result.to_dict()
+    first, second = (Path(p) for p in result.rendered_paths)
+
+    spec_a, spec_b = _spec_of(first), _spec_of(second)
+
+    names_a = {c["name"] for c in spec_a["containers"]}
+    names_b = {c["name"] for c in spec_b["containers"]}
+    assert names_a == {"vllm-0-nok8s-single", "epp-nok8s-single", "envoy-nok8s-single"}
+    assert names_b == {"vllm-0-nok8s-second", "epp-nok8s-second", "envoy-nok8s-second"}
+    assert not names_a & names_b
+
+    assert spec_a["workspaceHostDir"] != spec_b["workspaceHostDir"]
+    assert spec_a["workspaceHostDir"].endswith("/nok8s-single")
+    assert spec_b["workspaceHostDir"].endswith("/nok8s-second")
+
+    assert spec_a["endpoint"] == "http://localhost:8081"
+    assert spec_b["endpoint"] == "http://localhost:8181"
+
+    # Envoy runs --network host: the admin ports must differ too.
+    admin_a = yaml.safe_load(
+        next(first.glob("33_nok8s-envoy*")).read_text(encoding="utf-8")
+    )["admin"]["address"]["socket_address"]["port_value"]
+    admin_b = yaml.safe_load(
+        next(second.glob("33_nok8s-envoy*")).read_text(encoding="utf-8")
+    )["admin"]["address"]["socket_address"]["port_value"]
+    assert (admin_a, admin_b) == (19000, 19100)
+
+
+def test_single_stack_nok8s_names_stay_unsuffixed(tmp_path: Path) -> None:
+    """Back-compat: one stack keeps vllm-0 / epp / envoy and the shared workspace."""
+    spec = _spec_of(_stack_dir(_render(tmp_path)))
+    assert {c["name"] for c in spec["containers"]} == {"vllm-0", "epp", "envoy"}
+    assert spec["workspaceHostDir"] == "~/.llmdbench/nok8s"
+
+
+def test_nok8s_port_collision_is_a_render_error(tmp_path: Path) -> None:
+    """Two nok8s stacks on the same host ports fail the render, not the standup."""
+    result = _render_scenario(tmp_path, _two_stack_scenario(tmp_path, False))
+    assert result.has_errors
+
+    errors = result.stacks["nok8s-second"].render_errors
+    assert any(
+        "8081" in e and "nok8s.envoy.listenPort" in e and "nok8s-single" in e
+        for e in errors
+    ), errors
+    # The clashing stack is not rendered, so nothing downstream can launch it.
+    assert [Path(p).name for p in result.rendered_paths] == ["nok8s-single"]
+
+
+class _RecordingCmd:
+    """CommandExecutor stand-in that records every command it is handed."""
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    def execute(self, cmd, *_: Any, **__: Any):
+        self.commands.append(cmd)
+        return _FakeResult(True)
+
+    def removed(self) -> set[str]:
+        return {c.split()[-1] for c in self.commands if " rm -f " in c}
+
+    def launched(self) -> set[str]:
+        return {
+            c.split("--name ")[1].split()[0] for c in self.commands if "--name " in c
+        }
+
+
+def test_nok8s_deploy_never_removes_a_sibling_stacks_containers(
+    tmp_path: Path,
+) -> None:
+    """Stack B's idempotency sweep must not delete the containers stack A launched."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    result = _render_scenario(tmp_path, _two_stack_scenario(tmp_path, True))
+    first, second = (Path(p) for p in result.rendered_paths)
+
+    cmd_a, cmd_b = _RecordingCmd(), _RecordingCmd()
+    for stack, cmd in ((first, cmd_a), (second, cmd_b)):
+        ctx = _nok8s_ctx(tmp_path, cmd)
+        ctx.dry_run = True
+        ctx.rendered_stacks = [first, second]
+        assert NoK8sDeployStep().execute(ctx, stack).success is True
+
+    assert cmd_a.launched() and cmd_b.launched()
+    assert not cmd_b.removed() & cmd_a.launched()
+    assert not cmd_a.removed() & cmd_b.launched()
+
+
+def test_nok8s_teardown_leaves_siblings_alone_without_a_spec(tmp_path: Path) -> None:
+    """No spec + sibling stacks -> remove nothing, rather than the well-known names."""
+    from llmdbenchmark.teardown.steps.step_06_nok8s_teardown import NoK8sTeardownStep
+
+    specless = tmp_path / "modelservice-stack"
+    specless.mkdir()
+    cmd = _RecordingCmd()
+    ctx = _nok8s_ctx(tmp_path, cmd)
+    ctx.rendered_stacks = [specless, tmp_path / "nok8s-stack"]
+
+    assert NoK8sTeardownStep().execute(ctx, specless).success is True
+    assert cmd.removed() == set()
+
+    # Single-stack plan keeps the well-known-names fallback.
+    solo = _nok8s_ctx(tmp_path, _RecordingCmd())
+    solo.rendered_stacks = [specless]
+    NoK8sTeardownStep().execute(solo, specless)
+    assert solo.cmd.removed() == {"envoy", "epp", "vllm-0"}


### PR DESCRIPTION
## Description

Fixes #1699.

Two nok8s stacks in one scenario resolved to the same container names, the same host
ports and the same staged config directory. The sharp edge is teardown: step 06's
`docker rm -f` matched by name, so tearing down one stack destroyed a sibling's
running containers. Ports and the workspace collided the same way.

Names, ports and the workspace directory are now scoped per stack. Per @mengmeiye's
design note on the issue, several stacks coexisting on one host is the intent and
should be supported, so this scopes rather than forbids.

Scoping alone is not enough, because two stacks can still resolve to the same suffix.
I reproduced both routes on the pre-fix branch: stacks named `chat one` and `chat-one`
slug to one suffix, and an explicitly shared `nok8s.nameSuffix` does the same. Both
rendered with no errors and produced an identical container set, so the destruction
path stayed reachable. `render_plans.py` now carries `_nok8s_name_claims` beside the
port claims, and `_validate_nok8s_host_claims` (renamed from `_validate_nok8s_host_ports`)
claims every resolved container name and raises a render error when another stack
already owns it.

I validated the resolved name rather than making `nok8s.nameSuffix` renderer-owned and
unsettable. Removing the override would not have closed the slug-collapse half of the
same hole, would silently ignore a key defaults.yaml documents as author-settable, and
would remove the only escape hatch for a stack name that reads badly as a container
suffix. Claiming the resolved name covers all three routes with one guard.

Four related defects fixed in the same pass, each reachable once stacks can coexist:

- The run phase synthesised one scenario-wide endpoint from `all_stacks_info[0]`, so a
  two-stack scenario benchmarked stack 1 twice and filed the results under each stack's
  name. `_nok8s_endpoint_url` now raises a `PhaseError` listing each stack and its port
  when there is more than one stack and no `--endpoint-url`, and `--stack` resolves that
  stack's own `listenPort`, so the documented workaround no longer needs `--endpoint-url`.
- The step 00 preflight used `_load_plan_config`, which sees only the first rendered
  stack, and never checked the new `envoy.adminPort`. A busy 19000/19100 became a 900s
  wait for an Envoy that never started. It now unions six ports across every stack and
  sums `replicas x tensorParallel` for the GPU-capacity warning.
- Accelerator sharing was undocumented and unguarded. At replicas 1 every stack emits
  `--gpus all`, so the second vLLM OOMs. docs/nok8s.md now shows per-stack
  `gpus: "device=N"`, and the preflight warns when more than one stack is left on the
  default all-devices selection.
- A non-numeric `nok8s.vllm.replicas` raised an uncaught ValueError out of the renderer,
  which was a regression against main. Replaced with the `isinstance(..., int)` guard
  used elsewhere.

Two smaller ones: intra-stack port duplicates passed silently (`envoy.listenPort` equal
to `vllm.hostPort` rendered clean, then Envoy failed to bind while readiness polled
vLLM twice and reported ready), so port claims are now keyed `(stack_name, config_key)`;
and a YAML-quoted port like `'8181'` disabled the guard for that key, so digit strings
are coerced before the isinstance check.

Not done here: having step 03 read each stack's own `34_nok8s-containers.yaml` so all
stacks can be benchmarked in one invocation. That is a feature change to the run
pipeline. This PR only has to stop the silent wrong-data path.

docs/nok8s.md now also tells a reader converting an existing single-stack scenario to
run teardown first, since the unsuffixed `vllm-0`/`epp`/`envoy` are no longer matched
by the new suffixed names and would keep holding their ports and device memory.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (included)

## How Has This Been Tested?

Adds 5 tests to `tests/test_nok8s_plan.py` covering the container-name collision, the
shared `nameSuffix`, the same-stack duplicate port, the non-int replicas guard and the
run-endpoint guard.

```
$ python3 -m pytest tests/ -x -q -n2
749 passed, 31 skipped in 43.05s
```

Revert check, running the branch's test file against production code from main in a
throwaway worktree: `9 failed, 8 passed in 26.39s`. The two destruction-path tests fail
with `assert result.has_errors` -> False, which is main rendering both collisions
clean. The load-bearing pre-existing one fails verbatim as
`assert not ({'envoy', 'epp', 'vllm-0'} & {'envoy', 'epp', 'vllm-0'})`.

Exercised through the installed entry point, no GPU and no cluster:

- Slug-collapse two-stack scenario, `standup -n`: exit 1, three
  "nok8s container name 'X' is already used by stack 'chat one'" errors, and
  `grep -cE 'docker run|docker rm'` returns 0.
- Valid two-stack scenario: exit 0, names `{vllm-0,epp,envoy}-chat` and `-code`, every
  `docker rm -f` suffixed.
- `run -n` with no filter: exit 1 naming both stacks and ports. `run -n --stack code`:
  exit 0, three times `http://localhost:8181` (was 8081).
- Back-compat: the shipped single-stack `config/specification/guides/nok8s.yaml.j2`
  dry-run, standup docker commands and run endpoint, diffed against a main worktree is
  identical.

`pre-commit run`: py-compile, pytest, render-changed-scenarios, detect-secrets,
ruff-check and ruff-format all Passed. The SBOM hook failed and I did not "fix" it:
`python util/generate_sbom.py --check` on unmodified main prints the same
"SBOM out of date" here, so it is pre-existing host drift (no helm on this box,
different local .venv pins), not something this change introduces. The regenerated file
was reverted.

### Test Configuration

- Kubernetes version: none, and no GPU. A live standup was not run. "Two Envoys
  actually bind 19000 and 19100" and "the second vLLM OOMs on a shared GPU" are verified
  as emitted config and commands, not as running processes. I would rather flag that
  than imply otherwise.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [x] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly (`docs/nok8s.md`,
      `config/templates/values/defaults.yaml`)

No cluster and no GPU here. On the SBOM hook, see the note above.
