### PR TITLE
[Standup] Allow `--set` to override keys with dots on it

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -771,50 +771,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Set up extra command line parameters
-        id: prereqs_setup_extrac_cli_parms_llmdbenchmark
-        run: |
-          export LLMDBENCH_EXTRA_CMD=""
-          export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD=""
-          export LLMDBENCH_EXTRA_RUN_OPERATION_CMD=""
-          export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD=""
-          if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
-            export LLMDBENCH_EXTRA_CMD="--non-admin"
-          fi
-          if [[ "$LLMDBENCH_IS_DRY_RUN" == "true" ]]; then
-            export LLMDBENCH_EXTRA_CMD="--dry-run"
-          fi
-          if [[ "$LLMDBENCH_IS_VERBOSE" == "true" ]]; then
-            export LLMDBENCH_EXTRA_CMD="--verbose $LLMDBENCH_EXTRA_CMD "
-          fi
-          if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
-            export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--kustomize-deploy-timeout $LLMDBENCH_CICD_KUSTOMIZE_STANDUP_TIMEOUT --modelservice-deploy-timeout $LLMDBENCH_CICD_MODELSERVICE_STANDUP_TIMEOUT --standalone-deploy-timeout $LLMDBENCH_CICD_STANDALONE_STANDUP_TIMEOUT $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
-          fi
-          export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="--wait-timeout $LLMDBENCH_CICD_RUN_WAIT_TIMEOUT --pvc-bind-timeout $LLMDBENCH_CICD_RUN_PVC_BIND_TIMEOUT --data-access-timeout $LLMDBENCH_CICD_DATA_ACCESS_TIMEOUT $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
-          if [[ ! -z $LLMDBENCH_CICD_DETECTED_MODEL ]]; then
-            export LLMDBENCH_EXTRA_RUN_OPERATION_CMD="--model $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_RUN_OPERATION_CMD "
-          fi
-          if [[ "$LLMDBENCH_MONITORING_ENABLED" == "false" ]]; then
-            export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--no-monitoring $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
-            export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD="$LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD "
-          fi
-          if [[ ! -z $LLMDBENCH_CICD_DETECTED_MODEL ]]; then
-            export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--models $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
-            export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD="--models $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD "
-          fi
-          echo "### LLMDBENCH_EXTRA_CMD is \"$LLMDBENCH_EXTRA_CMD\""
-          echo "LLMDBENCH_EXTRA_CMD=$LLMDBENCH_EXTRA_CMD" >> $GITHUB_ENV
-          echo "### LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD is \"$LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD\""
-          echo "LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD=$LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD" >> $GITHUB_ENV
-          echo "### LLMDBENCH_EXTRA_RUN_OPERATION_CMD is \"$LLMDBENCH_EXTRA_RUN_OPERATION_CMD\""
-          echo "LLMDBENCH_EXTRA_RUN_OPERATION_CMD=$LLMDBENCH_EXTRA_RUN_OPERATION_CMD" >> $GITHUB_ENV
-          echo "### LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD is \"$LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD\""
-          echo "LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD=$LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD" >> $GITHUB_ENV
-          export LLMDBENCH_CICD_GATEWAY_CLASS=$(echo "$LLMDBENCH_CICD_GATEWAY_CLASS" | sed 's^standalone^epponly^g')
-          echo "LLMDBENCH_CICD_GATEWAY_CLASS is \"$LLMDBENCH_CICD_GATEWAY_CLASS\""
-          echo "LLMDBENCH_CICD_GATEWAY_CLASS=$LLMDBENCH_CICD_GATEWAY_CLASS"  >> $GITHUB_ENV
-        shell: bash
-
       - name: Cleanup target cloud
         id: guide_teardown
         run: |

--- a/docs/openshift-setup.md
+++ b/docs/openshift-setup.md
@@ -118,7 +118,7 @@ llmdbenchmark --spec examples/eval-containers-aider-polyglot run \
 | `anyuid-sa` ServiceAccount exists | Cluster-admin (you, once) | `oc create serviceaccount anyuid-sa` |
 | `anyuid` SCC bound to `anyuid-sa` | Cluster-admin (you, once) | `oc adm policy add-scc-to-user anyuid -z anyuid-sa` |
 | RWX PVC storage class exists | Cluster infra | Verify with `oc get sc` |
