### PR TITLE
[CICD] Synchronize the reusable nightly benchmark here with llm-d-infra

### DIFF
--- a/.github/workflows/ci-nightly-benchmark-gke-standalone.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke-standalone.yaml
@@ -52,51 +52,6 @@ on:
         required: false
         default: 'true'
         type: string
-      tpu_topology:
-        description: 'GKE TPU topology (e.g. 2x4, 2x2x1)'
-        required: false
-        type: 'string'
-        default: '2x4'
-      tpu_chips:
-        description: 'Total TPU chips to request (0 for simulated)'
-        required: false
-        type: 'string'
-        default: '0'
-      tpu_wait_timeout:
-        description: 'Minutes to wait for TPU chips to become available (0 = no wait, fail immediately)'
-        required: false
-        type: 'string'
-        default: '0'
-      tpu_nodepool:
-        description: 'Target TPU node pool name (empty = do not override)'
-        required: false
-        type: 'string'
-        default: ''
-      data_access_timeout:
-        description: 'Timeout in seconds for data access and harness run execution'
-        required: false
-        type: 'string'
-        default: '1200'
-      wait_timeout:
-        description: 'Timeout in seconds to wait for benchmark pods to complete'
-        required: false
-        type: 'string'
-        default: '1200'
-      pvc_bind_timeout:
-        description: 'Timeout in seconds to wait for a pvc to be bound'
-        required: false
-        type: 'string'
-        default: '1200'
-      job_timeout:
-        description: 'Timeout for the Kubernetes job itself (e.g. 2700s)'
-        required: false
-        type: 'string'
-        default: '2700s'
-      standup_timeout:
-        description: 'Timeout in seconds for standup of a new llm-d stack'
-        required: false
-        type: 'string'
-        default: '2400'
 
 #  push:
 #    branches:

--- a/.github/workflows/ci-nightly-benchmark-gke-standalone.yaml
+++ b/.github/workflows/ci-nightly-benchmark-gke-standalone.yaml
@@ -52,6 +52,51 @@ on:
         required: false
         default: 'true'
         type: string
+      tpu_topology:
+        description: 'GKE TPU topology (e.g. 2x4, 2x2x1)'
+        required: false
+        type: 'string'
+        default: '2x4'
+      tpu_chips:
+        description: 'Total TPU chips to request (0 for simulated)'
+        required: false
+        type: 'string'
+        default: '0'
+      tpu_wait_timeout:
+        description: 'Minutes to wait for TPU chips to become available (0 = no wait, fail immediately)'
+        required: false
+        type: 'string'
+        default: '0'
+      tpu_nodepool:
+        description: 'Target TPU node pool name (empty = do not override)'
+        required: false
+        type: 'string'
+        default: ''
+      data_access_timeout:
+        description: 'Timeout in seconds for data access and harness run execution'
+        required: false
+        type: 'string'
+        default: '1200'
+      wait_timeout:
+        description: 'Timeout in seconds to wait for benchmark pods to complete'
+        required: false
+        type: 'string'
+        default: '1200'
+      pvc_bind_timeout:
+        description: 'Timeout in seconds to wait for a pvc to be bound'
+        required: false
+        type: 'string'
+        default: '1200'
+      job_timeout:
+        description: 'Timeout for the Kubernetes job itself (e.g. 2700s)'
+        required: false
+        type: 'string'
+        default: '2700s'
+      standup_timeout:
+        description: 'Timeout in seconds for standup of a new llm-d stack'
+        required: false
+        type: 'string'
+        default: '2400'
 
 #  push:
 #    branches:

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -1034,8 +1034,11 @@ jobs:
             REG_RESULTS=$(find . -name results | sed "s^/results$^^g" | cut -d '/' -f 2)
             if [[ -n "$REG_RESULTS" && -d "$REG_RESULTS" ]]; then
               find $REG_RESULTS/ -name run_metadata.yaml -exec sh -c "echo 'github_run_id: \"${{ github.run_id }}\"' >> {}" \;
