### PR TITLE
fix: stop nok8s standup at the first container failure and roll back what launched

### DIFF
--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -77,7 +77,6 @@ class NoK8sDeployStep(Step):
                 f"[dry-run] would stage nok8s configs under {workspace}"
             )
 
-        errors: list[str] = []
         launched: list[str] = []
         for c in containers:
             name = c["name"]
@@ -88,13 +87,15 @@ class NoK8sDeployStep(Step):
             )
             result = cmd.execute(run_cmd, check=False)
             if not result.success and not context.dry_run:
-                errors.append(f"Failed to start container {name}: {result.stderr}")
+                # The stack is unusable without every container, so stop at the
+                # first failure instead of launching the rest, and remove what
+                # is already up so it does not hold host ports (epp/envoy use
+                # --network host) against the next standup.
+                err = f"Failed to start container {name}: {result.stderr}"
                 self._dump_logs(cmd, runtime, name, context)
-            else:
-                launched.append(name)
-
-        if errors:
-            return self._fail(stack_path, "; ".join(errors), errors)
+                self._rollback(cmd, runtime, launched, context)
+                return self._fail(stack_path, err, [err])
+            launched.append(name)
 
         # Readiness: each vLLM worker, then Envoy.
         if not context.dry_run:
@@ -105,6 +106,7 @@ class NoK8sDeployStep(Step):
                 )
                 if envoy:
                     self._dump_logs(cmd, runtime, envoy, context)