-| API key secret in namespace | You | `kubectl create secret generic eval-secrets --from-literal=OPENAI_API_KEY=...` |
+| API key secret in namespace | You | `kubectl create secret generic eval-secrets --from-literal=OPENAI_API_KEY=...` | <!-- pragma: allowlist secreti-->
 | The framework creates | Framework | Namespace (if missing), PVC, ConfigMaps, harness pods |
 
 ## Troubleshooting

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1946,7 +1946,6 @@ def cli() -> None:
     run.add_subcommands(subparsers, parents=[benchmark_parser])
     experiment_interface.add_subcommands(subparsers, parents=[benchmark_parser])
     results.add_subcommands(subparsers, parents=[])
-
     args = parser.parse_args()
 
     # Merge env vars for boolean flags (store_true can't use default=)

--- a/llmdbenchmark/experiment/parser.py
+++ b/llmdbenchmark/experiment/parser.py
@@ -83,6 +83,7 @@ def dotted_to_nested(flat: dict[str, Any]) -> dict[str, Any]:
                 f"Key conflict: '{dotted_key}' would overwrite a nested dict "
                 f"with scalar value {value!r}"
             )
+        leaf = leaf.replace("_PROTECTDOT_", ".")
         target[leaf] = value
     return nested
 

--- a/llmdbenchmark/experiment/parser.py
+++ b/llmdbenchmark/experiment/parser.py
@@ -53,11 +53,28 @@ class ExperimentPlan:
         return setup_count * max(self.run_treatments_count, 1)
 
 
+#: Placeholder standing in for a literal ``.`` inside a single key segment,
+#: so path splitting does not treat it as a separator. Written by the CLI's
+#: quoted-segment handling and unwound by :func:`restore_dots`.
+DOT_SENTINEL = "_PROTECTDOT_"
+
+
+def restore_dots(text: str) -> str:
+    """Turn :data:`DOT_SENTINEL` back into literal dots."""
+    return text.replace(DOT_SENTINEL, ".")
+
+
 def dotted_to_nested(flat: dict[str, Any]) -> dict[str, Any]:
     """Convert a flat dict with dotted keys to a nested dict.
 
     Raises ``ValueError`` if dotted keys conflict (e.g. ``a.b: 1`` and
     ``a.b.c: 2`` where ``a.b`` would need to be both a scalar and a dict).
+
+    A segment may carry a literal dot in its name (Kubernetes annotations
+    such as ``k8s.v1.cni.cncf.io/networks``). The CLI protects those by
+    swapping the dots for :data:`DOT_SENTINEL` before the path is split;
+    every segment is restored here, so a dotted key works in a parent
+    position as well as at the leaf.
 
     Example::
 
@@ -66,24 +83,24 @@ def dotted_to_nested(flat: dict[str, Any]) -> dict[str, Any]:
     """
     nested: dict[str, Any] = {}
     for dotted_key, value in flat.items():
-        parts = dotted_key.split(".")
+        parts = [restore_dots(part) for part in dotted_key.split(".")]
         target = nested
         for part in parts[:-1]:
             existing = target.get(part)
             if existing is not None and not isinstance(existing, dict):
                 raise ValueError(
-                    f"Key conflict: '{dotted_key}' requires '{part}' to be a "
-                    f"dict, but it was already set to {existing!r}"
+                    f"Key conflict: '{restore_dots(dotted_key)}' requires "
+                    f"'{part}' to be a dict, but it was already set to "
+                    f"{existing!r}"
                 )
             target = target.setdefault(part, {})
         leaf = parts[-1]
         existing_leaf = target.get(leaf)
         if isinstance(existing_leaf, dict) and not isinstance(value, dict):
             raise ValueError(
-                f"Key conflict: '{dotted_key}' would overwrite a nested dict "
-                f"with scalar value {value!r}"
+                f"Key conflict: '{restore_dots(dotted_key)}' would overwrite "
+                f"a nested dict with scalar value {value!r}"
             )
