### PR TITLE
fix: report nok8s harness container exit status

### DIFF
--- a/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
@@ -179,11 +179,23 @@ class DeployHarnessLocalStep(Step):
                     force=True,
                 )
                 for name in names:
+                    # In debug mode the container runs 'sleep infinity', so the
+                    # wait always times out -- there is no harness status to read.
+                    if not context.harness_debug:
+                        error = self._exit_status_error(cmd, runtime, name, timeout)
+                        if error:
+                            errors.append(error)
                     self._capture_and_remove(cmd, runtime, name, results_dir)
 
             context.experiment_ids.append(experiment_id)
 
         if errors:
+            # Non-fatal in the same sense as the k8s wait step: partial results
+            # are already on the host via the /requests bind-mount.
+            context.logger.log_warning(
+                f"Harness container(s) did not complete cleanly; partial "
+                f"results and .log files may still be under {results_dir}"
+            )
             return self._fail(stack_path, "; ".join(errors), errors)
 
         return StepResult(
@@ -205,6 +217,38 @@ class DeployHarnessLocalStep(Step):
         if tname:
             return f"{harness_name}-{tname}-{timestamp}-{rand}"
         return f"{harness_name}-{timestamp}-{rand}"
+
+    def _exit_status_error(self, cmd, runtime, name, timeout) -> str | None:
+        """Return an error string if harness container *name* did not exit 0.
+
+        ``<runtime> wait`` prints the exit code(s) to stdout and exits 0 itself,
+        so the wait's own status says nothing about the harness. Ask the runtime
+        for the container's terminal state instead. Must be called before
+        _capture_and_remove(), which removes the container.
+        """
+        result = cmd.execute(
+            f"{runtime} inspect "
+            f"-f '{{{{.State.Status}}}} {{{{.State.ExitCode}}}}' {name}",
+            check=False,
+            force=True,
+        )
+        fields = (result.stdout or "").strip().split()
+        if not result.success or len(fields) != 2:
+            return f"Could not read exit status of harness container {name}"
+
+        status, exit_code = fields
+        if status != "exited":
+            return (
+                f"Harness container {name} did not finish within {timeout}s "
+                f"(status={status}); raise --wait-timeout or check that "
+                f"'{name}.log' shows progress"
+            )
+        if exit_code != "0":
+            return (
+                f"Harness container {name} exited {exit_code}; "
+                f"see '{name}.log' in the results dir"
+            )
+        return None
 
     def _capture_and_remove(self, cmd, runtime, name, results_dir: Path) -> None:
         result = cmd.execute(f"{runtime} logs {name}", check=False, force=True)

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -168,6 +168,19 @@ class EnsureInfraStep(Step):
                 f"permissions). Verify with '{runtime} info'."
             )
 
