### PR TITLE
fix: make pollingInterval optional and align scenario schema with KEDA.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1469,11 +1469,11 @@ Each entry in the list produces one `ScaledObject`. The list is empty by default
 | Field | Default | Description |
 |-------|---------|-------------|
 | `name` | _(required)_ | `metadata.name` of the ScaledObject |
-| `targetRef.kind` | `Deployment` | Kind of the scale target |
-| `targetRef.name` | `model_id_label + "-decode"` | Name of the scale target; defaults to the model's decode Deployment |
+| `scaleTargetRef.kind` | `Deployment` | Kind of the scale target |
+| `scaleTargetRef.name` | `model_id_label + "-decode"` | Name of the scale target; defaults to the model's decode Deployment |
 | `minReplicas` | `1` | Minimum replica count |
 | `maxReplicas` | `10` | Maximum replica count |
-| `pollingInterval` | `15` | Seconds between KEDA polls |
+| `pollingInterval` | _(omitted)_ | Seconds between KEDA polls; omit to use KEDA's default (15 s) |
 | `triggers` | `[]` | List of KEDA trigger objects (see below) |
 | `behavior` | _(omitted)_ | Optional HPA behavior block rendered under `spec.advanced.horizontalPodAutoscalerConfig.behavior` |
 
@@ -1499,7 +1499,7 @@ keda:
 
   scaledObjects:
     - name: decode-saturation
-      targetRef:
+      scaleTargetRef:
         kind: Deployment
         name: ""              # defaults to model_id_label + "-decode"
       minReplicas: 1

--- a/config/templates/jinja/27_keda-scaledobjects.yaml.j2
+++ b/config/templates/jinja/27_keda-scaledobjects.yaml.j2
@@ -14,7 +14,7 @@
 {% set auth_mode = prom.authMode | default('none') %}
 {% set prom_addr = (prom.baseUrl | default('http://prometheus')) ~ ':' ~ (prom.port | default(9090)) %}
 {% for so in keda.scaledObjects %}
-{% set target_name = so.targetRef.name if so.targetRef is defined and so.targetRef.name else model_id_label ~ '-decode' %}
+{% set target_name = so.scaleTargetRef.name if so.scaleTargetRef is defined and so.scaleTargetRef.name else model_id_label ~ '-decode' %}
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -27,11 +27,13 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: {{ so.targetRef.kind | default('Deployment') if so.targetRef is defined else 'Deployment' }}
+    kind: {{ so.scaleTargetRef.kind | default('Deployment') if so.scaleTargetRef is defined else 'Deployment' }}
     name: {{ target_name }}
   minReplicaCount: {{ so.minReplicas | default(1) }}
   maxReplicaCount: {{ so.maxReplicas | default(10) }}
-  pollingInterval: {{ so.pollingInterval | default(15) }}
+{% if so.pollingInterval is defined %}
+  pollingInterval: {{ so.pollingInterval }}
+{% endif %}
   triggers:
 {% for trigger in so.triggers | default([]) %}
   - type: {{ trigger.type }}

--- a/tests/test_keda_scaledobjects_render.py
+++ b/tests/test_keda_scaledobjects_render.py
@@ -102,7 +102,8 @@ scenario:
         workers: 1
 """
 
-_KEDA_NONE_AUTH = """\
+_KEDA_NONE_AUTH = (  # pragma: allowlist secret
+    """\
     keda:
       prometheus:
         baseUrl: http://prometheus-operated.monitoring.svc.cluster.local
@@ -110,7 +111,7 @@ _KEDA_NONE_AUTH = """\
         authMode: none
       scaledObjects:
         - name: decode-saturation
-          targetRef:
+          scaleTargetRef:
             kind: Deployment
             name: ""
           minReplicas: 1
@@ -124,17 +125,19 @@ _KEDA_NONE_AUTH = """\
               threshold: "0.7"
               activationThreshold: "0"
 """
+)
 
-_KEDA_BEARER_AUTH = """\
+_KEDA_BEARER_AUTH = (  # pragma: allowlist secret
+    """\
     keda:
       prometheus:
         baseUrl: http://prometheus-operated.monitoring.svc.cluster.local
         port: 9090
         authMode: bearer-secret
-        secretName: keda-prom-secret  # pragma: allowlist secret
+        secretName: keda-prom-secret
       scaledObjects:
         - name: decode-saturation
-          targetRef:
+          scaleTargetRef:
             kind: Deployment
             name: ""
           minReplicas: 1
@@ -148,6 +151,7 @@ _KEDA_BEARER_AUTH = """\
               threshold: "0.7"
               activationThreshold: "0"
 """
+)
 
 _KEDA_NON_PROMETHEUS_TRIGGER = """\
     keda:
@@ -157,7 +161,7 @@ _KEDA_NON_PROMETHEUS_TRIGGER = """\
         authMode: none
       scaledObjects:
         - name: cpu-scaler
-          targetRef:
+          scaleTargetRef:
             kind: Deployment
             name: my-deploy
           minReplicas: 1


### PR DESCRIPTION
## Summary

- `pollingInterval` in `27_keda-scaledobjects.yaml.j2` is now only emitted when explicitly set; omitting it lets KEDA apply its own default (15 s)
- Updated `config/README.md` to reflect that `pollingInterval` has no default (was incorrectly documented as `15`)
- Wrapped `_KEDA_NONE_AUTH` and `_KEDA_BEARER_AUTH` string constants in parentheses with `# pragma: allowlist secret` to suppress false-positive secret-scanner hits on the variable names
- `targetRef` is now `scaleTargetRef`

## Test plan

- [ ] Run `pytest tests/test_keda_scaledobjects_render.py` — all tests should pass
- [ ] Confirm secret scanner no longer flags lines 105 and 130 in the test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)