### PR TITLE
Align EPP+KEDA saturation triggers with the upstream well-lit path

### DIFF
--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -1,12 +1,12 @@
 name: CI - Run Benchmark on OCP ("EPP+KEDA+FMA" autoscaling path)
 
-# Drives the EPP+KEDA saturation autoscaling path: KEDA scales on EPP pool
-# metrics (inference_pool_average_kv_cache_utilization / _average_queue_size).
+# Drives the EPP+KEDA saturation autoscaling path: KEDA scales on EPP flow-control
+# metrics (llm_d_epp_flow_control_pool_saturation / llm_d_epp_request_running).
 # Enabled purely via `eppKedaSaturation.enabled: true`.
 #
 # Three passes for direct comparison, under inference-perf load
-# (shared_prefix_synthetic_heavy.yaml, sized to push the EPP KV-cache / queue
-# gauges past the KEDA ScaledObject thresholds so it scales out):
+# (shared_prefix_synthetic_heavy.yaml, sized to push the EPP saturation / running-
+# requests gauges past the KEDA ScaledObject thresholds so it scales out):
 #   1. baseline (EPP+KEDA, no FMA)   -- `cicd/ocp-keda`
 #   2. FMA warm-start with EPP+KEDA  -- `cicd/ocp-keda-fma-warmstart`
 #   3. FMA hot-start with EPP+KEDA   -- `cicd/ocp-keda-fma-hotstart`
@@ -129,7 +129,8 @@ jobs:
   # Pass 1: EPP+KEDA without FMA
   #
   # EPP-only path — decode.replicas: 1 at idle, scaled by the KEDA-managed HPA
-  # on EPP pool metrics (kv-cache / queue). No FMA controllers, no launchers.
+  # on EPP flow-control metrics (pool saturation / running requests). No FMA
+  # controllers, no launchers.
   # =========================================================================
   baseline:
     name: Baseline (EPP+KEDA, no FMA)

