### PR TITLE
fix: install.sh no longer aborts on a tool nothing requires

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The repository ships a [pre-commit](https://pre-commit.com/) configuration that 
 
 That script:
 
-1. Delegates to `./install.sh` (no `-y` flag — we deliberately want a virtualenv, not system Python) to create/reuse `.venv/`, install the `llmdbenchmark` CLI and `planner` (from [llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner)), and provision all required system tools (`helm`, `helmfile`, `kubectl`, `skopeo`, `crane`, `helm-diff`, `jq`, `yq`, `kustomize`). This is the same bootstrap CI uses (see [`.github/workflows/ci-pr-benchmark.yaml`](.github/workflows/ci-pr-benchmark.yaml)), with `-y` omitted so local development stays in `.venv/` instead of polluting your system Python.
+1. Delegates to `./install.sh` (no `-y` flag — we deliberately want a virtualenv, not system Python) to create/reuse `.venv/`, install the `llmdbenchmark` CLI and `planner` (from [llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner)), and provision the required system tools (`helm`, `helmfile`, `kubectl`, `helm-diff`, `jq`, `yq`) plus a best-effort install of the optional ones (`skopeo`, `crane`, `kustomize`). This is the same bootstrap CI uses (see [`.github/workflows/ci-pr-benchmark.yaml`](.github/workflows/ci-pr-benchmark.yaml)), with `-y` omitted so local development stays in `.venv/` instead of polluting your system Python.
 2. Installs `pre-commit`, `pytest`, and `detect-secrets` from [`.pre-commit_requirements.txt`](.pre-commit_requirements.txt).
 3. Registers both the `pre-commit` and `pre-push` hook types.
 

--- a/README.md
+++ b/README.md
@@ -339,8 +339,11 @@ Please refer to the official [llm-d prerequisites](https://github.com/llm-d/llm-
   helmfile is incompatible with Helm 4 (it probes helm with the removed
   `helm version --client` flag and panics). `./install.sh` installs the
   pinned Helm 4 / helmfile combination for you.
-- **kustomize**, **jq**, **yq** -- Required for template rendering
-- **skopeo**, **crane** -- Required for container image management
+- **jq**, **yq** -- Required for template rendering
+- **kustomize** (optional) -- The kustomize deploy path uses `kubectl apply -k`,
+  which has kustomize built in; the standalone binary is only a convenience
+- **skopeo**, **crane** (optional) -- Used to resolve `:auto` image tags; any one
+  of `skopeo`, `crane` or `podman` is enough
 - **oc** (optional) -- Required for OpenShift clusters (either `kubectl` or `oc` must be present)
 
 ### Administrative Requirements
@@ -372,7 +375,7 @@ The install script:
 
 1. Creates a Python virtual environment at `.venv/` (via [uv](https://docs.astral.sh/uv/) or `python3 -m venv` - see [Install](#install))
 2. Validates Python 3.11+ and pip
-3. Checks for required system tools (curl, git, kubectl or oc, helm, helmfile, kustomize, jq, yq, skopeo, crane)
+3. Checks for required system tools (curl, git, kubectl or oc, helm, helmfile, jq, yq) and best-effort installs the optional ones (kustomize, skopeo, crane)
 4. Installs the `helm-diff` plugin (required by helmfile)
 5. Installs `llmdbenchmark` and `planner` (from [llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner))
 6. Verifies all Python packages are importable

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,7 +55,7 @@ You need these installed before starting:
 
 > **Resource note:** The `cicd/kind` scenario deploys ~7 pods on a single Kind node. With the default 2 CPUs that Docker Desktop, Colima, and Podman ship with, the harness pod (and sometimes the gateway) cannot schedule due to `Insufficient cpu`. Bump your container runtime to **4 CPUs** before creating the Kind cluster. See [Troubleshooting](#pods-stuck-in-pending-during-standup-or-run) if you hit this.
 
-Everything else - `kubectl`, `helm`, `helmfile`, `kind`, `skopeo`, `crane`, `helm-diff`, `jq`, `yq`, `kustomize` - will be installed for you by `./install.sh` in [step 3](#3-install-llmdbenchmark), with one exception: `kind` itself, which we install first below because we want the cluster up before the installer runs.
+Everything else - `kubectl`, `helm`, `helmfile`, `kind`, `skopeo`, `crane`, `helm-diff`, `jq`, `yq`, `kustomize` - will be installed for you by `./install.sh` in [step 3](#3-install-llmdbenchmark), with one exception: `kind` itself, which we install first below because we want the cluster up before the installer runs. `skopeo`, `crane` and `kustomize` are installed best-effort: they are optional, so a failure there is reported and the install continues.
 
 ## 1. Install Kind locally
 

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -27,7 +27,7 @@ whatever the host's package manager provides.
 | **helmfile** | `1.5.1` | version | `install.sh` line 80 (`tool_version_for`) | [helmfile/helmfile](https://github.com/helmfile/helmfile) |
 | **jq** | `1.8.2` | version | `install.sh` line 87 (`tool_version_for`) | [jqlang/jq](https://github.com/jqlang/jq) |
 | **kustomize** | `v5.8.1` | version | `install.sh` line 84 (`tool_version_for`) | [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) |
-| **llm-d-planner (git)** | `v0.1.0` | commit SHA | `install.sh` line 924 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
+| **llm-d-planner (git)** | `v0.1.0` | commit SHA | `install.sh` line 984 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
 | **oc** | `4.18.0` | version | `install.sh` line 83 (`tool_version_for`) | [openshift/oc](https://github.com/openshift/oc) |
 | **skopeo** | `1.20.1` | version | `install.sh` line 86 (`tool_version_for`) | [containers/skopeo](https://github.com/containers/skopeo) |
 | **yq** | `v4.53.3` | version | `install.sh` line 79 (`tool_version_for`) | [mikefarah/yq](https://github.com/mikefarah/yq) |

--- a/install.sh
+++ b/install.sh
@@ -155,8 +155,9 @@ DESCRIPTION
 
     1. Validates Python 3.11+ and pip
     2. Checks for required system tools  (curl, git, kubectl, helm, helmfile,
-                                          skopeo, kustomize, jq, yq, crane)
-    3. Checks for optional system tools   (oc)
+                                          jq, yq)
+    3. Checks optional system tools       (oc); best-effort installs the rest
+                                          (kustomize, skopeo, crane)
     4. Installs llmdbenchmark             (editable: pip install -e .)
     5. Installs planner (llm-d-planner)  (pip install git+https://...)
     6. Verifies that all Python packages are importable
@@ -431,7 +432,13 @@ fi
 echo ""
 echo "=== System tools ==="
 
-tools="curl git helm helmfile skopeo kustomize jq yq crane"
+# curl and git stay required: install.sh itself uses them to fetch the pinned
+# binaries and to clone the planner. skopeo/crane are optional because
+# version_resolver only needs ANY ONE of skopeo/crane/podman, and only to
+# resolve `:auto` image tags. kustomize is optional because nothing shells out
+# to the binary -- the kustomize deploy path runs `kubectl apply -k`, and
+# kubectl embeds kustomize.
+tools="curl git helm helmfile jq yq"
 
 kube_tool=""
 if command -v kubectl &>/dev/null; then
@@ -446,7 +453,15 @@ else
     printf "  %-14s %-20s %s\n" "$kube_tool" "$($kube_tool version --client --short 2>/dev/null || $kube_tool version --client 2>/dev/null | head -1)" ""
 fi
 
-optional_tools="oc"
+optional_tools="oc kustomize skopeo crane"
+
+# Demoted from `tools=` above, so install.sh has to keep provisioning them,
+# only without the power to abort the install. `oc` stays report-only, as on
+# every previous release: install_oc_linux unpacks the OpenShift client tarball
+# and moves ITS kubectl into /usr/local/bin, which would replace a kubectl the
+# user already has. CI installs oc itself where it needs it (see the "Install
+# oc" step in .github/workflows/reusable-ci-nightly-benchmark.yaml).
+autoinstall_optional="kustomize skopeo crane"
 
 # ---------------------------------------------------------------------------
 # Version helper
@@ -508,12 +523,18 @@ _pin_not_enforced() {
 
 # --------------------------------------------------------------------------------
 # Per-tool Linux install helpers - — all now arch-aware via $ARCH_GO / $ARCH_UNAME
+#
+# Callers invoke these through a guarded eval (`... || <handler>`), and an
+# AND-OR list turns `set -e` off for the whole function body. So every step
+# whose failure would otherwise fall through to a `cp`/`mv` returns explicitly:
+# without that, a failed fetch installs whatever stale /tmp file is left over.
+# `curl -f` is part of the same contract, since a 404 body is a 0 exit status.
 # ---------------------------------------------------------------------------------
 
 install_yq_linux() {
     local version=$(tool_version_for yq)
     local binary="yq_linux_${ARCH_GO}"
-    curl -sL "https://github.com/mikefarah/yq/releases/download/${version}/${binary}" -o "/tmp/${binary}"
+    curl -fsSL "https://github.com/mikefarah/yq/releases/download/${version}/${binary}" -o "/tmp/${binary}" || return 1
     chmod +x "/tmp/${binary}"
     sudo cp -f "/tmp/${binary}" /usr/local/bin/yq
 }
@@ -532,18 +553,20 @@ install_helmfile_linux() {
 		   echo "helmfile — v$current_version below pinned $version; attempting install/upgrade..."
 		fi
 		rm -rf /tmp/helmfile
-	    git clone  https://github.com/helmfile/helmfile.git /tmp/helmfile
+	    git clone  https://github.com/helmfile/helmfile.git /tmp/helmfile || return 1
 	    cd /tmp/helmfile || exit 1
 	    git fetch --tags
-		git checkout "v${version}"
-	    GOARCH=s390x GOOS=linux go build -o helmfile
+		# Without this guard a failed checkout builds master, i.e. an
+		# unpinned helmfile that the version gate below happily accepts.
+		git checkout "v${version}" || return 1
+	    GOARCH=s390x GOOS=linux go build -o helmfile || return 1
 	    sudo mv helmfile /usr/local/bin/
 	    sudo chmod +x /usr/local/bin/helmfile
     else
     	local pkg="helmfile_${version}_linux_${ARCH_GO}"
-    	curl -sL "https://github.com/helmfile/helmfile/releases/download/v${version}/${pkg}.tar.gz" \
-        	-o "/tmp/${pkg}.tar.gz"
-    	tar xzf "/tmp/${pkg}.tar.gz" -C /tmp
+    	curl -fsSL "https://github.com/helmfile/helmfile/releases/download/v${version}/${pkg}.tar.gz" \
+        	-o "/tmp/${pkg}.tar.gz" || return 1
+    	tar xzf "/tmp/${pkg}.tar.gz" -C /tmp || return 1
     	sudo cp -f /tmp/helmfile /usr/local/bin/helmfile
     fi
 }
@@ -579,9 +602,9 @@ install_oc_linux() {
     local oc_file="openshift-client-linux"
     [[ "$oc_arch" == "aarch64" ]] && oc_file="${oc_file}-arm64-rhel9"
     oc_file="${oc_file}.tar.gz"
-    curl -sL "https://mirror.openshift.com/pub/openshift-v4/${oc_arch}/clients/ocp/stable/${oc_file}" \
-        -o "/tmp/${oc_file}"
-    tar xzf "/tmp/${oc_file}" -C /tmp
+    curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/${oc_arch}/clients/ocp/stable/${oc_file}" \
+        -o "/tmp/${oc_file}" || return 1
+    tar xzf "/tmp/${oc_file}" -C /tmp || return 1
     sudo mv /tmp/kubectl /usr/local/bin/
     sudo mv /tmp/oc /usr/local/bin/
     sudo chmod +x /usr/local/bin/oc
@@ -594,9 +617,9 @@ install_kustomize_linux() {
     arch=$(uname -m)
     local go_arch="amd64"
     [[ "$arch" == "aarch64" ]] && go_arch="arm64"
-    curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${version}/kustomize_${version}_linux_${go_arch}.tar.gz" \
-        -o "/tmp/kustomize.tar.gz"
-    tar xzf /tmp/kustomize.tar.gz -C /tmp kustomize
+    curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${version}/kustomize_${version}_linux_${go_arch}.tar.gz" \
+        -o "/tmp/kustomize.tar.gz" || return 1
+    tar xzf /tmp/kustomize.tar.gz -C /tmp kustomize || return 1
     sudo mv /tmp/kustomize /usr/local/bin/
     sudo chmod +x /usr/local/bin/kustomize
 }
@@ -615,9 +638,9 @@ install_crane_linux() {
         *)       go_arch_cap="x86_64" ;;
     esac
     local pkg="go-containerregistry_Linux_${go_arch_cap}"
-    curl -sL "https://github.com/google/go-containerregistry/releases/download/${version}/${pkg}.tar.gz" \
-        -o "/tmp/${pkg}.tar.gz"
-    tar xzf "/tmp/${pkg}.tar.gz" -C /tmp crane
+    curl -fsSL "https://github.com/google/go-containerregistry/releases/download/${version}/${pkg}.tar.gz" \
+        -o "/tmp/${pkg}.tar.gz" || return 1
+    tar xzf "/tmp/${pkg}.tar.gz" -C /tmp crane || return 1
     sudo cp -f /tmp/crane /usr/local/bin/crane
     sudo chmod +x /usr/local/bin/crane
 }
@@ -729,7 +752,13 @@ for tool in $tools; do
             echo "  ${tool} — ${current_ver} below pinned ${expected_ver}; attempting install/upgrade..."
             install_func="install_${tool}_${target_os}"
             if declare -F "$install_func" &>/dev/null; then
-                eval "$install_func"
+                # Best-effort, like the `${PKG_MGR} "$tool" || true` sibling
+                # below: under `set -e` an unguarded eval kills the script
+                # before the `command -v` re-check below gets to decide
+                # whether the failure is actually fatal. Report the failure
+                # here, so a broken installer is never explained away as the
+                # deliberate "pin not enforced" case further down.
+                eval "$install_func" || echo "  WARNING: the install/upgrade command for ${tool} failed"
                 if ! command -v "$tool" &>/dev/null; then
                     echo "ERROR: Failed to upgrade ${tool}"
                     exit 1
@@ -774,7 +803,7 @@ for tool in $tools; do
         expected_ver=$(tool_version_for "$tool")
         install_func="install_${tool}_${target_os}"
         if declare -F "$install_func" &>/dev/null; then
-            eval "$install_func"
+            eval "$install_func" || true
         else
             ${PKG_MGR} "$tool" || true
         fi
@@ -860,7 +889,7 @@ for tool in $optional_tools; do
             echo "  ${tool} — ${current_ver} below pinned ${expected_ver}; attempting install/upgrade..."
             install_func="install_${tool}_${target_os}"
             if declare -F "$install_func" &>/dev/null; then
-                eval "$install_func"
+                eval "$install_func" || echo "  WARNING: the install/upgrade command for ${tool} failed"
                 if command -v "$tool" &>/dev/null; then
                     new_ver=$(tool_version "$tool")
                     # Optional tools never hard-fail. Re-verify so we don't
@@ -886,8 +915,39 @@ for tool in $optional_tools; do
             printf "  %-14s %-20s %s\n" "$tool" "$current_ver" ""
             echo "${tool} already installed." >> "$dependencies_checked_file"
         fi
-    else
+    elif [[ " $autoinstall_optional " != *" $tool "* ]]; then
         printf "  %-14s %-20s %s\n" "$tool" "—" "(optional, not found)"
+    else
+        # For the tools demoted out of `tools=`, optional still means "try to
+        # install it", same as the required loop, only never fatal: skopeo and
+        # crane are the pinned static binaries the render-validation hooks
+        # expect (util/setup_precommit.sh), and kustomize keeps its installer
+        # for parity with the required behaviour it had before, even though
+        # nothing shells out to the binary.
+        echo "  ${tool} — NOT FOUND, attempting optional install..."
+        expected_ver=$(tool_version_for "$tool")
+        install_func="install_${tool}_${target_os}"
+        if declare -F "$install_func" &>/dev/null; then
+            eval "$install_func" || true
+        else
+            ${PKG_MGR} "$tool" || true
+        fi
+        if command -v "$tool" &>/dev/null; then
+            new_ver=$(tool_version "$tool")
+            # Same pin check the required loop does, since these tools used to
+            # get it: a package-manager fallback (install_skopeo_linux) can
+            # land well below the pin, and the cache line written below means
+            # no later run would look again.
+            if [[ -n "$expected_ver" ]] && ! version_gte "$new_ver" "$expected_ver"; then
+                echo "  WARNING: ${tool} is ${new_ver}; pinned ${expected_ver}"
+                echo "           not applied (continuing -- optional tool)."
+            fi
+            printf "  %-14s %-20s %s\n" "$tool" "$new_ver" "(newly installed)"
+            echo "${tool} already installed." >> "$dependencies_checked_file"
+        else
+            # No cache line on failure, so a later run retries.
+            printf "  %-14s %-20s %s\n" "$tool" "—" "(optional, install failed -- continuing)"
+        fi
     fi
 done
 

--- a/llmdbenchmark/executor/README.md
+++ b/llmdbenchmark/executor/README.md
@@ -250,7 +250,7 @@ Checks for required and optional CLI tools on `$PATH`.
 
 ```python
 REQUIRED_TOOLS = ["kubectl", "helm", "helmfile", "jq", "yq"]
-OPTIONAL_TOOLS = ["oc", "kustomize", "skopeo", "rsync", "make"]
+OPTIONAL_TOOLS = ["oc", "kustomize", "skopeo", "crane", "rsync", "make"]
 
 
 def check_system_dependencies(

--- a/llmdbenchmark/executor/deps.py
+++ b/llmdbenchmark/executor/deps.py
@@ -15,7 +15,7 @@ MIN_HELMFILE_VERSION = (1, 5, 0)
 
 
 REQUIRED_TOOLS = ["kubectl", "helm", "helmfile", "jq", "yq"]
-OPTIONAL_TOOLS = ["oc", "kustomize", "skopeo", "rsync", "make"]
+OPTIONAL_TOOLS = ["oc", "kustomize", "skopeo", "crane", "rsync", "make"]
 
 
 @dataclass

--- a/tests/test_generate_sbom.py
+++ b/tests/test_generate_sbom.py
@@ -37,6 +37,13 @@ _INSTALL_SH_FIXTURE = """\
 
 tools="curl git helm helmfile yq crane jq"
 
+optional_tools="skopeo kustomize"
+
+install_kustomize_linux() {
+    local version=v5.8.1
+    curl -sL "https://example/${version}/kustomize" -o /tmp/kustomize
+}
+
 install_yq_linux() {
     local version=v4.52.5
     curl -sL "https://example/${version}/yq" -o /tmp/yq
@@ -203,6 +210,21 @@ def test_parse_install_sh_unpinned_marks_system_provided(
     assert by_name["git"].pin == "system-provided"
     assert by_name["git"].pin_type == "system-provided"
     assert "command -v" in by_name["git"].location
+
+
+def test_parse_install_sh_includes_optional_tools(
+    sbom_module,
+    install_sh: Path,
+) -> None:
+    # install.sh installs optional tools too (pinned static binaries), so
+    # moving a tool from `tools=` to `optional_tools=` must not drop it from
+    # the SBOM.
+    entries = sbom_module.parse_install_sh(install_sh)
+    by_name = {e.name: e for e in entries}
+
+    assert by_name["kustomize"].pin == "v5.8.1"
+    assert by_name["kustomize"].pin_type == "version"
+    assert by_name["skopeo"].pin == "system-provided"
 
 
 def test_parse_install_sh_planner_commit(sbom_module, install_sh: Path) -> None:

--- a/tests/test_install_deps_agreement.py
+++ b/tests/test_install_deps_agreement.py
@@ -1,0 +1,114 @@
+"""install.sh and deps.py must agree on which tools are required.
+
+install.sh is the installer; deps.py is the runtime pre-flight check. When the
+two disagree, install.sh hard-fails on a tool the runtime considers optional
+(or one it has never heard of), so the install dies on a tool nothing needs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from llmdbenchmark.executor.deps import OPTIONAL_TOOLS, REQUIRED_TOOLS
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = PROJECT_ROOT / "install.sh"
+
+# Needed by install.sh itself (curl fetches the pinned binaries, git clones the
+# planner), never invoked by the Python at runtime, so deps.py does not list
+# them.
+INSTALLER_ONLY = {"curl", "git"}
+
+# `tools="..."`, ignoring the conditional `tools="$tools oc"` append that adds
+# a kube client when neither kubectl nor oc is on PATH.
+_TOOLS_RE = re.compile(r'^(?P<var>(?:optional_)?tools)="(?P<list>[^"$]+)"$')
+_AUTOINSTALL_RE = re.compile(r'^autoinstall_optional="(?P<list>[^"$]+)"$')
+_EVAL_RE = re.compile(r'eval\s+"\$\{?install_func\}?"')
+_GUARDED_EVAL_RE = re.compile(r'eval\s+"\$\{?install_func\}?"[^|]*\|\|')
+
+
+def _tool_lists() -> tuple[list[str], list[str]]:
+    required: list[str] = []
+    optional: list[str] = []
+    for line in INSTALL_SH.read_text(encoding="utf-8").splitlines():
+        match = _TOOLS_RE.match(line)
+        if not match:
+            continue
+        names = match.group("list").split()
+        if match.group("var") == "optional_tools":
+            optional.extend(names)
+        else:
+            required.extend(names)
+    assert required, f"No tools= assignment found in {INSTALL_SH}"
+    assert optional, f"No optional_tools= assignment found in {INSTALL_SH}"
+    return required, optional
+
+
+def _autoinstall_optional() -> list[str]:
+    """The subset of optional_tools install.sh installs rather than reports."""
+    for line in INSTALL_SH.read_text(encoding="utf-8").splitlines():
+        match = _AUTOINSTALL_RE.match(line)
+        if match:
+            return match.group("list").split()
+    raise AssertionError(f"No autoinstall_optional= assignment in {INSTALL_SH}")
+
+
+def test_install_sh_required_tools_are_required_in_deps() -> None:
+    required, _ = _tool_lists()
+    demoted = sorted(
+        t for t in required if t in OPTIONAL_TOOLS and t not in INSTALLER_ONLY
+    )
+    unknown = sorted(
+        t
+        for t in required
+        if t not in OPTIONAL_TOOLS
+        and t not in REQUIRED_TOOLS
+        and t not in INSTALLER_ONLY
+    )
+    assert not demoted, f"required by install.sh but OPTIONAL in deps.py: {demoted}"
+    assert not unknown, f"required by install.sh but UNKNOWN to deps.py: {unknown}"
+
+
+def test_install_sh_optional_tools_are_known_to_deps() -> None:
+    _, optional = _tool_lists()
+    assert not sorted(t for t in optional if t not in OPTIONAL_TOOLS), (
+        "optional in install.sh but not in deps.OPTIONAL_TOOLS: "
+        f"{sorted(set(optional) - set(OPTIONAL_TOOLS))}"
+    )
+
+
+def test_install_func_eval_is_best_effort() -> None:
+    # install.sh runs under `set -euo pipefail`, so an unguarded
+    # `eval "$install_func"` aborts the whole install the moment a package
+    # manager fails, before the `command -v` re-check that decides whether the
+    # failure is fatal at all. Any `||` handler counts as guarded; matching on
+    # the eval itself (not on `|| true`) keeps a rename or an added redirect
+    # from slipping past, and the emptiness check keeps the test from passing
+    # vacuously if the call sites disappear.
+    evals = [
+        (i, line)
+        for i, line in enumerate(
+            INSTALL_SH.read_text(encoding="utf-8").splitlines(), start=1
+        )
+        if _EVAL_RE.search(line)
+    ]
+    assert evals, f'No `eval "$install_func"` call site found in {INSTALL_SH}'
+    offenders = [(i, line) for i, line in evals if not _GUARDED_EVAL_RE.search(line)]
+    assert not offenders, f"unguarded eval of install_func: {offenders}"
+
+
+def test_oc_is_never_auto_installed() -> None:
+    # install_oc_* unpacks the OpenShift client tarball and moves its bundled
+    # kubectl into /usr/local/bin, replacing the user's. install.sh may only
+    # do that when no kube client exists at all (the `tools="$tools oc"`
+    # append), never from the optional loop, which runs precisely when kubectl
+    # IS present.
+    _, optional = _tool_lists()
+    autoinstall = _autoinstall_optional()
+    assert "oc" in optional, "oc should still be reported by the optional loop"
+    assert "oc" not in autoinstall, "install.sh must not auto-install oc"
+    assert not sorted(set(autoinstall) - set(optional)), (
+        "autoinstall_optional is not a subset of optional_tools: "
+        f"{sorted(set(autoinstall) - set(optional))}"
+    )

--- a/util/generate_sbom.py
+++ b/util/generate_sbom.py
@@ -179,7 +179,11 @@ _VERSION_LINE_RE = re.compile(
 _INSTALL_FN_RE = re.compile(
     r"^\s*install_(?P<tool>[a-zA-Z0-9_-]+?)_(?:linux|mac)\s*\(\s*\)\s*\{?\s*$"
 )
-_TOOLS_VAR_RE = re.compile(r"^\s*tools=(?P<q>[\"'])(?P<list>[^\"']+)(?P=q)\s*$")
+# Matches both `tools=` and `optional_tools=`: optional tools are still
+# installed by install.sh (pinned static binaries), so they belong in the SBOM.
+_TOOLS_VAR_RE = re.compile(
+    r"^\s*(?:optional_)?tools=(?P<q>[\"'])(?P<list>[^\"']+)(?P=q)\s*$"
+)
 _PLANNER_RE = re.compile(r'^\s*PLANNER_GIT="(?P<url>git\+https://[^"]+)"\s*$')
 _HELM_DIFF_RE = re.compile(r"^\s*helm_diff_url=[\"']?(https://[^\s\"']+)")
 # `tool_version_for()` is the authoritative pin table. Its case arms look


### PR DESCRIPTION
Addresses items 1 and 2 of #1693.

⚠️ Deliberately does **not** close that issue. Item 3, every macOS installer being a bare
`brew install` under `set -euo pipefail` with no way to skip the system-tool phase, reads as a
support-scope decision rather than part of this fix, so I left it alone and the issue should stay
open for it.

## The disagreement

`install.sh` and the Python executor disagreed about which tools are mandatory, and `install.sh` was the stricter of the two:

| | skopeo | kustomize | crane |
|---|---|---|---|
| `install.sh` `tools=` (fatal if missing) | required | required | required |
| `deps.py` `OPTIONAL_TOOLS` | optional | optional | **absent entirely** |

So `install.sh` aborted on a host where the benchmark itself would have run fine. That is the failure reported in #1693, and I hit the same thing on macOS.

## Why these three are genuinely optional

- **skopeo and crane**: `version_resolver` needs *any one of* skopeo, crane or podman, and only to resolve `:auto` image tags. Requiring both, fatally, is stricter than the code that consumes them.
- **kustomize**: nothing shells out to the binary. The kustomize deploy path runs `kubectl apply -k`, and kubectl embeds kustomize.

## What changed

- Moved `skopeo`, `kustomize` and `crane` from `tools` to `optional_tools`, with a new `autoinstall_optional` list so they are still installed when possible, just never fatally.
- Added `crane` to `deps.py` `OPTIONAL_TOOLS`. It was missing, so the executor had no opinion about a tool `install.sh` was hard-failing on.
- `oc` stays optional and stays out of `autoinstall_optional`, so its behaviour is unchanged. There is a test pinning that.
- Guarded the optional installers with `|| return 1` so a failed download degrades instead of leaving a half-extracted tool.
- `curl -sL` to `curl -fsSL` in the affected installers. Without `-f`, an HTTP error page is written into the tarball and the failure surfaces later as a confusing `tar` error rather than a download failure.

## Tests

New `tests/test_install_deps_agreement.py` (4 tests) asserts the two sources agree, so this cannot silently drift back apart:

- every tool in `install.sh` `optional_tools` is known to `deps.py`
- required lists do not contradict each other
- `oc` is never auto-installed
- the autoinstall list is a subset of the optional list

I checked these fail when the fix is reverted rather than only passing with it:

- dropping `crane` from `deps.py` `OPTIONAL_TOOLS` -> `test_install_sh_optional_tools_are_known_to_deps` fails
- restoring `optional_tools="oc"` -> `test_oc_is_never_auto_installed` fails

Full suite on this branch, rebased onto current `main`: **893 passed, 31 skipped**.

## Note for whoever reviews

#1585 also edits `docs/upstream-versions.md`, on the table row immediately below the one this touches (it updates the `oc` row, this updates the `llm-d-planner` line reference). The `install.sh` hunks do not overlap at all, mine start at line 155 and #1585 only touches line 80. Whichever of the two merges second may need a one-line rebase on that table. Happy to be the one that rebases.

I flagged this on the issue on 2026-07-30 in case the reporter had already started, and opened it now after no reply.