+                self._rollback(cmd, runtime, launched, context)
                 return self._fail(stack_path, ready_err, [ready_err])
 
         return StepResult(
@@ -271,6 +273,25 @@ class NoK8sDeployStep(Step):
                 return f"Timed out waiting for {url} after {timeout}s"
             context.logger.log_info(f"nok8s endpoint ready: {url}")
         return None
+
+    def _rollback(
+        self,
+        cmd: CommandExecutor,
+        runtime: str,
+        launched: list[str],
+        context: ExecutionContext,
+    ) -> None:
+        """Remove the containers this standup already started, logs first.
+
+        ``rm -f`` destroys the container logs, and a failed standup is exactly
+        when they are needed, so every container is dumped before it is
+        removed. Removal is in reverse launch order and best-effort: a rollback
+        must not mask the failure that triggered it.
+        """
+        for name in reversed(launched):
+            self._dump_logs(cmd, runtime, name, context)
+            cmd.execute(f"{runtime} rm -f {name}", check=False)
+            context.logger.log_info(f"nok8s rollback: removed container {name}")
 
     def _dump_logs(
         self, cmd: CommandExecutor, runtime: str, name: str, context: ExecutionContext

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -226,6 +226,100 @@ def test_pin_env_per_replica() -> None:
     )
 
 
+class _RecordingCmd(_FakeCmd):
+    """_FakeCmd that records every command it was asked to run."""
+
+    def __init__(self, fail_substrings=(), stdout_for=None) -> None:
+        super().__init__(fail_substrings, stdout_for)
+        self.commands: list[str] = []
+
+    def execute(self, cmd, *args, **kwargs):
+        self.commands.append(cmd)
+        return super().execute(cmd, *args, **kwargs)
+
+    def removed(self) -> set[str]:
+        return {c.split()[-1] for c in self.commands if " rm -f " in c}
+
+    def launched(self) -> set[str]:
+        return {
+            c.split("--name ")[1].split()[0] for c in self.commands if "--name " in c
+        }
+
+
+def _nok8s_stack(tmp_path: Path) -> Path:
+    """Minimal rendered stack dir with a three-container launch spec."""
+    stack = tmp_path / "stack"
+    stack.mkdir()
+    spec = {
+        "runtime": "docker",
+        "workspaceHostDir": str(tmp_path / "ws"),
+        "model": "Qwen/Qwen2.5-0.5B-Instruct",
+        "endpoint": "http://localhost:8081",
+        "containers": [
+            {
+                "name": "vllm-0",
+                "kind": "vllm",
+                "image": "nonexistent:v0",
+                "hostPort": 8000,
+            },
+            {
+                "name": "epp",
+                "kind": "epp",
+                "image": "epp:v0",
+                "grpcPort": 9002,
+                "grpcHealthPort": 9003,
+                "metricsPort": 9090,
+            },
+            {"name": "envoy", "kind": "envoy", "image": "envoy:v0"},
+        ],
+    }
+    (stack / "34_nok8s-containers.yaml").write_text(yaml.safe_dump(spec), "utf-8")
+    return stack
+
+
+def test_nok8s_launch_failure_stops_and_rolls_back(tmp_path: Path) -> None:
+    """A container that fails to start aborts the launch and removes the rest."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _nok8s_stack(tmp_path)
+    # vllm-0 is launched first and fails.
+    cmd = _RecordingCmd(fail_substrings=("--name vllm-0",))
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sDeployStep().execute(ctx, stack)
+
+    assert result.success is False
+    assert "vllm-0" in result.message
+    # Nothing after the failing container is launched.
+    assert not any("run -d --name epp" in c for c in cmd.commands)
+    assert not any("run -d --name envoy" in c for c in cmd.commands)
+
+
+def test_nok8s_rollback_dumps_logs_before_removing(tmp_path: Path) -> None:
+    """Already-launched containers are removed, with logs captured first."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _nok8s_stack(tmp_path)
+    # vllm-0 and epp come up; envoy (launched last) fails.
+    cmd = _RecordingCmd(fail_substrings=("--name envoy",))
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sDeployStep().execute(ctx, stack)
+
+    assert result.success is False
+    for name in ("vllm-0", "epp"):
+        logs = cmd.commands.index(f"docker logs {name} --tail 100")
+        # rm -f appears twice per container: the idempotency wipe before the
+        # launch, and the rollback afterwards. The rollback one must come after
+        # the log dump, or the evidence is gone.
+        removals = [
+            i for i, c in enumerate(cmd.commands) if c == f"docker rm -f {name}"
+        ]
+        assert len(removals) == 2, cmd.commands
+        assert removals[-1] > logs, f"{name} removed before its logs were dumped"
+        assert (ctx.setup_logs_dir() / f"nok8s-{name}.log").exists()
+
+
 def test_resolve_deploy_method_forces_nok8s() -> None:
     """--methods nok8s wins and disables the other methods (mutual exclusion)."""
     rp = RenderPlans(
@@ -435,25 +529,6 @@ def test_nok8s_run_endpoint_needs_one_stack() -> None:
         assert "--stack" in str(e) and "8181" in str(e)
     else:
         raise AssertionError("expected a PhaseError for a multi-stack nok8s run")
-
-
-class _RecordingCmd:
-    """CommandExecutor stand-in that records every command it is handed."""
-
-    def __init__(self) -> None:
-        self.commands: list[str] = []
-
-    def execute(self, cmd, *_: Any, **__: Any):
-        self.commands.append(cmd)
-        return _FakeResult(True)
-
-    def removed(self) -> set[str]:
-        return {c.split()[-1] for c in self.commands if " rm -f " in c}
-
-    def launched(self) -> set[str]:
-        return {
-            c.split("--name ")[1].split()[0] for c in self.commands if "--name " in c
-        }
 
 
 def test_nok8s_deploy_never_removes_a_sibling_stacks_containers(


### PR DESCRIPTION
A nok8s standup that fails on `vllm-0` still pulls and starts `epp` and `envoy`, and leaves them running on the host.

`step_06_nok8s_deploy.py:82-97` iterates every container, accumulating into `errors`, and only returns once all of them have been attempted. There is no rollback of what already launched. Because `epp` and `envoy` use `--network host`, they then hold 9002/9003/9090/8081, so the next standup attempt trips the preflight's own host-ports-in-use warning. Recovery works (`teardown --methods nok8s`), but the docs only mention it under "Ports busy", not as a required step after a failed standup.

This stops at the first launch failure and removes what was already started before returning.

The ordering matters and the issue calls it out: rollback must not destroy the evidence. Logs for launched containers are dumped before anything is removed, so the failure is still diagnosable afterward. `_dump_logs` is already best-effort (`check=False`, `OSError` swallowed), so the dump cannot make the failure path worse.

Two regression tests, both verified to fail before the change: one that the loop stops and rolls back, one that logs are captured before removal. Full suite matches the pre-existing baseline on main.

Note this touches `step_06_nok8s_deploy.py`, as does #1719 (readiness-timeout log dumping) and my #1756. The changes are in different functions, but whichever lands last will want a quick rebase.

Fixes #1702