### PR TITLE
Align EPP EndpointPickerConfig across WVA and EPP+KEDA CI scenarios

### DIFF
--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -173,8 +173,35 @@ scenario:
 
     # =========================================================================
     # ROUTING / GAIE CONFIGURATION
+    #
+    # Ship a custom EndpointPickerConfig to enable the `flowControl` feature
+    # gate (off in the gaie chart's default) that EPP+KEDA autoscaling needs.
     # =========================================================================
-    router: {}
+    router:
+      epp:
+        pluginsConfigFile: "epp-keda-optimized-baseline.yaml"
+        pluginsCustomConfig:
+          epp-keda-optimized-baseline.yaml: |
+            apiVersion: llm-d.ai/v1alpha1
+            kind: EndpointPickerConfig
+            featureGates:
+              - flowControl
+            plugins:
+              - type: queue-scorer
+              - type: kv-cache-utilization-scorer
+              - type: prefix-cache-scorer
+              - type: no-hit-lru-scorer
+            schedulingProfiles:
+              - name: default
+                plugins:
+                  - pluginRef: queue-scorer
+                    weight: 2
+                  - pluginRef: kv-cache-utilization-scorer
+                    weight: 2
+                  - pluginRef: prefix-cache-scorer
+                    weight: 3
+                  - pluginRef: no-hit-lru-scorer
+                    weight: 2
 
     # =========================================================================
     # PREFILL / DECODE CONFIGURATION

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -203,11 +203,33 @@ scenario:
     # =========================================================================
     # ROUTING / GAIE CONFIGURATION
     # =========================================================================
-    # EPP+KEDA queries inference_pool_average_kv_cache_utilization and
-    # inference_pool_average_queue_size directly from EPP's /metrics endpoint.
-    # These gauges are emitted by default; no special plugin config needed, so
-    # router.epp.pluginsConfigFile is left at its default.
-    router: {}
+    # Ship a custom EndpointPickerConfig to enable the `flowControl` feature
+    # gate (off in the gaie chart's default) that EPP+KEDA autoscaling needs.
+    router:
+      epp:
+        pluginsConfigFile: "epp-keda-optimized-baseline.yaml"
+        pluginsCustomConfig:
+          epp-keda-optimized-baseline.yaml: |
+            apiVersion: llm-d.ai/v1alpha1
+            kind: EndpointPickerConfig
+            featureGates:
+              - flowControl
+            plugins:
+              - type: queue-scorer
+              - type: kv-cache-utilization-scorer
+              - type: prefix-cache-scorer
+              - type: no-hit-lru-scorer
+            schedulingProfiles:
+              - name: default
+                plugins:
+                  - pluginRef: queue-scorer
+                    weight: 2
+                  - pluginRef: kv-cache-utilization-scorer
+                    weight: 2
+                  - pluginRef: prefix-cache-scorer
+                    weight: 3
+                  - pluginRef: no-hit-lru-scorer
+                    weight: 2
 
     # =========================================================================
     # PREFILL / DECODE CONFIGURATION

--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -90,15 +90,34 @@ scenario:
     # =========================================================================
     # ROUTING / GAIE CONFIGURATION
     #
-    # EPP+KEDA queries inference_pool_average_kv_cache_utilization and
-    # inference_pool_average_queue_size directly from EPP's /metrics endpoint.
-    # These gauges are emitted by default; no special plugin config needed.
-    #
-    # Do NOT set router.epp.pluginsConfigFile — let it default to
-    # "default-plugins.yaml" which already includes metrics-data-source +
-    # core-metrics-extractor plugins required for these gauges.
+    # Ship a custom EndpointPickerConfig to enable the `flowControl` feature
+    # gate (off in the gaie chart's default) that EPP+KEDA autoscaling needs.
     # =========================================================================
-    router: {}
+    router:
+      epp:
+        pluginsConfigFile: "epp-keda-optimized-baseline.yaml"
+        pluginsCustomConfig:
+          epp-keda-optimized-baseline.yaml: |
+            apiVersion: llm-d.ai/v1alpha1
+            kind: EndpointPickerConfig
+            featureGates:
+              - flowControl
+            plugins:
+              - type: queue-scorer
+              - type: kv-cache-utilization-scorer
+              - type: prefix-cache-scorer
+              - type: no-hit-lru-scorer
+            schedulingProfiles:
+              - name: default
+                plugins:
+                  - pluginRef: queue-scorer
+                    weight: 2
+                  - pluginRef: kv-cache-utilization-scorer
+                    weight: 2
+                  - pluginRef: prefix-cache-scorer
+                    weight: 3
+                  - pluginRef: no-hit-lru-scorer
+                    weight: 2
 
     # =========================================================================
     # PREFILL / DECODE CONFIGURATION (same as inference-scheduling.yaml)

