### PR TITLE
fix(eval-containers): bring nightly GPU eval to a scoreable baseline

### DIFF
--- a/.github/workflows/ci-nightly-eval-gpu-ocp-aider-gemini.yaml
+++ b/.github/workflows/ci-nightly-eval-gpu-ocp-aider-gemini.yaml
@@ -1,6 +1,6 @@
 name: CI - Nightly Eval GPU on OCP (aider-polyglot / gemini-cli)
 
-# GPU-SERVED eval caller: stands up Qwen/Qwen3-32B on a single H100 via llm-d
+# GPU-SERVED eval caller: stands up Qwen/Qwen3.6-27B on a single H100 via llm-d
 # (modelservice) and drives the aider-polyglot / gemini-cli eval-containers
 # agent against that in-cluster served endpoint -- the standard llm-d path, NOT
 # run-only against LiteLLM. See reusable-ci-nightly-eval-gpu.yaml for the

--- a/.github/workflows/reusable-ci-nightly-eval-gpu.yaml
+++ b/.github/workflows/reusable-ci-nightly-eval-gpu.yaml
@@ -14,7 +14,7 @@ name: Reusable - Nightly Eval GPU (eval-containers, vLLM standup)
 # stood-up epponly endpoint. The in-pod bifrost gateway's OPENAI_API_KEY
 # defaults to a placeholder that llm-d ignores, so NO API key is forwarded and
 # NO `-U` is passed. EVAL_MODEL is derived from the scenario's model.name, which
-# must be the SERVED model id (e.g. Qwen/Qwen3-32B).
+# must be the SERVED model id (e.g. Qwen/Qwen3.6-27B).
 #
 # Target: OCP pok-prod (self-hosted runner + KUBECONFIG_DATA_OCP), same as the
 # run-only eval engine and the perf callers. Root for the eval image's /app
@@ -63,6 +63,11 @@ jobs:
       CLEANUP: ${{ inputs.cleanup }}
       # Forwarded to the model download job for gated models; harmless if empty.
       HF_TOKEN: ${{ secrets.LLMDBENCH_HF_TOKEN }}
+      # Pin the workspace so results land at a known path we can collect.
+      # Without --workspace the CLI falls back to the scenario's `workDir`
+      # (e.g. ~/data/eval-gaia-gpu) -- OUTSIDE the checkout, and on a
+      # self-hosted runner that path persists and mixes runs together.
+      WORKSPACE: ${{ github.workspace }}/eval-workspace
     steps:
       - uses: actions/checkout@v7
 
@@ -94,7 +99,7 @@ jobs:
           DRYFLAG=""; [ "$DRY" = "true" ] && DRYFLAG="--dry-run"
           llmdbenchmark --spec "$SPEC" $DRYFLAG standup \
             --cluster-config "$CC" \
-            -p "$NS" -t "$METHODS" --base-dir . \
+            -p "$NS" -t "$METHODS" --base-dir . --workspace "$WORKSPACE" \
             --pvc-bind-timeout "$PVC_TIMEOUT" \
             --modelservice-deploy-timeout "$MS_TIMEOUT"
 
@@ -105,7 +110,58 @@ jobs:
           llmdbenchmark --spec "$SPEC" $DRYFLAG run \
             --cluster-config "$CC" \
             -p "$NS" -t "$METHODS" -j "$TASKS" \
-            --base-dir . --analyze --wait-timeout "$WAIT"
+            --base-dir . --workspace "$WORKSPACE" \
+            --analyze --wait-timeout "$WAIT"
+
+      # Collect BEFORE teardown: teardown deletes the harness + vLLM pods, and
+      # with them any chance of reading pod logs. `if: always()` so a failed or
+      # timed-out run still yields diagnostics -- that is when they matter most.
+      - name: Collect eval results + pod logs
+        if: always()
+        run: |
+          DEST="$GITHUB_WORKSPACE/eval-artifacts"
+          mkdir -p "$DEST/cluster"
+
+          # Benchmark results (per-task dirs: stdout.log, run_metadata.yaml, and
+          # the analyze output). Stamp the run id in so a downloaded artifact is
+          # traceable back to the Actions run, as the perf nightly does.
+          if [ -d "$WORKSPACE" ]; then
+            find "$WORKSPACE" -name run_metadata.yaml \
+              -exec sh -c 'echo "github_run_id: \"'"$GITHUB_RUN_ID"'\"" >> "$1"' _ {} \; || true
+            cp -a "$WORKSPACE/." "$DEST/workspace/" 2>/dev/null || true
+          else
+            echo "WARNING: workspace $WORKSPACE not found -- no results to collect"
+          fi
+
+          # Cluster-side state. Each is best-effort: a missing pod must not fail
+          # the collection step and cost us the rest of the diagnostics.
+          oc get pods -n "$NS" -o wide          > "$DEST/cluster/pods.txt" 2>&1 || true
+          oc get events -n "$NS" \
+            --sort-by=.lastTimestamp             > "$DEST/cluster/events.txt" 2>&1 || true
+          oc describe pods -n "$NS"              > "$DEST/cluster/describe-pods.txt" 2>&1 || true
+
+          # Per-pod logs, including --previous to catch a crash-looped vLLM.
+          for pod in $(oc get pods -n "$NS" -o name 2>/dev/null | cut -d/ -f2); do
+            oc logs "$pod" -n "$NS" --all-containers --tail=-1 \
+              > "$DEST/cluster/log-${pod}.txt" 2>&1 || true
+            oc logs "$pod" -n "$NS" --all-containers --previous --tail=-1 \
+              > "$DEST/cluster/log-${pod}-previous.txt" 2>&1 || true
+            # Drop empty --previous files (no prior container = expected).
+            [ -s "$DEST/cluster/log-${pod}-previous.txt" ] || rm -f "$DEST/cluster/log-${pod}-previous.txt"
+          done
+
+          echo "### Collected artifacts:"
+          du -sh "$DEST" 2>/dev/null || true
+          find "$DEST" -type f | head -50
+
+      - name: Upload eval results + logs
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: eval-gpu-${{ github.run_id }}-${{ github.run_attempt }}
+          path: eval-artifacts/
+          retention-days: 30
+          if-no-files-found: warn
 
       - name: Teardown vLLM model (free the GPU)
         if: always()

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -6,8 +6,8 @@
 # eval-containers harness against that IN-CLUSTER endpoint -- no `-U`, no key.
 #
 # Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU.
