### PR TITLE
fix: revert typo-sweep damage from #1743

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -8,6 +8,17 @@ extend-exclude = [
 ]
 
 [default.extend-words]
+# Deliberate misspellings fed to the config schema by
+# tests/test_config_schema.py::TestTypoDetection to assert that
+# `extra="forbid"` rejects unknown keys. Correcting these turns them into
+# real fields and the tests silently stop testing anything.
+naem = "naem"
+Timout = "Timout"
+addtional = "addtional"
+replicsa = "replicsa"
+inferenceProt = "inferenceProt"
+# Typo shown as an example inside a docstring (render_plans.py)
+modle = "modle"
 # sed regex pattern (not a typo)
 ba = "ba"
 # Shell variable / abbreviation

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1703,7 +1703,7 @@ class RenderPlans:
     def _validate_shared_block(self, defaults: dict, shared: dict) -> None:
         """Pre-validate defaults+shared against the config schema.
 
-        A typo at the root of `shared:` (e.g. `` model :`` instead of
+        A typo at the root of `shared:` (e.g. ``modle:`` instead of
         ``model:``) silently merges into every stack's root where
         ``extra="allow"`` accepts it, so the typo propagates without a
         visible error and the misspelled value never takes effect. By

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -124,7 +124,14 @@ class TestScenarioValidation:
 
 
 class TestTypoDetection:
-    """Misspelled keys in modeled sections should be caught."""
+    """Misspelled keys in modeled sections should be caught.
+
+    The misspellings below are DELIBERATE -- each test feeds an unknown key
+    to the schema and asserts ``extra="forbid"`` rejects it. Correcting one
+    to its real spelling makes the key legitimate, so validation returns no
+    warnings and the test fails. Do not let a spell-checker "fix" them; the
+    sentinels are allow-listed in ``_typos.toml``.
+    """
 
     def test_decode_typo_caught(self, defaults_copy: dict) -> None:
         defaults_copy["decode"]["replicsa"] = 2
@@ -134,10 +141,10 @@ class TestTypoDetection:
         )
 
     def test_model_typo_caught(self, defaults_copy: dict) -> None:
-        defaults_copy["model"]["name"] = "test"
+        defaults_copy["model"]["naem"] = "test"
         warnings = validate_config(defaults_copy)
-        assert any("name" in w for w in warnings), (
-            f"Expected 'name' typo to be caught, got: {warnings}"
+        assert any("naem" in w for w in warnings), (
+            f"Expected 'naem' typo to be caught, got: {warnings}"
         )
 
     def test_vllm_common_typo_caught(self, defaults_copy: dict) -> None:
@@ -148,17 +155,17 @@ class TestTypoDetection:
         )
 
     def test_harness_typo_caught(self, defaults_copy: dict) -> None:
-        defaults_copy["harness"]["waitTimeout"] = 3600
+        defaults_copy["harness"]["waitTimout"] = 3600
         warnings = validate_config(defaults_copy)
-        assert any("waitTimeout" in w for w in warnings), (
-            f"Expected 'waitTimeout' typo to be caught, got: {warnings}"
+        assert any("waitTimout" in w for w in warnings), (
+            f"Expected 'waitTimout' typo to be caught, got: {warnings}"
         )
 
     def test_prefill_vllm_typo_caught(self, defaults_copy: dict) -> None:
-        defaults_copy["prefill"]["vllm"]["additionalFlags"] = []
+        defaults_copy["prefill"]["vllm"]["addtionalFlags"] = []
         warnings = validate_config(defaults_copy)
-        assert any("additionalFlags" in w for w in warnings), (
-            f"Expected 'additionalFlags' typo to be caught, got: {warnings}"
+        assert any("addtionalFlags" in w for w in warnings), (
+            f"Expected 'addtionalFlags' typo to be caught, got: {warnings}"
         )
 
 
@@ -203,7 +210,7 @@ class TestNonBlocking:
         assert isinstance(result, list)
 
     def test_returns_list_on_invalid(self, defaults_copy: dict) -> None:
-        defaults_copy["model"]["name"] = "bad"
+        defaults_copy["model"]["naem"] = "bad"
         result = validate_config(defaults_copy)
         assert isinstance(result, list)
         assert len(result) > 0

--- a/workload/harnesses/fma_functions.py
+++ b/workload/harnesses/fma_functions.py
@@ -1,5 +1,5 @@
 """
