### PR TITLE
Support EPP queue-based KEDA autoscaling in the ocp-keda scenarios

### DIFF
--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -155,19 +155,17 @@ scenario:
         maxReplicas: 6
         pollingInterval: 15
         unsafeSsl: true
-        # Defaults come from defaults.yaml; override the whole set here, e.g.
-        # (metricType + activationThreshold optional, default AverageValue/"0"):
+        # Triggers mirror the upstream llm-d workload-autoscaling KEDA guides.
+        # Defaults (from defaults.yaml) scale on EPP pool-saturation (the
+        # keda-epp-saturation guide). To scale on EPP queue size instead (the
+        # keda-epp-queue guide), override triggers here:
         # triggers:
-        #   - name: pool-saturation
-        #     query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
-        #     threshold: "0.7"
-        #     metricType: AverageValue
-        #     activationThreshold: "0"
+        #   - name: queue-size
+        #     query: 'sum(llm_d_epp_flow_control_queue_size{model_name="${modelName}"})'
+        #     threshold: "1"
         #   - name: running-requests
         #     query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
         #     threshold: "16"
-        #     metricType: AverageValue
-        #     activationThreshold: "0"
         behavior:
           scaleUp:
             stabilizationWindowSeconds: 0

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -179,19 +179,17 @@ scenario:
         maxReplicas: 6
         pollingInterval: 15
         unsafeSsl: true
-        # Defaults come from defaults.yaml; override the whole set here, e.g.
-        # (metricType + activationThreshold optional, default AverageValue/"0"):
+        # Triggers mirror the upstream llm-d workload-autoscaling KEDA guides.
+        # Defaults (from defaults.yaml) scale on EPP pool-saturation (the
+        # keda-epp-saturation guide). To scale on EPP queue size instead (the
+        # keda-epp-queue guide), override triggers here:
         # triggers:
-        #   - name: pool-saturation
-        #     query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
-        #     threshold: "0.7"
-        #     metricType: AverageValue
-        #     activationThreshold: "0"
+        #   - name: queue-size
+        #     query: 'sum(llm_d_epp_flow_control_queue_size{model_name="${modelName}"})'
+        #     threshold: "1"
         #   - name: running-requests
         #     query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
         #     threshold: "16"
-        #     metricType: AverageValue
-        #     activationThreshold: "0"
         behavior:
           scaleUp:
             stabilizationWindowSeconds: 0

--- a/config/scenarios/cicd/ocp-keda.yaml
+++ b/config/scenarios/cicd/ocp-keda.yaml
@@ -67,19 +67,17 @@ scenario:
         maxReplicas: 6
         pollingInterval: 15
         unsafeSsl: true
-        # Defaults come from defaults.yaml; override the whole set here, e.g.
-        # (metricType + activationThreshold optional, default AverageValue/"0"):
+        # Triggers mirror the upstream llm-d workload-autoscaling KEDA guides.
+        # Defaults (from defaults.yaml) scale on EPP pool-saturation (the
+        # keda-epp-saturation guide). To scale on EPP queue size instead (the
+        # keda-epp-queue guide), override triggers here:
         # triggers:
-        #   - name: pool-saturation
-        #     query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'
-        #     threshold: "0.7"
-        #     metricType: AverageValue
-        #     activationThreshold: "0"
+        #   - name: queue-size
+        #     query: 'sum(llm_d_epp_flow_control_queue_size{model_name="${modelName}"})'
+        #     threshold: "1"
         #   - name: running-requests
         #     query: 'sum(llm_d_epp_request_running{model_name="${modelName}"})'
         #     threshold: "16"
-        #     metricType: AverageValue
-        #     activationThreshold: "0"
         behavior:
           scaleUp:
             stabilizationWindowSeconds: 0

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -556,6 +556,7 @@ monitoring:
     - inference_pool_average_running_requests
     - inference_pool_ready_pods
     - llm_d_epp_flow_control_pool_saturation
+    - llm_d_epp_flow_control_queue_size
     - llm_d_epp_request_running
 
 # ============================================================================
@@ -1725,10 +1726,11 @@ eppKedaSaturation:
     pollingInterval: 15
     unsafeSsl: true
     # KEDA Prometheus triggers, fully defined here so new metrics/thresholds
-    # can be added without touching the Jinja. A scenario may redefine this
-    # entire list. Per entry: query (required), threshold, and optional
-    # name/metricType/activationThreshold. In `query`, ${poolName} and
-    # ${modelName} are substituted at render time.
+    # can be added without touching the Jinja. These mirror the upstream llm-d
+    # workload-autoscaling keda-epp-saturation guide; a scenario may redefine
+    # this entire list (e.g. the keda-epp-queue guide). Per entry: query
+    # (required), threshold, and optional name/metricType/activationThreshold.
+    # In `query`, ${poolName} and ${modelName} are substituted at render time.
     triggers:
       - name: pool-saturation
         query: 'max(llm_d_epp_flow_control_pool_saturation{inference_pool="${poolName}"})'

--- a/workload/harnesses/process_metrics.py
+++ b/workload/harnesses/process_metrics.py
@@ -55,8 +55,9 @@ LEGACY_AGGREGATE_METRICS = {
     "inference_pool_average_queue_size",
     "inference_pool_average_running_requests",
     "inference_pool_ready_pods",
-    # EPP flow-control metrics (KEDA saturation scale triggers)
+    # EPP flow-control metrics (KEDA saturation/queue scale triggers)
     "llm_d_epp_flow_control_pool_saturation",
+    "llm_d_epp_flow_control_queue_size",
     "llm_d_epp_request_running",
 }
 AGGREGATE_METRICS = (
@@ -124,6 +125,7 @@ METRIC_UNITS = {
     "inference_pool_average_running_requests": "count",
     "inference_pool_ready_pods": "count",
     "llm_d_epp_flow_control_pool_saturation": "ratio",
+    "llm_d_epp_flow_control_queue_size": "count",
     "llm_d_epp_request_running": "count",
     "inference_extension_scheduler_e2e_duration_seconds_bucket": "seconds",
     "inference_extension_scheduler_e2e_duration_seconds_sum": "seconds",


### PR DESCRIPTION

### Summary

Adds EPP queue-size as a selectable KEDA scale trigger for the `ocp-keda`, `ocp-keda-fma-warmstart`, and `ocp-keda-fma-hotstart` scenarios, alongside the existing pool-saturation default — mirroring the upstream llm-d workload-autoscaling KEDA guides. No new scenario files; switching is a config override.

### Changes

- `config/templates/values/defaults.yaml` — added `llm_d_epp_flow_control_queue_size` to the metrics-scrape list (so the queue trigger has data and it's available to the comparison table); noted the default triggers mirror the upstream saturation guide.
- `workload/harnesses/process_metrics.py` — added `llm_d_epp_flow_control_queue_size` to the aggregation set + units.
- Scenarios (`ocp-keda*.yaml`) — documented, via a commented triggers: example, how to switch to EPP queue-based scaling (l`lm_d_epp_flow_control_queue_size, threshold 1`); removed the redundant pool-saturation example (it's already the default from `defaults.yaml`).

### Notes

- Saturation remains the default; queue is opt-in via the existing `eppKedaSaturation.scaledObject.triggers` override — no template change.

