### PR TITLE
feat: allow treatments to override the workload profile file

### DIFF
--- a/llmdbenchmark/experiment/README.md
+++ b/llmdbenchmark/experiment/README.md
@@ -22,10 +22,11 @@ setup:
       decode.parallelism.tensor: 4
 
 treatments:                # Or "run:" -- workload treatments
-  - name: low-load
-    rate: 10
-  - name: high-load
-    rate: 100
+  - name: low-concurrency
+    load.stages.0.concurrency_level: 2
+  - name: high-concurrency
+    profile: random_concurrent.yaml     # Optional; selects a different source profile
+    load.stages.0.concurrency_level: 16
 ```
 
 ### Setup Treatments
@@ -36,7 +37,7 @@ Each setup treatment triggers a complete standup to run to teardown cycle.
 
 ### Run Treatments (Workload)
 
-Run treatments (under `treatments` or `run`) are consumed by the run phase's profile renderer (step 04). Multiple run treatments execute against a single stood-up stack.
+Run treatments (under `treatments` or `run`) are consumed by the run phase's profile renderer. Multiple run treatments execute against a single stood-up stack. Each treatment can optionally set `profile:` to select a different source file than the one resolved from the stack config or `--workload`, enabling a workload sweep across structurally different profiles without needing separate experiment files. Non-`name`/non-`profile` keys are dotted-path overrides applied to the rendered YAML.
 
 ### Matrix
 

--- a/llmdbenchmark/run/steps/step_05_render_profiles.py
+++ b/llmdbenchmark/run/steps/step_05_render_profiles.py
@@ -193,17 +193,18 @@ class RenderProfilesStep(Step):
                 treatment_name = treatment.get("name", f"treatment-{i}")
                 treatment_overrides = treatment.get("overrides", {})
 
+                treatment_profile = treatment.get("profile") or profile_name
                 source_file = self._resolve_source_file(
-                    profile_name, profiles_source, source_profile_file
+                    treatment_profile, profiles_source, source_profile_file
                 )
                 if source_file is None:
                     errors.append(
-                        f"Profile '{profile_name}' not found for treatment "
+                        f"Profile '{treatment_profile}' not found for treatment "
                         f"'{treatment_name}'"
                     )
                     continue
 
-                out_name = profile_name
+                out_name = treatment_profile
                 if out_name.endswith(".in"):
                     out_name = out_name[:-3]
                 if source_profile_file is not None:
@@ -384,14 +385,19 @@ class RenderProfilesStep(Step):
                                 # Constants first, then treatment overrides
                                 overrides = dict(constants)
                                 overrides.update(
-                                    {str(k): v for k, v in item.items() if k != "name"}
-                                )
-                                treatments.append(
                                     {
-                                        "name": item.get("name", f"t{i}"),
-                                        "overrides": overrides,
+                                        str(k): v
+                                        for k, v in item.items()
+                                        if k not in {"name", "profile"}
                                     }
                                 )
+                                treatment = {
+                                    "name": item.get("name", f"t{i}"),
+                                    "overrides": overrides,
+                                }
+                                if item.get("profile"):
+                                    treatment["profile"] = str(item["profile"])
+                                treatments.append(treatment)
                 return treatments
 
         # --overrides creates a single treatment

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -1090,8 +1090,11 @@ class DeployHarnessStep(Step):
         treatment_name = treatment.get("name", "")
         if not treatment_name:
             return base_name
-        stem = Path(base_name).stem
-        suffix = Path(base_name).suffix
+        source_name = treatment.get("profile") or base_name
+        if source_name.endswith(".in"):
+            source_name = source_name[:-3]
+        stem = Path(source_name).stem
+        suffix = Path(source_name).suffix
         return f"{stem}-{treatment_name}{suffix}"
 
     def _load_plan_config(self, context: ExecutionContext) -> dict | None:

--- a/tests/test_deploy_harness_status.py
+++ b/tests/test_deploy_harness_status.py
@@ -444,3 +444,39 @@ def test_debug_harness_uses_generic_name_and_mounts_all_profiles(
     mounts = {mount["name"]: mount["mountPath"] for mount in container["volumeMounts"]}
     assert mounts["guidellm-profiles"] == "/workspace/profiles/guidellm"
     assert mounts["inference-perf-profiles"] == "/workspace/profiles/inference-perf"
+
+
+def test_treatment_profile_name_no_treatment():
+    assert (
+        DeployHarnessStep._treatment_profile_name("shared_prefix.yaml", None)
+        == "shared_prefix.yaml"
+    )
+
+
+def test_treatment_profile_name_no_profile_override():
+    assert (
+        DeployHarnessStep._treatment_profile_name(
+            "shared_prefix.yaml", {"name": "prefix"}
+        )
+        == "shared_prefix-prefix.yaml"
+    )
+
+
+def test_treatment_profile_name_with_profile_override():
+    assert (
+        DeployHarnessStep._treatment_profile_name(
+            "shared_prefix.yaml",
+            {"name": "concurrent", "profile": "concurrent_sessions.yaml"},
+        )
+        == "concurrent_sessions-concurrent.yaml"
+    )
+
+
+def test_treatment_profile_name_strips_in_extension():
+    assert (
+        DeployHarnessStep._treatment_profile_name(
+            "shared_prefix.yaml",
+            {"name": "concurrent", "profile": "concurrent_sessions.yaml.in"},
+        )
+        == "concurrent_sessions-concurrent.yaml"
+    )

--- a/tests/test_render_profiles_workload_file_path.py
+++ b/tests/test_render_profiles_workload_file_path.py
@@ -150,6 +150,46 @@ def test_render_profiles_returns_error_for_missing_local_workload_file(
     assert result.errors == [f"Workload profile file not found: {missing_file}"]
 
 
+def test_treatment_profile_overrides_base_profile(tmp_path: Path) -> None:
+    """A treatment with `profile:` uses its own source file, not the base profile."""
+    base_dir = tmp_path / "base"
+    profiles_dir = base_dir / "workload" / "profiles" / "inference-perf"
+    profiles_dir.mkdir(parents=True)
+    (profiles_dir / "shared_prefix.yaml.in").write_text(
+        "workload: shared-prefix\n", encoding="utf-8"
+    )
+    (profiles_dir / "concurrent_sessions.yaml.in").write_text(
+        "workload: concurrent\n", encoding="utf-8"
+    )
+
+    experiments_file = tmp_path / "experiments.yaml"
+    experiments_file.write_text(
+        "treatments:\n"
+        "  - name: prefix\n"
+        "  - name: concurrent\n"
+        "    profile: concurrent_sessions.yaml\n",
+        encoding="utf-8",
+    )
+
+    context = _Context(
+        workspace=tmp_path / "workspace",
+        base_dir=base_dir,
+        harness_profile="shared_prefix.yaml",
+        experiment_treatments_file=str(experiments_file),
+    )
+
+    result = RenderProfilesStep().execute(context, _write_stack(tmp_path))
+
+    assert result.success
+    out_dir = context.workload_profiles_dir() / "inference-perf"
+    assert (out_dir / "shared_prefix-prefix.yaml").read_text(
+        encoding="utf-8"
+    ) == "workload: shared-prefix\n"
+    assert (out_dir / "concurrent_sessions-concurrent.yaml").read_text(
+        encoding="utf-8"
+    ) == "workload: concurrent\n"
+
+
 def test_debug_render_profiles_includes_all_harness_workloads(tmp_path: Path) -> None:
     base_dir = tmp_path / "base"
     inference_perf_dir = base_dir / "workload" / "profiles" / "inference-perf"


### PR DESCRIPTION
Each treatment in an experiments file can now specify `profile:` to select a different source profile file, falling back to `experiment.profile` when not set.

The motivation is sweeping structurally different workload shapes against a single stood-up stack, where dotted-key overrides are too coarse-grained and separate experiment files per workload add unnecessary overhead.