+        # 1b. Host tools the nok8s path shells out to (fatal). The k8s
+        #     toolchain check does not run for nok8s, so these would otherwise
+        #     go unchecked: 'timeout' bounds the harness wait in step 07 and
+        #     'curl' probes endpoint readiness in step 06.
+        for tool in ("timeout", "curl"):
+            if not cmd.execute(
+                f"command -v {tool}", check=False, force=True, silent=True
+            ).success:
+                errors.append(
+                    f"'{tool}' not found on PATH; the nok8s path needs it "
+                    f"(install GNU coreutils and curl)."
+                )
+
         # 2. Accelerator visible on the host (warning). Probe depends on the
         #    configured accelerator; cpu/spyre/custom are not probed here.
         probe = {

--- a/tests/test_nok8s_harness_status.py
+++ b/tests/test_nok8s_harness_status.py
@@ -1,0 +1,230 @@
+"""Tests for nok8s local harness exit-status reporting (issue #1700)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from llmdbenchmark.executor.context import ExecutionContext
+
+_STEP_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "llmdbenchmark"
+    / "run"
+    / "steps"
+    / "step_07_deploy_harness_local.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "step_07_deploy_harness_local_status", _STEP_PATH
+)
+harness_local = importlib.util.module_from_spec(_spec)
+sys.modules["step_07_deploy_harness_local_status"] = harness_local
+_spec.loader.exec_module(harness_local)
+DeployHarnessLocalStep = harness_local.DeployHarnessLocalStep
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+
+    def log_info(self, message: str, *_: Any, **__: Any) -> None:
+        self.infos.append(message)
+
+    def log_warning(self, message: str, *_: Any, **__: Any) -> None:
+        self.warnings.append(message)
+
+    def log_error(self, message: str, *_: Any, **__: Any) -> None:
+        self.errors.append(message)
+
+    def log_debug(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def line_break(self) -> None:
+        pass
+
+
+class _Result:
+    def __init__(self, exit_code: int = 0, stdout: str = "") -> None:
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = ""
+        self.dry_run = False
+
+    @property
+    def success(self) -> bool:
+        return self.exit_code == 0
+
+
+class _Command:
+    """Records every command and replays canned stdout for matched substrings."""
+
+    def __init__(self, replies: dict[str, _Result] | None = None) -> None:
+        self.commands: list[str] = []
+        self.replies = replies or {}
+
+    def execute(self, command: str, *_: Any, **__: Any) -> _Result:
+        self.commands.append(command)
+        for key, reply in self.replies.items():
+            if key in command:
+                return reply
+        return _Result()
+
+
+def _plan_config() -> dict[str, Any]:
+    return {
+        "model": {"name": "test-model"},
+        "images": {"benchmark": {"repository": "example.com/bench", "tag": "latest"}},
+        "harness": {
+            "name": "inference-perf",
+            "experimentProfile": "sanity_random.yaml",
+        },
+        "nok8s": {"hfTokenEnv": "HUGGING_FACE_HUB_TOKEN"},
+    }
+
+
+def _context(tmp_path: Path, cmd: _Command, logger: _Logger):
+    stack_path = tmp_path / "plan" / "stack"
+    stack_path.mkdir(parents=True)
+    (stack_path / "config.yaml").write_text(
+        yaml.safe_dump(_plan_config()), encoding="utf-8"
+    )
+    context = ExecutionContext(
+        plan_dir=tmp_path / "plan",
+        workspace=tmp_path,
+        base_dir=Path(__file__).resolve().parents[1],
+        deployed_methods=["nok8s"],
+        container_runtime="docker",
+        logger=logger,
+        cmd=cmd,
+    )
+    context.deployed_endpoints["stack"] = "http://localhost:8081"
+    context.run_results_dir().mkdir(parents=True, exist_ok=True)
+    return context, stack_path
+
+
+def _inspect_commands(cmd: _Command) -> list[str]:
+    return [c for c in cmd.commands if " inspect " in c]
+
+
+def test_clean_exit_reports_success(tmp_path: Path) -> None:
+    logger = _Logger()
+    cmd = _Command({" inspect ": _Result(stdout="exited 0\n")})
+    context, stack_path = _context(tmp_path, cmd, logger)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success
+    assert result.errors == []
+
+
+def test_nonzero_harness_exit_fails_the_step(tmp_path: Path) -> None:
+    """A container that starts and then exits non-zero must not report success."""
+    logger = _Logger()
+    cmd = _Command({" inspect ": _Result(stdout="exited 137\n")})
+    context, stack_path = _context(tmp_path, cmd, logger)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert not result.success
+    assert any("exited 137" in error for error in result.errors)
+    # The operator is pointed at the surviving evidence.
+    assert any(".log" in error for error in result.errors)
+    assert any("partial" in warning for warning in logger.warnings)
+
+
+def test_timeout_expired_container_still_running_fails(tmp_path: Path) -> None:
+    """`timeout ... docker wait` giving up leaves the container running."""
+    logger = _Logger()
+    cmd = _Command(
+        {
+            "timeout ": _Result(exit_code=124),
+            " inspect ": _Result(stdout="running 0\n"),
+        }
+    )
+    context, stack_path = _context(tmp_path, cmd, logger)
+    context.harness_wait_timeout = 30
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert not result.success
+    assert any("did not finish within 30s" in error for error in result.errors)
+
+
+def test_unreadable_exit_status_fails(tmp_path: Path) -> None:
+    """A failed or unparseable inspect is reported, not silently ignored."""
+    logger = _Logger()
+    cmd = _Command({" inspect ": _Result(exit_code=1)})
+    context, stack_path = _context(tmp_path, cmd, logger)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert not result.success
+    assert any("Could not read exit status" in error for error in result.errors)
+
+
+def test_status_read_happens_before_container_removal(tmp_path: Path) -> None:
+    """`docker rm -f` must not run before the exit status is read."""
+    logger = _Logger()
+    cmd = _Command({" inspect ": _Result(stdout="exited 0\n")})
+    context, stack_path = _context(tmp_path, cmd, logger)
+
+    DeployHarnessLocalStep().execute(context, stack_path)
+
+    inspect_at = next(i for i, c in enumerate(cmd.commands) if " inspect " in c)
+    # The pre-launch 'rm -f' is expected; the teardown one must come later.
+    removals = [i for i, c in enumerate(cmd.commands) if " rm -f " in c]
+    assert removals[-1] > inspect_at
+
+
+def test_dry_run_issues_no_wait_and_no_inspect(tmp_path: Path) -> None:
+    logger = _Logger()
+    cmd = _Command()
+    context, stack_path = _context(tmp_path, cmd, logger)
+    context.dry_run = True
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success
+    assert not any(c.startswith("timeout ") for c in cmd.commands)
+    assert _inspect_commands(cmd) == []
+
+
+def test_preflight_is_fatal_when_wait_tools_are_missing(tmp_path: Path) -> None:
+    """nok8s skips the k8s toolchain check, so it must check its own tools."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    for tool in ("timeout", "curl"):
+        logger = _Logger()
+        cmd = _Command({f"command -v {tool}": _Result(exit_code=1)})
+        context = ExecutionContext(
+            plan_dir=tmp_path,
+            workspace=tmp_path,
+            deployed_methods=["nok8s"],
+            container_runtime="docker",
+            logger=logger,
+            cmd=cmd,
+        )
+
+        result = EnsureInfraStep().execute(context)
+
+        assert not result.success
+        assert any(f"'{tool}' not found on PATH" in error for error in result.errors)
+
+
+def test_debug_mode_does_not_check_exit_status(tmp_path: Path) -> None:
+    """Debug containers run 'sleep infinity', so the wait always times out."""
+    logger = _Logger()
+    cmd = _Command({"timeout ": _Result(exit_code=124)})
+    context, stack_path = _context(tmp_path, cmd, logger)
+    context.harness_debug = True
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success
+    assert _inspect_commands(cmd) == []


### PR DESCRIPTION
## Description

The nok8s run path reported success regardless of whether the harness container succeeded.

`step_07_deploy_harness_local.py` blocked on `<runtime> wait` and discarded the result, then removed the containers. `docker wait` and `podman wait` print the container exit code(s) to **stdout** and exit 0 themselves, so the wait's own status says nothing about the harness. `errors` was only appended when `docker run -d` failed to start a container, so a harness that started and then exited non-zero (connection refused against a dead Envoy, a bad profile, an OOM kill) still produced `success=True` and "Run complete". The following `docker rm -f` then destroyed the container, leaving only a `.log` file nobody was told to read.

The fix reads each container's terminal state with `<runtime> inspect -f '{{.State.Status}} {{.State.ExitCode}}'` **before** `_capture_and_remove` removes it, and records an error for:

- a non-zero exit code,
- a container still running after the wait timed out,
- an inspect that fails or returns something unparseable.

`inspect` was chosen over parsing `wait`'s stdout because it is per-container and unambiguous (the wait's stdout is positional and unlabeled), and because it also diagnoses the timeout case, which produces no usable wait output at all. That also means the fix does not depend on GNU `timeout`'s exit-124 convention.

