### PR TITLE
fix(eval-containers): GPU-served agentic eval fixes + run-level metrics aggregation

### DIFF
--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -6,8 +6,8 @@
 # eval-containers harness against that IN-CLUSTER endpoint -- no `-U`, no key.
 #
 # Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU.
-# The eval agent (gemini-cli) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is
-# openai/<model.name>), which the in-pod gateway forwards to the discovered
+# The eval agent (gemini-cli) calls `Qwen/Qwen3.6-27B` (EVAL_MODEL is
+# <model.name>), which the in-pod gateway forwards to the discovered
 # in-cluster endpoint (epponly -> *-router-epp Service).
 #
 # Cluster-specific values (storage class, serviceAccount, runAsUser) live in a
@@ -31,6 +31,7 @@
 scenario:
   - name: "eval-aider-polyglot-gpu"
 
+<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -41,6 +42,20 @@ scenario:
         maxModelLen: 16000
         blockSize: 64
         gpuMemoryUtilization: 0.95
+=======
+    # -------------------------------------------------------------------------
+    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>.
+    # -------------------------------------------------------------------------
+    model:
+      name: Qwen/Qwen3.6-27B
+      shortName: qwen-qwen36-27b
+      path: models/Qwen/Qwen3.6-27B
+      huggingfaceId: Qwen/Qwen3.6-27B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+>>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -1,12 +1,12 @@
 # eval-containers / aider-polyglot example scenario -- GPU-SERVED variant
-# (cluster-generic), serving Qwen/Qwen3-32B on a single GPU (TP=1).
+# (cluster-generic), serving Qwen/Qwen3.6-27B on a single GPU (TP=1).
 #
 # Unlike the run-only "-pp" scenario (external LiteLLM via `-U`), this STANDS UP
-# Qwen/Qwen3-32B on a GPU the standard llm-d way (modelservice) and drives the
+# Qwen/Qwen3.6-27B on a GPU the standard llm-d way (modelservice) and drives the
 # eval-containers harness against that IN-CLUSTER endpoint -- no `-U`, no key.
 #
-# Served model: Qwen/Qwen3-32B, TP=1, on a single GPU.
-# The eval agent (gemini-cli) calls `openai/Qwen/Qwen3-32B` (EVAL_MODEL is
+# Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU.
+# The eval agent (gemini-cli) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is
 # openai/<model.name>), which the in-pod gateway forwards to the discovered
 # in-cluster endpoint (epponly -> *-router-epp Service).
 #
@@ -24,7 +24,7 @@
 #   llmdbenchmark --spec examples/eval-containers-aider-polyglot-gpu teardown \
 #     --cluster-config <cc> -p "$NS"
 #
-# aider-polyglot runs fully offline. Qwen3-32B is public on HF.
+# aider-polyglot runs fully offline. Qwen3.6-27B is public on HF.
 #
 # All parameters not defined here use defaults.yaml.
 

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -52,14 +52,24 @@ scenario:
           size: 1Ti
         uriProtocol: hf
 
-        images:
-          vllm:
-            repository: docker.io/vllm/vllm-openai
-            tag: latest
-          benchmark:
-            repository: ghcr.io/exgentic/evals/aider-polyglot--gemini-cli-standalone
-            tag: latest
-            pullPolicy: Always
+      # NOTE: this block must sit at `common.images`, NOT nested inside
+      # `common.storage`. Indented one level deeper it parses as
+      # common.storage.images, which nothing reads -- the harness then silently
+      # falls back to images.benchmark from defaults.yaml
+      # (ghcr.io/llm-d/llm-d-benchmark), an image with no /entrypoint.sh and no
+      # /usr/local/bin/run, so the harness container dies with exit 127 after
+      # ~18s having produced no task artifacts.
+      images:
+        vllm:
+          repository: docker.io/vllm/vllm-openai
+          tag: latest
+        benchmark:
+          # 2026-08-11 latest: 2-attempt grading (agent receives test failures
+          # after first attempt and gets one more try), plus fixed unpassable
+          # tasks and hidden test suite (PR #337 + #347, Exgentic/eval-containers).
+          repository: ghcr.io/exgentic/evals/aider-polyglot--gemini-cli-standalone
+          tag: latest
+          pullPolicy: Always
 
       vllmCommon:
         shmMemory: 4Gi

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -153,5 +153,24 @@ scenario:
       extraEnvVars:
         - name: EVAL_TIMEOUT
           value: "1500"
+        # Force the OpenAI wire. gemini-cli speaks the Gemini v1beta protocol
+        # (`/v1beta/models/<model>:generateContent`), but llm-d/vLLM serves the
+        # OpenAI wire only. Without this, /opt/gateway/start renders its NATIVE
+        # ROUTING mode -- caddy stamps X-Eval-Wire from the inbound path and one
+        # governance rule per provider keys on it -- so gemini-cli's requests are
+        # routed to bifrost's gemini provider and every call fails with:
+        #   BadRequest - no parser registered matching path suffix for:
+        #   /v1beta/models/Qwen/Qwen3.6-27B:generateContent
+        # The agent then silently writes a stub solution (observed: a literal
+        # `???` where a Rust type belonged), so the task scores 0 for what looks
+        # like a model-quality failure rather than a transport one.
+        #
+        # Setting EVAL_MODEL_API selects the image's WIRE OVERRIDE mode instead:
+        # a single cel_expression="true" rule pinning provider=openai and
+        # model=EVAL_MODEL. EVAL_MODEL itself stays the bare slashed handle.
+        # Verified against the image: renders id=pin, cel="true",
+        # provider="openai", model="Qwen/Qwen3.6-27B".
+        - name: EVAL_MODEL_API
+          value: openai
 
     workDir: "~/data/eval-aider-polyglot-gpu"

--- a/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot-gpu.yaml
@@ -31,7 +31,6 @@
 scenario:
   - name: "eval-aider-polyglot-gpu"
 
-<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -39,23 +38,14 @@ scenario:
         path: models/Qwen/Qwen3.6-27B
         huggingfaceId: Qwen/Qwen3.6-27B
         size: 1Ti
-        maxModelLen: 16000
+        # 32768, not 16000: at 16k, tasks that carry a repo's worth of context
+        # plus a <think> block hit the ceiling mid-solution and the request is
+        # rejected rather than answered. Note this HALVES per-pod concurrency --
+        # KV cache is a fixed token budget, so doubling context doubles the
+        # per-request reservation. Size -j off free GPUs accordingly.
+        maxModelLen: 32768
         blockSize: 64
         gpuMemoryUtilization: 0.95
-=======
-    # -------------------------------------------------------------------------
-    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>.
-    # -------------------------------------------------------------------------
-    model:
-      name: Qwen/Qwen3.6-27B
-      shortName: qwen-qwen36-27b
-      path: models/Qwen/Qwen3.6-27B
-      huggingfaceId: Qwen/Qwen3.6-27B
-      size: 1Ti
-      maxModelLen: 16000
-      blockSize: 64
-      gpuMemoryUtilization: 0.95
->>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:
@@ -141,6 +131,11 @@ scenario:
             - --enable-auto-tool-choice
             - --tool-call-parser
             - qwen3_coder
+            # --reasoning-parser qwen3: Qwen3.6-27B is a hybrid-reasoning model.
+            # Without this flag vLLM returns the <think> trace as ordinary content,
+            # so the agent receives reasoning prose where it expects a tool call.
+            - --reasoning-parser
+            - qwen3
 
     harness:
       name: eval-containers

--- a/config/scenarios/examples/eval-containers-aider-polyglot.yaml
+++ b/config/scenarios/examples/eval-containers-aider-polyglot.yaml
@@ -72,6 +72,7 @@ scenario:
         # The harness pod runs THIS image: agent + in-pod gateway + grader + otel,
         # the single-container standalone bundle. Swap for any published
         # evals/<benchmark>--<agent>-standalone image to run a different eval.
+        # 2026-08-11 latest: 2-attempt grading (PR #337 + #347, Exgentic/eval-containers).
         benchmark:
           repository: ghcr.io/exgentic/evals/aider-polyglot--claude-code-standalone
           tag: latest
@@ -218,6 +219,21 @@ scenario:
       # runAsUser and serviceAccount are OpenShift-specific.
       # Set them in your --cluster-config file (see docs/openshift-setup.md).
       # A real agent + in-pod gateway runs here, not a load generator -- give it room.
+      extraEnvVars:
+        # Per-task agent wall-clock cap (seconds), read by the image's run-agent.
+        # The image default of 300 truncates a reasoning model mid-edit. NOTE this
+        # is PER ATTEMPT: images with 2-attempt grading re-invoke run-agent on a
+        # failed first try, so a task's wall-clock can reach ~2x this value.
+        - name: EVAL_TIMEOUT
+          value: "1500"
+        # If you swap the image above for the gemini-cli variant, ALSO set
+        #   - name: EVAL_MODEL_API
+        #     value: openai
+        # gemini-cli speaks the Gemini v1beta wire
+        # (/v1beta/models/<model>:generateContent), which bifrost cannot parse
+        # against an OpenAI-only upstream: every call 400s, the agent writes a
+        # stub solution, and the run scores ~0 -- looking like a model failure
+        # rather than a transport one. Not needed for claude-code (this image).
       resources:
         cpu: "2"
         memory: 6Gi

--- a/config/scenarios/examples/eval-containers-gaia-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-gaia-gpu.yaml
@@ -6,7 +6,7 @@
 # against that IN-CLUSTER served endpoint -- no `-U`, no external key.
 #
 # Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU (e.g. NVIDIA-H100-80GB).
-# The eval agent (codex) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is derived
+# The eval agent (codex) calls `Qwen/Qwen3.6-27B` (EVAL_MODEL is derived
 # from model.name), which the in-pod bifrost gateway forwards to the deployed
 # endpoint that step_03 auto-discovers (epponly -> the *-router-epp Service).
 #
@@ -32,6 +32,7 @@
 scenario:
   - name: "eval-gaia-gpu"
 
+<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -42,6 +43,21 @@ scenario:
         maxModelLen: 16000
         blockSize: 64
         gpuMemoryUtilization: 0.95
+=======
+    # -------------------------------------------------------------------------
+    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>,
+    # so it MUST be the id the agent calls.
+    # -------------------------------------------------------------------------
+    model:
+      name: Qwen/Qwen3.6-27B
+      shortName: qwen-qwen36-27b
+      path: models/Qwen/Qwen3.6-27B
+      huggingfaceId: Qwen/Qwen3.6-27B
+      size: 1Ti
+      maxModelLen: 16000
+      blockSize: 64
+      gpuMemoryUtilization: 0.95
+>>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:

--- a/config/scenarios/examples/eval-containers-gaia-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-gaia-gpu.yaml
@@ -32,7 +32,6 @@
 scenario:
   - name: "eval-gaia-gpu"
 
-<<<<<<< HEAD
     common:
       model:
         name: Qwen/Qwen3.6-27B
@@ -40,24 +39,14 @@ scenario:
         path: models/Qwen/Qwen3.6-27B
         huggingfaceId: Qwen/Qwen3.6-27B
         size: 1Ti
-        maxModelLen: 16000
+        # 32768, not 16000: at 16k, tasks that carry a repo's worth of context
+        # plus a <think> block hit the ceiling mid-solution and the request is
+        # rejected rather than answered. Note this HALVES per-pod concurrency --
+        # KV cache is a fixed token budget, so doubling context doubles the
+        # per-request reservation. Size -j off free GPUs accordingly.
+        maxModelLen: 32768
         blockSize: 64
         gpuMemoryUtilization: 0.95
-=======
-    # -------------------------------------------------------------------------
-    # Model -- the SERVED model. model.name flows to EVAL_MODEL=<name>,
-    # so it MUST be the id the agent calls.
-    # -------------------------------------------------------------------------
-    model:
-      name: Qwen/Qwen3.6-27B
-      shortName: qwen-qwen36-27b
-      path: models/Qwen/Qwen3.6-27B
-      huggingfaceId: Qwen/Qwen3.6-27B
-      size: 1Ti
-      maxModelLen: 16000
-      blockSize: 64
-      gpuMemoryUtilization: 0.95
->>>>>>> 9df43bf (fix(eval-containers): EVAL_MODEL must be a bare model handle)
 
       storage:
         modelPvc:
@@ -159,6 +148,11 @@ scenario:
             - --enable-auto-tool-choice
             - --tool-call-parser
             - qwen3_coder
+            # --reasoning-parser qwen3: Qwen3.6-27B is a hybrid-reasoning model.
+            # Without this flag vLLM returns the <think> trace as ordinary content,
+            # so the agent receives reasoning prose where it expects a tool call.
+            - --reasoning-parser
+            - qwen3
 
     harness:
       name: eval-containers

--- a/config/scenarios/examples/eval-containers-gaia-gpu.yaml
+++ b/config/scenarios/examples/eval-containers-gaia-gpu.yaml
@@ -5,8 +5,8 @@
 # the standard llm-d way (modelservice) and drives the eval-containers harness
 # against that IN-CLUSTER served endpoint -- no `-U`, no external key.
 #
-# Served model: Qwen/Qwen3-32B, TP=1, on a single GPU (e.g. NVIDIA-H100-80GB).
-# The eval agent (codex) calls `openai/Qwen/Qwen3-32B` (EVAL_MODEL is derived
+# Served model: Qwen/Qwen3.6-27B, TP=1, on a single GPU (e.g. NVIDIA-H100-80GB).
+# The eval agent (codex) calls `openai/Qwen/Qwen3.6-27B` (EVAL_MODEL is derived
 # from model.name), which the in-pod bifrost gateway forwards to the deployed
 # endpoint that step_03 auto-discovers (epponly -> the *-router-epp Service).
 #
@@ -25,7 +25,7 @@
 #     --cluster-config <cc> -p "$NS"
 #
 # GAIA is a web/tool agentic task (harness pod needs internet egress).
