### PR TITLE
feat: preserve native YAML types in experiment treatment overrides

### DIFF
--- a/llmdbenchmark/run/steps/step_05_render_profiles.py
+++ b/llmdbenchmark/run/steps/step_05_render_profiles.py
@@ -3,6 +3,7 @@
 import posixpath
 import shutil
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -370,10 +371,10 @@ class RenderProfilesStep(Step):
                 with open(exp_path, encoding="utf-8") as f:
                     exp_data = yaml.safe_load(f)
                 if isinstance(exp_data, dict):
-                    constants: dict[str, str] = {}
+                    constants: dict[str, Any] = {}
                     raw_constants = exp_data.get("constants")
                     if isinstance(raw_constants, dict):
-                        constants = {k: str(v) for k, v in raw_constants.items()}
+                        constants = dict(raw_constants)
 
                     # Look for 'treatments' or 'run' key
                     raw = exp_data.get("treatments") or exp_data.get("run", [])
@@ -383,7 +384,7 @@ class RenderProfilesStep(Step):
                                 # Constants first, then treatment overrides
                                 overrides = dict(constants)
                                 overrides.update(
-                                    {k: str(v) for k, v in item.items() if k != "name"}
+                                    {k: v for k, v in item.items() if k != "name"}
                                 )
                                 treatments.append(
                                     {

--- a/llmdbenchmark/run/steps/step_05_render_profiles.py
+++ b/llmdbenchmark/run/steps/step_05_render_profiles.py
@@ -374,7 +374,7 @@ class RenderProfilesStep(Step):
                     constants: dict[str, Any] = {}
                     raw_constants = exp_data.get("constants")
                     if isinstance(raw_constants, dict):
-                        constants = dict(raw_constants)
+                        constants = {str(k): v for k, v in raw_constants.items()}
 
                     # Look for 'treatments' or 'run' key
                     raw = exp_data.get("treatments") or exp_data.get("run", [])
@@ -384,7 +384,7 @@ class RenderProfilesStep(Step):
                                 # Constants first, then treatment overrides
                                 overrides = dict(constants)
                                 overrides.update(
-                                    {k: v for k, v in item.items() if k != "name"}
+                                    {str(k): v for k, v in item.items() if k != "name"}
                                 )
                                 treatments.append(
                                     {

--- a/llmdbenchmark/utilities/profile_renderer.py
+++ b/llmdbenchmark/utilities/profile_renderer.py
@@ -255,7 +255,7 @@ def apply_overrides(
 
 
 def _coerce_value(value: Any) -> Any:
-    """Coerce a string to int, float, bool, or leave as str."""
+    """Coerce a string to int, float, bool, or leave as str. Non-string values are returned unchanged."""
     if not isinstance(value, str):
         return value
     if value.lower() in ("true", "yes"):

--- a/llmdbenchmark/utilities/profile_renderer.py
+++ b/llmdbenchmark/utilities/profile_renderer.py
@@ -206,7 +206,7 @@ def _assign(container: Any, part: str, value: Any) -> bool:
 
 
 def apply_overrides(
-    profile_content: str, overrides: dict[str, str]
+    profile_content: str, overrides: dict[str, Any]
 ) -> tuple[str, list[str]]:
     """Apply dotted key=value overrides to a rendered YAML profile.
 
@@ -254,8 +254,10 @@ def apply_overrides(
         return profile_content, []
 
 
-def _coerce_value(value: str):
+def _coerce_value(value: Any) -> Any:
     """Coerce a string to int, float, bool, or leave as str."""
+    if not isinstance(value, str):
+        return value
     if value.lower() in ("true", "yes"):
         return True
     if value.lower() in ("false", "no"):

--- a/tests/test_apply_overrides_warning.py
+++ b/tests/test_apply_overrides_warning.py
@@ -119,6 +119,31 @@ class TestApplyOverridesMatching:
         assert unmatched == []
         assert yaml.safe_load(content)["load"]["stages"][-1]["duration"] == 90
 
+    def test_native_int_value_is_preserved(self):
+        content, unmatched = apply_overrides(PROFILE, {"load.stages.0.rate": 10})
+        assert unmatched == []
+        import yaml
+        assert yaml.safe_load(content)["load"]["stages"][0]["rate"] == 10
+
+    def test_native_bool_value_is_preserved(self):
+        content, unmatched = apply_overrides(PROFILE, {"api.streaming": False})
+        assert unmatched == []
+        import yaml
+        assert yaml.safe_load(content)["api"]["streaming"] is False
+
+    def test_native_list_value_replaces_existing_list(self):
+        content, unmatched = apply_overrides(PROFILE, {"load.stages": []})
+        assert unmatched == []
+        import yaml
+        assert yaml.safe_load(content)["load"]["stages"] == []
+
+    def test_native_list_with_items_replaces_existing_list(self):
+        import yaml
+        new_stages = [{"rate": 5, "duration": 30}, {"rate": 20, "duration": 60}]
+        content, unmatched = apply_overrides(PROFILE, {"load.stages": new_stages})
+        assert unmatched == []
+        assert yaml.safe_load(content)["load"]["stages"] == new_stages
+
     def test_out_of_range_list_index_is_reported(self):
         """A list index past the end can't be reached (we set, never grow)."""
         _, unmatched = apply_overrides(PROFILE, {"load.stages.5.rate": "10"})

--- a/tests/test_apply_overrides_warning.py
+++ b/tests/test_apply_overrides_warning.py
@@ -123,22 +123,26 @@ class TestApplyOverridesMatching:
         content, unmatched = apply_overrides(PROFILE, {"load.stages.0.rate": 10})
         assert unmatched == []
         import yaml
+
         assert yaml.safe_load(content)["load"]["stages"][0]["rate"] == 10
 
     def test_native_bool_value_is_preserved(self):
         content, unmatched = apply_overrides(PROFILE, {"api.streaming": False})
         assert unmatched == []
         import yaml
+
         assert yaml.safe_load(content)["api"]["streaming"] is False
 
     def test_native_list_value_replaces_existing_list(self):
         content, unmatched = apply_overrides(PROFILE, {"load.stages": []})
         assert unmatched == []
         import yaml
+
         assert yaml.safe_load(content)["load"]["stages"] == []
 
     def test_native_list_with_items_replaces_existing_list(self):
         import yaml
+
         new_stages = [{"rate": 5, "duration": 30}, {"rate": 20, "duration": 60}]
         content, unmatched = apply_overrides(PROFILE, {"load.stages": new_stages})
         assert unmatched == []


### PR DESCRIPTION
Treatment overrides were silently stringified before being applied to the workload profile. This made it impossible to replace a whole list, e.g. `load.stages: []` would write the string `"[]"` instead of an empty list, so clearing or reconstructing `stages` from scratch was not possible.

By dropping the `str()` cast, native YAML types (lists, ints, bools) now round-trip correctly. String values from `--overrides` are still coerced as before.