--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -228,6 +228,7 @@ scenario:
               - type: queue-scorer
               - type: kv-cache-utilization-scorer
               - type: prefix-cache-scorer
+              - type: no-hit-lru-scorer
             schedulingProfiles:
               - name: default
                 plugins:
@@ -237,6 +238,8 @@ scenario:
                     weight: 2
                   - pluginRef: prefix-cache-scorer
                     weight: 3
+                  - pluginRef: no-hit-lru-scorer
+                    weight: 2
 
     # =========================================================================
     # PREFILL / DECODE CONFIGURATION

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -334,6 +334,7 @@ scenario:
               - type: queue-scorer
               - type: kv-cache-utilization-scorer
               - type: prefix-cache-scorer
+              - type: no-hit-lru-scorer
             schedulingProfiles:
               - name: default
                 plugins:
@@ -343,6 +344,8 @@ scenario:
                     weight: 2
                   - pluginRef: prefix-cache-scorer
                     weight: 3
+                  - pluginRef: no-hit-lru-scorer
+                    weight: 2
 
     # =========================================================================
     # PREFILL / DECODE CONFIGURATION

--- a/config/scenarios/cicd/ocp-wva.yaml
+++ b/config/scenarios/cicd/ocp-wva.yaml
@@ -208,6 +208,7 @@ scenario:
               - type: queue-scorer
               - type: kv-cache-utilization-scorer
               - type: prefix-cache-scorer
+              - type: no-hit-lru-scorer
             schedulingProfiles:
               - name: default
                 plugins:
@@ -217,6 +218,8 @@ scenario:
                     weight: 2
                   - pluginRef: prefix-cache-scorer
                     weight: 3
+                  - pluginRef: no-hit-lru-scorer
+                    weight: 2
 
     # =========================================================================
     # PREFILL / DECODE CONFIGURATION (same as inference-scheduling.yaml)


### PR DESCRIPTION
## Summary

Standardizes the EPP (router.epp) plugin configuration across the six autoscaling CI scenarios so all of them enable the flowControl feature gate and run the same scheduling-plugin set. Two groups of changes:

1. EPP+KEDA scenarios (`ocp-keda`, `ocp-keda-fma-warmstart`, `ocp-keda-fma-hotstart`) — previously had an empty router: {} relying on the gaie chart's default EndpointPickerConfig, which does not enable flowControl. They now ship a custom EndpointPickerConfig with flowControl enabled and the full plugin set.
2. WVA scenarios (`ocp-wva`, `ocp-wva-fma-warmstart`, `ocp-wva-fma-hotstart`) — already shipped a custom EndpointPickerConfig but were missing the `no-hit-lru-scorer` plugin and its scheduling-profile entry. Added both so they match the EPP+KEDA config.

## Why

EPP+KEDA autoscaling is driven by EPP queue-depth/pool metrics, which require the flowControl feature gate. The gaie chart's default config has no featureGates block, so the KEDA scenarios were running without it. This aligns every scenario on the same EndpointPickerConfig — same four scheduling plugins and weights — so the WVA and EPP+KEDA CI arms are apples-to-apples on the routing/scheduling path and only differ in the autoscaling backend.

## Changes

EPP+KEDA scenarios — replaced router: {} with:
- pluginsConfigFile: `epp-keda-optimized-baseline.yaml`
- EndpointPickerConfig with featureGates: [flowControl]
- plugins: `queue-scorer`, `kv-cache-utilization-scorer`, `prefix-cache-scorer`, `no-hit-lru-scorer`
- default profile weights: 2 / 2 / 3 / 2

WVA scenarios — added the missing entries to the existing wva-plugins.yaml config:
- added `no-hit-lru-score`r to plugins
- added `no-hit-lru-scorer` (weight 2) to the default scheduling profile

## Result

All six scenarios now share an identical plugin/profile set (queue-scorer:2, kv-cache-utilization-scorer:2, prefix-cache-scorer:3, no-hit-lru-scorer:2) with flowControl enabled. Verified each file parses and the nested pluginsCustomConfig string is valid YAML.

## Notes

- The WVA files keep their existing pluginsConfigFile: wva-plugins.yaml filename (only the plugin/profile contents were aligned); the KEDA files use epp-keda-optimized-baseline.yaml. The filename is just the mount key and doesn't affect behavior.
- Stale comments in the KEDA scenarios that said "no special plugin config needed / leave at default" were updated to reflect the flowControl requirement.