-# The eval agent (gemini-cli) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is
-# openai/<model.name>), which the in-pod gateway forwards to the discovered
+# The eval agent (gemini-cli) calls `Qwen/Qwen3.6-27B` (EVAL_MODEL is
+# <model.name>), which the in-pod gateway forwards to the discovered
 # in-cluster endpoint (epponly -> *-router-epp Service).
 #
 # Cluster-specific values (storage class, serviceAccount, runAsUser) live in a
@@ -31,6 +31,7 @@
 scenario:
   - name: "eval-aider-polyglot-gpu"
 
+<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -41,6 +42,20 @@ scenario:
         maxModelLen: 16000
         blockSize: 64
         gpuMemoryUtilization: 0.95
+=======
+    # -------------------------------------------------------------------------
+    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>.
+    # -------------------------------------------------------------------------
+    model:
+      name: Qwen/Qwen3.6-27B
+      shortName: qwen-qwen36-27b
+      path: models/Qwen/Qwen3.6-27B
+      huggingfaceId: Qwen/Qwen3.6-27B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+>>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -1,12 +1,12 @@
 # eval-containers / aider-polyglot example scenario -- GPU-SERVED variant
-# (cluster-generic), serving Qwen/Qwen3-32B on a single GPU (TP=1).
+# (cluster-generic), serving Qwen/Qwen3.6-27B on a single GPU (TP=1).
 #
 # Unlike the run-only "-pp" scenario (external LiteLLM via `-U`), this STANDS UP
-# Qwen/Qwen3-32B on a GPU the standard llm-d way (modelservice) and drives the
+# Qwen/Qwen3.6-27B on a GPU the standard llm-d way (modelservice) and drives the
 # eval-containers harness against that IN-CLUSTER endpoint -- no `-U`, no key.
 #
-# Served model: Qwen/Qwen3-32B, TP=1, on a single GPU.
-# The eval agent (gemini-cli) calls `openai/Qwen/Qwen3-32B` (EVAL_MODEL is
+# Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU.
+# The eval agent (gemini-cli) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is
 # openai/<model.name>), which the in-pod gateway forwards to the discovered
 # in-cluster endpoint (epponly -> *-router-epp Service).
 #
@@ -24,7 +24,7 @@
 #   llmdbenchmark --spec examples/eval-containers-aider-polyglot-gpu teardown \
 #     --cluster-config <cc> -p "$NS"
 #
-# aider-polyglot runs fully offline. Qwen3-32B is public on HF.
+# aider-polyglot runs fully offline. Qwen3.6-27B is public on HF.
 #
 # All parameters not defined here use defaults.yaml.
 

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -153,5 +153,24 @@ scenario:
       extraEnvVars:
         - name: EVAL_TIMEOUT
           value: "1500"
+        # Force the OpenAI wire. gemini-cli speaks the Gemini v1beta protocol
+        # (`/v1beta/models/<model>:generateContent`), but llm-d/vLLM serves the
+        # OpenAI wire only. Without this, /opt/gateway/start renders its NATIVE
+        # ROUTING mode -- caddy stamps X-Eval-Wire from the inbound path and one
+        # governance rule per provider keys on it -- so gemini-cli's requests are
+        # routed to bifrost's gemini provider and every call fails with:
+        #   BadRequest - no parser registered matching path suffix for:
+        #   /v1beta/models/Qwen/Qwen3.6-27B:generateContent
+        # The agent then silently writes a stub solution (observed: a literal
+        # `???` where a Rust type belonged), so the task scores 0 for what looks
+        # like a model-quality failure rather than a transport one.
+        #
+        # Setting EVAL_MODEL_API selects the image's WIRE OVERRIDE mode instead:
+        # a single cel_expression="true" rule pinning provider=openai and
+        # model=EVAL_MODEL. EVAL_MODEL itself stays the bare slashed handle.
+        # Verified against the image: renders id=pin, cel="true",
+        # provider="openai", model="Qwen/Qwen3.6-27B".
+        - name: EVAL_MODEL_API
+          value: openai
 
     workDir: "~/data/eval-aider-polyglot-gpu"

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -31,7 +31,6 @@
 scenario:
   - name: "eval-aider-polyglot-gpu"
 
-<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -39,23 +38,14 @@ scenario:
         path: models/Qwen/Qwen3.6-27B
         huggingfaceId: Qwen/Qwen3.6-27B
         size: 1Ti
