### PR TITLE
Add EPP flow-control metrics to the FMA+KEDA comparison table

### DIFF
--- a/llmdbenchmark/analysis/scripts/fma_comparison_table.py
+++ b/llmdbenchmark/analysis/scripts/fma_comparison_table.py
@@ -89,6 +89,9 @@ def fmt(v, unit="", precision=1):
 
 KV_CACHE_METRIC = "inference_pool_average_kv_cache_utilization"
 QUEUE_SIZE_METRIC = "inference_pool_average_queue_size"
+# EPP flow-control metrics that drive the KEDA saturation scale triggers.
+POOL_SATURATION_METRIC = "llm_d_epp_flow_control_pool_saturation"
+RUNNING_REQUESTS_METRIC = "llm_d_epp_request_running"
 
 
 def replica_stats(rdir):
@@ -338,6 +341,8 @@ def main():
     startup = [pod_startup_mean(r) for r in rdirs]
     kv = [epp_gauge_mean(r, KV_CACHE_METRIC) for r in rdirs]
     qd = [epp_gauge_mean(r, QUEUE_SIZE_METRIC) for r in rdirs]
+    sat = [epp_gauge_mean(r, POOL_SATURATION_METRIC) for r in rdirs]
+    rr = [epp_gauge_mean(r, RUNNING_REQUESTS_METRIC) for r in rdirs]
     kv_pct = [(v * 100 if v is not None and v <= 1.0 else v) for v in kv]
     cost = [(a * args.gpu_hourly_cost if a is not None else None) for a in avg_repl]
     hit = [fma_hit_rates(r) for r in rdirs]
@@ -353,6 +358,12 @@ def main():
     )
     out.append(
         "| Avg queue depth (EPP) | " + " | ".join(fmt(v, "", 1) for v in qd) + " |"
+    )
+    out.append(
+        "| Avg pool saturation (EPP) | " + " | ".join(fmt(v, "", 2) for v in sat) + " |"
+    )
+    out.append(
+        "| Avg running requests (EPP) | " + " | ".join(fmt(v, "", 1) for v in rr) + " |"
     )
     out.append(
         "| Avg pod startup (s) | " + " | ".join(fmt(v, "", 0) for v in startup) + " |"

--- a/workload/harnesses/process_metrics.py
+++ b/workload/harnesses/process_metrics.py
@@ -55,6 +55,9 @@ LEGACY_AGGREGATE_METRICS = {
     "inference_pool_average_queue_size",
     "inference_pool_average_running_requests",
     "inference_pool_ready_pods",
+    # EPP flow-control metrics (KEDA saturation scale triggers)
+    "llm_d_epp_flow_control_pool_saturation",
+    "llm_d_epp_request_running",
 }
 AGGREGATE_METRICS = (
     TIME_SERIES_METRIC_SET
@@ -120,6 +123,8 @@ METRIC_UNITS = {
     "inference_pool_average_queue_size": "count",
     "inference_pool_average_running_requests": "count",
     "inference_pool_ready_pods": "count",
+    "llm_d_epp_flow_control_pool_saturation": "ratio",
+    "llm_d_epp_request_running": "count",
     "inference_extension_scheduler_e2e_duration_seconds_bucket": "seconds",
     "inference_extension_scheduler_e2e_duration_seconds_sum": "seconds",
     "inference_extension_scheduler_e2e_duration_seconds_count": "count",


### PR DESCRIPTION
## Summary

Adds two new rows to the FMA vs. baseline comparison table — `Avg pool saturation (EPP)` and `Avg running requests (EPP)` — surfacing the EPP flow-control metrics (`llm_d_epp_flow_control_pool_saturation` and `llm_d_epp_request_running`) that now drive the KEDA saturation scale triggers.

## Motivation

The EPP+KEDA scaling path was recently migrated to scale on the EPP flow-control metrics, but the results table still only reported the old pool gauges (KV-cache utilization, queue depth). This surfaces the metrics KEDA actually scales on, so a run's report shows the signals behind its scaling decisions.

## Changes

- `workload/harnesses/process_metrics.py` — added `llm_d_epp_flow_control_pool_saturation` and `llm_d_epp_request_running` to the aggregation set (LEGACY_AGGREGATE_METRICS) and METRIC_UNITS (ratio / count), so they're aggregated into `metrics_summary.json.` (The active runtime metric list already picks them up from the defaults.yaml scrape list.)
-` llmdbenchmark/analysis/scripts/fma_comparison_table.py` — added constants for the two metrics and two rows (`Avg pool saturation (EPP)`, `Avg running requests (EPP))`, computed via the existing `epp_gauge_mean` helper. Row labels follow the table's existing human-readable style (e.g. "Avg queue depth (EPP)").

