### PR TITLE
Grant FMA Launcher Pods RBAC Permissions to Advertise Serving State

### DIFF
--- a/config/templates/jinja/24_fma-deployment.yaml.j2
+++ b/config/templates/jinja/24_fma-deployment.yaml.j2
@@ -70,6 +70,9 @@ spec:
 {% endfor %}
 {% endif %}
     spec:
+      # SA granted pods get/patch so the state-change-reflector can patch its
+      # own pod's serving state (Role in 25a_fma-launcher-rbac.yaml.j2).
+      serviceAccountName: fma-launcher
 {% if fma.launcher.runtimeClassName is defined and fma.launcher.runtimeClassName %}
       runtimeClassName: {{ fma.launcher.runtimeClassName }}
 {% endif %}

--- a/config/templates/jinja/25_fma-clusterrole.yaml.j2
+++ b/config/templates/jinja/25_fma-clusterrole.yaml.j2
@@ -1,8 +1,8 @@
 {# ============================================================================
    25_fma-clusterrole.yaml.j2
 
-   ClusterRole granting access to FMA.
-   Required by FMA.
+   Cluster-scoped RBAC required by FMA: ClusterRole fma-node-viewer
+   (node get/list/watch for the controllers).
 
    Only rendered when fma.enabled is true.
    ============================================================================ #}

--- a/config/templates/jinja/25a_fma-launcher-rbac.yaml.j2
+++ b/config/templates/jinja/25a_fma-launcher-rbac.yaml.j2
@@ -1,0 +1,43 @@
+{# ============================================================================
+   25a_fma-launcher-rbac.yaml.j2
+
+   Namespace-scoped RBAC letting the launcher (which runs as the SA below) patch
+   its own pod's serving state. SA is set on the LauncherConfig podTemplate in
+   24_fma-deployment.yaml.j2.
+
+   Only rendered when fma.enabled is true.
+   ============================================================================ #}
+{% if fma is defined and fma.enabled | default(false) %}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fma-launcher
+  namespace: {{ namespace.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fma-launcher-pod-state-writer
+  namespace: {{ namespace.name }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fma-launcher-pod-state-writer
+  namespace: {{ namespace.name }}
+subjects:
+  - kind: ServiceAccount
+    name: fma-launcher
+    namespace: {{ namespace.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fma-launcher-pod-state-writer
+{% endif %}

--- a/llmdbenchmark/standup/steps/step_06_fma_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_fma_deploy.py
@@ -52,8 +52,19 @@ class FMADeployStep(Step):
                 step_number=self.number,
                 step_name=self.name,
                 success=False,
-                message="No FMA ClusterRole YAML found, skipping",
-                errors=["FMA ClusterRole YAML is required"],
+                message="No FMA RBAC YAML found, skipping",
+                errors=["FMA RBAC YAML is required"],
+                stack_name=stack_path.name,
+            )
+
+        launcher_rbac_yaml = self._find_yaml(stack_path, "25a_fma-launcher-rbac")
+        if not launcher_rbac_yaml or not self._has_yaml_content(launcher_rbac_yaml):
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="No FMA launcher RBAC YAML found, skipping",
+                errors=["FMA launcher RBAC YAML is required"],
                 stack_name=stack_path.name,
             )
 
@@ -84,8 +95,11 @@ class FMADeployStep(Step):
             context, plan_config, errors
         )  # pylint disable=too-many-function-args
 
-        # Fast Model Actuation ClusterRole
+        # Fast Model Actuation cluster-scoped ClusterRole (create only if missing)
         self._install_fma_clusterole(context, clusterrole_yaml, errors)
+
+        # Namespace-scoped launcher RBAC -- always apply (idempotent, namespaced)
+        self._apply_fma_launcher_rbac(context, launcher_rbac_yaml, errors)
 
         if len(errors) == 0:
             # Fast Model Actuation Controllers chart
@@ -752,6 +766,21 @@ class FMADeployStep(Step):
             return
 
         context.logger.log_info("✅ Fast Model Actuation ClusterRole installed")
+
+    def _apply_fma_launcher_rbac(
+        self, context: ExecutionContext, launcher_rbac_yaml: Path, errors: list[str]
+    ) -> None:
+        # Namespace-scoped SA/Role/RoleBinding for the launcher: always apply
+        # (idempotent, namespaced) so it exists before the LauncherConfig's SA resolves.
+        cmd = context.require_cmd()
+        context.logger.log_info("🚚 Applying Fast Model Actuation launcher RBAC ...")
+
+        result = cmd.kube("apply", "-f", str(launcher_rbac_yaml))
+        if not result.success:
+            errors.append(f"Failed to apply fma launcher RBAC: {result.stderr}")
+            return
+
+        context.logger.log_info("✅ Fast Model Actuation launcher RBAC applied")
 
     def _propagate_standup_parameters(
         self, cmd: CommandExecutor, context: ExecutionContext, plan_config: dict


### PR DESCRIPTION
### Problem

FMA launcher pods run under the namespace default ServiceAccount, which has no pods: patch permission. The launcher's state-change-reflector sidecar patches its own pod to advertise serving state, so it fails every ~5s with:

```
WARNING launcher_pod_notifier: Notifier failure: (403) Forbidden
User "system:serviceaccount:<ns>:default" cannot patch resource "pods" in ... namespace "<ns>"
```

The FMA templates render only ClusterRole/fma-node-viewer (nodes get/list/watch) — nothing grants the launcher pod-patch, and the LauncherConfig pod template sets no serviceAccountName, so it falls back to default.

### Change

Add a dedicated launcher ServiceAccount + namespaced Role/RoleBinding, and run launcher pods under it. The RBAC mirrors upstream's launcher-pod-state-writer from llm-d-fast-model-actuation test/e2e/mkobjs-openshift.sh (https://github.com/llm-d-incubation/llm-d-fast-model-actuation/blob/main/test/e2e/mkobjs-openshift.sh) — same resource (pods) and verbs (get, patch).

Cluster-scoped and namespace-scoped RBAC are kept in separate manifests so the shared, potentially operator-managed ClusterRole is only created when missing, while the namespaced launcher RBAC is always applied:

- `25_fma-clusterrole.yaml.j2` — unchanged in scope: ClusterRole/fma-node-viewer only. Applied create-if-missing (never overwrites a pre-existing/hand-managed ClusterRole; no ClusterRole write perms needed on re-standup).
- `25a_fma-launcher-rbac.yaml.j2 `(new) — namespace-scoped, gated on fma.enabled:
  - `ServiceAccount/fma-launcher`
  - `Role/fma-launcher-pod-state-writer → pods: [get, patch]`
  - `RoleBinding/fma-launcher-pod-state-writer → binds the Role to fma-launcher`
- `24_fma-deployment.yaml.j2` — LauncherConfig.podTemplate.spec.serviceAccountName: fma-launcher, so launchers run as the SA above instead of default.
- `step_06_fma_deploy.py` — applies both manifests with the right semantics:
  - `ClusterRole (25_fma-clusterrole)`: keeps the existing "skip if fma-node-viewer already exists" behavior.
  - `Launcher RBAC (25a_fma-launcher-rbac)`: always kubectl apply (idempotent, namespace-local) so the fma-launcher SA reliably exists before the LauncherConfig references it.
