### PR TITLE
fix: reject multi-stack scenarios on the nok8s method

### DIFF
--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -22,6 +22,11 @@ equivalent of the upstream
 Use it for HPC/Slurm nodes, bare-metal boxes, or a single GPU workstation
 where standing up Kubernetes is not worth it.
 
+**One stack per host.** Container names, host ports and
+`nok8s.workspaceHostDir` are fixed, so a scenario with more than one stack on
+this method is rejected during plan rendering. Run one scenario per stack, or
+use a cluster-based method, to compare multiple stacks.
+
 ## Prerequisites
 
 `llmdbenchmark standup` validates these automatically in step 00; a missing or

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -846,6 +846,30 @@ class RenderPlans:
         return errors
 
     @staticmethod
+    def _validate_nok8s_single_stack(
+        values: dict,
+        total_stacks: int,
+        stack_name: str,
+    ) -> list[str]:
+        """Reject multi-stack scenarios on the ``nok8s`` deploy method.
+
+        nok8s launches plain host containers with fixed names (``vllm-N``,
+        ``epp``, ``envoy``), fixed host ports and a single staged config
+        directory (``nok8s.workspaceHostDir``). A second nok8s stack on the
+        same host reuses all three, and standup's ``rm -f`` idempotency step
+        tears down the first stack's containers before launching its own.
+        There is nothing to multiplex the stacks over, so refuse up front
+        instead of letting them silently clobber each other.
+        """
+        if total_stacks <= 1 or not (values.get("nok8s") or {}).get("enabled"):
+            return []
+        return [
+            f"[{stack_name}] the nok8s method supports one stack per host "
+            "(container names, host ports and nok8s.workspaceHostDir are "
+            f"shared). This scenario has {total_stacks} stacks."
+        ]
+
+    @staticmethod
     def _normalize_direct_service_mode(values: dict) -> dict:
         """Make ``gateway.className=none`` a true direct-vLLM baseline.
 
@@ -1969,6 +1993,15 @@ class RenderPlans:
             stack_name=stack_name,
         )
         for msg in direct_service_errors:
+            self.logger.log_error(msg)
+            stack_errors.render_errors.append(msg)
+
+        nok8s_errors = self._validate_nok8s_single_stack(
+            merged_values,
+            total_stacks=total_stacks,
+            stack_name=stack_name,
+        )
+        for msg in nok8s_errors:
             self.logger.log_error(msg)
             stack_errors.render_errors.append(msg)
 

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -29,11 +29,15 @@ class _Logger:
         pass
 
 
-def _render(tmp_path: Path, cli_methods: str | None = None):
+def _render(
+    tmp_path: Path,
+    cli_methods: str | None = None,
+    scenarios_file: Path = NOK8S_SCENARIO,
+):
     return RenderPlans(
         template_dir=TEMPLATE_DIR,
         defaults_file=DEFAULTS_FILE,
-        scenarios_file=NOK8S_SCENARIO,
+        scenarios_file=scenarios_file,
         output_dir=tmp_path / "plan",
         logger=_Logger(),
         cli_methods=cli_methods,
@@ -224,6 +228,28 @@ def test_pin_env_per_replica() -> None:
     assert (
         pin({"replicas": 2, "replicaIndex": 1, "deviceArgs": ["--device", "x"]}) == ""
     )
+
+
+def test_two_nok8s_stacks_are_rejected(tmp_path: Path) -> None:
+    """Two nok8s stacks would collide on container names/ports/workspace dir."""
+    scenario = yaml.safe_load(NOK8S_SCENARIO.read_text(encoding="utf-8"))
+    second = dict(scenario["scenario"][0])
+    second["name"] = "nok8s-second"
+    scenario["scenario"].append(second)
+    scenario_file = tmp_path / "two-nok8s.yaml"
+    scenario_file.write_text(yaml.safe_dump(scenario), encoding="utf-8")
+
+    result = _render(tmp_path, scenarios_file=scenario_file)
+
+    assert result.has_errors
+    for name in ("nok8s-single", "nok8s-second"):
+        assert any(
+            "one stack per host" in e for e in result.stacks[name].render_errors
+        ), f"stack {name} was not rejected"
+
+
+def test_single_nok8s_stack_still_renders(tmp_path: Path) -> None:
+    assert not _render(tmp_path).has_errors
 
 
 def test_resolve_deploy_method_forces_nok8s() -> None:


### PR DESCRIPTION
A scenario with two entries under `scenario:` that both set `nok8s.enabled: true` does not produce two stacks. It produces two attempts at the same one.

nok8s launches plain host containers with fixed names (`vllm-N`, `epp`, `envoy`), fixed host ports, and a single staged config directory (`nok8s.workspaceHostDir`). A second stack reuses all three. In dry-run both stacks emit byte-identical launch commands and report the same endpoint. Live, they race (`max_parallel_stacks` defaults to 4) and one loses to a name conflict.

The quiet failure is worse than the visible one: `step_06_nok8s_deploy.py:85` runs `docker rm -f <name>` for idempotency before each launch, so depending on interleaving, stack B destroys stack A's already-running `epp`/`envoy`, and the surviving containers serve stack B's config while standup reports stack A's endpoint. You get a green run measuring the wrong thing.

Issue #1699 offered two options: per-stack isolation, or refusing up front. This takes the second. There is nothing on this path to multiplex stacks over, and inventing stack-scoped names and workspace directories would be a large change to make a configuration work that has no reason to exist on a single host. Refusing during plan rendering costs one validation and tells the user exactly what to do instead.

Adds `docs/nok8s.md` note stating the one-stack-per-host constraint, since the docs did not say it.

One regression test, verified to fail before the change. Full suite matches the pre-existing baseline on main (same 4 unrelated failures in `test_config_schema.py`).

Fixes #1699