### PR TITLE
fix: emit input_token_rate in benchmark report v0.2

### DIFF
--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
@@ -2249,6 +2249,13 @@ def import_inference_perf(results_file: str) -> BenchmarkReportV02:
                         ["successes", "throughput", "total_tokens_per_sec"],
                     ),
                 },
+                "input_token_rate": {
+                    "units": Units.TOKEN_PER_S,
+                    "mean": get_nested(
+                        results,
+                        ["successes", "throughput", "input_tokens_per_sec"],
+                    ),
+                },
                 "request_rate": {
                     "units": Units.QUERY_PER_S,
                     "mean": get_nested(


### PR DESCRIPTION
The v0.2 report carries `output_token_rate` and `total_token_rate` but not `input_token_rate`, even though inference-perf provides it.

The data is present at every other layer:

```
summary_lifecycle_metrics.json:
  successes.throughput.input_tokens_per_sec  = 7372.65
  successes.throughput.output_tokens_per_sec =  205.68
  successes.throughput.total_tokens_per_sec  = 7578.33

report_v0.2.json (before):
  output_token_rate, total_token_rate, request_rate      <- input dropped
```

This matters for prefill-heavy workloads. On an `agentic_code_generation` run (gemma-4-31b-it, TPU v6e), input throughput was **37x** output — 11,795 vs 316 tokens/s at concurrency 40. A report showing only `output_token_rate` makes such a system look nearly idle.

Published reports in the results store do contain `input_token_rate` (e.g. `agentic-workloads/llm-d-optimized-baseline/reports-20260522-111942` shows 57911.04), so consumers already expect the field.

One-line mapping added alongside the existing rates.