### PR TITLE
feat: support additionalFlags with imageDefault in modelservice

### DIFF
--- a/config/templates/jinja/13_ms-values.yaml.j2
+++ b/config/templates/jinja/13_ms-values.yaml.j2
@@ -407,6 +407,9 @@ decode:
     args:
       - |
 {{ build_vllm_command('decode') | indent(8, first=True) }}
+{% elif decode_model_command == 'imageDefault' and decode.vllm.additionalFlags is defined and decode.vllm.additionalFlags %}
+    args:
+{{ decode.vllm.additionalFlags | toyaml | indent(6, true) }}
 {% endif %}
     env:
 {{ build_ms_env_vars('decode') | indent(6, true) }}
@@ -824,6 +827,9 @@ prefill:
     args:
       - |
 {{ build_vllm_command('prefill') | indent(8, first=True) }}
+{% elif prefill_model_command == 'imageDefault' and prefill.vllm.additionalFlags is defined and prefill.vllm.additionalFlags %}
+    args:
+{{ prefill.vllm.additionalFlags | toyaml | indent(6, true) }}
 {% endif %}
     env:
 {{ build_ms_env_vars('prefill') | indent(6, true) }}


### PR DESCRIPTION
## Summary

- Add `additionalFlags` support for `modelCommand: imageDefault` in the modelservice Jinja template (`13_ms-values.yaml.j2`) for both decode and prefill pods
- When `modelCommand: imageDefault` and `vllm.additionalFlags` is defined, the flags are emitted as `args:` in the rendered values (no shell wrapper), matching the existing behavior in the standalone template
- Update `pd-disaggregation-sim.yaml` to use `additionalFlags` with sim-specific latency flags instead of a full `args:` list

## Test plan

- [ ] Render a scenario with `modelCommand: imageDefault` and `additionalFlags` set on decode/prefill and verify the flags appear in the rendered Helm values
- [ ] Verify `pd-disaggregation-sim.yaml` standup produces pods whose containers include the sim latency flags
- [ ] Verify scenarios without `additionalFlags` (or with `modelCommand: custom`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)