-              echo "Skipping data upload to official bucket, due to test in fork, instead uploading to igw_benchmark"
-              gcloud storage cp -r $REG_RESULTS/ gs://igw-e2e-benchmark-results/tpu/$LLMDBENCH_CICD_SCENARIO || true
+              echo "Uploading data from directory \"REG_RESULTS\" to \"$GCS_FULL_PATH\""
+              gcloud storage cp -r $REG_RESULTS/ "$GCS_FULL_PATH" || true
+              # Commenting out for now, this can be made into knob later.
+              #echo "Skipping data upload to official bucket, due to test in fork, instead uploading to igw_benchmark"
+              #gcloud storage cp -r $REG_RESULTS/ gs://igw-e2e-benchmark-results/tpu/$LLMDBENCH_CICD_SCENARIO || true
             else
               echo "### No benchmark results directory found to upload"
             fi

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -29,7 +29,7 @@ on:
         type: 'string'
         default: 'auto'
       accelerator_type:
-        description: 'Type of accelerator (gpu, cpu, sim, amd, xpu, hpu, tpu/v6, tpu/v7) (ONLY VALID FOR "kustomize" standyp method)'
+        description: 'Type of accelerator (gpu, cpu, sim, amd, xpu, tpu/v6, tpu/v7) (ONLY VALID FOR "kustomize" standyp method)'
         required: false
         type: 'string'
         default: 'gpu'
@@ -49,10 +49,18 @@ on:
         type: 'string'
         default: ''
       connector:
-        description: 'Accelerator offloading connector (ONLY VALID FOR "kustomize" standyp method)'
+        description: 'Accelerator offloading connector (ONLY VALID FOR "kustomize" standup method)'
         required: false
         type: 'string'
         default: ''
+      cluster_name:
+        description: 'Name of the cluster to be used (ONLY USED BY "GKE" provider, default is "llm-d-e2e-us-east5")'
+        type: 'string'
+        default: 'llm-d-e2e-us-east5'
+      cluster_zone:
+        description: 'Zone where the cluster to be used is located (ONLY USED BY "GKE" provider, default is "us-east5")'
+        type: 'string'
+        default: 'us-east5'
       cluster_namespace:
         description: 'Cluster namespace'
         required: false
@@ -93,6 +101,26 @@ on:
         required: false
         type: 'string'
         default: 'true'
+      gaie_version:
+        description: 'Gateway API Inference Extension ("v1.5.0")'
+        required: false
+        type: 'string'
+        default: 'v1.5.0'
+      router_standalone_chart_url:
+        description: 'standalone router chart URL ("oci://ghcr.io/llm-d/charts/llm-d-router-standalone")'
+        required: false
+        type: 'string'
+        default: 'oci://ghcr.io/llm-d/charts/llm-d-router-standalone'
+      router_gateway_chart_url:
+        description: 'gateway router chart URL ("oci://ghcr.io/llm-d/charts/llm-d-router-gateway")'
+        required: false
+        type: 'string'
+        default: 'oci://ghcr.io/llm-d/charts/llm-d-router-gateway'
+      router_chart_version:
+        description: 'llm-d-router version ("v0" for latest, "v0.x.0" for a released chart)'
+        required: false
+        type: 'string'
+        default: 'v0'
       dry_run:
         description: 'Execute workflow in "dry-run" mode ("true", "false")'
         required: false
@@ -163,6 +191,25 @@ on:
         required: false
         type: 'string'
         default: '2400'
+      persistent_model:
+        description: 'Download model into a persistent storage'
+        required: false
+        default: 'false'
+        type: 'string'
+      deep_cleaning:
+        description: 'Delete everything, including namespace, during teardown'
+        required: false
+        default: 'false'
+        type: 'string'
+      admin_privileges:
+        description: 'Standup llm-d stack requiring admin privileges when interacting with the cluster'
+        required: false
+        default: 'false'
+        type: 'string'
+    outputs:
+      failure_category:
+        description: 'Category of the first failed step (prepare, prereqs, infra, guide, benchmark)'
+        value: ${{ jobs.benchmark.outputs.failure_category }}
 
 #  push:
 #    branches:
@@ -234,10 +281,6 @@ jobs:
           if [[ ! -z $IS_XPU ]]; then
             export CLUSTER_TYPE=xpu
           fi