-        leaf = leaf.replace("_PROTECTDOT_", ".")
         target[leaf] = value
     return nested
 

--- a/llmdbenchmark/parser/cli_overrides.py
+++ b/llmdbenchmark/parser/cli_overrides.py
@@ -23,6 +23,7 @@ same thing they would inside the scenario YAML.
 
 from __future__ import annotations
 
+import re
 import datetime
 import fnmatch
 from typing import Any
@@ -42,6 +43,15 @@ _GLOB_CHARS = "*?["
 
 class OverrideParseError(ValueError):
     """Raised when a ``--set`` expression cannot be parsed."""
+
+
+def protect_internal_dotting(raw: str) -> str:
+    """Ensure keys with dots in the name can be properly specified"""
+
+    processed = raw
+    for match in re.findall(r'"([^"]*)"', raw):
+        processed = processed.replace(f'"{match}"', match.replace(".", "_PROTECTDOT_"))
+    return processed
 
 
 def split_override_pairs(raw: str) -> list[str]:
@@ -191,7 +201,8 @@ def parse_cli_overrides(
     flat_by_selector: dict[str, dict[str, Any]] = {}
 
     for raw in values:
-        for pair in split_override_pairs(raw):
+        processed = protect_internal_dotting(raw)
+        for pair in split_override_pairs(processed):
             selector, key, value = parse_override_pair(pair)
             bucket = flat_by_selector.setdefault(selector, {})
             secret = is_secret_path(key)

--- a/llmdbenchmark/parser/cli_overrides.py
+++ b/llmdbenchmark/parser/cli_overrides.py
@@ -30,7 +30,11 @@ from typing import Any
 
 import yaml
 
-from llmdbenchmark.experiment.parser import dotted_to_nested
+from llmdbenchmark.experiment.parser import (
+    DOT_SENTINEL,
+    dotted_to_nested,
+    restore_dots,
+)
 
 # Selector that matches every stack -- what a pair with no ``stack:`` prefix
 # gets. Also the bucket the ``--cluster-config`` file is folded into, so the
@@ -46,11 +50,24 @@ class OverrideParseError(ValueError):
 
 
 def protect_internal_dotting(raw: str) -> str:
-    """Ensure keys with dots in the name can be properly specified"""
+    """Let a key segment carry a literal dot, e.g. a K8s annotation name.
 
+    A double-quoted run inside the key has its dots swapped for
+    :data:`~llmdbenchmark.experiment.parser.DOT_SENTINEL`, so path splitting
+    leaves them alone; ``dotted_to_nested`` restores them afterwards::
+
+        annotations.pod."k8s.v1.cni.cncf.io/networks"=multi-nic
+        -> {"annotations": {"pod": {"k8s.v1.cni.cncf.io/networks": ...}}}
+
+    Applied to the KEY half only. Quoting is load-bearing on the value side
+    too -- it protects commas from the pair splitter and is the documented
+    escape hatch for YAML's octal reading (``"012"``) and for multi-line
+    folding (``"a\\nb"``) -- so stripping quotes across a whole expression
+    would silently break those.
+    """
     processed = raw
     for match in re.findall(r'"([^"]*)"', raw):
-        processed = processed.replace(f'"{match}"', match.replace(".", "_PROTECTDOT_"))
+        processed = processed.replace(f'"{match}"', match.replace(".", DOT_SENTINEL))
     return processed
 
 
@@ -160,7 +177,9 @@ def parse_override_pair(pair: str) -> tuple[str, str, Any]:
         )
 
     key_part, raw_value = pair.split("=", 1)
-    key_part = key_part.strip()
+    # Protect quoted dots in the KEY only -- the value keeps its quoting,
+    # which YAML still needs (see protect_internal_dotting).
+    key_part = protect_internal_dotting(key_part.strip())
 
     selector = GLOBAL_SELECTOR
     if ":" in key_part:
