### PR TITLE
fix: validate only monitoring CRDs the plan renders

### DIFF
--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -658,30 +658,54 @@ class AdminPrerequisitesStep(Step):
         existing_crds: list[str],
         errors: list,
     ):
-        """Fail early when monitoring is enabled but required CRDs are missing.
+        """Fail early when rendered monitoring resources need missing CRDs.
 
-        Checks for ``podmonitors.monitoring.coreos.com`` and
-        ``servicemonitors.monitoring.coreos.com``.  If either is absent the
-        step records an error with platform-aware remediation guidance.
+        Direct harness scraping does not create Prometheus Operator resources,
+        so ``metricsScrapeEnabled`` alone does not require either CRD.
+        PodMonitor rendering requires the PodMonitor CRD. Modelservice router
+        monitoring requires the ServiceMonitor CRD only when Prometheus
+        monitoring is enabled and its resolved provider is
+        ``prometheusoperator``.
         """
         if context.dry_run:
             cmd.logger.log_info("Skipping monitoring CRD validation (dry-run)")
             return
 
-        monitoring = plan_config.get("monitoring", {})
-        podmonitor_enabled = monitoring.get("podmonitor", {}).get("enabled", False)
-        scrape_enabled = monitoring.get("metricsScrapeEnabled", False)
+        monitoring = plan_config.get("monitoring") or {}
+        podmonitor = monitoring.get("podmonitor") or {}
+        podmonitor_enabled = podmonitor.get("enabled", False)
 
-        if not podmonitor_enabled and not scrape_enabled:
-            return
+        router = plan_config.get("router") or {}
+        router_monitoring = router.get("monitoring") or {}
+        router_prometheus = router_monitoring.get("prometheus") or {}
+        monitoring_provider = router_monitoring.get("provider") or {}
+        provider_name = monitoring_provider.get("name")
+        if not isinstance(provider_name, str) or not provider_name.strip():
+            gateway_provider = plan_config.get("provider") or {}
+            gateway_provider_name = gateway_provider.get("name")
+            provider_name = (
+                "gmp"
+                if isinstance(gateway_provider_name, str)
+                and gateway_provider_name.lower() == "gke"
+                else "prometheusoperator"
+            )
 
-        required_crds = [
-            "podmonitors.monitoring.coreos.com",
-            "servicemonitors.monitoring.coreos.com",
-        ]
+        router_service_monitor_enabled = (
+            "modelservice" in (context.deployed_methods or [])
+            and router_prometheus.get("enabled", False)
+            and provider_name.lower() == "prometheusoperator"
+        )
+
+        required_crds = []
+        if podmonitor_enabled:
+            required_crds.append("podmonitors.monitoring.coreos.com")
+        if router_service_monitor_enabled:
+            required_crds.append("servicemonitors.monitoring.coreos.com")
+
         missing = [c for c in required_crds if c not in existing_crds]
         if not missing:
-            cmd.logger.log_info("✅ Monitoring CRDs present on cluster")
+            if required_crds:
+                cmd.logger.log_info("✅ Monitoring CRDs present on cluster")
             return
 
         missing_str = ", ".join(missing)
@@ -700,11 +724,13 @@ class AdminPrerequisitesStep(Step):
 
         if context.is_gke:
             return (
-                "On GKE, enable Google Managed Prometheus with managed collection:\n"
-                "  gcloud container clusters update <CLUSTER> \\\n"
-                "    --enable-managed-prometheus \\\n"
-                "    --location=<LOCATION>\n"
-                "This lets GKE natively scrape PodMonitor resources.\n"
+                "Google Managed Service for Prometheus uses "
+                "monitoring.googleapis.com/v1 PodMonitoring resources, not "
+                "Prometheus Operator PodMonitor or ServiceMonitor resources.\n"
+                "Install the Prometheus Operator CRDs required by this plan, or "
+                "disable those Operator resources and configure Google "
+                "PodMonitoring separately. Direct harness scraping can remain "
+                "enabled.\n"
                 "See: https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed\n"
                 f"{common_tail}"
             )

--- a/tests/test_admin_prerequisites_gateway_crds.py
+++ b/tests/test_admin_prerequisites_gateway_crds.py
@@ -357,3 +357,181 @@ def test_epponly_does_not_add_unused_istio_repo() -> None:
     assert not any("istio" in call for call in helm_calls)
     assert any("llmDInfra" in call for call in helm_calls)
     assert errors == []
+
+
+def _validate_monitoring_crds(
+    plan: dict[str, Any],
+    methods: list[str],
+    existing_crds: list[str] | None = None,
+) -> tuple[_Cmd, list[str]]:
+    cmd = _Cmd()
+    errors: list[str] = []
+    AdminPrerequisitesStep()._validate_monitoring_crds(
+        cmd,
+        _context(methods, cmd),
+        plan,
+        existing_crds=existing_crds or [],
+        errors=errors,
+    )
+    return cmd, errors
+
+
+def test_direct_metrics_scraping_does_not_require_prometheus_operator_crds() -> None:
+    plan = {
+        "monitoring": {
+            "podmonitor": {"enabled": False},
+            "metricsScrapeEnabled": True,
+        }
+    }
+
+    cmd, errors = _validate_monitoring_crds(plan, ["standalone"])
+
+    assert errors == []
+    cmd.logger.log_info.assert_not_called()
+
+
+def test_podmonitor_requires_only_its_own_crd() -> None:
+    plan = {"monitoring": {"podmonitor": {"enabled": True}}}
+
+    _, errors = _validate_monitoring_crds(plan, ["standalone"])
+
+    assert len(errors) == 1
+    assert "podmonitors.monitoring.coreos.com" in errors[0]
+    assert "servicemonitors.monitoring.coreos.com" not in errors[0]
+
+
+def test_modelservice_router_monitoring_requires_only_servicemonitor_crd() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": False}},
+        "router": {"monitoring": {"prometheus": {"enabled": True}}},
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["modelservice"])
+
+    assert len(errors) == 1
+    assert "servicemonitors.monitoring.coreos.com" in errors[0]
+    assert "podmonitors.monitoring.coreos.com" not in errors[0]
+
+
+def test_gmp_router_monitoring_does_not_require_servicemonitor_crd() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": False}},
+        "router": {
+            "monitoring": {
+                "provider": {"name": "gmp"},
+                "prometheus": {"enabled": True},
+            }
+        },
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["modelservice"])
+
+    assert errors == []
+
+
+def test_gke_router_defaults_to_gmp_without_servicemonitor_crd() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": False}},
+        "provider": {"name": "gke"},
+        "router": {"monitoring": {"prometheus": {"enabled": True}}},
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["modelservice"])
+
+    assert errors == []
+
+
+def test_unset_router_monitoring_uses_chart_disabled_default() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": False}},
+        "router": {},
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["modelservice"])
+
+    assert errors == []
+
+
+def test_explicit_prometheus_operator_overrides_gke_monitoring_default() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": False}},
+        "provider": {"name": "gke"},
+        "router": {
+            "monitoring": {
+                "provider": {"name": "prometheusoperator"},
+                "prometheus": {"enabled": True},
+            }
+        },
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["modelservice"])
+
+    assert len(errors) == 1
+    assert "servicemonitors.monitoring.coreos.com" in errors[0]
+
+
+def test_standalone_does_not_require_router_servicemonitor_crd() -> None:
+    plan = {
+        "monitoring": {
+            "podmonitor": {"enabled": False},
+            "metricsScrapeEnabled": True,
+        },
+        "router": {"monitoring": {"prometheus": {"enabled": True}}},
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["standalone"])
+
+    assert errors == []
+
+
+def test_both_operator_resources_report_both_missing_crds() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": True}},
+        "router": {"monitoring": {"prometheus": {"enabled": True}}},
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["modelservice"])
+
+    assert len(errors) == 1
+    assert "podmonitors.monitoring.coreos.com" in errors[0]
+    assert "servicemonitors.monitoring.coreos.com" in errors[0]
+
+
+def test_null_router_monitoring_blocks_do_not_crash_validation() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": False}},
+        "router": {"monitoring": None},
+    }
+
+    _, errors = _validate_monitoring_crds(plan, ["modelservice"])
+
+    assert errors == []
+
+
+def test_enabled_operator_resources_accept_their_matching_crds() -> None:
+    plan = {
+        "monitoring": {"podmonitor": {"enabled": True}},
+        "router": {"monitoring": {"prometheus": {"enabled": True}}},
+    }
+    existing_crds = [
+        "podmonitors.monitoring.coreos.com",
+        "servicemonitors.monitoring.coreos.com",
+    ]
+
+    cmd, errors = _validate_monitoring_crds(
+        plan, ["modelservice"], existing_crds=existing_crds
+    )
+
+    assert errors == []
+    cmd.logger.log_info.assert_called_once_with("✅ Monitoring CRDs present on cluster")
+
+
+def test_gke_monitoring_guidance_distinguishes_google_podmonitoring() -> None:
+    context = MagicMock()
+    context.is_gke = True
+
+    guidance = AdminPrerequisitesStep()._monitoring_guidance(context)
+
+    assert "monitoring.googleapis.com/v1 PodMonitoring" in guidance
+    assert "Direct harness scraping can remain enabled" in guidance
+    assert "natively scrape PodMonitor" not in guidance


### PR DESCRIPTION
## Description

Direct harness metrics scraping discovers the serving pods and calls their
`/metrics` endpoints itself. It does not create a Prometheus Operator
PodMonitor or ServiceMonitor.

The admin prerequisite check currently treats
`monitoring.metricsScrapeEnabled: true` as a reason to require both Operator
CRDs. This blocks direct scraping on clusters without Prometheus Operator,
including GKE clusters using Google Managed Service for Prometheus.

This change builds the required CRD list from the resources the selected plan
will actually create:

- Require `podmonitors.monitoring.coreos.com` when PodMonitor rendering is enabled.
- Require `servicemonitors.monitoring.coreos.com` when the modelservice router
  uses enabled Prometheus Operator monitoring.
- Require neither CRD for direct harness scraping alone.
- Preserve the router chart's provider resolution, including GKE's GMP default.

The GKE remediation text now distinguishes Google
`monitoring.googleapis.com/v1 PodMonitoring` from Prometheus Operator
`monitoring.coreos.com/v1` resources.

Fixes #1766

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a separate documentation update

## How Has This Been Tested?

- `python -m pytest tests/test_admin_prerequisites_gateway_crds.py -q`
  - 27 passed
- `python -m pytest tests/ -x -q -n2`
  - 1,237 passed, 32 skipped
- `python -m compileall -q llmdbenchmark`
  - passed
- `ruff check --output-format=full .`
  - passed
- `ruff format --check --diff .`
  - 284 files already formatted
- `git diff --check`
  - passed
- `llmdbenchmark --spec cicd/kind --dry-run plan`
  - rendered 39 templates with no render errors
  - the later Helmfile invocation was not run because Helmfile is unavailable locally

### Test Configuration

- Python 3.12.13
- No Kubernetes cluster or GPU used
- Cluster integration remains covered by the repository's PR workflows

## Checklist

- [x] My changes follow the style guidelines of this project
- [x] I have performed a self-review
- [ ] A full standup, run, and teardown sequence completed locally
- [ ] The complete pre-commit suite passed locally
- [x] Operator guidance was updated with the corrected behavior
