### PR TITLE
fix: detect Intel XPU from DRA driver

### DIFF
--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -550,7 +550,7 @@ monitoring:
 
 # ============================================================================
 # ACCELERATOR CONFIGURATION
-# Supports: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google
+# Supports: nvidia, intel-xpu, intel-i915, intel-xe, intel-gaudi, amd, google
 # ============================================================================
 accelerator:
   type: nvidia
@@ -571,6 +571,7 @@ accelerator:
   # Resource names for different accelerator types (optional override)
   # resources:
   #   nvidia: "nvidia.com/gpu"
+  #   intel-xpu: "gpu.intel.com"
   #   intel-i915: "gpu.intel.com/i915"
   #   intel-xe: "gpu.intel.com/xe"
   #   intel-gaudi: "habana.ai/gaudi"

--- a/config/templates/values/overlays/intel-xpu.yaml
+++ b/config/templates/values/overlays/intel-xpu.yaml
@@ -1,6 +1,6 @@
-# Shared Intel XPU machine profile. It is selected automatically for both the
-# classic i915 and Xe device-plugin resources; the resolver preserves the exact
-# resource/type as ``intel-i915`` or ``intel-xe``.
+# Shared Intel XPU machine profile. DRA clusters select it directly from the
+# stable ``gpu.intel.com`` driver/device class. Classic device-plugin clusters
+# continue to select it through their ``intel-i915`` or ``intel-xe`` profiles.
 
 accelerator:
   # Avoid duplicating VLLM_WORKER_MULTIPROC_METHOD: llm-d-benchmark already

--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -97,6 +97,7 @@ class ClusterResourceResolver:
         "habana.ai/gaudi": "intel-gaudi",
         "google.com/tpu": "google",
         "intel.com/gpu": "intel-i915",
+        "gpu.intel.com": "intel-xpu",
         "gpu.intel.com/i915": "intel-i915",
         "gpu.intel.com/xe": "intel-xe",
     }
@@ -105,6 +106,7 @@ class ClusterResourceResolver:
         "amd": "amd.com/gpu",
         "intel-gaudi": "habana.ai/gaudi",
         "google": "google.com/tpu",
+        "intel-xpu": "gpu.intel.com",
         "intel-i915": "gpu.intel.com/i915",
         "intel-xe": "gpu.intel.com/xe",
     }
@@ -512,6 +514,19 @@ class ClusterResourceResolver:
             discovered = ", ".join(resources.accelerator_resources)
             raise RuntimeError(
                 "Multiple accelerator resources were discovered "
+                f"({discovered}); set accelerator.resource or "
+                "accelerator.profile explicitly."
+            )
+        elif len(resources.dra_drivers) == 1:
+            resolved = resources.dra_drivers[0]
+            accel["resource"] = resolved
+            self.logger.log_info(
+                f"Resolved accelerator.resource from DRA driver: {resolved}"
+            )
+        elif len(resources.dra_drivers) > 1:
+            discovered = ", ".join(resources.dra_drivers)
+            raise RuntimeError(
+                "Multiple DRA accelerator drivers were discovered "
                 f"({discovered}); set accelerator.resource or "
                 "accelerator.profile explicitly."
             )

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -314,7 +314,10 @@ class RenderPlans:
 
         if profile and profile != "auto":
             profile_names = [profile]
-            if profile.startswith("intel-") and profile != "intel-gaudi":
+            if profile.startswith("intel-") and profile not in (
+                "intel-gaudi",
+                "intel-xpu",
+            ):
                 profile_names.append("intel-xpu")
 
             for profile_name in reversed(profile_names):

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -110,6 +110,28 @@ def test_explicit_profile_resolves_resource_without_cluster():
     assert resolver._connected is False
 
 
+def test_explicit_unified_xpu_profile_resolves_dra_driver_without_cluster():
+    resolver = ClusterResourceResolver(logger=MagicMock(), dry_run=False)
+
+    resolved = resolver.resolve_all(
+        {"accelerator": {"profile": "intel-xpu", "resource": "auto"}}
+    )
+
+    assert resolved["accelerator"]["resource"] == "gpu.intel.com"
+    assert resolved["accelerator"]["type"] == "intel-xpu"
+    assert resolver._connected is False
+
+
+def test_unified_xpu_dra_profile_uses_shared_xpu_overlay(tmp_path):
+    result, merged = _render(tmp_path, "intel-xpu", "gpu.intel.com")
+
+    assert not result.has_errors
+    assert merged["accelerator"]["type"] == "intel-xpu"
+    assert merged["accelerator"]["resource"] == "gpu.intel.com"
+    assert "llm-d-xpu" in merged["images"]["vllm"]["repository"]
+    assert "--enforce-eager" in merged["decode"]["vllm"]["customCommand"]
+
+
 def test_cluster_connection_uses_cli_kubeconfig(monkeypatch):
     observed: dict[str, str | None] = {}
     api_client = object()

--- a/tests/test_cluster_resource_resolver.py
+++ b/tests/test_cluster_resource_resolver.py
@@ -322,6 +322,32 @@ class TestDraGracefulDegradation:
         assert values["decode"]["acceleratorType"]["labelValue"] == "Data Center Max"
 
 
+class TestDraAcceleratorResourceResolution:
+    def test_resolves_from_stable_dra_driver_name(self, resolver):
+        resolver._node_resources = NodeResources(
+            dra_drivers=["gpu.intel.com"],
+        )
+        values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+        unresolved: list[str] = []
+
+        resolver._resolve_accelerator_resource(values, unresolved)
+        resolver._resolve_accelerator_profile(values, unresolved)
+
+        assert unresolved == []
+        assert values["accelerator"]["resource"] == "gpu.intel.com"
+        assert values["accelerator"]["profile"] == "intel-xpu"
+        assert values["accelerator"]["type"] == "intel-xpu"
+
+    def test_multiple_dra_drivers_require_explicit_selection(self, resolver):
+        resolver._node_resources = NodeResources(
+            dra_drivers=["gpu.intel.com", "gpu.nvidia.com"],
+        )
+        values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+
+        with pytest.raises(RuntimeError, match="Multiple DRA accelerator drivers"):
+            resolver._resolve_accelerator_resource(values, [])
+
+
 class TestGpuSkuLabelHeuristic:
     """The vendor-prefix + SKU-suffix heuristic that lets the resolver match
     GPU SKU labels from any vendor without per-vendor maintenance.


### PR DESCRIPTION
Resolve Intel XPU accelerator resource and profile from the stable gpu.intel.com DRA driver instead of relying on node capacity resources or device-specific i915/xe names. Validated against the live XPU DRA cluster: 56 focused tests passed and the PD disaggregation plan rendered 38 templates with 0 errors.