-          IS_HPU=$(echo "${{ github.workflow }}" | grep -i "\hpu" || true)$(echo "${{ inputs.standup_scenario }}" | grep -i "hpu" || true)
-          if [[ ! -z $IS_HPU ]]; then
-            export CLUSTER_TYPE=hpu
-          fi
           echo "Cluster provider is \"$CLUSTER_TYPE\""
           echo "cluster_type=$CLUSTER_TYPE" >> "$GITHUB_OUTPUT"
           echo "CLUSTER_TYPE=$CLUSTER_TYPE" >> "$GITHUB_ENV"
@@ -255,9 +298,6 @@ jobs:
           elif [[ "$CLUSTER_TYPE" == "xpu" ]]; then
             echo "Targetting self-hosted runners (Intel/CI)"
             RUNNERS_JSON_LIST='["xpu"]'
-          elif [[ "$CLUSTER_TYPE" == "hpu" ]]; then
-            echo "Targetting self-hosted runners (Intel/CI)"
-            RUNNERS_JSON_LIST='["hpu-dispatch-runner"]'
           else
             echo "Targetting hosted runners (non-OpenShift)"
             RUNNERS_JSON_LIST='["ubuntu-latest"]'
@@ -285,6 +325,8 @@ jobs:
     needs: [ensure-nightly-build-image]
     if: inputs.accelerator_type != 'tpu/v7' && inputs.accelerator_type != 'tpu-v7'
     timeout-minutes: 240
+    outputs:
+      failure_category: ${{ steps.detect_failure.outputs.failure_category }}
 
     env:
       LLMDBENCH_CICD_NS: ${{ inputs.cluster_namespace || 'llmdbenchcicd' }}
@@ -311,6 +353,10 @@ jobs:
       LLMDBENCH_WORKSPACE: ${{ inputs.workspace_dir || '/tmp/llmdbenchcicd' }}
       LLMDBENCH_HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
       HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
+      LLMDBENCH_CICD_GAIE_VERSION: ${{ inputs.gaie_version || 'v1.5.0' }}
+      LLMDBENCH_CICD_ROUTER_CHART_VERSION: ${{ inputs.router_chart_version || 'v0' }}
+      LLMDBENCH_CICD_ROUTER_STANDALONE_CHART_URL: ${{ inputs.router_standalone_chart_url || 'oci://ghcr.io/llm-d/charts/llm-d-router-standalone' }}
+      LLMDBENCH_CICD_ROUTER_GATEWAY_CHART_URL: ${{ inputs.router_gateway_chart_url || 'oci://ghcr.io/llm-d/charts/llm-d-router-gateway' }}
       LLMDBENCH_CICD_GATEWAY_CLASS: ${{ inputs.gateway_class || 'istio' }}
       LLMDBENCH_IS_DRY_RUN: ${{ inputs.dry_run || 'false' }}
       LLMDBENCH_IS_VERBOSE: ${{ inputs.verbose || 'false' }}
@@ -318,10 +364,13 @@ jobs:
       LLMDBENCH_CICD_HARNESS: ${{ inputs.harness || 'inference-perf' }}
       LLMDBENCH_CICD_WORKLOAD: ${{ inputs.workload || 'sanity_random.yaml' }}
       LLMDBENCH_CICD_PRIORITY_CLASS: nightly-llm-d-cicd-critical
+      LLMDBENCH_CICD_PERSISTENT_MODEL: ${{ inputs.persistent_model || 'false' }}
+      LLMDBENCH_CICD_DEEP_CLEANING: ${{ inputs.deep_cleaning || 'false' }}
+      LLMDBENCH_CICD_ADMIN_PRIVILEGES: ${{ inputs.admin_privileges || 'false' }}
       GCS_BASE_PATH: ${{ inputs.bucket_path || 'llm-d-benchmarks/regressions' }}
       GCP_PROJECT_ID: ${{ inputs.bucket_project || 'llm-d-scale' }}
-      GKE_CLUSTER_NAME: llm-d-e2e-us-east5
-      GKE_CLUSTER_ZONE: us-east5
+      GKE_CLUSTER_NAME: ${{ inputs.cluster_name || 'llm-d-e2e-us-east5' }}
+      GKE_CLUSTER_ZONE: ${{ inputs.cluster_zone || 'us-east5' }}
       TPU_TOPOLOGY: ${{ inputs.tpu_topology || '2x4' }}
       TPU_CHIPS: ${{ inputs.tpu_chips || '0' }}
       TPU_NODEPOOL: ${{ inputs.tpu_nodepool || '' }}