-        maxModelLen: 16000
+        # 32768, not 16000: at 16k, tasks that carry a repo's worth of context
+        # plus a <think> block hit the ceiling mid-solution and the request is
+        # rejected rather than answered. Note this HALVES per-pod concurrency --
+        # KV cache is a fixed token budget, so doubling context doubles the
+        # per-request reservation. Size -j off free GPUs accordingly.
+        maxModelLen: 32768
         blockSize: 64
         gpuMemoryUtilization: 0.95
-=======
-    # -------------------------------------------------------------------------
-    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>.
-    # -------------------------------------------------------------------------
-    model:
-      name: Qwen/Qwen3.6-27B
-      shortName: qwen-qwen36-27b
-      path: models/Qwen/Qwen3.6-27B
-      huggingfaceId: Qwen/Qwen3.6-27B
-      size: 1Ti
-      maxModelLen: 16000
-      blockSize: 64
-      gpuMemoryUtilization: 0.95
->>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:
@@ -141,6 +131,11 @@ scenario:
             - --enable-auto-tool-choice
             - --tool-call-parser
             - qwen3_coder
+            # --reasoning-parser qwen3: Qwen3.6-27B is a hybrid-reasoning model.
+            # Without this flag vLLM returns the <think> trace as ordinary content,
+            # so the agent receives reasoning prose where it expects a tool call.
+            - --reasoning-parser
+            - qwen3
 
     harness:
       name: eval-containers

--- a/config/scenarios/examples/eval-containers-gaia-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-gaia-gpu.yaml
@@ -6,7 +6,7 @@
 # against that IN-CLUSTER served endpoint -- no `-U`, no external key.
 #
 # Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU (e.g. NVIDIA-H100-80GB).
-# The eval agent (codex) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is derived
+# The eval agent (codex) calls `Qwen/Qwen3.6-27B` (EVAL_MODEL is derived
 # from model.name), which the in-pod bifrost gateway forwards to the deployed
 # endpoint that step_03 auto-discovers (epponly -> the *-router-epp Service).
 #
@@ -32,6 +32,7 @@
 scenario:
   - name: "eval-gaia-gpu"
 
+<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -42,6 +43,21 @@ scenario:
         maxModelLen: 16000
         blockSize: 64
         gpuMemoryUtilization: 0.95
+=======
+    # -------------------------------------------------------------------------
+    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>,
+    # so it MUST be the id the agent calls.
+    # -------------------------------------------------------------------------
+    model:
+      name: Qwen/Qwen3.6-27B
+      shortName: qwen-qwen36-27b
+      path: models/Qwen/Qwen3.6-27B
+      huggingfaceId: Qwen/Qwen3.6-27B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+>>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:

--- a/config/scenarios/examples/eval-containers-gaia-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-gaia-gpu.yaml
@@ -32,7 +32,6 @@
 scenario:
   - name: "eval-gaia-gpu"
 
-<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -40,24 +39,14 @@ scenario:
         path: models/Qwen/Qwen3.6-27B
         huggingfaceId: Qwen/Qwen3.6-27B
         size: 1Ti
-        maxModelLen: 16000
+        # 32768, not 16000: at 16k, tasks that carry a repo's worth of context
+        # plus a <think> block hit the ceiling mid-solution and the request is
+        # rejected rather than answered. Note this HALVES per-pod concurrency --
+        # KV cache is a fixed token budget, so doubling context doubles the
+        # per-request reservation. Size -j off free GPUs accordingly.
+        maxModelLen: 32768
         blockSize: 64
         gpuMemoryUtilization: 0.95
-=======
-    # -------------------------------------------------------------------------
-    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>,
-    # so it MUST be the id the agent calls.
-    # -------------------------------------------------------------------------
-    model:
-      name: Qwen/Qwen3.6-27B
-      shortName: qwen-qwen36-27b
-      path: models/Qwen/Qwen3.6-27B
-      huggingfaceId: Qwen/Qwen3.6-27B
-      size: 1Ti
-      maxModelLen: 16000
-      blockSize: 64
-      gpuMemoryUtilization: 0.95
->>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:
@@ -159,6 +148,11 @@ scenario:
             - --enable-auto-tool-choice
             - --tool-call-parser
             - qwen3_coder
+            # --reasoning-parser qwen3: Qwen3.6-27B is a hybrid-reasoning model.
+            # Without this flag vLLM returns the <think> trace as ordinary content,
+            # so the agent receives reasoning prose where it expects a tool call.
+            - --reasoning-parser
+            - qwen3
 
     harness:
       name: eval-containers

--- a/config/scenarios/examples/eval-containers-gaia-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-gaia-gpu.yaml
@@ -5,8 +5,8 @@
 # the standard llm-d way (modelservice) and drives the eval-containers harness
 # against that IN-CLUSTER served endpoint -- no `-U`, no external key.
 #
-# Served model: Qwen/Qwen3-32B, TP=1, on a single GPU (e.g. NVIDIA-H100-80GB).
-# The eval agent (codex) calls `openai/Qwen/Qwen3-32B` (EVAL_MODEL is derived
+# Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU (e.g. NVIDIA-H100-80GB).
+# The eval agent (codex) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is derived
 # from model.name), which the in-pod bifrost gateway forwards to the deployed
 # endpoint that step_03 auto-discovers (epponly -> the *-router-epp Service).
 #