-# Qwen/Qwen3-32B is public on HF, so `uriProtocol: hf` auto-downloads it.
+# Qwen/Qwen3.6-27B is public on HF, so `uriProtocol: hf` auto-downloads it.
 #
 # All parameters not defined here use defaults.yaml.
 
@@ -153,5 +153,21 @@ scenario:
       resources:
         cpu: "2"
         memory: 6Gi
+      # Per-task agent wall-clock timeout (seconds), read by the exgentic image's
+      # run-agent (`timeout $TIMEOUT`). The image default of 300 silently truncates
+      # tasks mid-solution -- the agent is killed while still working, so the run
+      # under-reports the pass rate rather than failing loudly. GAIA's multi-step
+      # web-fetch tasks are at least as exposed as aider-polyglot, which needed
+      # 1500 (max observed runtime there ~1020s); match it.
+      #
+      # EVAL_GAIA_SUBSET=no-search selects the 54-task subset that drops tasks
+      # requiring a search engine, keeping web-fetch + offline tasks. Without a
+      # search backend wired up, search tasks cannot pass, so including them only
+      # depresses the score.
+      extraEnvVars:
+        - name: EVAL_TIMEOUT
+          value: "1500"
+        - name: EVAL_GAIA_SUBSET
+          value: "no-search"
 
     workDir: "~/data/eval-gaia-gpu"

--- a/config/scenarios/examples/eval-containers-gaia.yaml
+++ b/config/scenarios/examples/eval-containers-gaia.yaml
@@ -61,34 +61,41 @@ scenario:
             - ReadWriteOnce
         uriProtocol: hf
 
-        images:
-          vllmOpenai:
-            repository: ghcr.io/llm-d/llm-d-inference-sim
-            tag: latest
-          vllm:
-            repository: ghcr.io/llm-d/llm-d-inference-sim
-            tag: latest
-          # The harness pod runs THIS image: agent + in-pod gateway + grader + otel,
-          # the single-container standalone bundle. Swap for any published
-          # evals/<benchmark>--<agent>-standalone image to run a different eval.
-          benchmark:
-            # codex agent: its web search is client-side, so it works on
-            # non-Anthropic served models (unlike claude-code's server-side one).
-            repository: ghcr.io/exgentic/evals/gaia--codex-standalone
-            tag: v0.1.0
-            pullPolicy: IfNotPresent
+      # NOTE: `images` and `vllmCommon` belong at `common.<key>`, NOT nested
+      # inside `common.storage`. One level deeper they parse as
+      # common.storage.images / common.storage.vllmCommon, which nothing reads,
+      # and the harness silently falls back to images.benchmark from
+      # defaults.yaml (ghcr.io/llm-d/llm-d-benchmark) -- an image with no
+      # /entrypoint.sh and no /usr/local/bin/run, so the harness container exits
+      # 127 within ~20s having produced no task artifacts.
+      images:
+        vllmOpenai:
+          repository: ghcr.io/llm-d/llm-d-inference-sim
+          tag: latest
+        vllm:
+          repository: ghcr.io/llm-d/llm-d-inference-sim
+          tag: latest
+        # The harness pod runs THIS image: agent + in-pod gateway + grader + otel,
+        # the single-container standalone bundle. Swap for any published
+        # evals/<benchmark>--<agent>-standalone image to run a different eval.
+        benchmark:
+          # codex agent: its web search is client-side, so it works on
+          # non-Anthropic served models (unlike claude-code's server-side one).
+          repository: ghcr.io/exgentic/evals/gaia--codex-standalone
+          tag: v0.1.0
+          pullPolicy: IfNotPresent
 
-        vllmCommon:
-          shmMemory: 500Mi
-          volumes:
-            - name: dshm
-              type: emptyDir
-              emptyDir:
-                medium: Memory
-                sizeLimit: 500Mi
-          volumeMounts:
-            - name: dshm
-              mountPath: /dev/shm
+      vllmCommon:
+        shmMemory: 500Mi
+        volumes:
+          - name: dshm
+            type: emptyDir
+            emptyDir:
+              medium: Memory
+              sizeLimit: 500Mi
+        volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
 
     # =========================================================================
     # STANDALONE -- Only applies when standalone.enabled: true

--- a/config/scenarios/examples/eval-containers-gaia.yaml
+++ b/config/scenarios/examples/eval-containers-gaia.yaml
@@ -224,6 +224,20 @@ scenario:
       # runAsUser and serviceAccount are OpenShift-specific.
       # Set them in your --cluster-config file (see docs/openshift-setup.md).
       # A real agent + in-pod gateway runs here, not a load generator -- give it room.
+      extraEnvVars:
+        # Per-task agent wall-clock cap (seconds), read by the image's run-agent.
+        # The image default of 300 truncates a reasoning model mid-task. NOTE this
+        # is PER ATTEMPT: images with 2-attempt grading re-invoke run-agent on a
+        # failed first try, so a task's wall-clock can reach ~2x this value.
+        - name: EVAL_TIMEOUT
+          value: "1500"
+        # GAIA's full set is 165 tasks, most of which need live web search. The
+        # agent's search is client-side, so in a cluster without egress those
+        # tasks fail for connectivity, not model quality. no-search is the 54
+        # tasks answerable without it -- the only subset whose score means
+        # anything here. Drop this to run all 165.
+        - name: EVAL_GAIA_SUBSET
+          value: no-search
       resources:
         cpu: "2"
         memory: 6Gi

--- a/config/templates/jinja/04_download_job.yaml.j2
+++ b/config/templates/jinja/04_download_job.yaml.j2
@@ -15,6 +15,22 @@ spec:
       containers:
         - name: downloader
           image: {{ images.benchmark.repository }}:{{ images.benchmark.tag }}
+          # Without this, a :latest tag makes Kubernetes default to
+          # imagePullPolicy: Always, so the node re-pulls the whole image on every
+          # standup even when it is already cached. That is invisible for a small
+          # image but not for a large one: with an agentic harness image (an agent
+          # CLI plus a multi-language toolchain, several GB) the pull outlived the
+          # download job's own timeout, so the job failed before transferring a
+          # single byte of weights -- surfacing as a weight-download timeout that
+          # points at storage or HuggingFace rather than at an image pull.
+          #
+          # IfNotPresent rather than changing which image this job runs: the pull
+          # policy is the actual cause, it is one line, and it keeps working
+          # whatever image a user points images.benchmark at. A user can also pin
+          # a hard version tag to get the same effect, but that is a workaround
+          # for a default that is wrong for this job -- nothing here needs a fresh
+          # pull, since the container only pip-installs huggingface_hub and exits.
+          imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/docs/agentic_eval.md
+++ b/docs/agentic_eval.md
@@ -91,13 +91,24 @@ Shipped examples: `config/scenarios/examples/eval-containers-{gaia,aider-polyglo
       entrypoint: /workspace/harnesses/eval-containers-llm-d-benchmark.sh
       resources: { cpu: "2", memory: 6Gi }
     model:
-      name: <model-id>                      # becomes EVAL_MODEL=openai/<name>
+      name: <model-id>                      # becomes EVAL_MODEL=<name>, BARE
       huggingfaceId: <hf-id-or-served-id>
 ```
 
 Change `images.benchmark` + `harness.experimentProfile` to point at a different
 benchmark/agent. The `model`/`decode`/`prefill`/`storage` blocks describe **how
 the model is served** (next section).
+
+`EVAL_MODEL` must stay a **bare** handle: the in-pod gateway carries the provider
+separately, so an `openai/` prefix becomes part of the model *name*, is looked up
+in the OpenAI catalog, and 404s every agent call — reward `0.0`, empty agent
+stdout, harness rc `0`. Silent green.
+
+Useful `harness.extraEnvVars` (see the shipped examples): `EVAL_TIMEOUT` raises
+the image's 300s per-task cap, which truncates reasoning models — it is applied
+**per attempt**, so images with 2-attempt grading can run ~2x it;
+`EVAL_GAIA_SUBSET=no-search` keeps GAIA's 54 egress-free tasks; and for
+`gemini-cli` images `EVAL_MODEL_API=openai` is **required**, not optional.
 
 **Keep scenarios cluster-agnostic.** RWX storage class, service account, and root
 privilege belong in a `--cluster-config` file
@@ -166,9 +177,31 @@ Per task, `eval-containers-<id>_<n>/` contains:
 | `model/gateway.log` | The in-pod gateway — first place to look on a call failure. |
 | `traces.jsonl` | One OTel batch per model call. **0 lines = no calls reached the model.** |
 
