### PR TITLE
Fix FMA launcher OOM on Qwen3-32B on FMA + KEDA Workflows

### DIFF
--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -99,6 +99,11 @@ scenario:
       enabled: true
       iterations: 1
 
+      launcher:
+        # Cap KV cache so sleep-mode leaves headroom for sampler warmup (avoids OOM).
+        # Re-tune per model/GPU if changed.
+        kvCacheMemory: 11259300148  # bytes (~10.49 GiB)
+
       # Opt in to pinning: step_06 picks ONE GPU node whose GPUs are all one
       # type and all free, labels it, and pins the LauncherPopulationPolicy +
       # requester Deployment to it; launcherCount/replicas are sized to that

--- a/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-warmstart.yaml
@@ -136,6 +136,11 @@ scenario:
                                        # are created once at standup and KEDA drives
                                        # scale during the run.
 
+      launcher:
+        # Cap KV cache so sleep-mode leaves headroom for sampler warmup (avoids OOM).
+        # Re-tune per model/GPU if changed.
+        kvCacheMemory: 11259300148  # bytes (~10.49 GiB)
+
       requester:
         replicas: 1
 

--- a/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-hotstart.yaml
@@ -104,6 +104,11 @@ scenario:
       enabled: true
       iterations: 1
 
+      launcher:
+        # Cap KV cache so sleep-mode leaves headroom for sampler warmup (avoids OOM).
+        # Re-tune per model/GPU if changed.
+        kvCacheMemory: 11259300148  # bytes (~10.49 GiB)
+
       # Pin the FMA launchers + requester to ONE GPU node. At standup (step_06)
       # the harness picks a GPU node of a single GPU type with free GPUs and CPU
       # (preferring a fully free/dedicated node, falling back to the most-free

--- a/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
+++ b/config/scenarios/cicd/ocp-wva-fma-warmstart.yaml
@@ -141,6 +141,11 @@ scenario:
                                        # are created once at standup and WVA drives
                                        # scale during the run.
 
+      launcher:
+        # Cap KV cache so sleep-mode leaves headroom for sampler warmup (avoids OOM).
+        # Re-tune per model/GPU if changed.
+        kvCacheMemory: 11259300148  # bytes (~10.49 GiB)
+
       requester:
         replicas: 1
 

--- a/config/templates/jinja/24_fma-deployment.yaml.j2
+++ b/config/templates/jinja/24_fma-deployment.yaml.j2
@@ -38,7 +38,7 @@ spec:
       VLLM_LOGGING_LEVEL: DEBUG
       VLLM_SERVER_DEV_MODE: "1"
       VLLM_USE_V1: "1"
-    options: "--model {{ model.name }} --enable-sleep-mode --no-enable-prefix-caching --load-format auto --gpu-memory-utilization 0.95 --tensor-parallel-size 1"
+    options: "--model {{ model.name }} --enable-sleep-mode --no-enable-prefix-caching --load-format auto{% if (model.gpuMemoryUtilization | default(0.95) | float) > 0 %} --gpu-memory-utilization {{ model.gpuMemoryUtilization | default(0.95) }}{% endif %} --max-model-len {{ model.maxModelLen }}{% if fma.launcher.kvCacheMemory is defined and fma.launcher.kvCacheMemory %} --kv-cache-memory {{ fma.launcher.kvCacheMemory }}{% endif %} --tensor-parallel-size 1"
     port: 8000
 ---
 apiVersion: fma.llm-d.ai/v1alpha1


### PR DESCRIPTION
### Problem

FMA launcher pods serving Qwen3-32B crash on startup with torch.OutOfMemoryError during vLLM's sampler warmup:

####  Error Summary
``
(EngineCore pid=4522) torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 594.00 MiB. GPU 0 has a total capacity of 79.18 GiB of which 544.31 MiB is free. Including non-PyTorch memory, this process has 78.64 GiB memory in use. Of the allocated memory 77.31 GiB is allocated by PyTorch, with 1.22 GiB allocated in private pools (e.g., CUDA Graphs), and 38.33 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)
``
AND
``
(EngineCore pid=208) INFO 08-12 23:21:14 [v1/worker/gpu_worker.py:857] Free memory on device (78.66/79.18 GiB) on startup. Desired GPU memory utilization is (0.95, 75.22 GiB). Actual usage is 61.03 GiB for weight, 1.48 GiB for peak activation, 0.21 GiB for non-torch memory, and 1.86 GiB for CUDAGraph memory. Replace gpu_memory_utilization config with `--kv-cache-memory=11259300148` (10.49 GiB) to fit into requested memory, or `--kv-cache-memory=14957778432` (13.93 GiB) to fully utilize gpu memory. Current kv cache memory in use is 12.5 GiB.
``

### Changes

`config/templates/jinja/24_fma-deployment.yaml.j2` — launcher options now:
- `--gpu-memory-utilization {{ model.gpuMemoryUtilization | default(0.95) }}` — config-driven (was hard-coded 0.95; default preserves prior behavior).
- `--max-model-len {{ model.maxModelLen }} `— the launcher now honors the scenario's context length (previously ignored → defaulted to native 40960).
-` --kv-cache-memory {{ fma.launcher.kvCacheMemory }}` — rendered only when set; caps the KV cache so sleep-mode leaves headroom for the sampler.