-Benchmarkk FMA functions
+Benchmark FMA functions
 """
 
 from __future__ import annotations
@@ -17,9 +17,9 @@ from kubernetes.client.exceptions import ApiException
 
 from dpc_log_parser import parse_dpc_log_file
 from nop_functions import (
-    BenchmarkkResult,
-    BenchmarkkScenario,
-    BenchmarkkVllmMetrics,
+    BenchmarkResult,
+    BenchmarkScenario,
+    BenchmarkVllmMetrics,
     PlatformEngineScenario,
     get_log_list,
     get_server_status_sleep,
@@ -224,7 +224,7 @@ def get_fma_launcher_infos(  # pylint: disable=too-many-locals,too-many-argument
     requester_infos: list[FMARequesterInfo],
     namespace: str,
     fma_launcher_port: str,
-    benchmark_result: BenchmarkkResult,
+    benchmark_result: BenchmarkResult,
 ) -> list[FMALauncherInfo]:
     """returns connected launchers info and populates BenchmarkResult engine"""
 
@@ -752,9 +752,9 @@ def inspect_vllm_instances(
             instance_id,
             False,
         ).get_vllm_logs()
-        scenario = BenchmarkkScenario()
+        scenario = BenchmarkScenario()
         engine = PlatformEngineScenario()
-        metrics = BenchmarkkVllmMetrics()
+        metrics = BenchmarkVllmMetrics()
         parse_logs(scenario, engine, metrics, get_log_list(pod_logs.decode("utf-8")))
         port = int(engine.args.get("port", 0))
         logger.info("Instance id '%s' info start:", instance_id)
@@ -818,7 +818,7 @@ def benchmark_fma(  # pylint: disable=too-many-arguments,too-many-positional-arg
     namespace: str,
     endpoint_url: str,
     fma_launcher_port: str,
-    benchmark_result: BenchmarkkResult,
+    benchmark_result: BenchmarkResult,
     load_format: LoadFormat,
     requests_dir: str,
     iterations: int,
@@ -857,7 +857,7 @@ def benchmark_fma(  # pylint: disable=too-many-arguments,too-many-positional-arg
         benchmark_result.extra_metrics.append(fma_metrics)
         for iteration in range(1, iterations + 1):  # pylint: disable=too-many-nested-blocks
             try:
-                logger.info("Benchmarkk FMA iteration '%d' start...", iteration)
+                logger.info("Benchmark FMA iteration '%d' start...", iteration)
                 # scale the requester Deployment to 1
                 requester_infos = scale_deployment(
                     v1, apps_v1, deployment_name, namespace, 1, FMA_TIMEOUT
@@ -1048,7 +1048,7 @@ def benchmark_fma(  # pylint: disable=too-many-arguments,too-many-positional-arg
                 )
                 fma_metrics.iterations.append(fma_metrics_iteration)
             finally:
-                logger.info("Benchmarkk FMA iteration '%d' end.", iteration)
+                logger.info("Benchmark FMA iteration '%d' end.", iteration)
     finally:
         write_controller_log(
             v1,


### PR DESCRIPTION
# Summary

- tests/test_config_schema.py -- TestTypoDetection feeds misspelled keys to the schema and asserts extra="forbid" rejects them. Rewriting `naem` -> `name`, `waitTimout` -> `waitTimeout` and `addtionalFlags` -> `additionalFlags` turned the sentinels into real fields, so validation returned no warnings and four tests failed (CI's maxfail=1 surfaced
only the first). Restore the sentinels and document why they must stay misspelled.

- workload/harnesses/fma_functions.py -- the sweep applied  `Benchmar` -> `Benchmark` to text that already read `Benchmark`, yielding `Benchmarkk`. nop_functions defines `BenchmarkResult`, so tests/test_fma_functions.py failed to import and never collected.

Also restores the `modle:` example in the _validate_shared_block docstring, which the sweep rewrote to `` model :`` and rendered meaningless, and allow-lists every sentinel in _typos.toml so a future sweep leaves them alone.