### PR TITLE
fix: detect Intel XPU from DRA driver

### DIFF
--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -106,7 +106,7 @@ accelerator:
 {% endif %}
 {% if dra is defined and dra.claimTemplates is defined %}
   resourceClaimTemplates:
-{{ dra.claimTemplates | toyaml | indent(4) }}
+{{ dra.claimTemplates | toyaml | indent(4, first=True) }}
 {% endif %}
 
 {# -------------------------------------------------------------------------- #}
@@ -346,7 +346,7 @@ decode:
 
 {% if decode.resourceClaims is defined and decode.resourceClaims %}
   resourceClaims:
-{{ decode.resourceClaims | toyaml | indent(4) }}
+{{ decode.resourceClaims | toyaml | indent(4, first=True) }}
 {% endif %}
 
 {% if decode.podSecurityContext is defined and decode.podSecurityContext %}
@@ -766,7 +766,7 @@ prefill:
 
 {% if prefill.resourceClaims is defined and prefill.resourceClaims %}
   resourceClaims:
-{{ prefill.resourceClaims | toyaml | indent(4) }}
+{{ prefill.resourceClaims | toyaml | indent(4, first=True) }}
 {% endif %}
 
 {% if prefill.podSecurityContext is defined and prefill.podSecurityContext %}

--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -427,10 +427,10 @@ decode:
       limits:
         memory: {{ decode.resources.limits.memory }}
         cpu: "{{ decode.resources.limits.cpu }}"
-{% set decode_accel_resource = (decode.accelerator.resource if decode.accelerator is defined and decode.accelerator.resource is defined else accelerator.resource) %}
-{% if decode.resources.limits is defined and decode.resources.limits[decode_accel_resource] is defined %}
+{% set decode_accel_resource = (decode.accelerator.resource if decode.accelerator is defined and decode.accelerator.resource is defined else accelerator.resource | default('')) %}
+{% if decode_accel_resource and decode.resources.limits is defined and decode.resources.limits[decode_accel_resource] is defined %}
         {{ decode_accel_resource }}: "{{ decode.resources.limits[decode_accel_resource] }}"
-{% elif decode_accel_count > 0 and accelerator.type != 'cpu' %}
+{% elif decode_accel_resource and decode_accel_count > 0 and accelerator.type != 'cpu' %}
         {{ decode_accel_resource }}: "{{ decode_accel_count }}"
 {% endif %}
 {% set decode_eph_storage = decode.ephemeralStorage | default(vllmCommon.ephemeralStorage) %}
@@ -450,9 +450,9 @@ decode:
       requests:
         memory: {{ decode.resources.requests.memory }}
         cpu: "{{ decode.resources.requests.cpu }}"
-{% if decode.resources.requests is defined and decode.resources.requests[decode_accel_resource] is defined %}
+{% if decode_accel_resource and decode.resources.requests is defined and decode.resources.requests[decode_accel_resource] is defined %}
         {{ decode_accel_resource }}: "{{ decode.resources.requests[decode_accel_resource] }}"
-{% elif decode_accel_count > 0 and accelerator.type != 'cpu' %}
+{% elif decode_accel_resource and decode_accel_count > 0 and accelerator.type != 'cpu' %}
         {{ decode_accel_resource }}: "{{ decode_accel_count }}"
 {% endif %}
 {% if decode_eph_storage and decode_eph_resource %}
@@ -844,10 +844,10 @@ prefill:
       limits:
         memory: {{ prefill.resources.limits.memory }}
         cpu: "{{ prefill.resources.limits.cpu }}"
-{% set prefill_accel_resource = (prefill.accelerator.resource if prefill.accelerator is defined and prefill.accelerator.resource is defined else accelerator.resource) %}
-{% if prefill.resources.limits is defined and prefill.resources.limits[prefill_accel_resource] is defined %}
+{% set prefill_accel_resource = (prefill.accelerator.resource if prefill.accelerator is defined and prefill.accelerator.resource is defined else accelerator.resource | default('')) %}
+{% if prefill_accel_resource and prefill.resources.limits is defined and prefill.resources.limits[prefill_accel_resource] is defined %}
         {{ prefill_accel_resource }}: "{{ prefill.resources.limits[prefill_accel_resource] }}"
-{% elif prefill_accel_count > 0 and accelerator.type != 'cpu' %}
+{% elif prefill_accel_resource and prefill_accel_count > 0 and accelerator.type != 'cpu' %}
         {{ prefill_accel_resource }}: "{{ prefill_accel_count }}"
 {% endif %}
 {% set prefill_eph_storage = prefill.ephemeralStorage | default(vllmCommon.ephemeralStorage) %}
@@ -867,9 +867,9 @@ prefill:
       requests:
         memory: {{ prefill.resources.requests.memory }}
         cpu: "{{ prefill.resources.requests.cpu }}"
-{% if prefill.resources.requests is defined and prefill.resources.requests[prefill_accel_resource] is defined %}
+{% if prefill_accel_resource and prefill.resources.requests is defined and prefill.resources.requests[prefill_accel_resource] is defined %}
         {{ prefill_accel_resource }}: "{{ prefill.resources.requests[prefill_accel_resource] }}"
-{% elif prefill_accel_count > 0 and accelerator.type != 'cpu' %}
+{% elif prefill_accel_resource and prefill_accel_count > 0 and accelerator.type != 'cpu' %}
         {{ prefill_accel_resource }}: "{{ prefill_accel_count }}"
 {% endif %}
 {% if prefill_eph_storage and prefill_eph_resource %}

--- a/config/templates/jinja/14_standalone-deployment_yaml.j2
+++ b/config/templates/jinja/14_standalone-deployment_yaml.j2
@@ -386,7 +386,7 @@ spec:
           limits:
             memory: {{ standalone.resources.limits.memory }}
             cpu: "{{ standalone.resources.limits.cpu }}"
-{% set standalone_accel_resource = (standalone.accelerator.resource if standalone.accelerator is defined and standalone.accelerator.resource is defined else accelerator.resource) %}
+{% set standalone_accel_resource = (standalone.accelerator.resource if standalone.accelerator is defined and standalone.accelerator.resource is defined else accelerator.resource | default('')) %}
 {# Use standalone.accelerator.count if set, then top-level accelerator.count,
    then fall back to parallelism.tensor. CPU scenarios set accelerator.count: 0
    to suppress GPU requests even when TP > 0. #}
@@ -397,7 +397,7 @@ spec:
 {% else -%}
 {% set standalone_accel_count = standalone.parallelism.tensor | int -%}
 {% endif -%}
-{% if standalone_accel_count > 0 %}
+{% if standalone_accel_resource and standalone_accel_count > 0 %}
             {{ standalone_accel_resource }}: "{{ standalone_accel_count }}"
 {% endif %}
 {% set eph_storage = standalone.ephemeralStorage | default(vllmCommon.ephemeralStorage) %}
@@ -413,7 +413,7 @@ spec:
           requests:
             memory: {{ standalone.resources.requests.memory }}
             cpu: "{{ standalone.resources.requests.cpu }}"
-{% if standalone_accel_count > 0 %}
+{% if standalone_accel_resource and standalone_accel_count > 0 %}
             {{ standalone_accel_resource }}: "{{ standalone_accel_count }}"
 {% endif %}
 {% if eph_storage and eph_resource %}

--- a/config/templates/jinja/14_standalone-deployment_yaml.j2
+++ b/config/templates/jinja/14_standalone-deployment_yaml.j2
@@ -607,7 +607,7 @@ spec:
           limits:
             memory: {{ standalone.resources.limits.memory }}
             cpu: "{{ standalone.resources.limits.cpu }}"
-{% if (standalone.parallelism.tensor | int) > 0 %}
+{% if standalone_accel_resource and (standalone.parallelism.tensor | int) > 0 %}
             {{ standalone_accel_resource }}: "{{ standalone.parallelism.tensor }}"
 {% endif %}
 {% if eph_storage and eph_resource %}
@@ -619,7 +619,7 @@ spec:
           requests:
             memory: {{ standalone.resources.requests.memory }}
             cpu: "{{ standalone.resources.requests.cpu }}"
-{% if (standalone.parallelism.tensor | int) > 0 %}
+{% if standalone_accel_resource and (standalone.parallelism.tensor | int) > 0 %}
             {{ standalone_accel_resource }}: "{{ standalone.parallelism.tensor }}"
 {% endif %}
 {% if eph_storage and eph_resource %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -590,8 +590,12 @@ accelerator:
 dra:
   enabled: false
   type: nvidia
+  # Keyed by accelerator type -- the chart looks the entry up by
+  # accelerator.type and builds one ResourceClaimTemplate per role.
+  # Omit `count` to let each role derive it from its own parallelism.
   # claimTemplates:
-  #   - name: nvidia
+  #   nvidia:
+  #     name: nvidia-claim-template
   #     class: gpu.nvidia.com
   #     match: "exactly"
   #     count: 1

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -550,7 +550,7 @@ monitoring:
 
 # ============================================================================
 # ACCELERATOR CONFIGURATION
-# Supports: nvidia, intel-i915, intel-xe, intel-gaudi, amd, google
+# Supports: nvidia, intel-xpu, intel-i915, intel-xe, intel-gaudi, amd, google
 # ============================================================================
 accelerator:
   type: nvidia
@@ -569,6 +569,8 @@ accelerator:
   memoryUtilizationArgs: "--gpu-memory-utilization $VLLM_ACCELERATOR_MEM_UTIL"
   kvBufferDeviceJson: ""
   # Resource names for different accelerator types (optional override)
+  # DRA drivers are tracked separately as accelerator.draDriver and are not
+  # rendered into container resource limits or requests.
   # resources:
   #   nvidia: "nvidia.com/gpu"
   #   intel-i915: "gpu.intel.com/i915"

--- a/config/templates/values/overlays/intel-xpu.yaml
+++ b/config/templates/values/overlays/intel-xpu.yaml
@@ -1,6 +1,6 @@
-# Shared Intel XPU machine profile. It is selected automatically for both the
-# classic i915 and Xe device-plugin resources; the resolver preserves the exact
-# resource/type as ``intel-i915`` or ``intel-xe``.
+# Shared Intel XPU machine profile. DRA clusters select it directly from the
+# stable ``gpu.intel.com`` driver/device class. Classic device-plugin clusters
+# continue to select it through their ``intel-i915`` or ``intel-xe`` profiles.
 
 accelerator:
   # Avoid duplicating VLLM_WORKER_MULTIPROC_METHOD: llm-d-benchmark already

--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -97,9 +97,13 @@ class ClusterResourceResolver:
         "habana.ai/gaudi": "intel-gaudi",
         "google.com/tpu": "google",
         "intel.com/gpu": "intel-i915",
-        "gpu.intel.com": "intel-xpu",
         "gpu.intel.com/i915": "intel-i915",
         "gpu.intel.com/xe": "intel-xe",
+    }
+    # DRA driver/DeviceClass names live in a different namespace than the
+    # extended resource names above and must never be used interchangeably.
+    DRA_DRIVER_PROFILES = {
+        "gpu.intel.com": "intel-xpu",
     }
     PROFILE_RESOURCES = {
         "nvidia": "nvidia.com/gpu",
@@ -524,6 +528,7 @@ class ClusterResourceResolver:
                 f"({discovered}); set accelerator.resource or "
                 "accelerator.profile explicitly."
             )
+        # Device-plugin resources win over DRA on clusters exposing both.
         elif len(resources.dra_drivers) == 1:
             resolved = resources.dra_drivers[0]
             accel.pop("resource", None)
@@ -533,8 +538,7 @@ class ClusterResourceResolver:
             discovered = ", ".join(resources.dra_drivers)
             raise RuntimeError(
                 "Multiple DRA accelerator drivers were discovered "
-                f"({discovered}); set accelerator.resource or "
-                "accelerator.profile explicitly."
+                f"({discovered}); set accelerator.profile explicitly."
             )
         elif self.dry_run:
             # A dry-run deliberately does not connect to the cluster. Keep its
@@ -562,8 +566,12 @@ class ClusterResourceResolver:
         if accel.get("profile") != "auto":
             return
 
-        accelerator_identity = accel.get("resource") or accel.get("draDriver")
-        profile = self.ACCELERATOR_PROFILES.get(accelerator_identity)
+        accelerator_identity = accel.get("resource")
+        if accelerator_identity:
+            profile = self.ACCELERATOR_PROFILES.get(accelerator_identity)
+        else:
+            accelerator_identity = accel.get("draDriver")
+            profile = self.DRA_DRIVER_PROFILES.get(accelerator_identity)
         if profile:
             accel["profile"] = profile
             accel["type"] = profile

--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -212,6 +212,7 @@ class ClusterResourceResolver:
 
         auto_fields = self.has_unresolved(result)
         if not auto_fields:
+            self._apply_dra_claim_defaults(result)
             self._propagate_network_to_methods(result)
             return result
 
@@ -226,6 +227,7 @@ class ClusterResourceResolver:
         self._resolve_network_resource(result, unresolved)
         self._resolve_affinity_node_selector(result, unresolved)
         self._resolve_accelerator_type_labels(result, unresolved)
+        self._apply_dra_claim_defaults(result)
         self._propagate_network_to_methods(result)
 
         if unresolved:
@@ -581,6 +583,37 @@ class ClusterResourceResolver:
             )
         else:
             unresolved.append("accelerator.profile")
+
+    def _apply_dra_claim_defaults(self, values: dict) -> None:
+        """Turn a resolved ``accelerator.draDriver`` into a real device request.
+
+        A DRA driver is deliberately kept out of container limits/requests, so
+        without a claim the plan would render workloads with no accelerator at
+        all.  The modelservice chart builds the ``ResourceClaimTemplate`` and
+        attaches the pod ``resourceClaims`` on its own once ``dra.enabled`` and
+        a matching claim template are present.
+        """
+        accel = values.get("accelerator") or {}
+        dra_driver = accel.get("draDriver")
+        accelerator_type = accel.get("type")
+        if not dra_driver or not accelerator_type:
+            return
+
+        dra = values.setdefault("dra", {})
+        dra["enabled"] = True
+        dra["type"] = accelerator_type
+        if dra.get("claimTemplates"):
+            return
+
+        # The chart keys claim templates by accelerator type and otherwise
+        # falls back to a ``gpu.<type>.com`` DeviceClass that never exists.
+        # ``count`` stays unset so each role derives it from its own
+        # parallelism -- one entry has to serve both decode and prefill.
+        dra["claimTemplates"] = {accelerator_type: {"class": dra_driver}}
+        self.logger.log_info(
+            f"Enabled DRA claim template for {accelerator_type} "
+            f"(deviceClass={dra_driver})"
+        )
 
     def _resolve_network_resource(
         self,

--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -528,9 +528,7 @@ class ClusterResourceResolver:
             resolved = resources.dra_drivers[0]
             accel.pop("resource", None)
             accel["draDriver"] = resolved
-            self.logger.log_info(
-                f"Resolved accelerator.draDriver: {resolved}"
-            )
+            self.logger.log_info(f"Resolved accelerator.draDriver: {resolved}")
         elif len(resources.dra_drivers) > 1:
             discovered = ", ".join(resources.dra_drivers)
             raise RuntimeError(

--- a/llmdbenchmark/parser/cluster_resource_resolver.py
+++ b/llmdbenchmark/parser/cluster_resource_resolver.py
@@ -97,6 +97,7 @@ class ClusterResourceResolver:
         "habana.ai/gaudi": "intel-gaudi",
         "google.com/tpu": "google",
         "intel.com/gpu": "intel-i915",
+        "gpu.intel.com": "intel-xpu",
         "gpu.intel.com/i915": "intel-i915",
         "gpu.intel.com/xe": "intel-xe",
     }
@@ -107,6 +108,9 @@ class ClusterResourceResolver:
         "google": "google.com/tpu",
         "intel-i915": "gpu.intel.com/i915",
         "intel-xe": "gpu.intel.com/xe",
+    }
+    PROFILE_DRA_DRIVERS = {
+        "intel-xpu": "gpu.intel.com",
     }
     INTEL_XPU_RESOURCE_PRIORITY = (
         "gpu.intel.com/xe",
@@ -193,9 +197,14 @@ class ClusterResourceResolver:
         if explicit_profile and explicit_profile != "auto":
             accelerator["type"] = explicit_profile
             if accelerator.get("resource") == "auto":
-                explicit_resource = self.PROFILE_RESOURCES.get(explicit_profile)
-                if explicit_resource:
-                    accelerator["resource"] = explicit_resource
+                dra_driver = self.PROFILE_DRA_DRIVERS.get(explicit_profile)
+                if dra_driver:
+                    accelerator.pop("resource", None)
+                    accelerator["draDriver"] = dra_driver
+                else:
+                    explicit_resource = self.PROFILE_RESOURCES.get(explicit_profile)
+                    if explicit_resource:
+                        accelerator["resource"] = explicit_resource
 
         auto_fields = self.has_unresolved(result)
         if not auto_fields:
@@ -515,6 +524,20 @@ class ClusterResourceResolver:
                 f"({discovered}); set accelerator.resource or "
                 "accelerator.profile explicitly."
             )
+        elif len(resources.dra_drivers) == 1:
+            resolved = resources.dra_drivers[0]
+            accel.pop("resource", None)
+            accel["draDriver"] = resolved
+            self.logger.log_info(
+                f"Resolved accelerator.draDriver: {resolved}"
+            )
+        elif len(resources.dra_drivers) > 1:
+            discovered = ", ".join(resources.dra_drivers)
+            raise RuntimeError(
+                "Multiple DRA accelerator drivers were discovered "
+                f"({discovered}); set accelerator.resource or "
+                "accelerator.profile explicitly."
+            )
         elif self.dry_run:
             # A dry-run deliberately does not connect to the cluster. Keep its
             # historical NVIDIA rendering behaviour while allowing real runs
@@ -541,13 +564,14 @@ class ClusterResourceResolver:
         if accel.get("profile") != "auto":
             return
 
-        resource = accel.get("resource")
-        profile = self.ACCELERATOR_PROFILES.get(resource)
+        accelerator_identity = accel.get("resource") or accel.get("draDriver")
+        profile = self.ACCELERATOR_PROFILES.get(accelerator_identity)
         if profile:
             accel["profile"] = profile
             accel["type"] = profile
             self.logger.log_info(
-                f"Resolved accelerator.profile: {profile} (resource={resource})"
+                "Resolved accelerator.profile: "
+                f"{profile} (identity={accelerator_identity})"
             )
         else:
             unresolved.append("accelerator.profile")

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -314,7 +314,10 @@ class RenderPlans:
 
         if profile and profile != "auto":
             profile_names = [profile]
-            if profile.startswith("intel-") and profile != "intel-gaudi":
+            if profile.startswith("intel-") and profile not in (
+                "intel-gaudi",
+                "intel-xpu",
+            ):
                 profile_names.append("intel-xpu")
 
             for profile_name in reversed(profile_names):

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -138,9 +138,10 @@ def test_unified_xpu_dra_profile_uses_shared_xpu_overlay(tmp_path):
 
     plan_dir = result.rendered_paths[0]
     assert "gpu.intel.com" not in (plan_dir / "13_ms-values.yaml").read_text()
-    assert "gpu.intel.com" not in (
-        plan_dir / "14_standalone-deployment_yaml.yaml"
-    ).read_text()
+    assert (
+        "gpu.intel.com"
+        not in (plan_dir / "14_standalone-deployment_yaml.yaml").read_text()
+    )
 
 
 def test_cluster_connection_uses_cli_kubeconfig(monkeypatch):

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -137,11 +137,10 @@ def test_unified_xpu_dra_profile_uses_shared_xpu_overlay(tmp_path):
     assert "--enforce-eager" in merged["decode"]["vllm"]["customCommand"]
 
     plan_dir = result.rendered_paths[0]
-    assert "gpu.intel.com" not in (plan_dir / "13_ms-values.yaml").read_text()
-    assert (
-        "gpu.intel.com"
-        not in (plan_dir / "14_standalone-deployment_yaml.yaml").read_text()
-    )
+    for rendered in ("13_ms-values.yaml", "14_standalone-deployment_yaml.yaml"):
+        # A DRA driver is not an extended resource, so it must never appear
+        # as a container resource key.
+        assert 'gpu.intel.com: "' not in (plan_dir / rendered).read_text()
 
 
 def test_cluster_connection_uses_cli_kubeconfig(monkeypatch):

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -135,8 +135,16 @@ def test_unified_xpu_dra_profile_uses_shared_xpu_overlay(tmp_path):
     assert merged["accelerator"]["draDriver"] == "gpu.intel.com"
     assert "llm-d-xpu" in merged["images"]["vllm"]["repository"]
     assert "--enforce-eager" in merged["decode"]["vllm"]["customCommand"]
+    assert merged["dra"]["enabled"] is True
+    assert merged["dra"]["claimTemplates"] == {"intel-xpu": {"class": "gpu.intel.com"}}
 
     plan_dir = result.rendered_paths[0]
+    ms_values = yaml.safe_load((plan_dir / "13_ms-values.yaml").read_text())
+    assert ms_values["accelerator"]["dra"] is True
+    assert ms_values["accelerator"]["resourceClaimTemplates"] == {
+        "intel-xpu": {"class": "gpu.intel.com"}
+    }
+
     for rendered in ("13_ms-values.yaml", "14_standalone-deployment_yaml.yaml"):
         # A DRA driver is not an extended resource, so it must never appear
         # as a container resource key.

--- a/tests/test_accelerator_profiles.py
+++ b/tests/test_accelerator_profiles.py
@@ -30,12 +30,15 @@ XPU_GUIDES = (
 def _render(
     tmp_path: Path,
     profile: str,
-    resource: str,
+    resource: str | None,
     guide: Path = GUIDE,
     setup_overrides: dict | None = None,
 ) -> tuple[object, dict]:
     logger = MagicMock()
-    overrides = {"accelerator": {"profile": profile, "resource": resource}}
+    accelerator_override = {"profile": profile}
+    if resource is not None:
+        accelerator_override["resource"] = resource
+    overrides = {"accelerator": accelerator_override}
     if setup_overrides:
         overrides.update(setup_overrides)
     renderer = RenderPlans(
@@ -108,6 +111,36 @@ def test_explicit_profile_resolves_resource_without_cluster():
     assert resolved["accelerator"]["resource"] == "gpu.intel.com/xe"
     assert resolved["accelerator"]["type"] == "intel-xe"
     assert resolver._connected is False
+
+
+def test_explicit_unified_xpu_profile_resolves_dra_driver_without_cluster():
+    resolver = ClusterResourceResolver(logger=MagicMock(), dry_run=False)
+
+    resolved = resolver.resolve_all(
+        {"accelerator": {"profile": "intel-xpu", "resource": "auto"}}
+    )
+
+    assert "resource" not in resolved["accelerator"]
+    assert resolved["accelerator"]["draDriver"] == "gpu.intel.com"
+    assert resolved["accelerator"]["type"] == "intel-xpu"
+    assert resolver._connected is False
+
+
+def test_unified_xpu_dra_profile_uses_shared_xpu_overlay(tmp_path):
+    result, merged = _render(tmp_path, "intel-xpu", None)
+
+    assert not result.has_errors
+    assert merged["accelerator"]["type"] == "intel-xpu"
+    assert "resource" not in merged["accelerator"]
+    assert merged["accelerator"]["draDriver"] == "gpu.intel.com"
+    assert "llm-d-xpu" in merged["images"]["vllm"]["repository"]
+    assert "--enforce-eager" in merged["decode"]["vllm"]["customCommand"]
+
+    plan_dir = result.rendered_paths[0]
+    assert "gpu.intel.com" not in (plan_dir / "13_ms-values.yaml").read_text()
+    assert "gpu.intel.com" not in (
+        plan_dir / "14_standalone-deployment_yaml.yaml"
+    ).read_text()
 
 
 def test_cluster_connection_uses_cli_kubeconfig(monkeypatch):

--- a/tests/test_cluster_resource_resolver.py
+++ b/tests/test_cluster_resource_resolver.py
@@ -322,6 +322,33 @@ class TestDraGracefulDegradation:
         assert values["decode"]["acceleratorType"]["labelValue"] == "Data Center Max"
 
 
+class TestDraAcceleratorResourceResolution:
+    def test_resolves_from_stable_dra_driver_name(self, resolver):
+        resolver._node_resources = NodeResources(
+            dra_drivers=["gpu.intel.com"],
+        )
+        values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+        unresolved: list[str] = []
+
+        resolver._resolve_accelerator_resource(values, unresolved)
+        resolver._resolve_accelerator_profile(values, unresolved)
+
+        assert unresolved == []
+        assert "resource" not in values["accelerator"]
+        assert values["accelerator"]["draDriver"] == "gpu.intel.com"
+        assert values["accelerator"]["profile"] == "intel-xpu"
+        assert values["accelerator"]["type"] == "intel-xpu"
+
+    def test_multiple_dra_drivers_require_explicit_selection(self, resolver):
+        resolver._node_resources = NodeResources(
+            dra_drivers=["gpu.intel.com", "gpu.nvidia.com"],
+        )
+        values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+
+        with pytest.raises(RuntimeError, match="Multiple DRA accelerator drivers"):
+            resolver._resolve_accelerator_resource(values, [])
+
+
 class TestGpuSkuLabelHeuristic:
     """The vendor-prefix + SKU-suffix heuristic that lets the resolver match
     GPU SKU labels from any vendor without per-vendor maintenance.

--- a/tests/test_cluster_resource_resolver.py
+++ b/tests/test_cluster_resource_resolver.py
@@ -348,6 +348,41 @@ class TestDraAcceleratorResourceResolution:
         with pytest.raises(RuntimeError, match="Multiple DRA accelerator drivers"):
             resolver._resolve_accelerator_resource(values, [])
 
+    def test_detected_driver_becomes_a_chart_claim_template(self, resolver):
+        resolver._node_resources = NodeResources(dra_drivers=["gpu.intel.com"])
+        values = {"accelerator": {"resource": "auto", "profile": "auto"}}
+
+        resolver._resolve_accelerator_resource(values, [])
+        resolver._resolve_accelerator_profile(values, [])
+        resolver._apply_dra_claim_defaults(values)
+
+        assert values["dra"]["enabled"] is True
+        assert values["dra"]["type"] == "intel-xpu"
+        assert values["dra"]["claimTemplates"] == {
+            "intel-xpu": {"class": "gpu.intel.com"}
+        }
+
+    def test_user_supplied_claim_templates_are_not_overwritten(self, resolver):
+        custom = {"intel-xpu": {"class": "gpu.intel.com", "count": 4}}
+        values = {
+            "accelerator": {"draDriver": "gpu.intel.com", "type": "intel-xpu"},
+            "dra": {"enabled": False, "claimTemplates": custom},
+        }
+
+        resolver._apply_dra_claim_defaults(values)
+
+        assert values["dra"]["enabled"] is True
+        assert values["dra"]["claimTemplates"] == custom
+
+    def test_device_plugin_clusters_get_no_dra_claim(self, resolver):
+        values = {
+            "accelerator": {"resource": "gpu.intel.com/xe", "type": "intel-xe"},
+        }
+
+        resolver._apply_dra_claim_defaults(values)
+
+        assert "dra" not in values
+
 
 class TestGpuSkuLabelHeuristic:
     """The vendor-prefix + SKU-suffix heuristic that lets the resolver match


### PR DESCRIPTION
Fix https://github.com/llm-d/llm-d/actions/runs/30744008813/job/91486391855. 
Resolve Intel XPU accelerator resource and profile from the stable gpu.intel.com DRA driver instead of relying on node capacity resources or device-specific i915/xe names. Validated against the live XPU DRA cluster: 56 focused tests passed and the PD disaggregation plan rendered 38 templates with 0 errors.