--- a/config/README.md
+++ b/config/README.md
@@ -1365,6 +1365,10 @@ This creates a ServiceMonitor for the EPP pod, enabling Prometheus to scrape inf
 When flow control is enabled (see [KV Transfer Configuration](#kv-transfer-configuration) for EPP config), additional metrics are emitted:
 - `inference_extension_flow_control_queue_size` -- flow control queue depth
 - `inference_extension_flow_control_pool_saturation` -- pool saturation level
+- `llm_d_epp_flow_control_pool_saturation` -- pool saturation (0.0–1.0); KEDA
+  EPP-saturation scale trigger (`saturationThreshold`)
+- `llm_d_epp_request_running` -- running requests; KEDA EPP-saturation scale
+  trigger (`runningRequestsThreshold`)
 
 #### CLI monitoring flags (`--monitoring` / `--no-monitoring`)
 

--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -49,7 +49,7 @@
 # dual-pods controller propagates them to the launcher pod at BIND time, so
 # only launchers actually serving traffic show up in the InferencePool.
 #
-# How KEDA scales FMA: the KEDA ScaledObject (30_epp-keda-saturation-scaledobject.yaml.j2)
+# How KEDA scales FMA: the KEDA ScaledObject (30_keda-scaledobject.yaml.j2)
 # targets the FMA requester Deployment (`fma-requester-<id>`) and scales it on EPP
 # pool saturation metrics (pool-average KV-cache utilization and queue size)
 # scraped from the EPP via Prometheus/Thanos.
@@ -154,10 +154,20 @@ scenario:
         minReplicas: 1
         maxReplicas: 6
         pollingInterval: 15
-        kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
-        queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
-        activationThreshold: "0"
         unsafeSsl: true
+        # Defaults come from defaults.yaml; override the whole set here, e.g.
+        # (metricType + activationThreshold optional, default AverageValue/"0"):
+        # triggers:
+        #   - name: pool-saturation
+        #     query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
+        #     threshold: "0.7"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
+        #   - name: running-requests
+        #     query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
+        #     threshold: "16"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
         behavior:
           scaleUp:
             stabilizationWindowSeconds: 0

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -34,7 +34,7 @@
 # dual-pods controller propagates them to the launcher pod at BIND time, so
 # only launchers actually serving traffic show up in the InferencePool.
 #
-# How KEDA scales FMA: the KEDA ScaledObject (30_epp-keda-saturation-scaledobject.yaml.j2)
+# How KEDA scales FMA: the KEDA ScaledObject (30_keda-scaledobject.yaml.j2)
 # targets the FMA requester Deployment (`fma-requester-<id>`) and scales it on EPP
 # pool saturation metrics (pool-average KV-cache utilization and queue size)
 # scraped from the EPP via Prometheus/Thanos.
@@ -178,10 +178,20 @@ scenario:
         minReplicas: 1
         maxReplicas: 6
         pollingInterval: 15
-        kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
-        queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
-        activationThreshold: "0"
         unsafeSsl: true
+        # Defaults come from defaults.yaml; override the whole set here, e.g.
+        # (metricType + activationThreshold optional, default AverageValue/"0"):
+        # triggers:
+        #   - name: pool-saturation
+        #     query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
+        #     threshold: "0.7"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
+        #   - name: running-requests
+        #     query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
+        #     threshold: "16"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
         behavior:
           scaleUp:
             stabilizationWindowSeconds: 0
@@ -264,12 +274,12 @@ scenario:
     # =========================================================================
     # EPP METRICS MONITORING (REQUIRED for KEDA)
     #
-    # KEDA scales on EPP pool saturation metrics (inference_pool_average_kv_cache_
-    # utilization / inference_pool_average_queue_size). The EPP-monitoring template
-    # (29_epp-keda-saturation-epp-monitoring.yaml.j2) scrapes those into
-    # user-workload-monitoring / Thanos, which the ScaledObject's Prometheus
-    # trigger then queries. Without it the ScaledObject has no metric source and
-    # never scales.
+    # KEDA scales on EPP flow-control metrics (llm_d_epp_flow_control_pool_saturation
+    # / llm_d_epp_request_running). The EPP-monitoring template
+    # (29_epp-keda-saturation-epp-monitoring.yaml.j2) scrapes the EPP /metrics
+    # endpoint into user-workload-monitoring / Thanos, which the ScaledObject's
+    # Prometheus trigger then queries. Without it the ScaledObject has no metric
+    # source and never scales.
     # =========================================================================
 
     # =========================================================================

--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -66,10 +66,20 @@ scenario:
         minReplicas: 1
         maxReplicas: 6
         pollingInterval: 15
-        kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
-        queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
-        activationThreshold: "0"
         unsafeSsl: true
+        # Defaults come from defaults.yaml; override the whole set here, e.g.
+        # (metricType + activationThreshold optional, default AverageValue/"0"):
+        # triggers:
+        #   - name: pool-saturation
+        #     query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
+        #     threshold: "0.7"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
+        #   - name: running-requests
+        #     query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
+        #     threshold: "16"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
         behavior:
           scaleUp:
             stabilizationWindowSeconds: 0

--- a/config/scenarios/guides/epp-keda-saturation.yaml
+++ b/config/scenarios/guides/epp-keda-saturation.yaml
@@ -72,10 +72,20 @@ scenario:
         minReplicas: 1
         maxReplicas: 10
         pollingInterval: 15
-        kvCacheThreshold: "0.7"  # scale up when pool-avg KV cache > 70%
-        queueSizeThreshold: "2"  # scale up when pool-avg queue > 2 requests
-        activationThreshold: "0"
         unsafeSsl: true
+        # Defaults come from defaults.yaml; override the whole set here, e.g.
+        # (metricType + activationThreshold optional, default AverageValue/"0"):
+        # triggers:
+        #   - name: pool-saturation
+        #     query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
+        #     threshold: "0.7"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
+        #   - name: running-requests
+        #     query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
+        #     threshold: "16"
+        #     metricType: AverageValue
+        #     activationThreshold: "0"
         behavior:
           scaleUp:
             stabilizationWindowSeconds: 0

--- a/config/templates/jinja/30_keda-scaledobject.yaml.j2
+++ b/config/templates/jinja/30_keda-scaledobject.yaml.j2
@@ -1,12 +1,13 @@
 {# ============================================================================
-   30_epp-keda-saturation-scaledobject.yaml.j2
+   30_keda-scaledobject.yaml.j2
 
-   Per-stack KEDA ScaledObject for direct EPP saturation autoscaling.
-   KEDA queries Prometheus for pool-average metrics (KV cache utilization
-   and queue depth) and scales the Deployment accordingly.
+   Per-stack KEDA ScaledObject for direct EPP saturation autoscaling
+   (Prometheus triggers → HPA; no WVA/VariantAutoscaling/prometheus-adapter).
 
-   No WVA controller, no VariantAutoscaling, no prometheus-adapter.
-   Just dual Prometheus triggers → HPA.
+   Triggers come entirely from scaledObject.triggers (see defaults.yaml); a
+   scenario can redefine the whole list. Each entry: query (required),
+   threshold, optional name/metricType/activationThreshold. In `query`,
+   ${poolName} and ${modelName} are substituted at render time.
 
    Only rendered when eppKedaSaturation.enabled is true.
    ============================================================================ #}
@@ -24,6 +25,7 @@
 {% set pool_name = eppKedaSaturation.epp.poolName | default(model_id_label ~ '-router', true) %}
 {% set prom_url = eppKedaSaturation.prometheus.baseUrl | default('https://thanos-querier.openshift-monitoring.svc.cluster.local', true) %}
 {% set prom_url = prom_url ~ ':' ~ (eppKedaSaturation.prometheus.port | default(9091, true)) %}
+{% set triggers = eppKedaSaturation.scaledObject.triggers | default([], true) %}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -41,33 +43,20 @@ spec:
   maxReplicaCount: {{ eppKedaSaturation.scaledObject.maxReplicas | default(10) }}
   pollingInterval: {{ eppKedaSaturation.scaledObject.pollingInterval | default(15) }}
   triggers:
-  # Pool-average KV cache utilization (0.0–1.0)
-  # Queries Prometheus/thanos directly (configurable via eppKedaSaturation.prometheus.baseUrl)
+{% for t in triggers %}
   - type: prometheus
-    name: kv-cache
-    metricType: AverageValue
+    name: {{ t.name | default('trigger-' ~ loop.index) }}
+    metricType: {{ t.metricType | default('AverageValue') }}
     authenticationRef:
       name: prometheus-auth
     metadata:
       serverAddress: "{{ prom_url }}"
       authModes: bearer
       query: |
-        max(inference_pool_average_kv_cache_utilization{name="{{ pool_name }}",namespace="{{ epp_ns }}"})
-      threshold: "{{ eppKedaSaturation.scaledObject.kvCacheThreshold | default('0.7') }}"
-      activationThreshold: "{{ eppKedaSaturation.scaledObject.activationThreshold | default('0') }}"
-  # Pool-average request queue size
-  - type: prometheus
-    name: queue-size
-    metricType: AverageValue
-    authenticationRef:
-      name: prometheus-auth
-    metadata:
-      serverAddress: "{{ prom_url }}"
-      authModes: bearer
-      query: |
-        max(inference_pool_average_queue_size{name="{{ pool_name }}",namespace="{{ epp_ns }}"})
-      threshold: "{{ eppKedaSaturation.scaledObject.queueSizeThreshold | default('2') }}"
-      activationThreshold: "{{ eppKedaSaturation.scaledObject.activationThreshold | default('0') }}"
+        {{ t.query | replace('${poolName}', pool_name) | replace('${modelName}', model.name) }}
+      threshold: "{{ t.threshold | default('1') }}"
+      activationThreshold: "{{ t.activationThreshold | default('0') }}"
+{% endfor %}
 {% if eppKedaSaturation.scaledObject.behavior is defined %}
   advanced:
     horizontalPodAutoscalerConfig:

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -547,6 +547,8 @@ monitoring:
     - inference_pool_average_queue_size
     - inference_pool_average_running_requests
     - inference_pool_ready_pods
+    - llm_d_epp_flow_control_pool_saturation
+    - llm_d_epp_request_running
 
 # ============================================================================
 # ACCELERATOR CONFIGURATION
@@ -1638,9 +1640,9 @@ wva:
 # ============================================================================
 # EPP+KEDA SATURATION AUTOSCALING
 # ============================================================================
-# Direct KEDA autoscaling using EPP pool metrics, without WVA controller.
-# Queries inference_pool_average_kv_cache_utilization and
-# inference_pool_average_queue_size directly.
+# Direct KEDA autoscaling using EPP flow-control metrics, without WVA controller.
+# Queries llm_d_epp_flow_control_pool_saturation and llm_d_epp_request_running
+# directly (see scaledObject.triggers below).
 eppKedaSaturation:
   enabled: false
   namespace: ""                 # defaults to namespace.name at render time
@@ -1658,10 +1660,21 @@ eppKedaSaturation:
     minReplicas: 1
     maxReplicas: 10
     pollingInterval: 15
-    kvCacheThreshold: "0.7"    # scale up when pool-avg KV cache > 70%
-    queueSizeThreshold: "2"    # scale up when pool-avg queue > 2 requests
-    activationThreshold: "0"
     unsafeSsl: true
+    # KEDA Prometheus triggers, fully defined here so new metrics/thresholds
+    # can be added without touching the Jinja. A scenario may redefine this
+    # entire list. Per entry: query (required), threshold, and optional
+    # name/metricType/activationThreshold. In `query`, ${poolName} and
+    # ${modelName} are substituted at render time.
+    triggers:
+      - name: pool-saturation
+        query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
+        threshold: "0.7"
+        activationThreshold: "0"
+      - name: running-requests
+        query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
+        threshold: "16"
+        activationThreshold: "0"
     behavior:
       scaleUp:
         stabilizationWindowSeconds: 0

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -748,7 +748,7 @@ class DeployModelserviceStep(Step):
         per-stack ScaledObject so KEDA can query metrics and auto-generate
         the HPA. Multiple models scale independently via their own ScaledObjects.
         """
-        for stem in ("30_epp-keda-saturation-scaledobject",):
+        for stem in ("30_keda-scaledobject",):
             yaml_path = self._find_yaml(stack_path, stem)
             if not (yaml_path and self._has_yaml_content(yaml_path)):
                 continue

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -642,7 +642,7 @@ class UninstallHelmStep(Step):
         if not pairs:
             return
 
-        # Per-stack: delete ScaledObject (rendered as 30_epp-keda-saturation-scaledobject.yaml.j2).
+        # Per-stack: delete ScaledObject (rendered as 30_keda-scaledobject.yaml.j2).
         # These are not Helm-managed; `kubectl delete` is idempotent.
         context.logger.log_info("Deleting EPP+KEDA ScaledObjects...")
         for stack_path, cfg in pairs:
@@ -653,9 +653,7 @@ class UninstallHelmStep(Step):
             if not epp_keda_ns:
                 continue
 
-            scaledobject_yaml = _find_yaml(
-                stack_path, "30_epp-keda-saturation-scaledobject"
-            )
+            scaledobject_yaml = _find_yaml(stack_path, "30_keda-scaledobject")
             if scaledobject_yaml and _has_yaml_content(scaledobject_yaml):
                 result = cmd.kube(
                     "delete",


### PR DESCRIPTION
## Summary

Switches the EPP+KEDA saturation ScaledObject triggers to match the upstream llm-d well-lit path: scale on EPP flow-control pool saturation and running requests instead of pool-average KV-cache utilization and queue depth.

## Changes

- `30_epp-keda-saturation-scaledobject.yaml.j2` — triggers swapped to pool-saturation (`llm_d_epp_flow_control_pool_saturation{inference_pool=<pool>}`) and running-requests (`llm_d_epp_request_running{model_name=<model>}`). Label selectors templated from `eppKedaSaturation.epp.poolName / model.name`.
- `defaults.yaml` — replaced `kvCacheThreshold/queueSizeThreshold with saturationThreshold (0.7) / runningRequestsThreshold (16)`; added the two `llm_d_epp_*` metrics to the scrape list.
- Scenarios (`ocp-keda`, `ocp-keda-fma-warmstart`, `ocp-keda-fma-hotstart`, `guides/epp-keda-saturation`) — swapped to the new threshold knobs.
- config/README.md — documented the two new metrics and which knob each drives.