### PR TITLE
Emit traffic-complete harness lifecycle event

### DIFF
--- a/tests/test_inference_perf_lifecycle.py
+++ b/tests/test_inference_perf_lifecycle.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+HELPER = (
+    Path(__file__).resolve().parent.parent
+    / "workload"
+    / "harnesses"
+    / "inference-perf-lifecycle.sh"
+)
+
+
+def _capture(tmp_path: Path, message: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$HELPER"; printf \'%s\\n\' "$MESSAGE" | '
+            'inference_perf_capture_stream "$RESULTS" stderr.log 2 experiment-1',
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "HELPER": str(HELPER),
+            "MESSAGE": message,
+            "RESULTS": str(tmp_path),
+        },
+    )
+
+
+def test_final_successful_stage_emits_event_and_marker(tmp_path: Path) -> None:
+    result = _capture(tmp_path, "2026-08-13 INFO Stage 2 - run completed")
+
+    marker = yaml.safe_load((tmp_path / "traffic_complete.yaml").read_text())
+    assert marker["schema_version"] == "1"
+    assert marker["event"] == "traffic_complete"
+    assert marker["experiment_id"] == "experiment-1"
+    assert marker["final_stage_id"] == 2
+    assert "LLMDBENCH_EVENT_V1 traffic_complete" in result.stdout
+    assert "Stage 2 - run completed" in (tmp_path / "stderr.log").read_text()
+
+
+def test_nonfinal_or_failed_stage_does_not_emit_event(tmp_path: Path) -> None:
+    _capture(tmp_path, "Stage 1 - run completed")
+    _capture(tmp_path, "Stage 2 - run failed")
+
+    assert not (tmp_path / "traffic_complete.yaml").exists()

--- a/workload/README.md
+++ b/workload/README.md
@@ -204,6 +204,14 @@ Each harness script is expected to:
 5. Capture timing metadata (start/stop timestamps, elapsed time)
 6. Exit with the benchmark tool's return code
 
+The inference-perf wrapper additionally writes `traffic_complete.yaml` and
+emits `LLMDBENCH_EVENT_V1 traffic_complete` immediately after its final
+explicitly configured stage drains successfully. Campaign orchestrators can
+use this stable boundary to release accelerator resources while inference-perf
+generates reports and llm-d-benchmark collects results. Sweep-generated stages
+do not emit the event because their final stage is not known from the rendered
+profile before load generation starts.
+
 ### How Harness Scripts Are Mounted
 
 The scripts in `workload/harnesses/` are packaged into a Kubernetes ConfigMap named `llmdbench-harness-scripts` by step 05. The harness pod template (`20_harness_pod.yaml.j2`) mounts this ConfigMap at `/workspace/harnesses/` with executable permissions (`defaultMode: 0755`).

--- a/workload/harnesses/inference-perf-lifecycle.sh
+++ b/workload/harnesses/inference-perf-lifecycle.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Helpers for exposing inference-perf lifecycle boundaries to campaign
+# orchestrators. This file is sourced by inference-perf-llm-d-benchmark.sh.
+
+inference_perf_final_stage_id() {
+  local config_file="$1" stage_count
+
+  stage_count="$(yq '.load.stages | length' "${config_file}" 2>/dev/null)" || return 0
+  if [[ "${stage_count}" =~ ^[1-9][0-9]*$ ]]; then
+    printf '%s\n' "$((stage_count - 1))"
+  fi
+}
+
+inference_perf_capture_stream() {
+  local results_dir="$1" log_name="$2" final_stage_id="$3" experiment_id="$4"
+  local line marker_tmp safe_experiment
+
+  safe_experiment="${experiment_id//\\/\\\\}"
+  safe_experiment="${safe_experiment//\"/\\\"}"
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    printf '%s\n' "${line}" | tee -a "${results_dir}/${log_name}"
+    if [[ -n "${final_stage_id}" && \
+        "${line}" == *"Stage ${final_stage_id} - run completed"* ]] && \
+        mkdir "${results_dir}/.traffic_complete.lock" 2>/dev/null; then
+      marker_tmp="${results_dir}/.traffic_complete.yaml.$$"
+      printf 'schema_version: "1"\nevent: "traffic_complete"\nexperiment_id: "%s"\nfinal_stage_id: %s\ncompleted_at: "%s"\n' \
+        "${safe_experiment}" "${final_stage_id}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        > "${marker_tmp}"
+      mv "${marker_tmp}" "${results_dir}/traffic_complete.yaml"
+      printf 'LLMDBENCH_EVENT_V1 traffic_complete experiment_id=%s final_stage_id=%s\n' \
+        "${experiment_id}" "${final_stage_id}" | tee -a "${results_dir}/stdout.log"
+    fi
+  done
+}

--- a/workload/harnesses/inference-perf-llm-d-benchmark.sh
+++ b/workload/harnesses/inference-perf-llm-d-benchmark.sh
@@ -6,6 +6,12 @@ pushd "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" > /dev/null  2>&1
 yq '.storage["local_storage"]["path"] = '\"${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR}\" <"${LLMDBENCH_RUN_WORKSPACE_DIR}/profiles/inference-perf/${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}" >${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}
 export LLMDBENCH_HARNESS_ARGS="--config_file $(realpath ./${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME})"
 
+# inference-perf generates its reports after the final traffic stage drains.
+# Expose that boundary so campaign orchestrators can release accelerators while
+# report generation and result collection continue.
+source /workspace/harnesses/inference-perf-lifecycle.sh
+LLMDBENCH_FINAL_STAGE_ID="$(inference_perf_final_stage_id "./${LLMDBENCH_RUN_EXPERIMENT_HARNESS_WORKLOAD_NAME}")"
+
 # Start metrics collection in background if enabled
 if [[ "${LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED:-false}" == "true" ]]; then
   echo "Starting metrics collection..."
@@ -16,7 +22,17 @@ if [[ "${LLMDBENCH_VLLM_COMMON_METRICS_SCRAPE_ENABLED:-false}" == "true" ]]; the
 fi
 
 start=$(date +%s.%N)
-inference-perf $LLMDBENCH_HARNESS_ARGS > >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log) 2> >(tee -a $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log >&2)
+inference-perf $LLMDBENCH_HARNESS_ARGS \
+  > >(inference_perf_capture_stream \
+    "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" \
+    stdout.log \
+    "$LLMDBENCH_FINAL_STAGE_ID" \
+    "${LLMDBENCH_RUN_EXPERIMENT_ID:-unknown}") \
+  2> >(inference_perf_capture_stream \
+    "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" \
+    stderr.log \
+    "$LLMDBENCH_FINAL_STAGE_ID" \
+    "${LLMDBENCH_RUN_EXPERIMENT_ID:-unknown}" >&2)
 export LLMDBENCH_RUN_EXPERIMENT_HARNESS_RC=$?
 stop=$(date +%s.%N)
 


### PR DESCRIPTION
## Description

Emit a stable event and persist `traffic_complete.yaml` after inference-perf drains its final explicitly configured stage. This lets campaign orchestration release accelerators while report generation and result collection continue.

Fixes: #1796

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- Full pre-commit suite
- Lifecycle event and marker unit tests
- Harness metadata, ConfigMap, and deploy-status tests
- Shell syntax validation

### Test Configuration

- Kubernetes version: not applicable to unit coverage

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully
- [x] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly