### PR TITLE
fix: skip Kubernetes-only version resolution on the nok8s path

### DIFF
--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -2033,7 +2033,9 @@ class RenderPlans:
 
         if self.version_resolver:
             try:
-                merged_values = self.version_resolver.resolve_all(merged_values)
+                merged_values = self.version_resolver.resolve_all(
+                    merged_values, skip_kubernetes=is_nok8s
+                )
             except Exception as e:
                 self.logger.log_warning(
                     f"Version resolution had issues for stack {stack_name}: {e}"

--- a/llmdbenchmark/parser/version_resolver.py
+++ b/llmdbenchmark/parser/version_resolver.py
@@ -334,8 +334,17 @@ class VersionResolver:
                     )
                     unresolved.append(f"{path}.image")
 
-    def resolve_all(self, values: dict) -> dict:
-        """Resolve all ``"auto"`` image tags and chart versions in the values dict."""
+    def resolve_all(self, values: dict, skip_kubernetes: bool = False) -> dict:
+        """Resolve all ``"auto"`` image tags and chart versions in the values dict.
+
+        ``skip_kubernetes`` drops the resolutions that only feed Kubernetes
+        manifests - the WVA image, Helm chart versions and the gateway version.
+        The no-Kubernetes (nok8s) path never consumes them, and resolving them
+        needs helm, which ``docs/nok8s.md`` states is not required. Attempting
+        it there only produced warnings telling users to install tools they do
+        not need. The container image tags are still resolved: nok8s runs those
+        images directly.
+        """
         result = deepcopy(values)
 
         if self.dry_run:
@@ -351,10 +360,11 @@ class VersionResolver:
         unresolved = []
         self._resolve_image_tags(result, unresolved)
         self._resolve_standalone_image(result, unresolved)
-        self._resolve_wva_image(result, unresolved)
         self._resolve_init_container_images(result, unresolved)
-        self._resolve_chart_versions(result, unresolved)
-        self._resolve_gateway_version(result)
+        if not skip_kubernetes:
+            self._resolve_wva_image(result, unresolved)
+            self._resolve_chart_versions(result, unresolved)
+            self._resolve_gateway_version(result)
 
         if unresolved:
             self.logger.log_warning(

--- a/tests/test_direct_service_mode.py
+++ b/tests/test_direct_service_mode.py
@@ -30,7 +30,7 @@ def _renderer() -> RenderPlans:
 def _passthrough_version_resolver() -> MagicMock:
     """Keep render tests deterministic and independent of image registries."""
     resolver = MagicMock()
-    resolver.resolve_all.side_effect = lambda values: values
+    resolver.resolve_all.side_effect = lambda values, **kwargs: values
     return resolver
 
 

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -29,7 +29,7 @@ class _Logger:
         pass
 
 
-def _render(tmp_path: Path, cli_methods: str | None = None):
+def _render(tmp_path: Path, cli_methods: str | None = None, version_resolver=None):
     return RenderPlans(
         template_dir=TEMPLATE_DIR,
         defaults_file=DEFAULTS_FILE,
@@ -37,6 +37,7 @@ def _render(tmp_path: Path, cli_methods: str | None = None):
         output_dir=tmp_path / "plan",
         logger=_Logger(),
         cli_methods=cli_methods,
+        version_resolver=version_resolver,
     ).eval()
 
 
@@ -495,3 +496,51 @@ def test_nok8s_teardown_leaves_siblings_alone_without_a_spec(tmp_path: Path) -> 
     solo.rendered_stacks = [specless]
     NoK8sTeardownStep().execute(solo, specless)
     assert solo.cmd.removed() == {"envoy", "epp", "vllm-0"}
+
+
+class _RecordingVersionResolver:
+    """Records how the renderer invokes version resolution."""
+
+    def __init__(self) -> None:
+        self.calls: list[bool] = []
+
+    def resolve_all(self, values: dict, skip_kubernetes: bool = False) -> dict:
+        self.calls.append(skip_kubernetes)
+        return values
+
+
+def test_nok8s_skips_kubernetes_version_resolution(tmp_path: Path) -> None:
+    """nok8s must not try to resolve helm chart versions or the WVA image.
+
+    Resolving them needs helm/skopeo, which docs/nok8s.md says are not
+    required, and nothing on this path consumes the results.
+    """
+    resolver = _RecordingVersionResolver()
+    _render(tmp_path, version_resolver=resolver)
+
+    assert resolver.calls, "version resolver was never invoked"
+    assert all(resolver.calls), (
+        f"expected skip_kubernetes=True for every nok8s stack, got {resolver.calls}"
+    )
+
+
+def test_kubernetes_scenario_still_resolves_versions(tmp_path: Path) -> None:
+    """Guard the test above: the flag is not unconditionally True."""
+    resolver = _RecordingVersionResolver()
+    RenderPlans(
+        template_dir=TEMPLATE_DIR,
+        defaults_file=DEFAULTS_FILE,
+        scenarios_file=REPO_ROOT
+        / "config"
+        / "scenarios"
+        / "guides"
+        / "optimized-baseline.yaml",
+        output_dir=tmp_path / "plan-k8s",
+        logger=_Logger(),
+        version_resolver=resolver,
+    ).eval()
+
+    assert resolver.calls, "version resolver was never invoked"
+    assert not any(resolver.calls), (
+        f"expected skip_kubernetes=False off the nok8s path, got {resolver.calls}"
+    )

--- a/tests/test_version_resolver.py
+++ b/tests/test_version_resolver.py
@@ -289,3 +289,72 @@ class TestResolveAllErrors:
         # The image should remain unchanged (still :auto)
         decode_ic = result["decode"]["initContainers"][0]
         assert decode_ic["image"] == "ghcr.io/foo/bar:auto"
+
+
+# ---------------------------------------------------------------------------
+# nok8s: Kubernetes-only resolutions are skipped
+# ---------------------------------------------------------------------------
+
+
+def _nok8s_values() -> dict:
+    """Values shaped like a rendered nok8s stack: container image plus the
+    Kubernetes-only WVA image and chart versions."""
+    return {
+        "images": {
+            "benchmark": {
+                "repository": "ghcr.io/llm-d/llm-d-benchmark",
+                "tag": "auto",
+            },
+        },
+        "wva": {
+            "image": {
+                "repository": "ghcr.io/llm-d/llm-d-workload-variant-autoscaler",
+                "tag": "auto",
+            }
+        },
+        "chartVersions": {"llmDInfra": "auto", "llmDModelservice": "auto"},
+    }
+
+
+class TestSkipKubernetes:
+    def test_nok8s_skips_wva_and_chart_warnings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No helm/skopeo warnings on the nok8s path: nothing consumes the
+        WVA image or the chart versions there."""
+        resolver = _make_resolver(monkeypatch)
+        monkeypatch.setattr(
+            VersionResolver,
+            "resolve_chart_version",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("helm missing")),
+        )
+
+        result = resolver.resolve_all(_nok8s_values(), skip_kubernetes=True)
+
+        assert resolver.logger.warnings == [], (
+            f"Expected no warnings on the nok8s path, got: {resolver.logger.warnings}"
+        )
+        # Kubernetes-only values are left untouched rather than resolved.
+        assert result["wva"]["image"]["tag"] == "auto"
+        assert result["chartVersions"] == {
+            "llmDInfra": "auto",
+            "llmDModelservice": "auto",
+        }
+        # The container image nok8s actually runs is still resolved.
+        assert result["images"]["benchmark"]["tag"] == "latest-stub"
+
+    def test_kubernetes_path_still_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The default path keeps warning, so the nok8s assertion above is
+        testing the skip and not an unreachable code path."""
+        resolver = _make_resolver(monkeypatch, fail=True)
+        monkeypatch.setattr(
+            VersionResolver,
+            "resolve_chart_version",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("helm missing")),
+        )
+
+        resolver.resolve_all(_nok8s_values())
+
+        warnings = " ".join(resolver.logger.warnings)
+        assert "Could not resolve WVA image tag" in warnings
+        assert "chartVersions.llmDInfra" in warnings


### PR DESCRIPTION
Every nok8s invocation (`plan`, `standup`, `run`, `teardown`) warns that skopeo/crane/podman and helm are missing, then says:

```
3 version(s) could not be resolved: wva.image.tag, chartVersions.llmDInfra, chartVersions.llmDModelservice. These will remain as 'auto' and must be resolved before deployment.
```

That last sentence is false on this path. Nothing consumes those chart versions when the deploy method is nok8s, and `docs/nok8s.md:41-42` states helm and helmfile are not required. A user following the docs is told they are missing tools the docs just told them they do not need, and that a deployment which is about to succeed cannot proceed.

`render_plans.py:1664-1668` already computes `is_nok8s` to skip cluster-resource resolution. This gates the WVA image tag and chart version resolution behind the same flag.

Scope note: issue #1704 also describes the render writing 36 files per stack, with real content in Kubernetes-only manifests that will never be applied. I left that out. Those files are reachable from teardown and from tooling I cannot rule out from the issue alone, and removing them is a much larger change with a real chance of breaking something that reads them. This PR fixes the false warnings only, which is the part that misleads users. The template-set question is worth a separate discussion.

Two regression tests, both verified to fail before the change. Full suite matches the pre-existing baseline on main.

Addresses #1704 (the version-resolution warnings; the template-set portion is left open)