### PR TITLE
Pin EPP+KEDA baseline to the same benchmark image as the FMA passes

### DIFF
--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -265,3 +265,8 @@ scenario:
       # Heavy variant -- matched RPS across the baseline and FMA passes.
       experimentProfile: shared_prefix_synthetic_heavy.yaml
       waitTimeout: 5400
+
+    # Match the FMA passes' benchmark image.
+    images:
+      benchmark:
+        tag: nightly


### PR DESCRIPTION
###  Summary

Adds `images.benchmark.tag: nightly` to `cicd/ocp-keda.yaml`, matching the `ocp-keda-fma-warmstart/hotstart` scenarios.

### Why

Pinning nightly makes all three EPP+KEDA passes use the same image, so the baseline aggregates the same metrics and the table is apples-to-apples.