@@ -25,7 +25,7 @@
 #     --cluster-config <cc> -p "$NS"
 #
 # GAIA is a web/tool agentic task (harness pod needs internet egress).
-# Qwen/Qwen3-32B is public on HF, so `uriProtocol: hf` auto-downloads it.
+# Qwen/Qwen3.6-27B is public on HF, so `uriProtocol: hf` auto-downloads it.
 #
 # All parameters not defined here use defaults.yaml.
 
@@ -153,5 +153,21 @@ scenario:
       resources:
         cpu: "2"
         memory: 6Gi
+      # Per-task agent wall-clock timeout (seconds), read by the exgentic image's
+      # run-agent (`timeout $TIMEOUT`). The image default of 300 silently truncates
+      # tasks mid-solution -- the agent is killed while still working, so the run
+      # under-reports the pass rate rather than failing loudly. GAIA's multi-step
+      # web-fetch tasks are at least as exposed as aider-polyglot, which needed
+      # 1500 (max observed runtime there ~1020s); match it.
+      #
+      # EVAL_GAIA_SUBSET=no-search selects the 54-task subset that drops tasks
+      # requiring a search engine, keeping web-fetch + offline tasks. Without a
+      # search backend wired up, search tasks cannot pass, so including them only
+      # depresses the score.
+      extraEnvVars:
+        - name: EVAL_TIMEOUT
+          value: "1500"
+        - name: EVAL_GAIA_SUBSET
+          value: "no-search"
 
     workDir: "~/data/eval-gaia-gpu"

--- a/config/templates/jinja/04_download_job.yaml.j2
+++ b/config/templates/jinja/04_download_job.yaml.j2
@@ -14,7 +14,16 @@ spec:
     spec:
       containers:
         - name: downloader
-          image: {{ images.benchmark.repository }}:{{ images.benchmark.tag }}
+          # This job only needs Python + pip (it pip-installs huggingface_hub
+          # below), so it uses images.python rather than images.benchmark. With
+          # the benchmark image the weight download inherited whatever the
+          # harness image happens to be: for agentic harnesses (e.g. the
+          # exgentic eval images) that is a multi-GB image bundling an agent CLI
+          # and its toolchain, and since this template sets no imagePullPolicy a
+          # :latest tag defaults to Always -- so every standup re-pulled
+          # gigabytes of image unrelated to fetching weights, stalling the
+          # download job past its timeout before any bytes transferred.
+          image: {{ images.python.repository }}:{{ images.python.tag }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -20,7 +20,30 @@ if [[ -z "${EVAL_TASK_ID:-}" ]]; then
   # parallel_idx is 1-based (framework: range(1, N+1)); fall back to 1 for a
   # missing / non-numeric / zero suffix so EVAL_TASK_ID can never go negative.
   case "$idx" in ''|*[!0-9]*|0) idx=1 ;; esac
