### PR TITLE
fix: apply the guide render step and scope router overrides per accel…

### DIFF
--- a/llmdbenchmark/kustomize/readme_parser.py
+++ b/llmdbenchmark/kustomize/readme_parser.py
@@ -12,6 +12,7 @@ class CommandPhase(str, Enum):
     PREREQUISITES = "prerequisites"
     ROUTER = "router"
     MODELSERVER = "modelserver"
+    RENDER = "render"
     MONITORING = "monitoring"
     VERIFY = "verify"
     CLEANUP = "cleanup"
@@ -79,11 +80,12 @@ class ParsedGuide:
     def get_deploy_commands(
         self, mode: DeployMode = DeployMode.STANDALONE
     ) -> list[GuideCommand]:
-        """Return all deployment commands (prerequisites + router + modelserver + monitoring)."""
+        """Return all deployment commands (prerequisites + router + modelserver + render + monitoring)."""
         phases = (
             CommandPhase.PREREQUISITES,
             CommandPhase.ROUTER,
             CommandPhase.MODELSERVER,
+            CommandPhase.RENDER,
             CommandPhase.MONITORING,
         )
         return [
@@ -114,6 +116,7 @@ class _Section(str, Enum):
     ROUTER_STANDALONE = "router_standalone"
     ROUTER_GATEWAY = "router_gateway"
     MODELSERVER = "modelserver"
+    RENDER = "render"
     MONITORING = "monitoring"
     VERIFICATION = "verification"
     CLEANUP = "cleanup"
@@ -170,6 +173,10 @@ def _classify_heading(text: str, current: _Section) -> _Section:
         return _Section.VERIFICATION
     if "monitoring" in lower:
         return _Section.MONITORING
+    # Checked before the model-server branch: without its own section the render
+    # step inherits MODELSERVER, where only one command is ever applied.
+    if "render" in lower:
+        return _Section.RENDER
     if "deploy the model server" in lower or "model server" in lower:
         return _Section.MODELSERVER
     if "standalone mode" in lower or "standalone" in lower:
@@ -198,6 +205,7 @@ def _section_to_phase_mode(
         _Section.ROUTER_STANDALONE: (CommandPhase.ROUTER, DeployMode.STANDALONE),
         _Section.ROUTER_GATEWAY: (CommandPhase.ROUTER, DeployMode.GATEWAY),
         _Section.MODELSERVER: (CommandPhase.MODELSERVER, DeployMode.ANY),
+        _Section.RENDER: (CommandPhase.RENDER, DeployMode.ANY),
         _Section.MONITORING: (CommandPhase.MONITORING, DeployMode.ANY),
         _Section.VERIFICATION: (CommandPhase.VERIFY, DeployMode.ANY),
         _Section.CLEANUP: (CommandPhase.CLEANUP, DeployMode.ANY),

--- a/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import re
 import shlex
 import tempfile
 from pathlib import Path
@@ -18,6 +19,29 @@ from llmdbenchmark.kustomize.readme_parser import (
     parse_guide_readme,
 )
 from llmdbenchmark.kustomize.variable_resolver import GuideVariableResolver
+
+
+# Accelerator names that may appear as `router/<name>.values.yaml` in a guide
+# README, grouped with the spellings that refer to the same hardware.
+_ACCELERATOR_ALIASES = {
+    "gpu": {"gpu", "cuda", "nvidia"},
+    "xpu": {"xpu", "intel"},
+    "amd": {"amd", "rocm"},
+    "tpu": {"tpu"},
+    "cpu": {"cpu"},
+    "gaudi": {"gaudi"},
+}
+_ALL_ACCELERATOR_TOKENS = {t for group in _ACCELERATOR_ALIASES.values() for t in group}
+_ROUTER_VALUES_FILE_RE = re.compile(r"router/([A-Za-z0-9_-]+)\.values\.ya?ml")
+
+
+def _accelerator_family(accel_backend: str) -> str:
+    """Reduce e.g. ``"xpu/vllm"`` to the accelerator family ``"xpu"``."""
+    head = (accel_backend or "").split("/")[0].strip().lower()
+    for family, aliases in _ACCELERATOR_ALIASES.items():
+        if head in aliases:
+            return family
+    return head
 
 
 class KustomizeDeployStep(Step):
@@ -193,7 +217,12 @@ class KustomizeDeployStep(Step):
                 )
 
         # --- 2. Router ---
-        router_cmds = parsed.get_commands(CommandPhase.ROUTER, DeployMode.STANDALONE)
+        router_cmds = self._select_router_commands(
+            parsed.get_commands(CommandPhase.ROUTER, DeployMode.STANDALONE),
+            accel_backend,
+            resolver,
+            context,
+        )
         for gc in router_cmds:
             resolved = resolver.resolve(gc.raw)
             resolved = self._inject_extra_helm_args(
@@ -261,7 +290,19 @@ class KustomizeDeployStep(Step):
                 errors, stack_path, "Model server deployment failed", context=context
             )
 
-        # --- 4. Monitoring ---
+        # --- 4. Render (tokenizer) ---
+        for gc in parsed.get_commands(CommandPhase.RENDER, DeployMode.ANY):
+            resolved_render = resolver.resolve(gc.raw)
+            result = self._run_resolved(
+                cmd, resolved_render, check=False, context=context, phase="render"
+            )
+            if not result.success:
+                errors.append(f"Render deploy failed: {result.stderr}")
+                return self._fail(
+                    errors, stack_path, "Render deployment failed", context=context
+                )
+
+        # --- 5. Monitoring ---
         if monitoring:
             mon_path = (
                 Path(repo_path)
@@ -282,7 +323,7 @@ class KustomizeDeployStep(Step):
                     f"Monitoring apply failed (non-fatal): {result.stderr}"
                 )
 
-        # --- 5. Wait ---
+        # --- 6. Wait ---
         context.logger.log_info(f"Waiting for pods (timeout={deploy_timeout}s)...")
         wait_result = cmd.wait_for_pods(
             label=f"llm-d.ai/guide={guide_name}",
@@ -643,6 +684,35 @@ class KustomizeDeployStep(Step):
         if commands:
             return commands[0]
         return None
+
+    @staticmethod
+    def _select_router_commands(commands, accel_backend, resolver, context):
+        """Drop router commands that layer another accelerator's values file.
+
+        Guide READMEs document accelerator-specific router overrides as extra
+        ``helm`` blocks (e.g. ``router/xpu.values.yaml``). Every router block is
+        executed, so without this filter a GPU run also applies the XPU override
+        and the EPP ends up selecting no model servers.
+        """
+        family = _accelerator_family(accel_backend)
+        aliases = _ACCELERATOR_ALIASES.get(family, {family})
+
+        selected = []
+        for gc in commands:
+            resolved = resolver.resolve(gc.raw)
+            foreign = {
+                token
+                for token in _ROUTER_VALUES_FILE_RE.findall(resolved)
+                if token in _ALL_ACCELERATOR_TOKENS and token not in aliases
+            }
+            if foreign:
+                context.logger.log_info(
+                    f"[router] skipping command for accelerator(s) "
+                    f"{', '.join(sorted(foreign))} (running on '{family}')"
+                )
+                continue
+            selected.append(gc)
+        return selected
 
     @staticmethod
     def _inject_extra_helm_args(

--- a/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
@@ -291,7 +291,7 @@ class KustomizeDeployStep(Step):
             )
 
         # --- 4. Render (tokenizer) ---
-        for gc in parsed.get_commands(CommandPhase.RENDER, DeployMode.ANY):
+for gc in parsed.get_commands(CommandPhase.RENDER):
             resolved_render = resolver.resolve(gc.raw)
             result = self._run_resolved(
                 cmd, resolved_render, check=False, context=context, phase="render"

--- a/tests/test_kustomize_render_and_router_accel.py
+++ b/tests/test_kustomize_render_and_router_accel.py
@@ -1,0 +1,195 @@
+"""Tests for the render phase and the accelerator-aware router command filter.
+
+Before these behaviours existed a guide's "Deploy the Render (Tokenizer)
+Service" section inherited the model-server section -- where only a single
+command is ever applied -- so the render Service was silently never created.
+Router commands were likewise all executed, so a GPU run also applied a
+guide's ``router/xpu.values.yaml`` override.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+from llmdbenchmark.kustomize.readme_parser import (
+    CommandPhase,
+    DeployMode,
+    parse_guide_readme,
+)
+
+# See test_kustomize_deploy_logging.py: the `llmdbenchmark.standup.steps` package
+# __init__ pulls in the top-level `planner` package, which is not a declared
+# pyproject dependency. Load the step module directly instead.
+_STEP_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "llmdbenchmark"
+    / "standup"
+    / "steps"
+    / "step_06_kustomize_deploy.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "step_06_kustomize_deploy_render_isolated", _STEP_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+sys.modules["step_06_kustomize_deploy_render_isolated"] = _module
+_spec.loader.exec_module(_module)
+KustomizeDeployStep = _module.KustomizeDeployStep
+
+
+def _write_readme(tmp_path: Path, body: str) -> Path:
+    guide_dir = tmp_path / "test-guide"
+    guide_dir.mkdir()
+    readme = guide_dir / "README.md"
+    readme.write_text(textwrap.dedent(body), encoding="utf-8")
+    return readme
+
+
+class _IdentityResolver:
+    def resolve(self, raw: str) -> str:
+        return raw
+
+
+class _RecordingContext:
+    def __init__(self):
+        self.messages: list[str] = []
+        outer = self
+
+        class _Logger:
+            @staticmethod
+            def log_info(message: str) -> None:
+                outer.messages.append(message)
+
+        self.logger = _Logger()
+
+
+class TestRenderPhase:
+    def test_render_section_gets_its_own_phase(self, tmp_path: Path):
+        readme = _write_readme(
+            tmp_path,
+            """\
+            ### 3. Deploy the Model Server
+
+            ```bash
+            kubectl apply -n ns -k guides/g/modelserver/gpu/vllm/
+            ```
+
+            ### 4. Deploy the Render (Tokenizer) Service
+
+            ```bash
+            kubectl apply -n ns -k guides/g/render/
+            ```
+            """,
+        )
+
+        parsed = parse_guide_readme(readme)
+
+        modelserver = [c.raw for c in parsed.get_commands(CommandPhase.MODELSERVER)]
+        render = [c.raw for c in parsed.get_commands(CommandPhase.RENDER, DeployMode.ANY)]
+
+        assert modelserver == ["kubectl apply -n ns -k guides/g/modelserver/gpu/vllm/"]
+        assert render == ["kubectl apply -n ns -k guides/g/render/"]
+
+    def test_render_commands_are_part_of_deploy_commands(self, tmp_path: Path):
+        readme = _write_readme(
+            tmp_path,
+            """\
+            ### Deploy the Render (Tokenizer) Service
+
+            ```bash
+            kubectl apply -n ns -k guides/g/render/
+            ```
+            """,
+        )
+
+        parsed = parse_guide_readme(readme)
+
+        raws = [c.raw for c in parsed.get_deploy_commands()]
+        assert "kubectl apply -n ns -k guides/g/render/" in raws
+
+
+class TestRouterAcceleratorFilter:
+    README = """\
+        ### 1. Deploy the llm-d Router
+
+        ```bash
+        helm install g chart -f guides/g/router/g.values.yaml -n ns
+        ```
+
+        For Intel XPU, add the XPU router override:
+
+        ```bash
+        helm install g chart -f guides/g/router/g.values.yaml -f guides/g/router/xpu.values.yaml -n ns
+        ```
+        """
+
+    def _router_commands(self, tmp_path: Path):
+        parsed = parse_guide_readme(_write_readme(tmp_path, self.README))
+        return parsed.get_commands(CommandPhase.ROUTER, DeployMode.STANDALONE)
+
+    def test_gpu_run_skips_the_xpu_override(self, tmp_path: Path):
+        commands = self._router_commands(tmp_path)
+        context = _RecordingContext()
+
+        selected = KustomizeDeployStep._select_router_commands(
+            commands, "gpu/vllm", _IdentityResolver(), context
+        )
+
+        assert len(commands) == 2
+        assert [c.raw for c in selected] == [commands[0].raw]
+        assert any("skipping" in m for m in context.messages)
+
+    def test_xpu_run_keeps_every_command(self, tmp_path: Path):
+        commands = self._router_commands(tmp_path)
+
+        selected = KustomizeDeployStep._select_router_commands(
+            commands, "xpu/vllm", _IdentityResolver(), _RecordingContext()
+        )
+
+        assert [c.raw for c in selected] == [c.raw for c in commands]
+
+    def test_guide_named_values_file_is_never_treated_as_accelerator(
+        self, tmp_path: Path
+    ):
+        readme = _write_readme(
+            tmp_path,
+            """\
+            ### 1. Deploy the llm-d Router
+
+            ```bash
+            helm install g chart -f guides/g/router/wide-ep-lws.values.yaml -n ns
+            ```
+            """,
+        )
+        commands = parse_guide_readme(readme).get_commands(
+            CommandPhase.ROUTER, DeployMode.STANDALONE
+        )
+
+        selected = KustomizeDeployStep._select_router_commands(
+            commands, "xpu/vllm", _IdentityResolver(), _RecordingContext()
+        )
+
+        assert len(selected) == 1
+
+    def test_rocm_backend_keeps_the_amd_override(self, tmp_path: Path):
+        readme = _write_readme(
+            tmp_path,
+            """\
+            ### 1. Deploy the llm-d Router
+
+            ```bash
+            helm install g chart -f guides/g/router/amd.values.yaml -n ns
+            ```
+            """,
+        )
+        commands = parse_guide_readme(readme).get_commands(
+            CommandPhase.ROUTER, DeployMode.STANDALONE
+        )
+
+        selected = KustomizeDeployStep._select_router_commands(
+            commands, "rocm/vllm", _IdentityResolver(), _RecordingContext()
+        )
+
+        assert len(selected) == 1


### PR DESCRIPTION

Two kustomize standup defects, both visible in the precise-prefix-cache-routing nightlies.

The guide README heading "Deploy the Render (Tokenizer) Service" matched no branch in `_classify_heading`, so it inherited the preceding MODELSERVER section. `_select_modelserver_command` applies exactly one command per run, so `kubectl apply -k guides/<guide>/render/` was silently dropped and the render Service was never created. The EPP `token-producer` then had no tokenizer endpoint to call. Give the render section its own section/phase and apply it after the model server.

Router commands were also all executed unconditionally, unlike model server commands which are selected by accelerator backend. A guide that documents an accelerator-specific override as an extra helm block -- wide-ep-lws does, with `router/xpu.values.yaml` -- therefore had that override applied on GPU runs too, where its `accelerator-variant: xpu` matchLabels leave the EPP with no model servers. Skip router commands that layer another accelerator's values file.