### PR TITLE
Generalize epponly proxy log message

### DIFF
--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -568,7 +568,7 @@ class AdminPrerequisitesStep(Step):
             cmd.logger.log_info(
                 "✅ gateway.className=epponly -- no Kubernetes Gateway / "
                 "provider control plane is needed (EPP runs llm-d's "
-                "standalone router topology with an Envoy sidecar)"
+                "standalone router topology with a proxy sidecar)"
             )
 
     def _install_lws_if_needed(


### PR DESCRIPTION
## Description

Replace the Envoy-specific wording in the `epponly` prerequisite log with
"proxy sidecar." The topology supports both Envoy and agentgateway proxies.

No runtime behavior changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `pytest tests/test_admin_prerequisites_gateway_crds.py -q` (15 passed)
- `pre-commit run` (all applicable checks passed)

### Test Configuration

- Kubernetes version: Not applicable; log-message-only change

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [x] I confirm that `pre-commit run` was run and all checks passed
- [ ] I have updated the documentation accordingly
