### PR TITLE
fix: Error: ❗No privileges to setup Fast Model Actuation API crds.

### DIFF
--- a/llmdbenchmark/standup/steps/step_06_fma_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_fma_deploy.py
@@ -680,8 +680,10 @@ class FMADeployStep(Step):
         self, context: ExecutionContext, plan_config: dict, errors: list[str]
     ) -> None:
         if context.non_admin:
-            errors.append(
-                "❗No privileges to setup Fast Model Actuation API crds. "
+            # --non-admin: CI cannot create cluster-scoped CRDs, so skip
+            # installing them and assume a privileged user already did.
+            context.logger.log_warning(
+                "--non-admin: skipping Fast Model Actuation CRD setup. "
                 "Will assume a user with proper privileges already performed this action."
             )
             return


### PR DESCRIPTION
```
2026-08-11 14:54:39,235 - INFO    -     | 📋 Deployment metadata to configmap/llm-d-benchmark-standup-parameters in ns/llmdbenchcicdfns-ocp
2026-08-11 14:54:39,235 - ERROR   - ❌     |     ❗No privileges to setup Fast Model Actuation API crds. Will assume a user with proper privileges already performed this action.
2026-08-11 14:54:39,235 - INFO    -     |    oc get configmap llm-d-benchmark-standup-parameters -n llmdbenchcicdfns-ocp -o yaml
2026-08-11 14:54:39,235 - ERROR   - ❌ [06] Stack 'ocp-cicd': FAILED: [06] fma_deploy (ocp-cicd): FAILED - FMA deployment had errors
2026-08-11 14:54:39,236 - ERROR   - ❌ Standup failed:
Phase: standup
Stack 'ocp-cicd' failures:
  - [06] fma_deploy (ocp-cicd): FAILED - FMA deployment had errors
    * Error: ❗No privileges to setup Fast Model Actuation API crds. Will assume a user with proper privileges already performed this action.
Error: Process completed with exit code 1.
```
https://github.com/llm-d/llm-d-benchmark/actions/runs/31501389149/job/93819029381 standup failing with this error due to llm-d-infra change https://github.com/llm-d/llm-d-infra/commit/6101f9f39d082155b7360c330eeca15c18587a61#diff-76aa8153aa984642af989210a9322029a73f0a44e8d16f2888b82dc165fc1149R369