@@ -329,13 +378,13 @@ jobs:
     steps:
       - name: Checkout Code
         id: prepare_checkout_code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Python
         id: prepare_setup_python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -430,6 +479,21 @@ jobs:
         run: |
           echo "### Attempting to list node names..."
           kubectl get node
+        shell: bash
+
+      - name: Show cluster annotations, labels and resources
+        if: env.LLMDBENCH_IS_VERBOSE == 'true'
+        id: infra_show_cluster_nodes_deep
+        run: |
+          echo "### Attempting to show node annotations..."
+          kubectl get nodes -o json | jq -r '.items[].metadata.annotations'
+          echo ""
+          echo "### Attempting to show node labels..."
+          kubectl get nodes -o json | jq -r '.items[].metadata.labels'
+          echo ""
+          echo "### Attempting to show node resources..."
+          kubectl get nodes -o json | jq -r '.items[].status.allocatable'
+          echo ""
         shell: bash
 
       - name: Show cluster storageclasses
@@ -556,7 +620,6 @@ jobs:
             -l job-name=tpu-request-job \
             -n "$LLMDBENCH_CICD_NS" \
             --timeout=$LLMDBENCH_CICD_JOB_TIMEOUT
-
           # Export topology and accelerator so subsequent steps (like scenario overrides) can read them
           echo "TPU_ACCELERATOR=$ACCELERATOR" >> $GITHUB_ENV
           echo "TPU_TOPOLOGY=$TOPOLOGY" >> $GITHUB_ENV
@@ -618,6 +681,10 @@ jobs:
         run: |
           #find ~ -type f -name "cks_nvshmem3.3.9.patch" -print
           cd ~
+          if [[ -d ~/_work/llm-d/llm-d ]];
+          then
+            ln -s ~/_work ~/work
+          fi
           if [[ ! -d ~/work/llm-d ]];
           then
             mkdir -p ~/work/llm-d/
@@ -677,16 +744,43 @@ jobs:
           echo -n "$lkcmd" > ~/work/lkcmd.txt
           eval $lkcmd
           cat $LLMDBENCH_CICD_SCENARIO_FILE | yq '.scenario[0].kustomize.guideVariableOverrides.INFRA_PROVIDER'
+          #
           echo "### Setting \"REPO_ROOT\" to \"$HOME/work/llm-d/llm-d\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
           lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.REPO_ROOT = \\\"$HOME/work/llm-d/llm-d\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt
           eval $lkcmd
           cat $LLMDBENCH_CICD_SCENARIO_FILE | yq '.scenario[0].kustomize.guideVariableOverrides.REPO_ROOT'
+          #
           echo "### Setting \"GUIDE_NAME\" to \"$LLMDBENCH_CICD_EFFECTIVE_GUIDE_NAME\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
           lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.GUIDE_NAME = \\\"$LLMDBENCH_CICD_EFFECTIVE_GUIDE_NAME\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt
           eval $lkcmd
           cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.GUIDE_NAME'
+          #
+          echo "### Setting \"GAIE_VERSION\" to \"$LLMDBENCH_CICD_GAIE_VERSION\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
+          lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.GAIE_VERSION = \\\"$LLMDBENCH_CICD_GAIE_VERSION\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+          echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+          eval $lkcmd
+          cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.GAIE_VERSION'
+          #
+          echo "### Setting \"ROUTER_STANDALONE_CHART\" to \"$LLMDBENCH_CICD_ROUTER_STANDALONE_CHART_URL\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
+          lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.ROUTER_STANDALONE_CHART = \\\"$LLMDBENCH_CICD_ROUTER_STANDALONE_CHART_URL\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+          echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+          eval $lkcmd
+          cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.ROUTER_STANDALONE_CHART'
+          #
+          echo "### Setting \"ROUTER_GATEWAY_CHART\" to \"$LLMDBENCH_CICD_ROUTER_GATEWAY_CHART_URL\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
+          lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.ROUTER_GATEWAY_CHART = \\\"$LLMDBENCH_CICD_ROUTER_GATEWAY_CHART_URL\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+          echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+          eval $lkcmd
+          cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.ROUTER_GATEWAY_CHART'
+          #
+          echo "### Setting \"ROUTER_CHART_VERSION\" to \"$LLMDBENCH_CICD_ROUTER_CHART_VERSION\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
+          lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.ROUTER_CHART_VERSION = \\\"$LLMDBENCH_CICD_ROUTER_CHART_VERSION\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+          echo -n "; $lkcmd" >> ~/work/lkcmd.txt
+          eval $lkcmd
+          cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.ROUTER_CHART_VERSION'
+          #
           if [[ ! -z $LLMDBENCH_CICD_CONNECTOR ]]; then
             echo "### Setting \"CONNECTOR\" to \"$LLMDBENCH_CICD_CONNECTOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
             lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.CONNECTOR = \\\"$LLMDBENCH_CICD_CONNECTOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
