### PR TITLE
fix(workload): increase request_timeout to 300s for guide_optimized-b…

### DIFF
--- a/workload/profiles/inference-perf/guide_optimized-baseline_1.yaml.in
+++ b/workload/profiles/inference-perf/guide_optimized-baseline_1.yaml.in
@@ -39,7 +39,7 @@ load:
       duration: 26
     - rate: 60
       duration: 25
-  request_timeout: 30
+  request_timeout: 300.0
 api:
   type: completion
   streaming: true


### PR DESCRIPTION
CI for llm-d has been failing for optimized baseline, for example: https://github.com/llm-d/llm-d/actions/runs/31587431261/job/94084497061

Generating 1000 output tokens on a 32B model with 7200 prompt tokens under high-rate Poisson stages (up to 60 req/s) leads to queuing delays that exceed the previous 30s timeout. Increasing request_timeout to 300s aligns with other guide workloads (e.g. predicted-latency-routing) and prevents premature client-side aborts.


cc @rlakhtakia 