-  export EVAL_TASK_ID="$(( idx - 1 + ${EVAL_TASK_OFFSET:-0} ))"
+
+  # EVAL_TASK_LIST selects an ARBITRARY set of task ids: a comma-separated list
+  # indexed by this pod's 1-based position. EVAL_TASK_OFFSET can only express a
+  # contiguous range, and the aider-polyglot dataset is language-ORDERED (cpp
+  # 0-25, go 26-64, java 65-111, javascript 112-160, python 161-194, rust
+  # 195-224), so every contiguous slice is effectively single-language and its
+  # score is not comparable to any other slice. A representative sample needs an
+  # explicit list.
+  if [[ -n "${EVAL_TASK_LIST:-}" ]]; then
+    IFS=',' read -r -a _task_ids <<< "$EVAL_TASK_LIST"
+    if (( idx > ${#_task_ids[@]} )); then
+      echo "eval-containers: FATAL pod index $idx exceeds EVAL_TASK_LIST length ${#_task_ids[@]}" >&2
+      exit 1
+    fi
+    _tid="${_task_ids[$(( idx - 1 ))]}"
+    _tid="${_tid//[[:space:]]/}"
+    case "$_tid" in ''|*[!0-9]*)
+      echo "eval-containers: FATAL EVAL_TASK_LIST entry $idx is not a task id: '$_tid'" >&2
+      exit 1 ;;
+    esac
+    export EVAL_TASK_ID="$_tid"
+  else
+    export EVAL_TASK_ID="$(( idx - 1 + ${EVAL_TASK_OFFSET:-0} ))"
+  fi
 fi
 
 # --- point the eval's in-pod model gateway at the deployed llm-d endpoint -----

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -48,6 +48,73 @@ export EVAL_MODEL="${LLMDBENCH_DEPLOY_CURRENT_MODEL:?model not provided}"
 
 echo "eval-containers: task=$EVAL_TASK_ID model=$EVAL_MODEL endpoint=$OPENAI_API_BASE"
 
+# --- raise the in-pod gateway's per-request timeout --------------------------
+# bifrost's built-in per-request timeout is 30s, which is SHORTER than a
+# reasoning model's generation latency (the model emits a <think> block before
+# the answer). Measured 2026-07-30 over two 20-task waves: 65/198 (33%) and
+# 55/156 (35%) of gateway requests returned 504 with durations pinned at
+# 30002-30064 ms -- a fixed client deadline, not model variance. A successful
+# call landed at 26460 ms, i.e. 3.5s under the wire. No task with 3+ 504s ever
+# passed, so this silently depresses the score rather than failing the run.
+#
+# bifrost names the fix in its own error body ("increase it by setting the
+# default_request_timeout_in_seconds in the network_config"), and
+# config.json.template already writes a network_config block per provider
+# holding base_url + allow_private_network. /opt/gateway/start renders that
+# template with plain sed and never parses the JSON, so an injected field
+# passes straight through -- no image rebuild needed.
+#
+# Keyed on "allow_private_network": true, which appears in all three provider
+# blocks (anthropic, openai, gemini), so it survives base_url differences.
+# 600s is comfortably above the worst observed generation and still bounded
+# well under EVAL_TIMEOUT, so a wedged request cannot outlive its own task.
+gw_timeout="${EVAL_GATEWAY_TIMEOUT:-600}"
+gw_template=/opt/gateway/data/config.json.template
+# Saved copy lives under $HOME, not /tmp: /tmp is not guaranteed to survive
+# (macOS has wiped it mid-run) and this file's whole job is to be there for
+# the revert below, so a cleared /tmp would turn a loud-skip patch into a
+# silent, unrevertable one.
+gw_template_orig="${HOME:-/tmp}/eval-containers-gw-config.json.template.orig"
+if [[ -f "$gw_template" && -w "$(dirname "$gw_template")" ]]; then
+  if grep -q 'default_request_timeout_in_seconds' "$gw_template"; then
+    echo "eval-containers: gateway template already sets a request timeout; leaving it alone"
+  elif ! cp "$gw_template" "$gw_template_orig"; then
+    # Without a saved copy we cannot revert, so patching would be
+    # unguarded -- skip it and leave the provider default in place. This is
+    # the same degrade-gracefully outcome as the "not present/writable"
+    # branch below, just discovered one step later.
+    echo "eval-containers: WARNING could not save gateway template backup to ${gw_template_orig}; skipping timeout patch, provider default applies" >&2
+  else
+    gw_restore() {
+      if ! cp "$gw_template_orig" "$gw_template"; then
+        echo "eval-containers: WARNING revert failed; ${gw_template} may be left in a half-patched state" >&2
+      fi
+    }
+    if ! sed -i "s/\"allow_private_network\": true/\"allow_private_network\": true, \"default_request_timeout_in_seconds\": ${gw_timeout}/g" \
+      "$gw_template"; then
+      # A disk-full temp-file write or a permissions race after the -w
+      # dirname check above can make sed itself fail. Restore rather than
+      # leave a possibly half-patched template in place.
+      echo "eval-containers: WARNING timeout patch sed failed; reverting" >&2
+      gw_restore
+    else
+      n=$(grep -c 'default_request_timeout_in_seconds' "$gw_template") || n=0
+      if [[ "$n" -eq 3 ]]; then
+        echo "eval-containers: gateway request timeout set to ${gw_timeout}s for 3 providers"
+        rm -f "$gw_template_orig"
+      else
+        # Restore rather than run with a half-patched template: a malformed
+        # config.json makes bifrost fail to boot, which surfaces later as an
+        # opaque startup failure rather than as this patch's fault.
+        echo "eval-containers: WARNING timeout patch hit $n/3 providers; reverting" >&2
+        gw_restore
+      fi
+    fi
+  fi
+else
+  echo "eval-containers: note gateway template not present/writable; provider default applies"
+fi
+
 # --- run the eval ------------------------------------------------------------
 # image ENTRYPOINT stages /app for EVAL_TASK_ID, then execs the pipeline.
 rc=0

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -138,6 +138,120 @@ else
   echo "eval-containers: note gateway template not present/writable; provider default applies"
 fi
 
+# --- preserve the grader's test output (opt-in: EVAL_GRADE_VERBOSE=1) ---------
+# The image's /grade.sh discards the entire test phase:
+#
+#   if timeout 120 sh -c "$TEST_CMD" >/dev/null 2>&1; then
+#
+# so a failed task leaves ONLY "0.0" in logs/verifier/reward.txt -- no compiler
+# error, no failing assertion, no stack trace. A zero is then undiagnosable:
+# "wrong answer", "solution written to the wrong path", and "toolchain missing
+# from the image" are indistinguishable, and all three produce uniform zeros.
+#
+# It also logs grade.sh's SOLUTION COPY. grade.sh copies each solution file from
+# /app/$f and skips it SILENTLY when absent (`if [ -f "$src" ]`), so if the agent
+# wrote elsewhere the suite grades the untouched STUB and every task scores 0.0
+# no matter how good the solution was -- invisible in the shipped script.
+#
+# It also copies each solution file to logs/verifier/solution/. The agent writes
+# into /app and the graded copy lands in $EXERCISE_DIR, both inside the container
+# -- so once the pod exits, the code that was actually graded is gone and only
+# the compiler's complaint about it survives. That made one class of failure
+# undiagnosable: a Go task failed with "syntax error: non-declaration statement
+# outside function body" at lines 15 and 76, which is what raw markdown fences or
+# prose in a .go file look like -- but with the file gone and the agent's stdout
+# showing no fences, the cause could not be established either way.
+#
+# Grading semantics are unchanged: same TEST_CMD, same 120s timeout, same
+# 1.0/0.0 from the same exit status to the same path. Only the output is kept.
+# Guarded by `|| true` throughout: a patch failure must never fail the eval, and
+# an image whose grade.sh has changed shape is left strictly alone.
+if [[ "${EVAL_GRADE_VERBOSE:-0}" == "1" && -f /grade.sh ]]; then
+  cp -a /grade.sh /grade.sh.orig 2>/dev/null || true
+  python3 - <<'PY' || echo "eval-containers: grade.sh patch skipped (see above)" >&2
+import sys
+p = "/grade.sh"
+try:
+    src = open(p).read()
+except OSError as e:
+    sys.exit("cannot read %s: %s" % (p, e))
+
+old_run = 'if timeout 120 sh -c "$TEST_CMD" >/dev/null 2>&1; then'
+new_run = ('echo "=== TEST_CMD: $TEST_CMD" > /logs/verifier/test_output.log\n'
+           'echo "=== LANGUAGE: $LANGUAGE  EXERCISE: $EXERCISE" >> /logs/verifier/test_output.log\n'
+           'echo "=== EXERCISE_DIR: $EXERCISE_DIR  cwd: $(pwd)" >> /logs/verifier/test_output.log\n'
+           'echo "=== files in cwd:" >> /logs/verifier/test_output.log\n'
+           'ls -la >> /logs/verifier/test_output.log 2>&1\n'
+           'echo "=== test run:" >> /logs/verifier/test_output.log\n'
+           'if timeout 120 sh -c "$TEST_CMD" >>/logs/verifier/test_output.log 2>&1; then')
+old_cp = ('  if [ -f "$src" ]; then\n'
+          '    cp "$src" "$dst"\n'
+          '  fi')
+new_cp = ('  if [ -f "$src" ]; then\n'
+          '    cp "$src" "$dst"\n'
+          '    echo "COPIED  $src -> $dst ($(wc -c < "$src") bytes)" >> /logs/verifier/copy.log\n'
+          '    mkdir -p /logs/verifier/solution\n'
+          '    cp "$src" "/logs/verifier/solution/$(basename "$f")" 2>/dev/null || true\n'
+          '  else\n'
+          '    echo "MISSING $src (agent did not write it; tests grade the STUB)" >> /logs/verifier/copy.log\n'
+          '  fi')
+
+if old_run not in src or old_cp not in src:
+    sys.exit("grade.sh does not match the expected shape; refusing to patch blind")
+
+src = src.replace(old_run, new_run, 1).replace(old_cp, new_cp, 1)
+src = src.replace("mkdir -p /logs/verifier",
+                  "mkdir -p /logs/verifier\n: > /logs/verifier/copy.log", 1)
+open(p, "w").write(src)
+print("eval-containers: grade.sh patched (test output + copy log preserved)")
+PY
+  # A syntax error here would make every task score 0.0 for a NEW reason, so
+  # revert rather than grade with a broken script.
+  if ! bash -n /grade.sh 2>/dev/null; then
+    echo "eval-containers: patched grade.sh failed syntax check -- reverting" >&2
+    cp -a /grade.sh.orig /grade.sh 2>/dev/null || true
+  fi
+fi
+
+# --- LOCAL WORKAROUND: disable codex's live web search ------------------------
+# NOT FOR UPSTREAM. Tracked as an exgentic issue; delete when the image stops
+# hardcoding this.
+#
+# The gaia--codex image's /run.sh passes `-c 'web_search="live"'` to
+# `codex exec`, enabling the native Responses web_search tool. There is no
+# search backend reachable from the cluster, so every task that tries to search
+# errors instead of falling back to offline reasoning.
+#
+# It cannot be turned off from the outside: /usr/local/bin/run-agent invokes the
+# agent under `env -i` with a strict allow-list, so no env var survives into the
+# codex process. The setting exists only in /run.sh.
+#
+# DELETE the flag rather than setting web_search="off"/false. Deletion lands on
+# codex's own documented default -- `--search` is opt-in ("Enable live web
+# search", codex-cli 0.120.0) -- whereas the disable enum is NOT verifiable:
+# `codex exec -c web_search=bogus --help` exits 0 because --help short-circuits
+# before config validation, so a wrong value would fail at task time.
+#
+# Separate lever from EVAL_GAIA_SUBSET=no-search, which is task SELECTION. Do
+# both: the subset stops us grading tasks that need a search engine, this stops
+# codex reaching for one on the tasks that remain.
+if [[ "${EVAL_DISABLE_WEB_SEARCH:-1}" == "1" && -f /run.sh ]]; then
+  if grep -q "web_search=" /run.sh; then
+    cp -a /run.sh /run.sh.orig 2>/dev/null || true
+    before=$(grep -c "web_search=" /run.sh || true)
+    # Drop just the `-c 'web_search="live"'` argument, leaving the rest of the
+    # codex invocation (including its line continuations) intact.
+    sed -i "s/[[:space:]]*-c[[:space:]]*'web_search=\"live\"'//g" /run.sh || true
+    after=$(grep -c "web_search=" /run.sh || true)
+    if [[ "$after" -lt "$before" ]] && bash -n /run.sh 2>/dev/null; then
+      echo "eval-containers: codex web_search disabled (removed $((before-after)) flag(s) from /run.sh)"
+    else
+      echo "eval-containers: WARNING web_search patch failed syntax check or matched nothing; reverting" >&2
+      cp -a /run.sh.orig /run.sh 2>/dev/null || true
+    fi
+  fi
+fi
+
 # --- run the eval ------------------------------------------------------------
 # image ENTRYPOINT stages /app for EVAL_TASK_ID, then execs the pipeline.
 rc=0
@@ -147,6 +261,27 @@ rc=0
 # --- hand results back to llm-d-benchmark's collector ------------------------
 output_dir="${EVAL_OUTPUT_DIR:-/output}"
 if [[ -d "$output_dir" ]]; then cp -a "$output_dir/." "$results_dir/"; fi
+
+# Report what traces were captured, so a run that silently lost them is visible
+# in the harness log instead of only discoverable by digging afterwards.
+if [[ -s "$results_dir/traces.jsonl" ]]; then
+  span_lines=$(wc -l < "$results_dir/traces.jsonl" | tr -d ' ')
+  echo "eval-containers: captured traces.jsonl ($span_lines OTLP records)"
+else
+  echo "eval-containers: WARNING no traces captured for task $EVAL_TASK_ID" >&2
+fi
+
+# Collect the verifier's own logs. The eval writes grading output to
+# /logs/verifier, which is OUTSIDE /output and so was otherwise discarded with
+# the pod. Without it a `reward: 0.0` is unattributable: there is no way to tell
+# a genuinely wrong answer from a build/test-harness mismatch (missing file,
+# wrong path, compile error) after the fact -- the agent's own stdout only says
+# what it *believed* it did.
+if [[ -d /logs ]]; then
+  mkdir -p "$results_dir/logs"
+  cp -a /logs/. "$results_dir/logs/" 2>/dev/null || true
+fi
+
 printf 'harness_name: eval-containers\nharness_rc: %s\ntask_id: %s\nmodel: %s\n' \
   "$rc" "$EVAL_TASK_ID" "$EVAL_MODEL" > "$results_dir/run_metadata.yaml"
 

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -36,7 +36,15 @@ endpoint="${endpoint%/}"
 endpoint="${endpoint%/v1}"
 export OPENAI_API_BASE="$endpoint"
 export OPENAI_API_KEY="${OPENAI_API_KEY:-sk-llm-d}"  # pragma: allowlist secret (placeholder; llm-d ignores it)
-export EVAL_MODEL="openai/${LLMDBENCH_DEPLOY_CURRENT_MODEL:?model not provided}"
+# EVAL_MODEL must be the BARE served model handle, with NO provider prefix.
+# /opt/gateway/start documents it as "a BARE handle" and renders it into a
+# bifrost routing rule that carries the provider SEPARATELY:
+#   "targets": [{ "provider": "<wire>", "model": "<EVAL_MODEL>" }]
+# So an `openai/` prefix here is not a provider selector -- it becomes part of
+# the model NAME. bifrost then looks up `openai/<model>` in the OpenAI catalog,
+# finds nothing, and returns 404 "The model ... does not exist" for every agent
+# call: reward 0.0, empty agent stdout, harness rc 0. Silent green.
+export EVAL_MODEL="${LLMDBENCH_DEPLOY_CURRENT_MODEL:?model not provided}"
 
 echo "eval-containers: task=$EVAL_TASK_ID model=$EVAL_MODEL endpoint=$OPENAI_API_BASE"
 


### PR DESCRIPTION
## What this PR does

This PR fixes a set of independent bugs that together prevent the nightly GPU eval scenarios (`eval-containers-gaia-gpu` and `eval-containers-aider-polyglot-gpu`) from scoring above zero, or from producing a representative sample. Each fix is a separate commit; the commits that belong upstream are described below.

> **Note:** The last commit (`local: keep fork-only eval workarounds...`) contains three patches that are **deliberately not intended for upstream** (in-image runtime patches for grade.sh verbosity, codex web_search, and /logs collection). They are kept as a single identifiable commit so they are trivial to drop or cherry-pick separately.

---

### Fix 1 — EVAL_MODEL must be a bare handle `9df43bf` → `86c17a7`

`/opt/gateway/start` documents `EVAL_MODEL` as *"a BARE handle (e.g. aws/claude-opus-4-8)"* and renders it into a bifrost routing rule that carries the provider **separately**:

```sh
"targets": [{ "provider": "<wire>", "model": "<EVAL_MODEL>" }]
```

Upstream set `EVAL_MODEL="openai/${model}"`. The `openai/` prefix is not a provider selector — it becomes part of the model NAME. bifrost looks up `openai/Qwen/Qwen3.6-27B`, finds nothing, and returns HTTP 404 for **every** agent call. The failure is silent green: reward 0.0, llm_calls 0, harness exit 0. As it stands the nightly eval-GPU workflow cannot score above zero for this reason alone.

**Fix:** drop the prefix.

---

### Fix 2 — Raise the in-pod gateway request timeout `0e55c27` → `37d1f60`

bifrost's built-in per-request timeout is 30 s. Qwen3.6-27B emits a `<think>` block before answering and routinely exceeds it.

**Measured** (2026-07-30, two 20-task waves): 65/198 (33%) and 55/156 (35%) of gateway requests returned **504**, with durations pinned at 30002–30064 ms — a fixed deadline, not model variance. A successful call landed at 26 460 ms, 3.5 s under the wire. No task that saw 3+ 504s ever passed.

bifrost names the fix in its own error body (`default_request_timeout_in_seconds` in the `network_config`). The field is absent from the shipped template. `/opt/gateway/start` renders that template with plain `sed` and never parses the JSON, so an injected field passes straight through — no image rebuild needed.

The patch is keyed on `"allow_private_network": true` (appears exactly 3× in both images) and reverts from a saved copy if the substitution count is not exactly 3.

Default: **600 s**. Overridable via `EVAL_GATEWAY_TIMEOUT`.

---

### Fix 3 — `EVAL_TASK_LIST`: select an arbitrary task set `9034875` → `ee0d907`

`EVAL_TASK_OFFSET` can only express a contiguous range. The aider-polyglot dataset is **language-ordered** (cpp 0–25, go 26–64, java 65–111, javascript 112–160, python 161–194, rust 195–224), so every contiguous slice is single-language and not comparable to any other slice.

`EVAL_TASK_LIST` accepts a comma-separated list of task ids and maps each pod's 1-based position through it. Fully backward-compatible: the `else` branch is upstream's existing `EVAL_TASK_OFFSET` arithmetic, byte for byte.

---

### Fix 4 — Run the weight-download job on the python image `a020fc1` → `c4568e8`

The download job pip-installs `huggingface_hub` — Python and pip are all it needs — but it ran on `images.benchmark`, the multi-GB harness image. With `:latest` defaulting to `Always`, every standup re-pulled gigabytes that had nothing to do with fetching weights, causing the job to sit in ContainerCreating past its timeout. `images.python` (`python:3.10`) is already defined in `config/defaults.yaml`.

---

### Fix 5 — Serve the GPU eval scenarios at 32k with a reasoning parser `f0814f7` → `8ba1865`

Two changes, both required before either scenario can score honestly:

- **`maxModelLen: 32768`** (was 16000). An agentic task carries a repo's worth of context plus a `<think>` block; at 16k the request is rejected mid-solution.
- **`--reasoning-parser qwen3`**. Qwen3.6-27B is a hybrid-reasoning model. Without this flag vLLM returns the `<think>` trace as ordinary assistant content, so the agent receives reasoning prose where it expects a tool call.

Note: 32k halves per-pod concurrency — KV cache is a fixed token budget. Size `-j` off free GPUs, not off node capacity.

---

### Fix 6 — Set `EVAL_TIMEOUT` and `no-search` subset on GAIA `bb059da` → `f88ee8f`

The exgentic image's `run-agent` wraps each task in `timeout $EVAL_TIMEOUT`, defaulting to 300 s. At that ceiling the agent is killed mid-solution — the run silently under-reports the pass rate. `eval-containers-aider-polyglot-gpu` already carried `EVAL_TIMEOUT=1500`; the GAIA scenario was missing it.

Also set `EVAL_GAIA_SUBSET=no-search`, selecting the 54-task subset that drops tasks requiring a search engine. With no search backend wired up, those 111 tasks cannot pass and only depress the score.

---

### Fix 7 — Force the OpenAI wire for the gemini-cli polyglot harness `36af32b` → `365e048`

gemini-cli speaks the Gemini v1beta protocol, but llm-d/vLLM serves the OpenAI wire only. Without `EVAL_MODEL_API=openai`, the image routes gemini-cli requests to bifrost's gemini provider and fails with `no parser registered matching path suffix for: /v1beta/models/...:generateContent`. The agent then writes a stub solution (`???` was observed where a Rust type belonged) — indistinguishable from poor model quality.

`EVAL_MODEL_API=openai` selects the image's WIRE OVERRIDE mode: a single `cel_expression="true"` rule pinning `provider=openai`.

---

### Fix 8 — Collect and upload eval results + pod logs `8b382a6` → `314be58`

The nightly eval workflow had no result-publishing step: outputs lived only in the runner workspace and vanished. Adds workspace pinning and an `upload-artifact` step that runs before teardown and is `if: always()` so a failed run still produces diagnostics.

---

## Run results that motivated these fixes

### GAIA (no-search subset, 54 tasks) — 2026-08-06

Model: **Qwen/Qwen3.6-27B** · maxModelLen: **32768** · 20 replicas (H100 80GB) · 3 waves

| Wave | Tasks | Passed | CTX32K rejections | HTTP 504 |
|------|-------|--------|-------------------|----------|
| Wave 0 | 20 | 10 | 2 | 4 |
| Wave 1 | 20 | 10 | 0 | 4 |
| Wave 2 | 14 | 7 | 0 | 0 |
| **Total** | **54** | **27 (50%)** | **2** | **8** |

The 16k baseline had 6–12 context rejections per run; 32k brought that to **2** (wave 0 only) then **0**. The web-search capability gap is a separate issue ([exgentic issue filed separately](docs/harness-workarounds-explained.md#8-codex-web_search----the-errors-you-saw)) and caps the score independently of these infrastructure fixes.

### aider-polyglot — 100-task cross-language run (2026-07-30 baseline, pre-fixes)

The 100-task polyglot run used `EVAL_TASK_LIST` to sample across all 6 languages (cpp/go/java/javascript/python/rust). Without it, every contiguous slice was effectively single-language. The `EVAL_TASK_LIST` feature in this PR is the enabler for that cross-language sampling.

---

## Checklist

- [x] Rebased on `main` (`765d2a3`)
- [x] Each fix is a separate commit with a standalone commit message
- [x] Local-only patches (grade.sh, web_search, /logs) isolated to final commit and **not** intended for merge
- [x] Scenario changes verified against `ghcr.io/exgentic/evals/gaia--codex-standalone` and `aider-polyglot--gemini-cli-standalone` (probed 2026-08-06, digests in docs/harness-workarounds-explained.md)