@@ -716,7 +810,7 @@ jobs:
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt
           eval $lkcmd
           cat ~/work/llm-d-benchmark/llm-d-benchmark/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml | yq '.scenario[0].kustomize.guideVariableOverrides.NAMESPACE'
-          export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND | sed 's^//^/^g')
+          export LLMDBENCH_CICD_BACKEND_ACCELERATOR=$(echo $LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND | sed -e 's^//^/^g' -e 's^/$^^g')
           echo "### Setting \"acceleratorBackend\" to \"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
           lkcmd="yq -i \".scenario[0].kustomize.acceleratorBackend = \\\"$LLMDBENCH_CICD_BACKEND_ACCELERATOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
           echo -n "; $lkcmd" >> ~/work/lkcmd.txt
@@ -738,9 +832,9 @@ jobs:
         run: |
           LLMDBENCH_CICD_KUSTOMIZE_PATH=~/work/llm-d/llm-d/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO/modelserver/$LLMDBENCH_CICD_ACCELERATOR/$LLMDBENCH_CICD_BACKEND/$LLMDBENCH_CICD_CONNECTOR/$LLMDBENCH_CICD_OFFLOADING_TARGET/$LLMDBENCH_CICD_INFRA_PROVIDER
           echo "Kustomize full path is \"$LLMDBENCH_CICD_KUSTOMIZE_PATH\". Will now attempt to detect model name..."
-          detected_model=$(kubectl kustomize $LLMDBENCH_CICD_KUSTOMIZE_PATH | yq .spec.template.spec.containers[0].args | grep -Ev "\- \--|\- '|\---|\- \||    \--|.*exec vllm|'|null|#|\"|find|START_RANK" | sed -e 's^ ^^g' -e 's|^-||g' -e 's^\\^^g' -e '/^$/d' | uniq || true)
+          detected_model=$(kubectl kustomize $LLMDBENCH_CICD_KUSTOMIZE_PATH | yq .spec.template.spec.containers[0].args | sed 's^--model-path=^^g' | grep -Ev "\- \--|\- '|\---|\- \||    \--|.*exec vllm|'|null|#|\"|find|START_RANK" | sed -e 's^ ^^g' -e 's|^-||g' -e 's^\\^^g' -e '/^$/d' | uniq || true)
           if [[ -z $detected_model ]]; then
-            detected_model=$(kubectl kustomize $LLMDBENCH_CICD_KUSTOMIZE_PATH |  yq .spec.leaderWorkerTemplate.workerTemplate.spec.containers[0].args | grep -Ev "\- \--|\- '|\---|\- \||    \--|.*exec vllm|'|null|#|\"|find|START_RANK" | sed -e 's^ ^^g' -e 's|^-||g' -e 's^\\^^g' -e '/^$/d' | uniq || true)
+            detected_model=$(kubectl kustomize $LLMDBENCH_CICD_KUSTOMIZE_PATH |  yq .spec.leaderWorkerTemplate.workerTemplate.spec.containers[0].args | sed 's^--model-path=^^g' | grep -Ev "\- \--|\- '|\---|\- \||    \--|.*exec vllm|'|null|#|\"|find|START_RANK" | sed -e 's^ ^^g' -e 's|^-||g' -e 's^\\^^g' -e '/^$/d' | uniq || true)
           fi
           if [[ -z $detected_model ]]; then
             echo "### ERROR: unable to detect model"
@@ -782,7 +876,7 @@ jobs:
           export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD=""
           export LLMDBENCH_EXTRA_RUN_OPERATION_CMD=""
           export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD=""