@@ -201,20 +220,22 @@ def parse_cli_overrides(
     flat_by_selector: dict[str, dict[str, Any]] = {}
 
     for raw in values:
-        processed = protect_internal_dotting(raw)
-        for pair in split_override_pairs(processed):
+        for pair in split_override_pairs(raw):
             selector, key, value = parse_override_pair(pair)
             bucket = flat_by_selector.setdefault(selector, {})
-            secret = is_secret_path(key)
+            # `key` still carries the sentinel so dotted_to_nested can split
+            # it correctly; everything user-facing uses the restored form.
+            shown_key = restore_dots(key)
+            secret = is_secret_path(shown_key)
             if key in bucket:
                 shown = f"({REDACTED})" if secret else f"({bucket[key]!r} -> {value!r})"
                 warnings.append(
-                    f"override '{key}' set more than once for "
+                    f"override '{shown_key}' set more than once for "
                     f"'{selector}' -- last value wins {shown}"
                 )
             if value is None:
                 warnings.append(
-                    f"override '{key}' resolves to null, which cannot clear a "
+                    f"override '{shown_key}' resolves to null, which cannot clear a "
                     "value (null is treated as 'no value' by the config merge) "
                     "-- use an explicit empty string ('') instead"
                 )
@@ -224,7 +245,7 @@ def parse_cli_overrides(
             ):
                 # The message quotes the raw value, so it is suppressed
                 # entirely for credential paths rather than redacted.
-                warnings.append(f"override '{key}': {surprise}")
+                warnings.append(f"override '{shown_key}': {surprise}")
             bucket[key] = value
 
     nested_by_selector: dict[str, dict] = {}

--- a/llmdbenchmark/parser/cli_overrides.py
+++ b/llmdbenchmark/parser/cli_overrides.py
@@ -369,20 +369,37 @@ def redact(dotted_path: str, value: Any) -> Any:
 _MISSING = object()
 
 
-def dotted_leaves(nested: dict, prefix: str = "") -> list[tuple[str, Any]]:
-    """Flatten a nested override dict to ``(dotted.path, value)`` pairs.
+def leaf_entries(
+    nested: dict, prefix: tuple[str, ...] = ()
+) -> list[tuple[tuple[str, ...], Any]]:
+    """Flatten a nested override dict to ``(segments, value)`` pairs.
+
+    Segments rather than a joined path: a key may itself contain a dot
+    (``k8s.v1.cni.cncf.io/networks``), so a string built by joining on ``.``
+    cannot be split back into the original segments. Callers that need to
+    look the path up in another dict must use these.
 
     An empty mapping is itself a leaf -- ``kustomize.extraHelmSets={}`` is a
     meaningful assignment, not an empty branch to recurse into.
     """
-    leaves: list[tuple[str, Any]] = []
+    leaves: list[tuple[tuple[str, ...], Any]] = []
     for key, value in nested.items():
-        path = f"{prefix}.{key}" if prefix else key
+        path = prefix + (key,)
         if isinstance(value, dict) and value:
-            leaves.extend(dotted_leaves(value, path))
+            leaves.extend(leaf_entries(value, path))
         else:
             leaves.append((path, value))
     return leaves
+
+
+def dotted_leaves(nested: dict, prefix: str = "") -> list[tuple[str, Any]]:
+    """Flatten to ``(dotted.path, value)`` pairs, for display only.
+
+    Lossy when a key contains a dot -- use :func:`leaf_entries` for anything
+    that has to address the config.
+    """
+    root = tuple(prefix.split(".")) if prefix else ()
+    return [(".".join(segs), value) for segs, value in leaf_entries(nested, root)]
 
 
 def resolve_dotted(values: dict, dotted_path: str) -> Any:
@@ -392,8 +409,17 @@ def resolve_dotted(values: dict, dotted_path: str) -> Any:
     against :data:`MISSING` rather than ``None`` (a key explicitly set to
     ``None`` is not the same as an absent key).
     """
+    return resolve_segments(values, dotted_path.split("."))
+
+
+def resolve_segments(values: dict, segments: tuple[str, ...] | list[str]) -> Any:
+    """Return the value at ``segments``, or :data:`MISSING` if absent.
+
+    The segment-wise counterpart of :func:`resolve_dotted`; correct for keys
+    that contain a literal dot.
+    """
     current: Any = values
-    for part in dotted_path.split("."):
+    for part in segments:
         if not isinstance(current, dict) or part not in current:
             return _MISSING
         current = current[part]

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -21,10 +21,10 @@ from llmdbenchmark.logging.logger import get_logger
 from llmdbenchmark.parser.cli_overrides import (
     MISSING,
     REDACTED,
-    dotted_leaves,
     find_broken_parent_paths,
     is_secret_path,
-    resolve_dotted,
+    leaf_entries,
+    resolve_segments,
     selectors_for_stack,
     validate_selectors,
 )
@@ -1661,8 +1661,12 @@ class RenderPlans:
         with CLI overrides is auditable from the log alone, without diffing
         the rendered config against the scenario file.
         """
-        for path, new_value in dotted_leaves(overrides):
-            old_value = resolve_dotted(base_values, path)
+        for segments, new_value in leaf_entries(overrides):
+            # Look up by segments, not by a joined string: an override key
+            # may itself contain a dot (a Kubernetes annotation), and a
+            # joined path cannot be split back into the original segments.
+            old_value = resolve_segments(base_values, segments)
+            path = ".".join(segments)
             if is_secret_path(path):
                 # Never echo a credential, not even the value it replaced.
                 previous, current = REDACTED, REDACTED

--- a/tests/test_cli_set_overrides.py
+++ b/tests/test_cli_set_overrides.py
@@ -23,8 +23,10 @@ from llmdbenchmark.parser.cli_overrides import (
     find_broken_parent_paths,
     is_glob,
     is_secret_path,
+    leaf_entries,
     parse_cli_overrides,
     resolve_dotted,
+    resolve_segments,
     selectors_for_stack,
     split_override_pairs,
     validate_selectors,
@@ -117,6 +119,19 @@ class TestQuotedDottedKeys:
         )
         joined = " ".join(warnings)
         assert "hf_AAA" not in joined and "hf_BBB" not in joined
+
+    def test_log_reports_the_true_previous_value_of_a_dotted_key(self):
+        # A joined path cannot be split back into segments when a key
+        # contains a dot, so the log used to report <unset> for an override
+        # that was in fact replacing a real value -- which reads as "the
+        # override did not work" even though it did.
+        base = {"annotations": {"pod": {"k8s.io/networks": "old-net"}}}
+        overrides = {"annotations": {"pod": {"k8s.io/networks": "new-net"}}}
+        [(segments, new_value)] = leaf_entries(overrides)
+        assert segments == ("annotations", "pod", "k8s.io/networks")
+        assert resolve_segments(base, segments) == "old-net"
+        # The lossy, display-only form cannot find it:
+        assert resolve_dotted(base, ".".join(segments)) is MISSING
 
     def test_sentinel_is_not_observable_in_output(self):
         parsed, _ = parse_cli_overrides(['annotations.pod."a.b"=x'])

--- a/tests/test_cli_set_overrides.py
+++ b/tests/test_cli_set_overrides.py
@@ -50,6 +50,79 @@ MULTI_STACK = (
 # ---------------------------------------------------------------------------
 
 
+class TestQuotedDottedKeys:
+    """Keys whose *name* contains dots, e.g. Kubernetes annotations.
+
+    A quoted segment protects its dots from path splitting. The quoting must
+    apply to the KEY half only -- quoting is also load-bearing on the value
+    side (comma protection, and the documented escape hatches for YAML's
+    octal reading and for multi-line folding), so a transform applied to the
+    whole expression would silently break those.
+    """
+
+    def test_annotation_key_with_dots(self):
+        parsed, _ = parse_cli_overrides(
+            ['annotations.prefill.pod."k8s.v1.cni.cncf.io/networks"=multi-nic']
+        )
+        assert parsed == {
+            GLOBAL_SELECTOR: {
+                "annotations": {
+                    "prefill": {"pod": {"k8s.v1.cni.cncf.io/networks": "multi-nic"}}
+                }
+            }
+        }
+
+    def test_dotted_key_in_a_parent_position(self):
+        parsed, _ = parse_cli_overrides(['annotations."k8s.io/zone".pod=east'])
+        assert parsed == {
+            GLOBAL_SELECTOR: {"annotations": {"k8s.io/zone": {"pod": "east"}}}
+        }
+
+    def test_unquoted_dots_still_split_into_a_path(self):
+        parsed, _ = parse_cli_overrides(["decode.resources.limits.cpu=8"])
+        assert parsed == {
+            GLOBAL_SELECTOR: {"decode": {"resources": {"limits": {"cpu": 8}}}}
+        }
+
+    # --- value-side quoting must survive ---------------------------------
+
+    def test_quoted_value_with_a_comma_is_still_one_pair(self):
+        parsed, _ = parse_cli_overrides(
+            ['annotations.pod.note="a,b",decode.replicas=3']
+        )
+        assert parsed[GLOBAL_SELECTOR]["annotations"]["pod"]["note"] == "a,b"
+        assert parsed[GLOBAL_SELECTOR]["decode"]["replicas"] == 3
+
+    def test_quoted_value_keeps_the_octal_escape_hatch(self):
+        parsed, _ = parse_cli_overrides(['model.blockSize="012"'])
+        assert parsed[GLOBAL_SELECTOR]["model"]["blockSize"] == "012"
+
+    def test_quoted_value_keeps_the_multiline_escape_hatch(self):
+        parsed, _ = parse_cli_overrides(
+            [r'decode.vllm.customCommand="export FOO=1\nvllm serve /x"']
+        )
+        assert parsed[GLOBAL_SELECTOR]["decode"]["vllm"]["customCommand"] == (
+            "export FOO=1\nvllm serve /x"
+        )
+
+    def test_dotted_key_and_quoted_value_together(self):
+        parsed, _ = parse_cli_overrides(['annotations.pod."k8s.io/limit"="1,2"'])
+        assert parsed[GLOBAL_SELECTOR]["annotations"]["pod"]["k8s.io/limit"] == "1,2"
+
+    def test_dotted_secret_key_is_still_recognised(self):
+        # Redaction keys off the last path segment; a quoted segment must
+        # not smuggle a credential past it.
+        _, warnings = parse_cli_overrides(
+            ['foo."my.token"=hf_AAA', 'foo."my.token"=hf_BBB']
+        )
+        joined = " ".join(warnings)
+        assert "hf_AAA" not in joined and "hf_BBB" not in joined
+
+    def test_sentinel_is_not_observable_in_output(self):
+        parsed, _ = parse_cli_overrides(['annotations.pod."a.b"=x'])
+        assert "_PROTECTDOT_" not in str(parsed)
+
+
 class TestSplitOverridePairs:
     def test_single_pair(self):
         assert split_override_pairs("decode.replicas=2") == ["decode.replicas=2"]

--- a/tests/test_kustomize_deploy_logging.py
+++ b/tests/test_kustomize_deploy_logging.py
@@ -55,7 +55,7 @@ class TestScrubSecrets:
         assert KustomizeDeployStep._scrub_secrets(text) == text
 
     def test_real_hf_token_gets_redacted(self, monkeypatch):
-        secret = "hf_realtoken_1234567890" #pragma: allowlist secret
+        secret = "hf_realtoken_1234567890"  # pragma: allowlist secret
         monkeypatch.setenv("HF_TOKEN", secret)
         text = f"kubectl create secret HF_TOKEN={secret}"
         scrubbed = KustomizeDeployStep._scrub_secrets(text)
@@ -65,7 +65,7 @@ class TestScrubSecrets:
     def test_llmdbench_hf_token_gets_redacted(self, monkeypatch):
         for v in KustomizeDeployStep._SECRET_ENV_VARS:
             monkeypatch.delenv(v, raising=False)
-        secret = "hf_llmdbench_9876" #pragma: allowlist secret
+        secret = "hf_llmdbench_9876"  # pragma: allowlist secret
         monkeypatch.setenv("LLMDBENCH_HF_TOKEN", secret)
         text = f"echo {secret}"
         assert secret not in KustomizeDeployStep._scrub_secrets(text)
@@ -73,13 +73,13 @@ class TestScrubSecrets:
     def test_huggingface_hub_token_gets_redacted(self, monkeypatch):
         for v in KustomizeDeployStep._SECRET_ENV_VARS:
             monkeypatch.delenv(v, raising=False)
-        secret = "hf_hub_abc" #pragma: allowlist secret
+        secret = "hf_hub_abc"  # pragma: allowlist secret
         monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", secret)
         text = f"kubectl set env HF={secret}"
         assert secret not in KustomizeDeployStep._scrub_secrets(text)
 
     def test_multiple_matches_all_redacted(self, monkeypatch):
-        secret = "hf_multi" #pragma: allowlist secret
+        secret = "hf_multi"  # pragma: allowlist secret
         monkeypatch.setenv("HF_TOKEN", secret)
         text = f"cmd --a={secret} --b={secret}"
         scrubbed = KustomizeDeployStep._scrub_secrets(text)
@@ -149,7 +149,7 @@ class TestRunResolvedLogging:
         )
 
     def test_secrets_scrubbed_from_log(self, monkeypatch):
-        secret = "hf_shouldnotleak" #pragma: allowlist secret
+        secret = "hf_shouldnotleak"  # pragma: allowlist secret
         monkeypatch.setenv("HF_TOKEN", secret)
         ctx = self._make_context()
         cmd = self._make_cmd()

--- a/tests/test_kustomize_deploy_logging.py
+++ b/tests/test_kustomize_deploy_logging.py
@@ -55,7 +55,7 @@ class TestScrubSecrets:
         assert KustomizeDeployStep._scrub_secrets(text) == text
 
     def test_real_hf_token_gets_redacted(self, monkeypatch):
-        secret = "hf_realtoken_1234567890"
+        secret = "hf_realtoken_1234567890" #pragma: allowlist secret
         monkeypatch.setenv("HF_TOKEN", secret)
         text = f"kubectl create secret HF_TOKEN={secret}"
         scrubbed = KustomizeDeployStep._scrub_secrets(text)
@@ -65,7 +65,7 @@ class TestScrubSecrets:
     def test_llmdbench_hf_token_gets_redacted(self, monkeypatch):
         for v in KustomizeDeployStep._SECRET_ENV_VARS:
             monkeypatch.delenv(v, raising=False)
-        secret = "hf_llmdbench_9876"
+        secret = "hf_llmdbench_9876" #pragma: allowlist secret
         monkeypatch.setenv("LLMDBENCH_HF_TOKEN", secret)
         text = f"echo {secret}"
         assert secret not in KustomizeDeployStep._scrub_secrets(text)
@@ -73,13 +73,13 @@ class TestScrubSecrets:
     def test_huggingface_hub_token_gets_redacted(self, monkeypatch):
         for v in KustomizeDeployStep._SECRET_ENV_VARS:
             monkeypatch.delenv(v, raising=False)
-        secret = "hf_hub_abc"
+        secret = "hf_hub_abc" #pragma: allowlist secret
         monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", secret)
         text = f"kubectl set env HF={secret}"
         assert secret not in KustomizeDeployStep._scrub_secrets(text)
 
     def test_multiple_matches_all_redacted(self, monkeypatch):
-        secret = "hf_multi"
+        secret = "hf_multi" #pragma: allowlist secret
         monkeypatch.setenv("HF_TOKEN", secret)
         text = f"cmd --a={secret} --b={secret}"
         scrubbed = KustomizeDeployStep._scrub_secrets(text)
@@ -149,7 +149,7 @@ class TestRunResolvedLogging:
         )
 
     def test_secrets_scrubbed_from_log(self, monkeypatch):
-        secret = "hf_shouldnotleak"
+        secret = "hf_shouldnotleak" #pragma: allowlist secret
         monkeypatch.setenv("HF_TOKEN", secret)
         ctx = self._make_context()
         cmd = self._make_cmd()


### PR DESCRIPTION
The main idea here is to allow keys with `dots` on their names to be properly processed. Illustrative example: `llmdbenchmark --spec scenarios/pd-disaggregation standup --set 'annotations.prefill.pod."k8s.v1.cni.cncf.io/networks"'=multi-nic-compute`