### PR TITLE
fix: nok8s preflight misses replica ports and Envoy admin, and passes silently without ss

### DIFF
--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -15,6 +15,10 @@ from llmdbenchmark.executor.deps import (
 )
 from llmdbenchmark.utilities.cluster import print_phase_banner
 
+# Listening-socket probes, first one available wins. ss is iproute2 (Linux);
+# lsof covers macOS and hosts without iproute2.
+PORT_PROBES = ("ss -ltn", "lsof -nP -iTCP -sTCP:LISTEN")
+
 
 class EnsureInfraStep(Step):
     """Validate system dependencies and print cluster summary banner."""
@@ -143,7 +147,12 @@ class EnsureInfraStep(Step):
                 port
                 for cfg in stacks
                 for port in (
-                    cfg.get("vllm", {}).get("hostPort", 8000),
+                    # One worker per replica, hostPort .. hostPort+replicas-1
+                    # (34_nok8s-containers.yaml.j2).
+                    *(
+                        int(cfg.get("vllm", {}).get("hostPort", 8000)) + i
+                        for i in range(int(cfg.get("vllm", {}).get("replicas", 1) or 1))
+                    ),
                     cfg.get("envoy", {}).get("listenPort", 8081),
                     cfg.get("envoy", {}).get("adminPort", 19000),
                     cfg.get("epp", {}).get("grpcPort", 9002),
@@ -264,10 +273,27 @@ class EnsureInfraStep(Step):
                 f"download in the vLLM container."
             )
 