-          if [[ $LLMDBENCH_CICD_METHOD == "kustomize" ]]; then
+          if [[ "$LLMDBENCH_CICD_METHOD" == "kustomize" || "$LLMDBENCH_CICD_ADMIN_PRIVILEGES" == "false" ]]; then
             export LLMDBENCH_EXTRA_CMD="--non-admin"
           fi
           if [[ "$LLMDBENCH_IS_DRY_RUN" == "true" ]]; then
@@ -801,6 +895,9 @@ jobs:
           if [[ "$LLMDBENCH_MONITORING_ENABLED" == "false" ]]; then
             export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--no-monitoring $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
             export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD="$LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD "
+          fi
+          if [[ "$LLMDBENCH_CICD_DEEP_CLEANING" ]]; then
+            export LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD="$LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD --deep"
           fi
           if [[ ! -z $LLMDBENCH_CICD_DETECTED_MODEL ]]; then
             export LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD="--models $LLMDBENCH_CICD_DETECTED_MODEL $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD "
@@ -850,6 +947,15 @@ jobs:
           fi
         shell: bash
 
+      - name: Model Download
+        id: guide_model_download
+        if: env.LLMDBENCH_CICD_PERSISTENT_MODEL == 'true'
+        run: |
+          cd ~/work/llm-d-benchmark/llm-d-benchmark/
+          LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD standup $LLMDBENCH_EXTRA_STANDUP_OPERATION_CMD --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --release $LLMDBENCH_CICD_R --methods standalone --step 0-4 --skip-smoketest"
+          echo "### $(cat ~/work/lkcmd.txt); $LLMDBENCH_CMD ###"
+          eval $LLMDBENCH_CMD
+
       - name: Standup
         id: guide_standup
         run: |
@@ -894,6 +1000,11 @@ jobs:
           if [[ $LLMDBENCH_CICD_CLEANUP == 'false' ]]; then
             exit 0
           fi
+          HAS_LLMDBENCHMARK_VERSION=$(llmdbenchmark 2>&1 --version | grep '^llmdbenchmark:' | cut -d ':' -f 2 || true)
+          if [[ -z $HAS_LLMDBENCHMARK_VERSION ]]; then
+            echo "### llmdbenchmark was not even installed, will not attempt to teardown"
+            exit 0
+          fi
           cd ~/work/llm-d-benchmark/llm-d-benchmark/
           LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD teardown $LLMDBENCH_EXTRA_TEARDOWN_OPERATION_CMD  --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --release $LLMDBENCH_CICD_R --methods $LLMDBENCH_CICD_METHOD"
           echo "### $LLMDBENCH_CMD ###"
@@ -918,14 +1029,16 @@ jobs:
         run: |
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             echo "Skipping data upload to bucket, due to \"dry-run\" mode activated"
-          elif [[ "${{ inputs.workload }}" == "sanity_random.yaml" ]]; then
-            echo "Skipping data upload to bucket, workload is \"sanity_random.yml\""
           else
             cd "$LLMDBENCH_WORKSPACE"
             REG_RESULTS=$(find . -name results | sed "s^/results$^^g" | cut -d '/' -f 2)
-            find $REG_RESULTS/ -name run_metadata.yaml -exec sh -c "echo 'github_run_id: \"${{ github.run_id }}\"' >> {}" \;
-            echo "Uploading data from directory \"REG_RESULTS\" to \"$GCS_FULL_PATH\""
-            gcloud storage cp -r $REG_RESULTS/ "$GCS_FULL_PATH" || true
+            if [[ -n "$REG_RESULTS" && -d "$REG_RESULTS" ]]; then
+              find $REG_RESULTS/ -name run_metadata.yaml -exec sh -c "echo 'github_run_id: \"${{ github.run_id }}\"' >> {}" \;
+              echo "Skipping data upload to official bucket, due to test in fork, instead uploading to igw_benchmark"
+              gcloud storage cp -r $REG_RESULTS/ gs://igw-e2e-benchmark-results/tpu/$LLMDBENCH_CICD_SCENARIO || true
+            else
+              echo "### No benchmark results directory found to upload"
+            fi
           fi
         shell: bash
 
@@ -954,4 +1067,47 @@ jobs:
             done
           fi
           exit 1