-There is **no aggregate score**: each task writes its own `result.json`. A healthy run:
- gateway logs a successful startup, `traces.jsonl` has `llm.call` spans with status `200`, 
- and `stdout.log` is non-empty and free of `API Error`.
+A healthy run: gateway logs a successful startup, `traces.jsonl` has spans with
+status `200`, and `stdout.log` is non-empty and free of `API Error`.
+
+### Run-level aggregate
+
+`--analyze` also rolls every task up into `agentic-summary/` at the results root
+(one task per pod means the per-task reports alone can't answer "how did the run
+do"):
+
+| File | Contains |
+|---|---|
+| `agentic_run_report.yaml` | Benchmark-report v0.2 for the whole run: pass rate, pooled LLM-call latency, token totals, and per-language pass rates for `aider-polyglot`. |
+| `agentic_tasks.csv` | One row per task — score, exit code, call count, latency, tokens. Units are in the column names. |
+
+```bash
+grep -E 'tasks|passed_count|pass_rate|total_tokens' \
+  <results>/agentic-summary/agentic_run_report.yaml
+column -s, -t < <results>/agentic-summary/agentic_tasks.csv
+```
+
+Scores live under `results.observability` as `eval_containers_*` keys. Read
+`_tasks_exit_timeout` and `_tasks_exit_error` beside the pass rate: a task killed
+at `EVAL_TIMEOUT` scores 0 without the model having failed. `_ttft_discarded_calls`
+counts time-to-first-token values rejected as impossible (larger than their own
+call), so a low `_ttft_valid_calls` means treat that metric as thin.
 
 ### Debugging
 

--- a/llmdbenchmark/analysis/aggregate_eval_containers.py
+++ b/llmdbenchmark/analysis/aggregate_eval_containers.py
@@ -256,7 +256,9 @@ class _TaskMetrics:
         self.last_call_end_ns = last_end
         self.task_llm_span_s = (
             (last_end - first_start) / 1e9
-            if first_start is not None and last_end is not None and last_end > first_start
+            if first_start is not None
+            and last_end is not None
+            and last_end > first_start
             else None
         )
 
@@ -416,7 +418,9 @@ def _build_report(tasks: list[_TaskMetrics]) -> dict:
         observability["eval_containers_reward_mean"] = sum(rewards) / scored
         observability["eval_containers_reward_sum"] = sum(rewards)
     if llm_calls:
-        observability["eval_containers_llm_calls_per_task_mean"] = llm_calls / len(tasks)
+        observability["eval_containers_llm_calls_per_task_mean"] = llm_calls / len(
+            tasks
+        )
 
     # Per-language pass rates, so a task-mix shift is not mistaken for a
     # regression. Only meaningful for the language-ordered polyglot dataset.
@@ -474,8 +478,9 @@ def _build_report(tasks: list[_TaskMetrics]) -> dict:
                 "native": {
                     "args": {
                         "harness": "eval-containers",
-                        "benchmark": benchmarks[0] if len(benchmarks) == 1 else
-                        ",".join(benchmarks),
+                        "benchmark": benchmarks[0]
+                        if len(benchmarks) == 1
+                        else ",".join(benchmarks),
                         "model": models[0] if len(models) == 1 else ",".join(models),
                         "workload_type": "agentic-multi-turn",
                         "aggregation": "run-level",

--- a/llmdbenchmark/analysis/aggregate_eval_containers.py
+++ b/llmdbenchmark/analysis/aggregate_eval_containers.py
@@ -215,6 +215,7 @@ class _TaskMetrics:
         self.harness_rc = metadata.get("harness_rc")
         self.model = str(metadata.get("model") or "")
         self.task_latency_s = _duration_seconds(metadata.get("harness_delta"))
+        self.harness_start_ns = _iso_to_unix_ns(metadata.get("harness_start"))
 
         self.call_latencies_ms: list[float] = []
         self.input_tokens = 0
@@ -290,6 +291,32 @@ def _latency_ms(attrs: dict, start_ns: int, end_ns: int) -> float | None:
     if start_ns and end_ns and end_ns > start_ns:
         return (end_ns - start_ns) / 1e6
     return None
+
+
+def _iso_to_unix_ns(value: Any) -> int | None:
+    """Parse the harness's ISO-8601 ``harness_start`` into unix nanoseconds.
+
+    Needed to anchor time-to-first-call: the span clock is unix-epoch
+    nanoseconds, so the task's own start has to be expressed in the same units.
+    Returns None on anything unparseable, so the metric is blanked rather than
+    guessed.
+    """
+    if value is None:
+        return None
+    text = str(value).strip().strip('"')
+    if not text:
+        return None
+    try:
+        from datetime import datetime
+
+        dt = datetime.fromisoformat(text)
+    except (ValueError, ImportError):
+        return None
+    if dt.tzinfo is None:
+        # The harness writes an offset; a naive value would silently be read as
+        # local time and skew the delta by hours.
+        return None
+    return int(dt.timestamp() * 1e9)
 
 
 def _duration_seconds(delta: Any) -> float | None:
@@ -514,15 +541,15 @@ def _time_to_first_call_s(task: _TaskMetrics) -> float | str:
     anchor, and anchoring to the first span would define the answer as 0. Blank
     rather than fabricated when either input is missing.
     """
-    if task.task_latency_s is None or task.first_call_start_ns is None:
+    if task.first_call_start_ns is None or task.harness_start_ns is None:
         return ""
-    if task.last_call_end_ns is None:
+    delta_s = (task.first_call_start_ns - task.harness_start_ns) / 1e9
+    # A negative delta means the two clocks disagree (harness_start is written by
+    # the pod's shell, span timestamps by the gateway), so the figure would be
+    # meaningless rather than merely imprecise. Blank it instead.
+    if delta_s < 0:
         return ""
-    # Task end is known only to the second, so derive the start from it.
-    task_end_ns = task.last_call_end_ns
-    task_start_ns = task_end_ns - int(task.task_latency_s * 1e9)
-    delta_s = (task.first_call_start_ns - task_start_ns) / 1e9
-    return delta_s if delta_s >= 0 else ""
+    return delta_s
 
 
 def generate_agentic_summary(

--- a/llmdbenchmark/analysis/aggregate_eval_containers.py
+++ b/llmdbenchmark/analysis/aggregate_eval_containers.py
@@ -1,0 +1,571 @@
+"""Run-level aggregation for the eval-containers agentic harness.
+
+The framework runs ONE benchmark task per parallel harness pod, so a 50-task
+scenario leaves 50 result directories each holding a single-task benchmark
+report. Nothing rolls those up: ``cross_treatment.py`` treats every directory as
+a separate experimental *treatment* (its intended meaning -- one row per
+configuration, compared side by side), which for this harness produces N rows
+that look like N configurations of one task each. It also carries no
+``observability`` columns, so the score cannot appear there at all.
+
+This module answers the question a run actually poses: across all N tasks, what
+was the score, the latency, and the token usage? It reads only artifacts that
+already exist and writes two files under ``agentic-summary/``:
+
+* ``agentic_run_report.yaml`` -- one v0.2-shaped benchmark report for the whole
+  run, so existing tooling can read it.
+* ``agentic_tasks.csv`` -- one row per task, with units in the column names.
+
+Deliberately NOT written as ``benchmark_report_v0.2*.yaml`` at the results root:
+``cross_treatment`` discovers inputs by that glob, and a run-level report sitting
+there would be re-ingested as if it were another task.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from llmdbenchmark.analysis.benchmark_report.base import Units
+from llmdbenchmark.analysis.benchmark_report.core import load_benchmark_report
+from llmdbenchmark.analysis.benchmark_report.native_to_br0_2 import (
+    agentic_stat,
+    is_agentic_request_span,
+)
+
+# aider-polyglot ships language-ordered, so a task id implies its language. Used
+# to report per-language pass rates: a contiguous slice of this dataset is
+# effectively single-language, and mixing languages without splitting them hides
+# that (e.g. a python-heavy wave scoring lower than a javascript-heavy one is a
+# task-mix effect, not a regression). Upper bounds inclusive.
+_POLYGLOT_LANGUAGE_BOUNDS: tuple[tuple[int, str], ...] = (
+    (25, "cpp"),
+    (64, "go"),
+    (111, "java"),
+    (160, "javascript"),
+    (194, "python"),
+    (224, "rust"),
+)
+
+_CSV_COLUMNS = [
+    "task_id",
+    "benchmark",
+    "language",
+    "passed",
+    "reward",
+    "exit_code",
+    "harness_rc",
+    "llm_calls",
+    "call_errors",
+    "retries",
+    "call_latency_mean_ms",
+    "call_latency_p50_ms",
+    "call_latency_max_ms",
+    "task_latency_s",
+    "task_llm_span_s",
+    "time_to_first_call_s",
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+]
+
+
+def _log(context: Any, message: str) -> None:
+    if context is not None and getattr(context, "logger", None) is not None:
+        context.logger.log_info(message)
+
+
+def _polyglot_language(task_id: int | None) -> str:
+    if task_id is None:
+        return ""
+    for upper, name in _POLYGLOT_LANGUAGE_BOUNDS:
+        if task_id <= upper:
+            return name
+    return ""
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _read_yaml(path: Path) -> dict:
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _read_exit_code(task_dir: Path) -> int | None:
+    """Read ``agent/.exit-code``.
+
+    Two-attempt images rewrite this file to attempt 2's status and preserve
+    attempt 1 as ``.exit-code-1``; the retry wrapper resets it to 0 when the
+    first attempt was clean. Whatever it ends up holding is the value the
+    dashboard reads, so that is the value reported here. Note the file has no
+    trailing newline, so it must be read per-file -- concatenating several
+    yields one run-together string.
+    """
+    path = task_dir / "agent" / ".exit-code"
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _read_reward(task_dir: Path) -> tuple[float | None, bool | None, str, int | None]:
+    """Return ``(reward, passed, benchmark, task_id)`` for one task.
+
+    ``task/result.json`` is authoritative. Fall back to
+    ``logs/verifier/reward.txt`` (the grader writes it before the result file, so
+    it survives a task that died between the two).
+    """
+    result = _read_json(task_dir / "task" / "result.json")
+    benchmark = str(result.get("benchmark") or "")
+
+    task_id = result.get("task_id")
+    if task_id is None:
+        task_id = _read_yaml(task_dir / "run_metadata.yaml").get("task_id")
+    try:
+        task_id_int = int(task_id)
+    except (TypeError, ValueError):
+        task_id_int = None
+
+    if "reward" in result:
+        reward = result.get("reward")
+        passed = result.get("passed")
+        try:
+            reward_f = float(reward)
+        except (TypeError, ValueError):
+            reward_f = None
+        if passed is None and reward_f is not None:
+            passed = reward_f >= 1.0
+        return reward_f, passed, benchmark, task_id_int
+
+    try:
+        text = (task_dir / "logs" / "verifier" / "reward.txt").read_text(
+            encoding="utf-8"
+        )
+        reward_f = float(text.strip())
+    except (OSError, ValueError):
+        return None, None, benchmark, task_id_int
+    return reward_f, reward_f >= 1.0, benchmark, task_id_int
+
+
+def _iter_call_spans(traces: Path):
+    """Yield ``(name, attributes, start_ns, end_ns)`` for every span in a file."""
+    try:
+        lines = traces.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            doc = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        for resource_spans in doc.get("resourceSpans", []):
+            for scope_spans in resource_spans.get("scopeSpans", []):
+                for span in scope_spans.get("spans", []):
+                    attrs = {
+                        a.get("key", ""): a.get("value", {})
+                        for a in span.get("attributes", [])
+                    }
+                    yield (
+                        span.get("name", ""),
+                        attrs,
+                        int(span.get("startTimeUnixNano", 0) or 0),
+                        int(span.get("endTimeUnixNano", 0) or 0),
+                    )
+
+
+def _int_attr(attrs: dict, key: str) -> int:
+    value = attrs.get(key)
+    if not value:
+        return 0
+    return int(value.get("intValue") or 0)
+
+
+class _TaskMetrics:
+    """Per-task metrics gathered from one result directory."""
+
+    def __init__(self, task_dir: Path):
+        self.name = task_dir.name
+        reward, passed, benchmark, task_id = _read_reward(task_dir)
+        self.reward = reward
+        self.passed = passed
+        self.benchmark = benchmark
+        self.task_id = task_id
+        self.exit_code = _read_exit_code(task_dir)
+
+        metadata = _read_yaml(task_dir / "run_metadata.yaml")
+        self.harness_rc = metadata.get("harness_rc")
+        self.model = str(metadata.get("model") or "")
+        self.task_latency_s = _duration_seconds(metadata.get("harness_delta"))
+
+        self.call_latencies_ms: list[float] = []
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.call_errors = 0
+        self.retries = 0
+        self.ttft_values_s: list[float] = []
+        self.ttft_discarded = 0
+
+        first_start: int | None = None
+        last_end: int | None = None
+        for name, attrs, start_ns, end_ns in _iter_call_spans(
+            task_dir / "traces.jsonl"
+        ):
+            # Usage rides on the provider span, not the HTTP span.
+            if "gen_ai.usage.input_tokens" in attrs:
+                self.input_tokens += _int_attr(attrs, "gen_ai.usage.input_tokens")
+                self.output_tokens += _int_attr(attrs, "gen_ai.usage.output_tokens")
+            if "gen_ai.error" in attrs or "gen_ai.error.type" in attrs:
+                self.call_errors += 1
+            self.retries += _int_attr(attrs, "gen_ai.number_of_retries")
+
+            latency_ms = _latency_ms(attrs, start_ns, end_ns)
+            if latency_ms is not None:
+                self._record_ttft(attrs, latency_ms)
+
+            if not is_agentic_request_span(name):
+                continue
+            if start_ns and end_ns and end_ns > start_ns:
+                self.call_latencies_ms.append((end_ns - start_ns) / 1e6)
+                first_start = (
+                    start_ns if first_start is None else min(first_start, start_ns)
+                )
+                last_end = end_ns if last_end is None else max(last_end, end_ns)
+
+        self.llm_calls = len(self.call_latencies_ms)
+        self.first_call_start_ns = first_start
+        self.last_call_end_ns = last_end
+        self.task_llm_span_s = (
+            (last_end - first_start) / 1e9
+            if first_start is not None and last_end is not None and last_end > first_start
+            else None
+        )
+
+    def _record_ttft(self, attrs: dict, latency_ms: float) -> None:
+        """Collect time-to-first-token, discarding values that cannot be real.
+
+        The raw attribute's unit is not dependable: on a 54-task GAIA run its
+        maximum implied 2,838 s inside an 823 s call. Rather than trust a
+        documented scale factor, interpret it as microseconds and keep only
+        values that fit inside their own call. A discarded count travels with
+        the metric so a thin sample is visible instead of silently averaged.
+        """
+        raw = attrs.get("gen_ai.response.time_to_first_token")
+        if not raw:
+            return
+        micros = raw.get("intValue") or raw.get("doubleValue")
+        if micros is None:
+            return
+        seconds = float(micros) / 1e6
+        if 0.0 <= seconds <= latency_ms / 1000.0:
+            self.ttft_values_s.append(seconds)
+        else:
+            self.ttft_discarded += 1
+
+
+def _latency_ms(attrs: dict, start_ns: int, end_ns: int) -> float | None:
+    reported = attrs.get("gen_ai.response.total_latency_ms")
+    if reported:
+        value = reported.get("intValue") or reported.get("doubleValue")
+        if value is not None:
+            return float(value)
+    if start_ns and end_ns and end_ns > start_ns:
+        return (end_ns - start_ns) / 1e6
+    return None
+
+
+def _duration_seconds(delta: Any) -> float | None:
+    """Parse an ISO-8601 ``PT<n>S`` duration, the form the harnesses write."""
+    if delta is None:
+        return None
+    text = str(delta).strip().strip('"')
+    if text.startswith("PT") and text.endswith("S"):
+        text = text[2:-1]
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _task_dirs(results_dir: Path) -> list[Path]:
+    return sorted(
+        d
+        for d in results_dir.iterdir()
+        if d.is_dir()
+        and d.name != "agentic-summary"
+        and d.name != "cross-treatment-comparison"
+        and (d / "run_metadata.yaml").exists()
+    )
+
+
+def _run_uid(tasks: list[_TaskMetrics]) -> str:
+    """Derive a run id from the task directory names.
+
+    Pods are named ``<experiment-id>_<parallel-index>``, so stripping the index
+    yields the experiment they shared. Falls back to the first directory name if
+    the pattern does not hold.
+    """
+    for task in tasks:
+        base, sep, tail = task.name.rpartition("_")
+        if sep and tail.isdigit():
+            return base
+    return tasks[0].name if tasks else "eval-containers"
+
+
+def _build_report(tasks: list[_TaskMetrics]) -> dict:
+    """Assemble the run-level v0.2-shaped report."""
+    latencies_ms = [ms for t in tasks for ms in t.call_latencies_ms]
+    task_latencies_s = [t.task_latency_s for t in tasks if t.task_latency_s is not None]
+    llm_spans_s = [t.task_llm_span_s for t in tasks if t.task_llm_span_s is not None]
+    ttft_s = [v for t in tasks for v in t.ttft_values_s]
+
+    rewards = [t.reward for t in tasks if t.reward is not None]
+    passed_count = sum(1 for t in tasks if t.passed)
+    scored = len(rewards)
+
+    input_tokens = sum(t.input_tokens for t in tasks)
+    output_tokens = sum(t.output_tokens for t in tasks)
+    llm_calls = sum(t.llm_calls for t in tasks)
+
+    # Prefer real wall-clock for throughput; fall back to the LLM-span proxy so a
+    # run predating the timestamps still reports a rate.
+    wall_s = sum(task_latencies_s) if task_latencies_s else sum(llm_spans_s)
+
+    latency: dict[str, Any] = {}
+    request_latency = agentic_stat(latencies_ms, Units.MS)
+    if request_latency:
+        latency["request_latency"] = request_latency
+
+    throughput: dict[str, Any] = {}
+    if wall_s > 0:
+        throughput["request_rate"] = {
+            "units": Units.QUERY_PER_S,
+            "mean": llm_calls / wall_s,
+        }
+        throughput["total_token_rate"] = {
+            "units": Units.TOKEN_PER_S,
+            "mean": (input_tokens + output_tokens) / wall_s,
+        }
+
+    observability: dict[str, Any] = {
+        "eval_containers_tasks": len(tasks),
+        "eval_containers_tasks_scored": scored,
+        "eval_containers_passed_count": passed_count,
+        "eval_containers_llm_calls": llm_calls,
+        "eval_containers_call_errors": sum(t.call_errors for t in tasks),
+        "eval_containers_retries": sum(t.retries for t in tasks),
+        "eval_containers_input_tokens": input_tokens,
+        "eval_containers_output_tokens": output_tokens,
+        "eval_containers_total_tokens": input_tokens + output_tokens,
+        "eval_containers_tasks_exit_timeout": sum(
+            1 for t in tasks if t.exit_code == 124
+        ),
+        "eval_containers_tasks_exit_error": sum(
+            1 for t in tasks if t.exit_code not in (0, 124, None)
+        ),
+        "eval_containers_ttft_valid_calls": len(ttft_s),
+        "eval_containers_ttft_discarded_calls": sum(t.ttft_discarded for t in tasks),
+    }
+    if scored:
+        observability["eval_containers_pass_rate"] = passed_count / scored
+        observability["eval_containers_reward_mean"] = sum(rewards) / scored
+        observability["eval_containers_reward_sum"] = sum(rewards)
+    if llm_calls:
+        observability["eval_containers_llm_calls_per_task_mean"] = llm_calls / len(tasks)
+
+    # Per-language pass rates, so a task-mix shift is not mistaken for a
+    # regression. Only meaningful for the language-ordered polyglot dataset.
+    by_language: dict[str, list[_TaskMetrics]] = {}
+    for task in tasks:
+        if task.benchmark == "aider-polyglot":
+            language = _polyglot_language(task.task_id)
+            if language:
+                by_language.setdefault(language, []).append(task)
+    for language, group in sorted(by_language.items()):
+        graded = [t for t in group if t.reward is not None]
+        if not graded:
+            continue
+        hits = sum(1 for t in graded if t.passed)
+        observability[f"eval_containers_pass_rate_{language}"] = hits / len(graded)
+        observability[f"eval_containers_tasks_{language}"] = len(graded)
+
+    # Task-level durations go in observability, not aggregate.latency:
+    # AggregateLatency forbids extra fields and defines only per-REQUEST slots
+    # (request_latency, TTFT, TPOT, ITL). A whole-task duration is not a request
+    # latency, so it has no slot there -- observability is the schema's
+    # extra-permitted area.
+    task_latency_stat = agentic_stat(task_latencies_s, Units.S)
+    if task_latency_stat:
+        observability["eval_containers_task_latency_seconds"] = task_latency_stat
+    llm_span_stat = agentic_stat(llm_spans_s, Units.S)
+    if llm_span_stat:
+        observability["eval_containers_task_llm_span_seconds"] = llm_span_stat
+    ttft_stat = agentic_stat(ttft_s, Units.S)
+    if ttft_stat:
+        # Deliberately NOT aggregate.latency.time_to_first_token until the
+        # emitter's unit is confirmed; see _record_ttft.
+        observability["eval_containers_ttft_seconds"] = ttft_stat
+
+    benchmarks = sorted({t.benchmark for t in tasks if t.benchmark})
+    models = sorted({t.model for t in tasks if t.model})
+
+    return {
+        "version": "0.2",
+        # run.uid is required by the schema. Reuse the experiment id the pods
+        # already share (results dirs are named <experiment>_<index>) so this
+        # report is traceable to the run that produced it, rather than minting an
+        # unrelated identifier.
+        "run": {"uid": _run_uid(tasks)},
+        "scenario": {
+            "load": {
+                "metadata": {"schema_version": "0.0.1"},
+                "standardized": {
+                    "tool": "eval-containers",
+                    "tool_version": "",
+                    "source": "sampled",
+                    "parallelism": len(tasks),
+                    "input_seq_len": {"distribution": "other", "value": 0},
+                },
+                "native": {
+                    "args": {
+                        "harness": "eval-containers",
+                        "benchmark": benchmarks[0] if len(benchmarks) == 1 else
+                        ",".join(benchmarks),
+                        "model": models[0] if len(models) == 1 else ",".join(models),
+                        "workload_type": "agentic-multi-turn",
+                        "aggregation": "run-level",
+                        "tasks_completed": len(tasks),
+                    }
+                },
+            }
+        },
+        "results": {
+            "request_performance": {
+                "aggregate": {"latency": latency, "throughput": throughput}
+            },
+            "observability": observability,
+        },
+    }
+
+
+def _write_csv(tasks: list[_TaskMetrics], path: Path) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=_CSV_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        for task in sorted(
+            tasks, key=lambda t: (t.task_id if t.task_id is not None else -1, t.name)
+        ):
+            call_stat = agentic_stat(task.call_latencies_ms, Units.MS) or {}
+            writer.writerow(
+                {
+                    "task_id": task.task_id if task.task_id is not None else "",
+                    "benchmark": task.benchmark,
+                    "language": _polyglot_language(task.task_id)
+                    if task.benchmark == "aider-polyglot"
+                    else "",
+                    "passed": task.passed if task.passed is not None else "",
+                    "reward": task.reward if task.reward is not None else "",
+                    "exit_code": task.exit_code if task.exit_code is not None else "",
+                    "harness_rc": task.harness_rc
+                    if task.harness_rc is not None
+                    else "",
+                    "llm_calls": task.llm_calls,
+                    "call_errors": task.call_errors,
+                    "retries": task.retries,
+                    "call_latency_mean_ms": call_stat.get("mean", ""),
+                    "call_latency_p50_ms": call_stat.get("p50", ""),
+                    "call_latency_max_ms": call_stat.get("max", ""),
+                    "task_latency_s": task.task_latency_s
+                    if task.task_latency_s is not None
+                    else "",
+                    "task_llm_span_s": task.task_llm_span_s
+                    if task.task_llm_span_s is not None
+                    else "",
+                    "time_to_first_call_s": _time_to_first_call_s(task),
+                    "input_tokens": task.input_tokens,
+                    "output_tokens": task.output_tokens,
+                    "total_tokens": task.input_tokens + task.output_tokens,
+                }
+            )
+
+
+def _time_to_first_call_s(task: _TaskMetrics) -> float | str:
+    """Seconds from the task's own start to its first LLM call.
+
+    Requires the harness-recorded wall-clock: without a task start there is no
+    anchor, and anchoring to the first span would define the answer as 0. Blank
+    rather than fabricated when either input is missing.
+    """
+    if task.task_latency_s is None or task.first_call_start_ns is None:
+        return ""
+    if task.last_call_end_ns is None:
+        return ""
+    # Task end is known only to the second, so derive the start from it.
+    task_end_ns = task.last_call_end_ns
+    task_start_ns = task_end_ns - int(task.task_latency_s * 1e9)
+    delta_s = (task.first_call_start_ns - task_start_ns) / 1e9
+    return delta_s if delta_s >= 0 else ""
+
+
+def generate_agentic_summary(
+    results_dir: Path | str,
+    output_dir: Path | str | None = None,
+    context: Any = None,
+) -> int:
+    """Aggregate every eval-containers task under ``results_dir``.
+
+    Returns the number of tasks aggregated (0 if there was nothing to do), so a
+    caller can log it the way the cross-treatment step does.
+    """
+    results_dir = Path(results_dir)
+    if not results_dir.is_dir():
+        return 0
+
+    task_dirs = _task_dirs(results_dir)
+    if not task_dirs:
+        _log(context, "No eval-containers task directories found for aggregation")
+        return 0
+
+    tasks = [_TaskMetrics(d) for d in task_dirs]
+
+    output_dir = Path(output_dir) if output_dir else results_dir / "agentic-summary"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    report = _build_report(tasks)
+    report_path = output_dir / "agentic_run_report.yaml"
+    # Round-trip through the schema rather than dumping the dict: it validates
+    # the output (Statistics forbids extra keys, and units are checked per field)
+    # and serializes the Units enum, which yaml.safe_dump cannot represent.
+    load_benchmark_report(report).export_yaml(str(report_path))
+
+    csv_path = output_dir / "agentic_tasks.csv"
+    _write_csv(tasks, csv_path)
+
+    observability = report["results"]["observability"]
+    passed = observability.get("eval_containers_passed_count", 0)
+    scored = observability.get("eval_containers_tasks_scored", 0)
+    _log(
+        context,
+        f"Agentic summary: {len(tasks)} tasks, {passed}/{scored} passed, "
+        f"{observability.get('eval_containers_llm_calls', 0)} LLM calls, "
+        f"{observability.get('eval_containers_total_tokens', 0)} tokens -> {report_path}",
+    )
+    return len(tasks)

--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
@@ -1555,6 +1555,30 @@ def import_inference_max(results_file: str) -> BenchmarkReportV02:
     return load_benchmark_report(br_dict)
 
 
+def agentic_stat(xs: list[float], units: Units) -> dict | None:
+    """Summarize ``xs`` in the v0.2 ``Statistics`` shape, or None if empty.
+
+    Shared by the per-task converter below and the run-level aggregator in
+    ``llmdbenchmark.analysis.aggregate_eval_containers`` so both report
+    identical numbers. Only the field names the schema's ``Statistics`` model
+    permits -- notably ``p50`` rather than ``median`` -- since that model
+    forbids extras.
+    """
+    if not xs:
+        return None
+    a = np.array(xs, dtype=float)
+    return {
+        "units": units,
+        "mean": float(a.mean()),
+        "stddev": float(a.std()),
+        "min": float(a.min()),
+        "p50": float(np.percentile(a, 50)),
+        "p90": float(np.percentile(a, 90)),
+        "p99": float(np.percentile(a, 99)),
+        "max": float(a.max()),
+    }
+
+
 def import_eval_containers(results_file: str) -> BenchmarkReportV02:
     """Convert eval-containers agentic output into a v0.2 Benchmark Report.
 
@@ -1656,19 +1680,7 @@ def import_eval_containers(results_file: str) -> BenchmarkReportV02:
                             t_last = en if t_last is None else max(t_last, en)
 
     def _stat(xs: list[float]):
-        if not xs:
-            return None
-        a = np.array(xs, dtype=float)
-        return {
-            "units": Units.MS,
-            "mean": float(a.mean()),
-            "stddev": float(a.std()),
-            "min": float(a.min()),
-            "p50": float(np.percentile(a, 50)),
-            "p90": float(np.percentile(a, 90)),
-            "p99": float(np.percentile(a, 99)),
-            "max": float(a.max()),
-        }
+        return agentic_stat(xs, Units.MS)
 
     n = n_calls
     dur_s = (

--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
@@ -1555,6 +1555,33 @@ def import_inference_max(results_file: str) -> BenchmarkReportV02:
     return load_benchmark_report(br_dict)
 
 
+#: Span-name fragments identifying a gateway's per-REQUEST span, one per LLM
+#: call. bifrost names it after the inbound path, which differs per wire:
+#: OpenAI chat/responses (completions, responses), Anthropic (messages), and
+#: Gemini (generatecontent); litellm emits litellm_request. Token usage is NOT
+#: here -- it rides on the provider span ("chat <model>") -- so these names are
+#: used only for counting calls and measuring request latency.
+#:
+#: Lowercase, and matched case-insensitively: Gemini's streaming variant is
+#: ":streamGenerateContent" with a capital G, so a case-sensitive
+#: "generateContent" test silently drops every streamed call. On a 100-task
+#: gemini-cli run that was 738 of 1037 calls (71%), which looks like a quiet
+#: undercount rather than an error.
+AGENTIC_REQUEST_SPAN_NAMES: tuple[str, ...] = (
+    "messages",
+    "completions",
+    "responses",
+    "generatecontent",
+    "litellm_request",
+)
+
+
+def is_agentic_request_span(name: str) -> bool:
+    """True if ``name`` is a gateway per-request span (one per LLM call)."""
+    lowered = name.lower()
+    return any(s in lowered for s in AGENTIC_REQUEST_SPAN_NAMES)
+
+
 def agentic_stat(xs: list[float], units: Units) -> dict | None:
     """Summarize ``xs`` in the v0.2 ``Statistics`` shape, or None if empty.
 
@@ -1657,19 +1684,9 @@ def import_eval_containers(results_file: str) -> BenchmarkReportV02:
                             else:
                                 out_tok += iv
 
-                        # one span per LLM request, across gateways: bifrost emits
-                        # /anthropic/v1/messages or /openai/.../completions; litellm
-                        # emits litellm_request. Skip the child provider span
-                        # (llm.call) so requests aren't double-counted.
-                        if not any(
-                            s in name
-                            for s in (
-                                "messages",
-                                "completions",
-                                "responses",
-                                "litellm_request",
-                            )
-                        ):
+                        # One span per LLM request. Skips the provider span
+                        # ("chat <model>") so requests aren't double-counted.
+                        if not is_agentic_request_span(name):
                             continue
                         n_calls += 1
                         st = int(sp.get("startTimeUnixNano", 0) or 0)

--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_2.py
@@ -1599,6 +1599,40 @@ def import_eval_containers(results_file: str) -> BenchmarkReportV02:
                 for ss in rs.get("scopeSpans", []):
                     for sp in ss.get("spans", []):
                         name = sp.get("name", "")
+                        attrs = {
+                            a.get("key", ""): a.get("value", {})
+                            for a in sp.get("attributes", [])
+                        }
+
+                        # Token usage rides on the PROVIDER span, not the HTTP
+                        # span. bifrost names it "chat <model>"; the HTTP span
+                        # (/openai/v1/responses, /anthropic/v1/messages) carries
+                        # routing only and no gen_ai.usage.* at all. Selecting by
+                        # attribute presence rather than span name keeps this
+                        # working across gateways instead of hard-coding each
+                        # one's naming. Counted separately from n_calls so a
+                        # provider span never inflates the request count.
+                        #
+                        # Exact keys, not endswith():
+                        # gen_ai.usage.reasoning.output_tokens also ends in
+                        # "output_tokens" and would be double-counted into the
+                        # output total on reasoning models.
+                        for tok_key, prompt_key, target in (
+                            ("gen_ai.usage.input_tokens", "prompt_tokens", "in"),
+                            ("gen_ai.usage.output_tokens", "completion_tokens", "out"),
+                        ):
+                            val = attrs.get(tok_key)
+                            if val is None:
+                                # litellm/openai-style flat naming fallback
+                                val = attrs.get(prompt_key)
+                            if val is None:
+                                continue
+                            iv = int(val.get("intValue") or 0)
+                            if target == "in":
+                                in_tok += iv
+                            else:
+                                out_tok += iv
+
                         # one span per LLM request, across gateways: bifrost emits
                         # /anthropic/v1/messages or /openai/.../completions; litellm
                         # emits litellm_request. Skip the child provider span
@@ -1620,17 +1654,6 @@ def import_eval_containers(results_file: str) -> BenchmarkReportV02:
                             lats_ms.append((en - st) / 1e6)
                             t_first = st if t_first is None else min(t_first, st)
                             t_last = en if t_last is None else max(t_last, en)
-                        for a in sp.get("attributes", []):
-                            k = a.get("key", "")
-                            iv = int(a.get("value", {}).get("intValue") or 0)
-                            if k.endswith("input_tokens") or k.endswith(
-                                "prompt_tokens"
-                            ):
-                                in_tok += iv
-                            elif k.endswith("output_tokens") or k.endswith(
-                                "completion_tokens"
-                            ):
-                                out_tok += iv
 
     def _stat(xs: list[float]):
         if not xs:

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -962,6 +962,12 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
             if getattr(args, "wait_timeout", None) is not None
             else (plan_info.get("harness", {}) or {}).get("waitTimeout") or 3600
         ),
+        data_access_lookup_attempts=int(
+            getattr(args, "data_access_lookup_attempts", None) or 5
+        ),
+        data_access_lookup_delay=float(
+            getattr(args, "data_access_lookup_delay", None) or 3.0
+        ),
         harness_debug=getattr(args, "debug", False),
         harness_skip_run=getattr(args, "skip", False),
         harness_fast_collect=getattr(args, "fast_collect", False),
@@ -1658,6 +1664,14 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_OUTPUT": ("output", "--output"),
         "LLMDBENCH_PARALLELISM": ("parallelism", "--parallelism"),
         "LLMDBENCH_WAIT_TIMEOUT": ("wait_timeout", "--wait-timeout"),
+        "LLMDBENCH_DATA_ACCESS_LOOKUP_ATTEMPTS": (
+            "data_access_lookup_attempts",
+            "--data-access-lookup-attempts",
+        ),
+        "LLMDBENCH_DATA_ACCESS_LOOKUP_DELAY": (
+            "data_access_lookup_delay",
+            "--data-access-lookup-delay",
+        ),
         "LLMDBENCH_DATASET": ("dataset", "--dataset"),
         "LLMDBENCH_ENDPOINT_URL": ("endpoint_url", "--endpoint-url"),
         "LLMDBENCH_SKIP": ("skip", "--skip"),
@@ -1761,6 +1775,8 @@ def _all_flag_forms(flag: str) -> list[str]:
         "--output": ["--output", "-r"],
         "--parallelism": ["--parallelism", "-j"],
         "--wait-timeout": ["--wait-timeout"],
+        "--data-access-lookup-attempts": ["--data-access-lookup-attempts"],
+        "--data-access-lookup-delay": ["--data-access-lookup-delay"],
         "--dataset": ["--dataset", "-x"],
         "--endpoint-url": ["--endpoint-url", "-U"],
         "--skip": ["--skip", "-z"],

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -92,6 +92,12 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     harness_output: str = "local"
     harness_parallelism: int = 1
     harness_wait_timeout: int = 3600
+    # Retry budget for locating the data-access pod, which gates result
+    # collection: a single failed API call there discards a completed run whose
+    # output is still on the PVC. Tunable because how flaky the apiserver is is a
+    # property of the cluster, not of the code.
+    data_access_lookup_attempts: int = 5
+    data_access_lookup_delay: float = 3.0
     harness_debug: bool = False
     harness_skip_run: bool = False
     # When True, collect results via a gzip'd ``oc exec | tar`` stream instead

--- a/llmdbenchmark/interface/env.py
+++ b/llmdbenchmark/interface/env.py
@@ -25,3 +25,14 @@ def env_int(name: str, default: int | None = None) -> int | None:
         return int(val)
     except ValueError:
         return default
+
+
+def env_float(name: str, default: float | None = None) -> float | None:
+    """Return env var as float, or default if not set / not parseable."""
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -2,7 +2,7 @@
 
 import argparse
 from llmdbenchmark.interface.commands import Command
-from llmdbenchmark.interface.env import env, env_bool, env_int
+from llmdbenchmark.interface.env import env, env_bool, env_float, env_int
 
 
 def add_subcommands(
@@ -139,6 +139,26 @@ def add_subcommands(
         type=int,
         default=env_int("LLMDBENCH_WAIT_TIMEOUT"),
         help="Seconds to wait for harness completion (0 = do not wait).",
+    )
+    run_parser.add_argument(
+        "--data-access-lookup-attempts",
+        type=int,
+        default=env_int("LLMDBENCH_DATA_ACCESS_LOOKUP_ATTEMPTS"),
+        help=(
+            "How many times to look for the data-access pod before giving up on "
+            "collecting results (default: 5). This lookup gates collection, so a "
+            "single failed API call would otherwise discard a completed run whose "
+            "output is still on the PVC. Raise it on a flaky cluster."
+        ),
+    )
+    run_parser.add_argument(
+        "--data-access-lookup-delay",
+        type=float,
+        default=env_float("LLMDBENCH_DATA_ACCESS_LOOKUP_DELAY"),
+        help=(
+            "Seconds between data-access pod lookup attempts (default: 3.0). "
+            "Total worst-case wait is attempts x delay."
+        ),
     )
     run_parser.add_argument(
         "--treatment-max-attempts",

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -120,6 +120,8 @@ llmdbenchmark --spec guides/inference-scheduling run -p <NS> -z
 | `-r DEST` | `LLMDBENCH_OUTPUT` | Results destination: local path, `gs://bucket`, or `s3://bucket` |
 | `-x DATASET` | `LLMDBENCH_DATASET` | Dataset URL for harness replay |
 | `--wait-timeout N` | `LLMDBENCH_WAIT_TIMEOUT` | Seconds to wait for harness completion (default: 3600) |
+| `--data-access-lookup-attempts N` | `LLMDBENCH_DATA_ACCESS_LOOKUP_ATTEMPTS` | Tries to locate the data-access pod before abandoning result collection (default: 5) |
+| `--data-access-lookup-delay S` | `LLMDBENCH_DATA_ACCESS_LOOKUP_DELAY` | Seconds between those attempts (default: 3.0) |
 | `-z` | `LLMDBENCH_SKIP` | Skip execution, only collect existing results from PVC |
 | `-d` | `LLMDBENCH_DEBUG` | Debug mode -- start harness with `sleep infinity` |
 | `--analyze` | | Run local analysis on collected results |

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -25,6 +25,7 @@ from llmdbenchmark.executor.command import CommandResult
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext, is_fma_only_mode
 from llmdbenchmark.utilities.kube_helpers import (
+    DATA_ACCESS_LABEL,
     find_data_access_pod,
     wait_for_pods_by_label,
     collect_pod_results,
@@ -693,9 +694,20 @@ class DeployHarnessStep(Step):
 
         data_pod = find_data_access_pod(cmd, namespace)
         if not data_pod:
+            # The results are NOT lost when this fails -- they are on the workload
+            # PVC, written by harness pods that have already completed. Say so, and
+            # say how to get them, because the next thing that happens is cleanup
+            # deleting the pods and the run reporting failure, which reads as
+            # "the work is gone" when it is merely uncollected.
             errors.append(
                 f"Data access pod not found in namespace '{namespace}' -- "
-                f"cannot collect results for {experiment_id}"
+                f"cannot collect results for {experiment_id}. The results are "
+                f"still on the workload PVC; recover them with:\n"
+                f"  pod=$(kubectl get pod -n {namespace} "
+                f"-l {DATA_ACCESS_LABEL} -o name | head -1)\n"
+                f"  kubectl cp -n {namespace} "
+                f'"${{pod#pod/}}:/requests/<dir>" ./<dir>   '
+                f"# dirs matching {experiment_id}_*"
             )
             return errors
 
@@ -839,9 +851,16 @@ class DeployHarnessStep(Step):
 
         data_pod = find_data_access_pod(cmd, namespace)
         if not data_pod:
+            # As above: uncollected is not lost. Point at the PVC copy.
             errors.append(
                 f"Data access pod not found in namespace '{namespace}' \u2014 "
-                f"cannot collect results for {experiment_id}"
+                f"cannot collect results for {experiment_id}. The results are "
+                f"still on the workload PVC; recover them with:\n"
+                f"  pod=$(kubectl get pod -n {namespace} "
+                f"-l {DATA_ACCESS_LABEL} -o name | head -1)\n"
+                f"  kubectl cp -n {namespace} "
+                f'"${{pod#pod/}}:/requests/<dir>" ./<dir>   '
+                f"# dirs matching {experiment_id}_*"
             )
             return errors
 

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -692,7 +692,13 @@ class DeployHarnessStep(Step):
         """
         errors: list[str] = []
 
-        data_pod = find_data_access_pod(cmd, namespace)
+        data_pod = find_data_access_pod(
+            cmd,
+            namespace,
+            attempts=context.data_access_lookup_attempts,
+            delay=context.data_access_lookup_delay,
+            context=context,
+        )
         if not data_pod:
             # The results are NOT lost when this fails -- they are on the workload
             # PVC, written by harness pods that have already completed. Say so, and
@@ -849,7 +855,13 @@ class DeployHarnessStep(Step):
         """
         errors: list[str] = []
 
-        data_pod = find_data_access_pod(cmd, namespace)
+        data_pod = find_data_access_pod(
+            cmd,
+            namespace,
+            attempts=context.data_access_lookup_attempts,
+            delay=context.data_access_lookup_delay,
+            context=context,
+        )
         if not data_pod:
             # As above: uncollected is not lost. Point at the PVC copy.
             errors.append(

--- a/llmdbenchmark/run/steps/step_09_collect_results.py
+++ b/llmdbenchmark/run/steps/step_09_collect_results.py
@@ -78,7 +78,13 @@ class CollectResultsStep(Step):
         )
 
         # Find the data-access pod
-        data_pod = find_data_access_pod(cmd, harness_ns)
+        data_pod = find_data_access_pod(
+            cmd,
+            harness_ns,
+            attempts=context.data_access_lookup_attempts,
+            delay=context.data_access_lookup_delay,
+            context=context,
+        )
         if not data_pod:
             if context.dry_run:
                 data_pod = "<dry-run-data-pod>"

--- a/llmdbenchmark/run/steps/step_12_analyze_results.py
+++ b/llmdbenchmark/run/steps/step_12_analyze_results.py
@@ -109,6 +109,32 @@ class AnalyzeResultsStep(Step):
             except Exception as exc:
                 context.logger.log_warning(f"Cross-treatment comparison failed: {exc}")
 
+        # Run-level roll-up for the agentic harness. Not gated on analyzed >= 2:
+        # this harness puts one TASK per result dir, so even a single-task smoke
+        # run has something to summarize. Cross-treatment cannot answer this --
+        # it reads each dir as a separate experimental treatment and carries no
+        # observability columns, so the score never reaches it.
+        if harness_name == "eval-containers":
+            try:
+                from llmdbenchmark.analysis.aggregate_eval_containers import (
+                    generate_agentic_summary,
+                )
+
+                summary_dir = results_dir / "agentic-summary"
+                summarized = generate_agentic_summary(
+                    results_dir,
+                    output_dir=summary_dir,
+                    context=context,
+                )
+                if summarized:
+                    context.logger.log_info(
+                        f"Agentic summary: {summarized} task(s) aggregated "
+                        f"in {summary_dir}",
+                        emoji="📊",
+                    )
+            except Exception as exc:
+                context.logger.log_warning(f"Agentic summary failed: {exc}")
+
         return StepResult(
             step_number=self.number,
             step_name=self.name,

--- a/llmdbenchmark/utilities/README.md
+++ b/llmdbenchmark/utilities/README.md
@@ -114,7 +114,11 @@ Shared kubectl patterns for the run phase.
 
 ### Pod Discovery
 
-- `find_data_access_pod(cmd, namespace) -> str | None` -- Find the data-access pod by its well-known label.
+- `find_data_access_pod(cmd, namespace, attempts=5, delay=3.0) -> str | None` -- Find
+  the data-access pod by its well-known label, retrying on failure. This lookup
+  gates result collection, so a single failed API call would otherwise discard a
+  completed run whose output is still on the PVC. Tunable via
+  `--data-access-lookup-attempts` / `--data-access-lookup-delay`.
 
 ### Pod Waiting
 

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -33,7 +33,7 @@ DATA_ACCESS_LABEL = "role=llm-d-benchmark-data-access"
 # to what it guards: ~14s of polling against a wave of results that cost hours of
 # GPU time and cannot be regenerated once the harness pods are deleted.
 DATA_ACCESS_LOOKUP_ATTEMPTS = 5
-DATA_ACCESS_LOOKUP_DELAY_S = 3.0
+DATA_ACCESS_LOOKUP_DELAY_SECONDS = 3.0
 
 
 def _terminated_state_detail(prefix: str, state: dict) -> str:
@@ -105,7 +105,8 @@ def find_data_access_pod(
     cmd,
     namespace: str,
     attempts: int = DATA_ACCESS_LOOKUP_ATTEMPTS,
-    delay: float = DATA_ACCESS_LOOKUP_DELAY_S,
+    delay: float = DATA_ACCESS_LOOKUP_DELAY_SECONDS,
+    context: ExecutionContext | None = None,
 ) -> str | None:
     """Find the data-access pod by its well-known label.
 
@@ -123,7 +124,6 @@ def find_data_access_pod(
     afterwards with a plain ``kubectl cp``. Retrying costs a few seconds;
     not retrying costs the run.
     """
-    last_detail = ""
     for attempt in range(1, max(1, attempts) + 1):
         result = cmd.kube(
             "get",
@@ -142,13 +142,24 @@ def find_data_access_pod(
         # stdout is not proof of a pod name. Require a single bare token.
         if result.success and name and "\n" not in name and " " not in name:
             return name
-        last_detail = (
-            (result.stderr or "").strip() or name or "no pod matched the label"
-        )
+        detail = (result.stderr or "").strip() or name or "no pod matched the label"
         if attempt < attempts:
+            if context is not None:
+                # Log per attempt rather than only at the end: on a slow apiserver
+                # this is the only signal that collection is retrying rather than
+                # hung, and the reason often differs between attempts.
+                context.logger.log_warning(
+                    f"Data-access pod lookup attempt {attempt}/{attempts} failed "
+                    f"in {namespace} ({detail}); retrying in {delay}s"
+                )
             time.sleep(delay)
-    # Left to the caller to report: it knows which treatment was being collected
-    # and where the results still live on the PVC.
+        elif context is not None:
+            context.logger.log_warning(
+                f"Data-access pod lookup failed after {attempts} attempts in "
+                f"{namespace} ({detail})"
+            )
+    # The caller reports the user-facing failure: it knows which treatment was
+    # being collected and where the results still live on the PVC.
     return None
 
 

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -29,6 +29,12 @@ CRASH_STATES = {
 
 DATA_ACCESS_LABEL = "role=llm-d-benchmark-data-access"
 
+# Retry budget for locating the data-access pod. Deliberately generous relative
+# to what it guards: ~14s of polling against a wave of results that cost hours of
+# GPU time and cannot be regenerated once the harness pods are deleted.
+DATA_ACCESS_LOOKUP_ATTEMPTS = 5
+DATA_ACCESS_LOOKUP_DELAY_S = 3.0
+
 
 def _terminated_state_detail(prefix: str, state: dict) -> str:
     """Format a terminated container state for a user-facing error."""
@@ -95,24 +101,54 @@ def _pod_crash_details(pod: dict) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def find_data_access_pod(cmd, namespace: str) -> str | None:
+def find_data_access_pod(
+    cmd,
+    namespace: str,
+    attempts: int = DATA_ACCESS_LOOKUP_ATTEMPTS,
+    delay: float = DATA_ACCESS_LOOKUP_DELAY_S,
+) -> str | None:
     """Find the data-access pod by its well-known label.
 
-    Returns the pod name, or ``None`` if not found.
+    Returns the pod name, or ``None`` if not found after ``attempts`` tries.
+
+    Retries because this lookup gates result collection, and a single failed
+    API call here discards a whole run's results. ``check=False`` makes a
+    transient failure (API server hiccup, DNS blip, the pod restarting because
+    its container definition changed) indistinguishable from a genuinely absent
+    pod, and the caller treats either as fatal -- so one unlucky second can
+    throw away hours of GPU time whose output is sitting intact on the PVC.
+
+    Observed on a 100-task agentic run (2026-08-12): two separate 30-task waves
+    aborted collection this way, and every task directory was still recoverable
+    afterwards with a plain ``kubectl cp``. Retrying costs a few seconds;
+    not retrying costs the run.
     """
-    result = cmd.kube(
-        "get",
-        "pod",
-        "-l",
-        DATA_ACCESS_LABEL,
-        "--namespace",
-        namespace,
-        "-o",
-        "jsonpath={.items[0].metadata.name}",
-        check=False,
-    )
-    if result.success and result.stdout.strip():
-        return result.stdout.strip()
+    last_detail = ""
+    for attempt in range(1, max(1, attempts) + 1):
+        result = cmd.kube(
+            "get",
+            "pod",
+            "-l",
+            DATA_ACCESS_LABEL,
+            "--namespace",
+            namespace,
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+            check=False,
+        )
+        name = (result.stdout or "").strip()
+        # An empty label match makes kubectl's jsonpath emit a multi-line
+        # "array index out of bounds" diagnostic on stdout, so a non-empty
+        # stdout is not proof of a pod name. Require a single bare token.
+        if result.success and name and "\n" not in name and " " not in name:
+            return name
+        last_detail = (
+            (result.stderr or "").strip() or name or "no pod matched the label"
+        )
+        if attempt < attempts:
+            time.sleep(delay)
+    # Left to the caller to report: it knows which treatment was being collected
+    # and where the results still live on the PVC.
     return None
 
 

--- a/tests/test_aggregate_eval_containers.py
+++ b/tests/test_aggregate_eval_containers.py
@@ -268,7 +268,9 @@ def test_csv_has_units_in_column_names_and_one_row_per_task(tmp_path: Path) -> N
     _write_task(tmp_path, "run_2", task_id=170, spans=spans)
 
     generate_agentic_summary(tmp_path)
-    with open(tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8") as f:
+    with open(
+        tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8"
+    ) as f:
         rows = list(csv.DictReader(f))
 
     assert len(rows) == 2
@@ -325,7 +327,9 @@ def test_time_to_first_call_anchors_on_harness_start(tmp_path: Path) -> None:
         tmp_path, "run_1", task_id=1, spans=spans, delta="PT100S", harness_start=start
     )
     generate_agentic_summary(tmp_path)
-    with open(tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8") as f:
+    with open(
+        tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8"
+    ) as f:
         row = list(csv.DictReader(f))[0]
     # The real answer is 10s. The buggy derivation would give 100 - 2 = 98.
     assert float(row["time_to_first_call_s"]) == pytest.approx(10.0, abs=0.01)
@@ -338,6 +342,8 @@ def test_time_to_first_call_blank_without_harness_start(tmp_path: Path) -> None:
     spans = [_span("/openai/v1/responses", 1_000_000_000, 2_000_000_000, {})]
     _write_task(tmp_path, "run_1", task_id=1, spans=spans, delta="PT100S")
     generate_agentic_summary(tmp_path)
-    with open(tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8") as f:
+    with open(
+        tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8"
+    ) as f:
         row = list(csv.DictReader(f))[0]
     assert row["time_to_first_call_s"] == ""

--- a/tests/test_aggregate_eval_containers.py
+++ b/tests/test_aggregate_eval_containers.py
@@ -41,6 +41,7 @@ def _write_task(
     spans: list[dict] | None = None,
     delta: str | None = "PT120S",
     reward_txt: str | None = None,
+    harness_start: str | None = None,
 ) -> Path:
     task_dir = root / name
     (task_dir / "task").mkdir(parents=True)
@@ -67,6 +68,8 @@ def _write_task(
     metadata = f"harness_name: eval-containers\nharness_rc: 0\ntask_id: {task_id}\nmodel: test-model\n"
     if delta:
         metadata += f'harness_delta: "{delta}"\n'
+    if harness_start:
+        metadata += f'harness_start: "{harness_start}"\n'
     (task_dir / "run_metadata.yaml").write_text(metadata, encoding="utf-8")
 
     if exit_code is not None:
@@ -302,3 +305,39 @@ def test_report_validates_against_v0_2_schema(tmp_path: Path) -> None:
     report = load_benchmark_report(data)
     assert report.version == "0.2"
     assert report.run.uid == "run"
+
+
+def test_time_to_first_call_anchors_on_harness_start(tmp_path: Path) -> None:
+    """It must measure harness_start -> first call, not task_latency - llm_span.
+
+    Anchoring on the LAST call's end forces the answer to equal
+    (task_latency - task_llm_span), i.e. the trailing grading time, which is a
+    different quantity wearing this column's name.
+    """
+    # harness starts at t=0; the only call runs from t=+10s to t=+12s.
+    start = "2026-08-12T00:00:00+00:00"
+    base_ns = 1786492800 * 10**9  # 2026-08-12T00:00:00Z
+    spans = [
+        _span("/openai/v1/responses", base_ns + 10 * 10**9, base_ns + 12 * 10**9, {}),
+    ]
+    # 100s total: 10s before the call, 2s of call, 88s of grading after.
+    _write_task(
+        tmp_path, "run_1", task_id=1, spans=spans, delta="PT100S", harness_start=start
+    )
+    generate_agentic_summary(tmp_path)
+    with open(tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8") as f:
+        row = list(csv.DictReader(f))[0]
+    # The real answer is 10s. The buggy derivation would give 100 - 2 = 98.
+    assert float(row["time_to_first_call_s"]) == pytest.approx(10.0, abs=0.01)
+    assert float(row["task_latency_s"]) == pytest.approx(100.0)
+    assert float(row["task_llm_span_s"]) == pytest.approx(2.0)
+
+
+def test_time_to_first_call_blank_without_harness_start(tmp_path: Path) -> None:
+    """Runs predating the timestamps must blank it, not fabricate it."""
+    spans = [_span("/openai/v1/responses", 1_000_000_000, 2_000_000_000, {})]
+    _write_task(tmp_path, "run_1", task_id=1, spans=spans, delta="PT100S")
+    generate_agentic_summary(tmp_path)
+    with open(tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8") as f:
+        row = list(csv.DictReader(f))[0]
+    assert row["time_to_first_call_s"] == ""

--- a/tests/test_aggregate_eval_containers.py
+++ b/tests/test_aggregate_eval_containers.py
@@ -1,0 +1,304 @@
+"""Tests for the eval-containers run-level aggregator."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from llmdbenchmark.analysis.aggregate_eval_containers import (
+    generate_agentic_summary,
+    _polyglot_language,
+)
+from llmdbenchmark.analysis.benchmark_report.native_to_br0_2 import (
+    is_agentic_request_span,
+)
+
+
+def _span(name: str, start_ns: int, end_ns: int, attrs: dict) -> dict:
+    return {
+        "name": name,
+        "startTimeUnixNano": str(start_ns),
+        "endTimeUnixNano": str(end_ns),
+        "attributes": [
+            {"key": k, "value": v if isinstance(v, dict) else {"intValue": str(v)}}
+            for k, v in attrs.items()
+        ],
+    }
+
+
+def _write_task(
+    root: Path,
+    name: str,
+    *,
+    task_id: int,
+    benchmark: str = "aider-polyglot",
+    reward: float | None = 1.0,
+    exit_code: str | None = "0",
+    spans: list[dict] | None = None,
+    delta: str | None = "PT120S",
+    reward_txt: str | None = None,
+) -> Path:
+    task_dir = root / name
+    (task_dir / "task").mkdir(parents=True)
+    (task_dir / "agent").mkdir(parents=True)
+
+    if reward is not None:
+        (task_dir / "task" / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_id": str(task_id),
+                    "benchmark": benchmark,
+                    "reward": reward,
+                    "passed": reward >= 1.0,
+                }
+            ),
+            encoding="utf-8",
+        )
+    if reward_txt is not None:
+        verifier = task_dir / "logs" / "verifier"
+        verifier.mkdir(parents=True)
+        # No trailing newline, matching what the grader writes.
+        (verifier / "reward.txt").write_text(reward_txt, encoding="utf-8")
+
+    metadata = f"harness_name: eval-containers\nharness_rc: 0\ntask_id: {task_id}\nmodel: test-model\n"
+    if delta:
+        metadata += f'harness_delta: "{delta}"\n'
+    (task_dir / "run_metadata.yaml").write_text(metadata, encoding="utf-8")
+
+    if exit_code is not None:
+        # Deliberately no trailing newline: the real files have none.
+        (task_dir / "agent" / ".exit-code").write_text(exit_code, encoding="utf-8")
+
+    if spans:
+        doc = {"resourceSpans": [{"scopeSpans": [{"spans": spans}]}]}
+        (task_dir / "traces.jsonl").write_text(json.dumps(doc) + "\n", encoding="utf-8")
+    return task_dir
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("/openai/v1/responses", True),
+        ("/openai/v1/chat/completions", True),
+        ("/anthropic/v1/messages", True),
+        # The Gemini wire, which gemini-cli uses; both forms must match.
+        ("/genai/v1beta/models/m:generateContent", True),
+        ("/genai/v1beta/models/m:streamGenerateContent?alt=sse", True),
+        ("litellm_request", True),
+        # The provider span carries usage, and must NOT be counted as a request.
+        ("chat Qwen/Qwen3.6-27B", False),
+        ("plugin.telemetry.prehook", False),
+        ("key.selection", False),
+        ("dock-gateway", False),
+    ],
+)
+def test_request_span_detection(name: str, expected: bool) -> None:
+    assert is_agentic_request_span(name) is expected
+
+
+def test_polyglot_language_bounds() -> None:
+    # Boundary ids on both sides of each language's range.
+    assert _polyglot_language(0) == "cpp"
+    assert _polyglot_language(25) == "cpp"
+    assert _polyglot_language(26) == "go"
+    assert _polyglot_language(64) == "go"
+    assert _polyglot_language(65) == "java"
+    assert _polyglot_language(111) == "java"
+    assert _polyglot_language(112) == "javascript"
+    assert _polyglot_language(160) == "javascript"
+    assert _polyglot_language(161) == "python"
+    assert _polyglot_language(194) == "python"
+    assert _polyglot_language(195) == "rust"
+    assert _polyglot_language(224) == "rust"
+    assert _polyglot_language(None) == ""
+
+
+def test_empty_dir_returns_zero(tmp_path: Path) -> None:
+    assert generate_agentic_summary(tmp_path) == 0
+    assert generate_agentic_summary(tmp_path / "missing") == 0
+
+
+def test_tokens_come_from_provider_span_not_http_span(tmp_path: Path) -> None:
+    """Usage is on "chat <model>"; the HTTP span defines the call count."""
+    spans = [
+        _span("/openai/v1/responses", 1_000_000_000, 3_000_000_000, {}),
+        _span(
+            "chat test-model",
+            1_100_000_000,
+            2_900_000_000,
+            {
+                "gen_ai.usage.input_tokens": 1000,
+                "gen_ai.usage.output_tokens": 200,
+                # Ends in "output_tokens" but must NOT be added to the total.
+                "gen_ai.usage.reasoning.output_tokens": 77,
+            },
+        ),
+    ]
+    _write_task(tmp_path, "run_1", task_id=200, spans=spans)
+
+    assert generate_agentic_summary(tmp_path) == 1
+    report = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )
+    obs = report["results"]["observability"]
+    assert obs["eval_containers_input_tokens"] == 1000
+    assert obs["eval_containers_output_tokens"] == 200  # not 277
+    assert obs["eval_containers_total_tokens"] == 1200
+    # Two spans, one logical call.
+    assert obs["eval_containers_llm_calls"] == 1
+
+
+def test_score_and_language_aggregation(tmp_path: Path) -> None:
+    rust = [
+        _span("/openai/v1/responses", 1_000_000_000, 2_000_000_000, {}),
+    ]
+    _write_task(tmp_path, "run_1", task_id=200, reward=1.0, spans=rust)
+    _write_task(tmp_path, "run_2", task_id=201, reward=0.0, spans=rust)
+    _write_task(tmp_path, "run_3", task_id=170, reward=1.0, spans=rust)
+
+    assert generate_agentic_summary(tmp_path) == 3
+    obs = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )["results"]["observability"]
+
+    assert obs["eval_containers_tasks"] == 3
+    assert obs["eval_containers_passed_count"] == 2
+    assert obs["eval_containers_pass_rate"] == pytest.approx(2 / 3)
+    assert obs["eval_containers_reward_sum"] == pytest.approx(2.0)
+    # Per-language split: rust 1/2, python 1/1.
+    assert obs["eval_containers_pass_rate_rust"] == pytest.approx(0.5)
+    assert obs["eval_containers_tasks_rust"] == 2
+    assert obs["eval_containers_pass_rate_python"] == pytest.approx(1.0)
+
+
+def test_reward_txt_fallback_when_result_json_missing(tmp_path: Path) -> None:
+    _write_task(tmp_path, "run_1", task_id=5, reward=None, reward_txt="1.0")
+    assert generate_agentic_summary(tmp_path) == 1
+    obs = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )["results"]["observability"]
+    assert obs["eval_containers_passed_count"] == 1
+    assert obs["eval_containers_reward_sum"] == pytest.approx(1.0)
+
+
+def test_exit_code_classification(tmp_path: Path) -> None:
+    _write_task(tmp_path, "run_1", task_id=1, exit_code="0")
+    _write_task(tmp_path, "run_2", task_id=2, exit_code="124")
+    _write_task(tmp_path, "run_3", task_id=3, exit_code="1")
+
+    generate_agentic_summary(tmp_path)
+    obs = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )["results"]["observability"]
+    assert obs["eval_containers_tasks_exit_timeout"] == 1
+    assert obs["eval_containers_tasks_exit_error"] == 1
+
+
+def test_ttft_discards_values_exceeding_their_call(tmp_path: Path) -> None:
+    """A TTFT longer than its own call cannot be real and must not be averaged."""
+    spans = [
+        _span(
+            "/openai/v1/responses",
+            0,
+            1_000_000_000,
+            {
+                "gen_ai.response.total_latency_ms": 1000,
+                # 0.5s inside a 1s call: valid.
+                "gen_ai.response.time_to_first_token": 500_000,
+            },
+        ),
+        _span(
+            "/openai/v1/responses",
+            2_000_000_000,
+            3_000_000_000,
+            {
+                "gen_ai.response.total_latency_ms": 1000,
+                # 2838s inside a 1s call: impossible, discard.
+                "gen_ai.response.time_to_first_token": 2_838_000_000,
+            },
+        ),
+    ]
+    _write_task(tmp_path, "run_1", task_id=1, spans=spans)
+
+    generate_agentic_summary(tmp_path)
+    obs = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )["results"]["observability"]
+    assert obs["eval_containers_ttft_valid_calls"] == 1
+    assert obs["eval_containers_ttft_discarded_calls"] == 1
+    assert obs["eval_containers_ttft_seconds"]["mean"] == pytest.approx(0.5)
+
+
+def test_task_latency_uses_harness_wall_clock(tmp_path: Path) -> None:
+    spans = [_span("/openai/v1/responses", 1_000_000_000, 2_000_000_000, {})]
+    _write_task(tmp_path, "run_1", task_id=1, spans=spans, delta="PT300S")
+
+    generate_agentic_summary(tmp_path)
+    obs = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )["results"]["observability"]
+    # Wall-clock (300s) is reported separately from the LLM-span proxy (1s).
+    assert obs["eval_containers_task_latency_seconds"]["mean"] == pytest.approx(300.0)
+    assert obs["eval_containers_task_llm_span_seconds"]["mean"] == pytest.approx(1.0)
+
+
+def test_missing_timestamps_omit_task_latency(tmp_path: Path) -> None:
+    """Runs predating the harness timestamps must not fabricate a task latency."""
+    spans = [_span("/openai/v1/responses", 1_000_000_000, 2_000_000_000, {})]
+    _write_task(tmp_path, "run_1", task_id=1, spans=spans, delta=None)
+
+    generate_agentic_summary(tmp_path)
+    obs = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )["results"]["observability"]
+    assert "eval_containers_task_latency_seconds" not in obs
+    assert obs["eval_containers_task_llm_span_seconds"]["mean"] == pytest.approx(1.0)
+
+
+def test_csv_has_units_in_column_names_and_one_row_per_task(tmp_path: Path) -> None:
+    spans = [_span("/openai/v1/responses", 1_000_000_000, 2_000_000_000, {})]
+    _write_task(tmp_path, "run_1", task_id=200, spans=spans)
+    _write_task(tmp_path, "run_2", task_id=170, spans=spans)
+
+    generate_agentic_summary(tmp_path)
+    with open(tmp_path / "agentic-summary" / "agentic_tasks.csv", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 2
+    # Sorted by task id.
+    assert [r["task_id"] for r in rows] == ["170", "200"]
+    assert rows[0]["language"] == "python"
+    assert rows[1]["language"] == "rust"
+    # Latency columns state their unit, unlike treatment_comparison.csv's
+    # `_s`-suffixed columns that actually carry milliseconds.
+    header = rows[0].keys()
+    assert "call_latency_mean_ms" in header
+    assert "task_latency_s" in header
+
+
+def test_report_validates_against_v0_2_schema(tmp_path: Path) -> None:
+    """The emitted YAML must load as a real v0.2 report, not just be YAML."""
+    from llmdbenchmark.analysis.benchmark_report.core import load_benchmark_report
+
+    spans = [
+        _span("/openai/v1/responses", 1_000_000_000, 2_000_000_000, {}),
+        _span(
+            "chat test-model",
+            1_000_000_000,
+            2_000_000_000,
+            {"gen_ai.usage.input_tokens": 10, "gen_ai.usage.output_tokens": 5},
+        ),
+    ]
+    _write_task(tmp_path, "run_1", task_id=1, spans=spans)
+    generate_agentic_summary(tmp_path)
+
+    data = yaml.safe_load(
+        (tmp_path / "agentic-summary" / "agentic_run_report.yaml").read_text()
+    )
+    report = load_benchmark_report(data)
+    assert report.version == "0.2"
+    assert report.run.uid == "run"

--- a/tests/test_data_access_pod_lookup.py
+++ b/tests/test_data_access_pod_lookup.py
@@ -75,3 +75,54 @@ def test_jsonpath_out_of_bounds_is_not_a_pod_name() -> None:
 def test_whitespace_only_stdout_is_not_a_pod_name() -> None:
     cmd = _FakeCmd([_Result(True, "   \n  ")] * 2)
     assert find_data_access_pod(cmd, "ns", attempts=2, delay=0) is None
+
+
+def test_env_float_parses_and_falls_back() -> None:
+    """The delay flag's default comes from the environment."""
+    import os
+    from llmdbenchmark.interface.env import env_float
+
+    os.environ["LLMDBENCH_TEST_DELAY"] = "2.5"
+    try:
+        assert env_float("LLMDBENCH_TEST_DELAY") == 2.5
+    finally:
+        del os.environ["LLMDBENCH_TEST_DELAY"]
+    assert env_float("LLMDBENCH_TEST_DELAY_UNSET", 3.0) == 3.0
+    os.environ["LLMDBENCH_TEST_DELAY"] = "not-a-number"
+    try:
+        assert env_float("LLMDBENCH_TEST_DELAY", 3.0) == 3.0
+    finally:
+        del os.environ["LLMDBENCH_TEST_DELAY"]
+
+
+def test_context_defaults_match_the_helper() -> None:
+    """A default drift here would silently change collection robustness."""
+    from llmdbenchmark.executor.context import ExecutionContext
+    from llmdbenchmark.utilities import kube_helpers as kh
+
+    ctx = ExecutionContext.__dataclass_fields__
+    assert ctx["data_access_lookup_attempts"].default == kh.DATA_ACCESS_LOOKUP_ATTEMPTS
+    assert (
+        ctx["data_access_lookup_delay"].default == kh.DATA_ACCESS_LOOKUP_DELAY_SECONDS
+    )
+
+
+def test_cli_exposes_the_lookup_flags() -> None:
+    """Vezio's review point: these must be reachable without editing source."""
+    import argparse
+    from llmdbenchmark.interface import run as run_iface
+
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    run_iface.add_subcommands(sub)
+    args = parser.parse_args(
+        [
+            "run",
+            "--data-access-lookup-attempts",
+            "9",
+            "--data-access-lookup-delay",
+            "1.5",
+        ]
+    )
+    assert args.data_access_lookup_attempts == 9
+    assert args.data_access_lookup_delay == 1.5

--- a/tests/test_data_access_pod_lookup.py
+++ b/tests/test_data_access_pod_lookup.py
@@ -1,0 +1,77 @@
+"""Tests for the data-access pod lookup retry.
+
+This lookup gates result collection: when it returns None the caller abandons a
+completed wave's results, so a transient API failure must not be fatal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from llmdbenchmark.utilities.kube_helpers import find_data_access_pod
+
+
+@dataclass
+class _Result:
+    success: bool
+    stdout: str = ""
+    stderr: str = ""
+
+
+class _FakeCmd:
+    """Returns queued results in order, recording how many calls were made."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = 0
+
+    def kube(self, *args, **kwargs):
+        self.calls += 1
+        if self._results:
+            return self._results.pop(0)
+        return _Result(False, "", "exhausted")
+
+
+def test_returns_pod_on_first_success() -> None:
+    cmd = _FakeCmd([_Result(True, "access-to-harness-data-workload-pvc")])
+    assert (
+        find_data_access_pod(cmd, "ns", attempts=5, delay=0)
+        == "access-to-harness-data-workload-pvc"
+    )
+    assert cmd.calls == 1  # no needless retries on the happy path
+
+
+def test_retries_then_succeeds() -> None:
+    """A transient failure must not discard the run's results."""
+    cmd = _FakeCmd(
+        [
+            _Result(False, "", "dial tcp: lookup api...: no such host"),
+            _Result(False, "", "connection refused"),
+            _Result(True, "access-to-harness-data-workload-pvc"),
+        ]
+    )
+    assert find_data_access_pod(cmd, "ns", attempts=5, delay=0) is not None
+    assert cmd.calls == 3
+
+
+def test_gives_up_after_attempts() -> None:
+    cmd = _FakeCmd([_Result(False, "", "boom")] * 10)
+    assert find_data_access_pod(cmd, "ns", attempts=4, delay=0) is None
+    assert cmd.calls == 4  # bounded, not infinite
+
+
+def test_jsonpath_out_of_bounds_is_not_a_pod_name() -> None:
+    """kubectl prints a multi-line diagnostic on stdout when the label matches
+    nothing; treating that as a pod name would produce a bogus `kubectl cp`."""
+    noise = (
+        'error: error executing jsonpath "{.items[0].metadata.name}": '
+        "array index out of bounds: index 0, length 0\n"
+        "template was:\n\t{.items[0].metadata.name}\n"
+    )
+    cmd = _FakeCmd([_Result(True, noise)] * 3)
+    assert find_data_access_pod(cmd, "ns", attempts=3, delay=0) is None
+
+
+def test_whitespace_only_stdout_is_not_a_pod_name() -> None:
+    cmd = _FakeCmd([_Result(True, "   \n  ")] * 2)
+    assert find_data_access_pod(cmd, "ns", attempts=2, delay=0) is None

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -20,7 +20,30 @@ if [[ -z "${EVAL_TASK_ID:-}" ]]; then
   # parallel_idx is 1-based (framework: range(1, N+1)); fall back to 1 for a
   # missing / non-numeric / zero suffix so EVAL_TASK_ID can never go negative.
   case "$idx" in ''|*[!0-9]*|0) idx=1 ;; esac
-  export EVAL_TASK_ID="$(( idx - 1 + ${EVAL_TASK_OFFSET:-0} ))"
+
+  # EVAL_TASK_LIST selects an ARBITRARY set of task ids: a comma-separated list
+  # indexed by this pod's 1-based position. EVAL_TASK_OFFSET can only express a
+  # contiguous range, and the aider-polyglot dataset is language-ORDERED (cpp
+  # 0-25, go 26-64, java 65-111, javascript 112-160, python 161-194, rust
+  # 195-224), so every contiguous slice is effectively single-language and its
+  # score is not comparable to any other slice. A representative sample needs an
+  # explicit list.
+  if [[ -n "${EVAL_TASK_LIST:-}" ]]; then
+    IFS=',' read -r -a _task_ids <<< "$EVAL_TASK_LIST"
+    if (( idx > ${#_task_ids[@]} )); then
+      echo "eval-containers: FATAL pod index $idx exceeds EVAL_TASK_LIST length ${#_task_ids[@]}" >&2
+      exit 1
+    fi
+    _tid="${_task_ids[$(( idx - 1 ))]}"
+    _tid="${_tid//[[:space:]]/}"
+    case "$_tid" in ''|*[!0-9]*)
+      echo "eval-containers: FATAL EVAL_TASK_LIST entry $idx is not a task id: '$_tid'" >&2
+      exit 1 ;;
+    esac
+    export EVAL_TASK_ID="$_tid"
+  else
+    export EVAL_TASK_ID="$(( idx - 1 + ${EVAL_TASK_OFFSET:-0} ))"
+  fi
 fi
 
 # --- point the eval's in-pod model gateway at the deployed llm-d endpoint -----

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -48,6 +48,73 @@ export EVAL_MODEL="${LLMDBENCH_DEPLOY_CURRENT_MODEL:?model not provided}"
 
 echo "eval-containers: task=$EVAL_TASK_ID model=$EVAL_MODEL endpoint=$OPENAI_API_BASE"
 
+# --- raise the in-pod gateway's per-request timeout --------------------------
+# bifrost's built-in per-request timeout is 30s, which is SHORTER than a
+# reasoning model's generation latency (the model emits a <think> block before
+# the answer). Measured 2026-07-30 over two 20-task waves: 65/198 (33%) and
+# 55/156 (35%) of gateway requests returned 504 with durations pinned at
+# 30002-30064 ms -- a fixed client deadline, not model variance. A successful
+# call landed at 26460 ms, i.e. 3.5s under the wire. No task with 3+ 504s ever
+# passed, so this silently depresses the score rather than failing the run.
+#
+# bifrost names the fix in its own error body ("increase it by setting the
+# default_request_timeout_in_seconds in the network_config"), and
+# config.json.template already writes a network_config block per provider
+# holding base_url + allow_private_network. /opt/gateway/start renders that
+# template with plain sed and never parses the JSON, so an injected field
+# passes straight through -- no image rebuild needed.
+#
+# Keyed on "allow_private_network": true, which appears in all three provider
+# blocks (anthropic, openai, gemini), so it survives base_url differences.
+# 600s is comfortably above the worst observed generation and still bounded
+# well under EVAL_TIMEOUT, so a wedged request cannot outlive its own task.
+gw_timeout="${EVAL_GATEWAY_TIMEOUT:-600}"
+gw_template=/opt/gateway/data/config.json.template
+# Saved copy lives under $HOME, not /tmp: /tmp is not guaranteed to survive
+# (macOS has wiped it mid-run) and this file's whole job is to be there for
+# the revert below, so a cleared /tmp would turn a loud-skip patch into a
+# silent, unrevertable one.
+gw_template_orig="${HOME:-/tmp}/eval-containers-gw-config.json.template.orig"
+if [[ -f "$gw_template" && -w "$(dirname "$gw_template")" ]]; then
+  if grep -q 'default_request_timeout_in_seconds' "$gw_template"; then
+    echo "eval-containers: gateway template already sets a request timeout; leaving it alone"
+  elif ! cp "$gw_template" "$gw_template_orig"; then
+    # Without a saved copy we cannot revert, so patching would be
+    # unguarded -- skip it and leave the provider default in place. This is
+    # the same degrade-gracefully outcome as the "not present/writable"
+    # branch below, just discovered one step later.
+    echo "eval-containers: WARNING could not save gateway template backup to ${gw_template_orig}; skipping timeout patch, provider default applies" >&2
+  else
+    gw_restore() {
+      if ! cp "$gw_template_orig" "$gw_template"; then
+        echo "eval-containers: WARNING revert failed; ${gw_template} may be left in a half-patched state" >&2
+      fi
+    }
+    if ! sed -i "s/\"allow_private_network\": true/\"allow_private_network\": true, \"default_request_timeout_in_seconds\": ${gw_timeout}/g" \
+      "$gw_template"; then
+      # A disk-full temp-file write or a permissions race after the -w
+      # dirname check above can make sed itself fail. Restore rather than
+      # leave a possibly half-patched template in place.
+      echo "eval-containers: WARNING timeout patch sed failed; reverting" >&2
+      gw_restore
+    else
+      n=$(grep -c 'default_request_timeout_in_seconds' "$gw_template") || n=0
+      if [[ "$n" -eq 3 ]]; then
+        echo "eval-containers: gateway request timeout set to ${gw_timeout}s for 3 providers"
+        rm -f "$gw_template_orig"
+      else
+        # Restore rather than run with a half-patched template: a malformed
+        # config.json makes bifrost fail to boot, which surfaces later as an
+        # opaque startup failure rather than as this patch's fault.
+        echo "eval-containers: WARNING timeout patch hit $n/3 providers; reverting" >&2
+        gw_restore
+      fi
+    fi
+  fi
+else
+  echo "eval-containers: note gateway template not present/writable; provider default applies"
+fi
+
 # --- run the eval ------------------------------------------------------------
 # image ENTRYPOINT stages /app for EVAL_TASK_ID, then execs the pipeline.
 rc=0

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -140,9 +140,16 @@ fi
 
 # --- run the eval ------------------------------------------------------------
 # image ENTRYPOINT stages /app for EVAL_TASK_ID, then execs the pipeline.
+# Wall-clock is recorded around the whole task because the OTel traces only
+# cover LLM calls: a span-derived duration silently omits agent startup, tool
+# execution, and grading, and a task that hangs outside its calls looks fast.
+# Analysis needs the real task window to report task latency and time-to-first
+# -call honestly.
+start=$(date +%s)
 rc=0
 "${EVAL_CONTAINERS_ENTRYPOINT:-/entrypoint.sh}" \
   "${EVAL_CONTAINERS_RUN:-/usr/local/bin/run}" || rc=$?
+stop=$(date +%s)
 
 # --- hand results back to llm-d-benchmark's collector ------------------------
 output_dir="${EVAL_OUTPUT_DIR:-/output}"
@@ -168,9 +175,14 @@ _yaml_escape() {
 }
 _description_text="$(_yaml_escape "${LLMDBENCH_DESCRIPTION_TEXT:-}")"
 _description_keywords="$(_yaml_escape "${LLMDBENCH_DESCRIPTION_KEYWORDS:-}")"
-printf 'harness_name: eval-containers\nharness_rc: %s\ntask_id: %s\nmodel: %s\nexperiment_id: "%s"\ndescription_text: "%s"\ndescription_keywords: "%s"\n' \
+# harness_start / harness_stop / harness_delta use the same key names and
+# ISO-8601 formats the other harnesses write, so existing readers need no special
+# case. BusyBox date has no -d @<epoch>, hence the -r fallback.
+_iso() { date -d "@$1" --iso-8601=seconds 2>/dev/null || date -r "$1" +%Y-%m-%dT%H:%M:%S%z; }
+printf 'harness_name: eval-containers\nharness_rc: %s\ntask_id: %s\nmodel: %s\nexperiment_id: "%s"\ndescription_text: "%s"\ndescription_keywords: "%s"\nharness_start: "%s"\nharness_stop: "%s"\nharness_delta: "PT%sS"\n' \
   "$rc" "$EVAL_TASK_ID" "$EVAL_MODEL" "${LLMDBENCH_RUN_EXPERIMENT_ID:-}" \
   "$_description_text" "$_description_keywords" \
+  "$(_iso "$start")" "$(_iso "$stop")" "$(( stop - start ))" \
   > "$results_dir/run_metadata.yaml"
 
 exit "$rc"

--- a/workload/harnesses/eval-containers-llm-d-benchmark.sh
+++ b/workload/harnesses/eval-containers-llm-d-benchmark.sh
@@ -36,7 +36,15 @@ endpoint="${endpoint%/}"
 endpoint="${endpoint%/v1}"
 export OPENAI_API_BASE="$endpoint"
 export OPENAI_API_KEY="${OPENAI_API_KEY:-sk-llm-d}"  # pragma: allowlist secret (placeholder; llm-d ignores it)
-export EVAL_MODEL="openai/${LLMDBENCH_DEPLOY_CURRENT_MODEL:?model not provided}"
+# EVAL_MODEL must be the BARE served model handle, with NO provider prefix.
+# /opt/gateway/start documents it as "a BARE handle" and renders it into a
+# bifrost routing rule that carries the provider SEPARATELY:
+#   "targets": [{ "provider": "<wire>", "model": "<EVAL_MODEL>" }]
+# So an `openai/` prefix here is not a provider selector -- it becomes part of
+# the model NAME. bifrost then looks up `openai/<model>` in the OpenAI catalog,
+# finds nothing, and returns 404 "The model ... does not exist" for every agent
+# call: reward 0.0, empty agent stdout, harness rc 0. Silent green.
+export EVAL_MODEL="${LLMDBENCH_DEPLOY_CURRENT_MODEL:?model not provided}"
 
 echo "eval-containers: task=$EVAL_TASK_ID model=$EVAL_MODEL endpoint=$OPENAI_API_BASE"
 


### PR DESCRIPTION
Fixes for running the `eval-containers` agentic harness against an llm-d-served
model on GPUs, plus a run-level metrics aggregator. Every change below was found
by running the harness end to end on OpenShift (30 H100s, Qwen3.6-27B served by
llm-d) and is validated by the results at the bottom.

## What was broken

Each of these produced a *silent* failure — a run that reported success while
scoring ~0, or a metric that read as a real measurement while measuring nothing.

| Fix | Symptom before |
|---|---|
| `EVAL_MODEL` must be a bare handle | An `openai/` prefix became part of the model *name*; bifrost looked up `openai/<model>`, 404'd every agent call. reward `0.0`, empty agent stdout, harness rc `0`. |
| Raise the in-pod gateway timeout | bifrost's 30s per-request default is shorter than a reasoning model's generation. 33–35% of calls returned 504 pinned at 30002–30064 ms. No task with 3+ 504s ever passed. |
| `EVAL_TASK_LIST` | `EVAL_TASK_OFFSET` can only express a contiguous range, and aider-polyglot is language-ordered — so every slice was effectively single-language and scores were not comparable. |
| Weight download on `images.python` | The download job ran on the *harness* image. For agentic harnesses that is multi-GB with `:latest` ⇒ `imagePullPolicy: Always`, so every standup re-pulled gigabytes and the job timed out before transferring a byte. |
| 32k context + reasoning parser | At 16k, tasks carrying a repo's worth of context plus a `<think>` block hit the ceiling mid-solution. Without `--reasoning-parser` the `<think>` trace arrives as ordinary content and the tool call is lost inside it. |
| Force the OpenAI wire for gemini-cli | gemini-cli speaks Gemini v1beta, which bifrost cannot parse against an OpenAI-only upstream. Every call 400'd and the agent wrote a stub solution — a transport failure that reads as model quality. |
| Un-nest `images` from `common.storage` | Two scenarios indented `images:` one level too deep, so it parsed as `common.storage.images`, which nothing reads. The harness silently fell back to `ghcr.io/llm-d/llm-d-benchmark` — an image with no `/entrypoint.sh` — and the pod exited **127** in ~18s with no artifacts and nothing naming the image. |
| Read tokens from the provider span | The converter counted the HTTP span, but `gen_ai.usage.*` lives on the sibling `chat <model>` span. `total_token_rate` reported **0.0** and the token counters vanished from every report. Also fixed an `endswith` that double-counted reasoning tokens, and a span filter that matched only the OpenAI/Anthropic wires — so **gemini-cli reported 0 LLM calls and no latency at all**. |
| Retry the data-access pod lookup | The lookup returned `None` on the first failed API call, and the caller abandons collection. A one-second hiccup discarded two completed 30-task waves whose output was sitting intact on the PVC. |

## New: run-level aggregation

The framework runs one task per pod, so an N-task run left N single-task reports
and nothing that answered "how did the run do". `cross_treatment` cannot: it
reads each result dir as a separate experimental *treatment* and carries no
`observability` columns, so the score never reaches it.

`llmdbenchmark/analysis/aggregate_eval_containers.py` writes, under
`agentic-summary/` at the results root:

- **`agentic_run_report.yaml`** — a benchmark-report v0.2 for the whole run: pass
  rate, pooled LLM-call latency, token totals, task wall-clock, and per-language
  pass rates for `aider-polyglot`.
- **`agentic_tasks.csv`** — one row per task, units named in the columns.

Two metrics are reported conservatively rather than confidently:

- **time-to-first-token** is validated per call against its own call latency and
  the discarded count is published, because the raw attribute's unit is not
  dependable (one run implied 2,838 s inside an 823 s call).
- **task latency** comes from a harness-recorded wall-clock (`harness_start` /
  `harness_stop` / `harness_delta`, matching the other harnesses' key names), and
  is kept distinct from the span-derived `task_llm_span`, which omits agent
  setup, tool execution and grading.

## Validation

OpenShift, 30× H100, Qwen3.6-27B served by llm-d at `maxModelLen: 32768`,
`-j 30`, exercising the committed scenario values.

| | tasks | passed | LLM calls | tokens (in / out) | exit 124 | ctx rejections |
|---|---|---|---|---|---|---|
| **GAIA** (no-search, `codex`) | 54 / 54 | **27 (50.0%)** | 419 | 5.58M / 189k | 0 | 0 |
| **aider-polyglot** (`gemini-cli`) | 100 / 100 | **59 (59.0%)** | 1889 | 15.91M / 1.24M | 1 | 1 |

polyglot per-language: javascript 18/21 · python 16/19 · java 16/25 ·
rust 5/10 · cpp 4/11 · **go 0/14**.

**Timeout fix, measured:** 226 polyglot requests exceeded 30s and **224 returned
HTTP 200**. Against the unpatched 30s default every one of those would have been
killed. The 2 failures sit at 300,004 ms — a separate, 10× higher client-side
ceiling, not bifrost's. GAIA is silent on this fix (`slow30s=0` both waves), so
polyglot is its only evidence.

Some notes on the results:

- `go 0/14` is real: zero passes across fourteen tasks. cpp 4/11. Those two
  languages are where this model+agent combination fails due to performance
- Two GAIA tasks show `ServiceUnavailable` bursts confined to a 22-second window
  at the end of their wave: they were still calling when `run` scaled decode to
  0. Self-inflicted by wave teardown, not a model or config failure — but it
  scores as a failure, so it is worth knowing.

## Docs and examples

`docs/agentic_eval.md` now reflects the state of the fixes and new aggregation artifacts

The two eval containers example scenarios have been updated

## Test coverage

1253 passed, 32 skipped. new tests cover the span-selection and case-sensitivity
traps, the reasoning-token double-count, the `reward.txt` fallback, TTFT discarding,
schema validation of the emitted report, and the lookup retry.