-        # 4. Required host ports free (warning).
-        res = cmd.execute("ss -ltn", check=False, force=True, silent=True)
-        if res.success and res.stdout:
-            busy = [p for p in ports if f":{p} " in res.stdout]
+        # 4. Required host ports free (warning). Pick the first probe tool that
+        #    exists; warn rather than pass silently when none does.
+        probe_cmd = next(
+            (
+                p
+                for p in PORT_PROBES
+                if cmd.execute(
+                    f"command -v {p.split()[0]}", check=False, force=True, silent=True
+                ).success
+            ),
+            None,
+        )
+        if probe_cmd is None:
+            warnings.append(
+                f"Cannot verify host ports {ports}: none of "
+                f"{', '.join(p.split()[0] for p in PORT_PROBES)} found on PATH. "
+                f"Install iproute2 or lsof, or check the ports yourself."
+            )
+        else:
+            res = cmd.execute(probe_cmd, check=False, force=True, silent=True)
+            busy = [p for p in ports if f":{p} " in (res.stdout or "")]
             if busy:
                 warnings.append(
                     f"Host ports already in use: {busy}. Free them, run "

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -130,7 +130,17 @@ class _FakeCmd:
         return _FakeResult(ok, out)
 
 
-def _nok8s_ctx(tmp_path: Path, cmd):
+class _CapturingLogger(_Logger):
+    """Logger that keeps the warning lines the preflight emits."""
+
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+
+    def log_warning(self, msg: str, *_: Any, **__: Any) -> None:
+        self.warnings.append(msg)
+
+
+def _nok8s_ctx(tmp_path: Path, cmd, nok8s: dict | None = None):
     from llmdbenchmark.executor.context import ExecutionContext
 
     ctx = ExecutionContext(
@@ -141,7 +151,14 @@ def _nok8s_ctx(tmp_path: Path, cmd):
         container_runtime="docker",
     )
     ctx.cmd = cmd
-    ctx.logger = _Logger()
+    ctx.logger = _CapturingLogger()
+    if nok8s is not None:
+        stack = tmp_path / "stack"
+        stack.mkdir(exist_ok=True)
+        (stack / "config.yaml").write_text(
+            yaml.safe_dump({"nok8s": nok8s}), encoding="utf-8"
+        )
+        ctx.rendered_stacks = [stack]
     return ctx
 
 
@@ -167,6 +184,68 @@ def test_nok8s_preflight_passes_when_runtime_and_gpu_present(tmp_path: Path) -> 
     finally:
         os.environ.pop("HUGGING_FACE_HUB_TOKEN", None)
     assert result.success is True
+
+
+def _busy_warning(ctx) -> str:
+    return next((w for w in ctx.logger.warnings if "already in use" in w), "")
+
+
+def test_nok8s_preflight_checks_every_replica_port(tmp_path: Path) -> None:
+    """Replicas occupy hostPort..hostPort+N-1, not just hostPort."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ss_out = "LISTEN 0 4096 0.0.0.0:8002 0.0.0.0:*\n"
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _FakeCmd(stdout_for={"ss -ltn": ss_out}),
+        nok8s={"vllm": {"replicas": 3, "hostPort": 8000, "accelerator": "cpu"}},
+    )
+    EnsureInfraStep().execute(ctx)
+    assert "8002" in _busy_warning(ctx)
+
+
+def test_nok8s_preflight_checks_envoy_admin_port(tmp_path: Path) -> None:
+    """19000 is hard-coded in the Envoy bootstrap and must be free."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ss_out = "LISTEN 0 4096 127.0.0.1:19000 0.0.0.0:*\n"
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _FakeCmd(stdout_for={"ss -ltn": ss_out}),
+        nok8s={"vllm": {"accelerator": "cpu"}},
+    )
+    EnsureInfraStep().execute(ctx)
+    assert "19000" in _busy_warning(ctx)
+
+
+def test_nok8s_preflight_falls_back_to_lsof(tmp_path: Path) -> None:
+    """Hosts without iproute2 (macOS) still get a real port check."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    lsof_out = "envoy 42 u 10u IPv4 0t0 TCP 127.0.0.1:8081 (LISTEN)\n"
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _FakeCmd(
+            fail_substrings=("command -v ss",),
+            stdout_for={"lsof": lsof_out},
+        ),
+        nok8s={"vllm": {"accelerator": "cpu"}},
+    )
+    EnsureInfraStep().execute(ctx)
+    assert "8081" in _busy_warning(ctx)
+
+
+def test_nok8s_preflight_warns_when_no_port_probe_available(tmp_path: Path) -> None:
+    """Neither ss nor lsof present -> say so instead of silently passing."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _FakeCmd(fail_substrings=("command -v ss", "command -v lsof")),
+        nok8s={"vllm": {"accelerator": "cpu"}},
+    )
+    EnsureInfraStep().execute(ctx)
+    assert any("Cannot verify host ports" in w for w in ctx.logger.warnings)
 
 
 def test_device_args_per_accelerator() -> None:


### PR DESCRIPTION
The nok8s preflight port check has three gaps, all of which let a standup proceed into a conflict it could have predicted.

`hostPort` is checked for replica 0 only. With `nok8s.vllm.replicas: N` the workers bind `hostPort .. hostPort+N-1` (`34_nok8s-containers.yaml.j2:24`), so `8001..800N` were never looked at. Envoy's admin port 19000 is hard-coded in `33_nok8s-envoy.yaml.j2` and listed as a required free port in `docs/nok8s.md:37`, but was not in the list either.

The third one is the reason I noticed. The check runs `ss -ltn` inside `if res.success and res.stdout:`, so on any host without iproute2 it reports nothing and passes. On macOS `ss` does not exist, so the check has never done anything there. `tests/test_nok8s_plan.py:157-170` only covered the path where `ss` succeeds and finds no listeners, so nothing caught it.

This expands the port list, adds `lsof -nP -iTCP -sTCP:LISTEN` as a fallback probe so the check works on macOS, and warns when no probe is available rather than passing silently. A warning that says it could not check is worth more than a silent pass that reads as all clear.

Four regression tests, each verified to fail before the change: every replica port checked, admin port checked, lsof fallback used when ss is absent, and the no-probe-available warning. Full suite matches the pre-existing baseline on main (same 4 unrelated failures in `test_config_schema.py`).

Fixes #1703