+        shell: bash
+
+      - name: Detect failure category
+        id: detect_failure
+        if: failure()
+        run: |
+          CATEGORY=""
+          if [ "${{ steps.benchmark_run.outcome }}" = "failure" ]; then
+            CATEGORY="benchmark"
+          elif [ "${{ steps.guide_standup.outcome }}" = "failure" ] || \
+               [ "${{ steps.guide_teardown.outcome }}" = "failure" ] || \
+               [ "${{ steps.guide_teardown_again.outcome }}" = "failure" ]; then
+            CATEGORY="guide"
+          elif [ "${{ steps.prereq_install_oc.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereq_install_yq.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereq_set_gcs_full_path.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereq_conditionally_clone_llmd.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereq_install_llmdbenchmark.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereqs_apply_overrides_to_llmdbenchmark_scenarios.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereqs_set_harness_executable.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereqs_apply_overrides_to_kustomize_manifests.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereqs_setup_extrac_cli_parms_llmdbenchmark.outcome }}" = "failure" ]; then
+            CATEGORY="prereqs"
+          elif [ "${{ steps.infra_create_kind_cluster.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_authenticate_google_cloud.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_setup_gcloud_cli.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_get_gke_credentials.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_get_kubeconfig_from_secret.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_show_cluster_names.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_show_cluster_nodes.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_show_cluster_storageclasses.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_request_tpus.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_create_nightly_prioclass.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_label_node_for_simulated_accelerators.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_handle_namesace_and_secret.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_upload_results_to_gcs.outcome }}" = "failure" ] || \
+               [ "${{ steps.infra_block_waiting_for_standalone_baseline.outcome }}" = "failure" ]; then
+            CATEGORY="infra"
+          elif [ "${{ steps.prepare_checkout_code.outcome }}" = "failure" ] || \
+               [ "${{ steps.prepare_setup_python.outcome }}" = "failure" ]; then
+            CATEGORY="prepare"
+          fi
+          echo "failure_category=$CATEGORY" >> $GITHUB_OUTPUT
         shell: bash

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -65,16 +65,16 @@ WORKDIR /workspace
 RUN pip install --upgrade pip setuptools setuptools-rust wheel
 
 ARG INFERENCE_PERF_REPO=https://github.com/kubernetes-sigs/inference-perf.git
-ARG INFERENCE_PERF_BRANCH=v0.6.0
-ARG INFERENCE_PERF_COMMIT=v0.6.0
+ARG INFERENCE_PERF_BRANCH=v0.6.1
+ARG INFERENCE_PERF_COMMIT=v0.6.1
 RUN git clone --branch ${INFERENCE_PERF_BRANCH} ${INFERENCE_PERF_REPO}
 RUN cd inference-perf; \
     git checkout ${INFERENCE_PERF_COMMIT}; \
     pip install .
 
 ARG VLLM_BENCHMARK_REPO=https://github.com/vllm-project/vllm.git
-ARG VLLM_BENCHMARK_BRANCH=v0.24.0
-ARG VLLM_BENCHMARK_COMMIT=v0.24.0
+ARG VLLM_BENCHMARK_BRANCH=v0.26.0
+ARG VLLM_BENCHMARK_COMMIT=v0.26.0
 RUN git clone --branch ${VLLM_BENCHMARK_BRANCH} ${VLLM_BENCHMARK_REPO}
 RUN cd vllm; git checkout ${VLLM_BENCHMARK_COMMIT}
 # Patch the pyproject.toml to allow "pip install -e ."
@@ -100,8 +100,8 @@ RUN cd vllm; VLLM_TARGET_DEVICE=empty pip install -e . --no-build-isolation
 
 # GuideLLM also requires torch, installed above
 ARG GUIDELLM_REPO=https://github.com/vllm-project/guidellm.git
-ARG GUIDELLM_BRANCH=v0.6.1
-ARG GUIDELLM_COMMIT=v0.6.1
+ARG GUIDELLM_BRANCH=v0.7.3
+ARG GUIDELLM_COMMIT=v0.7.3
 RUN git clone --branch ${GUIDELLM_BRANCH} ${GUIDELLM_REPO}
 RUN cd guidellm; \
     git checkout ${GUIDELLM_COMMIT}; \


### PR DESCRIPTION
Update versions for harnesses `inference-perf`, `guidellm` and `vllm-benchmark`