### PR TITLE
Add EPP flow-control queue to the FMA+KEDA summary table

### DIFF
--- a/llmdbenchmark/analysis/scripts/fma_comparison_table.py
+++ b/llmdbenchmark/analysis/scripts/fma_comparison_table.py
@@ -92,8 +92,10 @@ def fmt(v, unit="", precision=1):
 
 KV_CACHE_METRIC = "inference_pool_average_kv_cache_utilization"
 QUEUE_SIZE_METRIC = "inference_pool_average_queue_size"
-# EPP flow-control metrics that drive the KEDA saturation scale triggers.
+# EPP flow-control metrics that drive the KEDA scale triggers: pool saturation
+# for the saturation trigger, queue size for the queue trigger.
 POOL_SATURATION_METRIC = "llm_d_epp_flow_control_pool_saturation"
+FLOW_CONTROL_QUEUE_METRIC = "llm_d_epp_flow_control_queue_size"
 RUNNING_REQUESTS_METRIC = "llm_d_epp_request_running"
 
 
@@ -345,6 +347,7 @@ def main():
     kv = [epp_gauge_mean(r, KV_CACHE_METRIC) for r in rdirs]
     qd = [epp_gauge_mean(r, QUEUE_SIZE_METRIC) for r in rdirs]
     sat = [epp_gauge_mean(r, POOL_SATURATION_METRIC) for r in rdirs]
+    fcq = [epp_gauge_mean(r, FLOW_CONTROL_QUEUE_METRIC) for r in rdirs]
     rr = [epp_gauge_mean(r, RUNNING_REQUESTS_METRIC) for r in rdirs]
     kv_pct = [(v * 100 if v is not None and v <= 1.0 else v) for v in kv]
     cost = [(a * args.gpu_hourly_cost if a is not None else None) for a in avg_repl]
@@ -363,7 +366,14 @@ def main():
         "| Avg queue depth (EPP) | " + " | ".join(fmt(v, "", 1) for v in qd) + " |"
     )
     out.append(
-        "| Avg pool saturation (EPP) | " + " | ".join(fmt(v, "", 2) for v in sat) + " |"
+        "| Avg flow-control pool saturation (EPP) | "
+        + " | ".join(fmt(v, "", 2) for v in sat)
+        + " |"
+    )
+    out.append(
+        "| Avg flow-control queue (EPP) | "
+        + " | ".join(fmt(v, "", 1) for v in fcq)
+        + " |"
     )
     out.append(
         "| Avg running requests (EPP) | " + " | ".join(fmt(v, "", 1) for v in rr) + " |"


### PR DESCRIPTION
### Summary

Adds an Avg flow-control queue (EPP) row to the comparison table (metric llm_d_epp_flow_control_queue_size) and clarifies the existing saturation row label as Avg flow-control pool saturation (EPP) so it's clear both come from EPP's flow-control subsystem.

### Motivation

The table already reported Avg queue depth (EPP) — but that's the model-server queue (`inference_pool_average_queue_size`). The KEDA queue-based trigger scales on the EPP flow-control queue (`llm_d_epp_flow_control_queue_size`), a different, upstream signal that wasn't surfaced. Adding it lets the comparison show the metric the queue trigger actually reacts to, alongside the model-server queue. The saturation row is relabeled for the same clarity — `llm_d_epp_flow_control_pool_saturation` is also a flow-control metric.

### Changes

`llmdbenchmark/analysis/scripts/fma_comparison_table.py`:
- Added FLOW_CONTROL_QUEUE_METRIC = `llm_d_epp_flow_control_queue_size` and an Avg flow-control queue (EPP) row (read via the existing epp_gauge_mean helper).
- Relabeled Avg pool saturation (EPP) → `Avg flow-control pool saturation (EPP)`.

No scrape/aggregation changes needed — `llm_d_epp_flow_control_queue_size` was already added to defaults.yaml and `process_metrics.py` by the earlier queue-trigger PR (#1775).