Failures are non-fatal in the same sense as the Kubernetes path in `step_08_wait_completion.py`, which returns `success=(failed == 0)` and notes that partial results may still be available: nok8s writes results straight to the host through the `/requests` bind-mount, so a warning points the operator at the results dir and the error names the captured `<container>.log`.

Debug mode is deliberately untouched. Its containers run `sleep infinity`, so the wait always times out and there is no harness status to read; checking it would turn every `--debug` run into a reported failure.

Second, smaller change in the same area: the nok8s preflight now requires `timeout` and `curl` on PATH. `step_00_ensure_infra.execute` returns to `_check_nok8s_infra` before the k8s `check_system_dependencies()` call, so neither tool was ever verified, even though step 07 bounds its wait with `timeout` and step 06 probes endpoint readiness with `curl`. Both calls use `check=False, force=True`, so a missing tool was swallowed silently.

This is not hypothetical: on the macOS host used to develop this change, `command -v timeout` returns nothing (GNU coreutils is not installed, and there is no `gtimeout` either), while `curl` is present at `/usr/bin/curl`. So the exact platform the nok8s path targets for cluster-free use is one where the wait bound silently does not apply today.

Implemented with the existing `command -v` pattern rather than `check_system_dependencies(extra_required=...)`, because that would also require the kubectl/helm/helmfile/jq/yq toolchain that nok8s intentionally skips.

Fixes #1700

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

New file `tests/test_nok8s_harness_status.py`, following the stub-executor pattern in `tests/test_deploy_harness_status.py` (importlib-loaded step module, fake Command/Logger). Eight tests:

- a container that exits 137 fails the step, and the error names the `.log`
- a wait that times out with the container still running fails the step and reports the timeout value
- an inspect that fails is reported rather than silently ignored
- the exit status is read before the teardown `rm -f`
- a clean exit 0 still succeeds
- `--dry-run` issues no wait and no inspect
- `--debug` issues no inspect and still succeeds
- the nok8s preflight is fatal when `timeout` or `curl` is missing

Reverting the two production changes while keeping the tests fails 5 of the 8; restoring passes all 8.

```
$ python3 -m pytest tests/ -x -q -n2
896 passed, 31 skipped in 75.83s

$ uvx ruff@0.15.11 check
All checks passed!
$ uvx ruff@0.15.11 format --check
259 files already formatted
```

### Test Configuration

- Kubernetes version: none. I have no GPU and no Kubernetes cluster, so I did not run a live `standup.sh` -> `run.sh` -> `teardown.sh` sequence. Both changed paths are nok8s-only and are covered by the stub-executor tests above; the container-runtime interaction is exercised through recorded commands, not a real daemon. A reviewer with hardware should confirm the `inspect` output format against both docker and podman.

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully (no GPU or cluster available, see Test Configuration)
- [x] I confirm that `pre-commit run` was run and all checks passed
- [ ] I have updated the documentation accordingly (no documented behavior changes; a failing nok8s run now reports the failure it always had)
