### PR TITLE
Make the FMA+KEDA comparison table work with locally-run results

### DIFF
--- a/llmdbenchmark/analysis/scripts/fma_comparison_table.py
+++ b/llmdbenchmark/analysis/scripts/fma_comparison_table.py
@@ -41,10 +41,13 @@ except ImportError:
 def newest_run_dir(root):
     """Return the newest run directory under ``root`` (or "").
 
-    Runs are ``runner-<UTC YYYYMMDD-HHMMSS>-<id>`` dirs holding a ``results/``,
-    so the newest is simply the latest-sorting ``runner-*`` match. (Lexical, not
-    mtime: these are GCS-downloaded, so mtimes are the download time.)"""
-    runs = glob.glob(os.path.join(root, "**", "runner-*", "results"), recursive=True)
+    A run dir is any directory holding a ``results/`` subdir -- CI names them
+    ``runner-<UTC>-<id>`` and local runs ``<user>-<UTC>-<id>``, so match any
+    ``*/results`` rather than only ``runner-*``. ``root`` may itself be a run dir
+    (its own ``results/`` matches). Newest = latest-sorting name (lexical, since
+    GCS-downloaded mtimes are download time). Timestamped names sort chronologically."""
+    runs = glob.glob(os.path.join(root, "**", "results"), recursive=True)
+    runs = [r for r in runs if os.path.isdir(r)]
     return os.path.dirname(sorted(runs)[-1]) if runs else ""
 
 


### PR DESCRIPTION
### Summary

Generalizes `newest_run_dir()` in `fma_comparison_table.py` to locate run directories regardless of naming, so the comparison-table script can be run locally against results produced by a local llmdbenchmark run, not just CI-uploaded results.

### Problem

newest_run_dir() only matched runner-*/results — the naming CI produces. Local runs name their result dirs <user>-<UTC>-<id>/results (e.g. brauliodumba-20260810-120935-517/results), which the runner-* glob never matched. As a result, running the script against local data returned an empty run dir and every metric row rendered as _n/a_, even though the underlying metrics_summary.json was present and complete.

### Change

`llmdbenchmark/analysis/scripts/fma_comparison_table.py` — newest_run_dir() now globs for any `*/results` directory (filtered to real dirs) instead of only `runner-*/results`. This matches both CI (`runner-*`) and local (`<user>-*`) run layouts, and still selects the newest by lexical name (timestamped names sort chronologically; a latest symlink, if present, resolves correctly).

### Why it's safe

- No change to CI behavior: `runner-*/results` still matches, and newest-by-name selection is unchanged.
- Read path is otherwise untouched — _find_one already globs recursively under the resolved run dir.

### Validation

Ran the script locally against a real local run (`ocp-keda-fma-hotstart`, `brauliodumba-20260810`-...) with no GCS access:
- newest_run_dir correctly resolved the run (via its latest symlink).
- The table populated from the local metrics_summary.json, including the EPP flow-control rows (`Avg pool saturation (EPP) = 0.59`, `Avg running requests (EPP) = 16.4`).

## Usage

```
python3 llmdbenchmark/analysis/scripts/fma_comparison_table.py \
  --baseline-dir  <local baseline results root> \
  --warmstart-dir <local warmstart results root> \
  --hotstart-dir  <local hotstart results root> \
  --col-baseline "Baseline" --col-warmstart "Warm" --col-hotstart "Hot" \
  --model Qwen/Qwen3-32B --harness inference-perf --workload shared_prefix_synthetic_heavy.yaml
```