### PR TITLE
Raise readiness/liveness probe tolerance

### DIFF
--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -966,8 +966,14 @@ decode:
   # Probe configuration
   probes:
     startup: *probe_startup
-    liveness: *probe_liveness
-    readiness: *probe_readiness
+    liveness:
+      <<: *probe_liveness
+      failureThreshold: 10
+      timeoutSeconds: 15
+    readiness:
+      <<: *probe_readiness
+      failureThreshold: 10
+      timeoutSeconds: 15
 
   # vLLM configuration
   vllm:


### PR DESCRIPTION
The decode readiness and liveness probes inherited no timeoutSeconds, so the kubelet applied its 1s default. With failureThreshold 3 and periodSeconds 5, a saturated vLLM only had to miss three 1s /health checks (~15s) to be marked NotReady, which de-registered the endpoint from the InferencePool and left the EPP with no candidates.

Set failureThreshold 10 and timeoutSeconds 15 on both probes.