### PR TITLE
Fix typos detected by nightly scan

### DIFF
--- a/llmdbenchmark/analysis/aggregate_eval_containers.py
+++ b/llmdbenchmark/analysis/aggregate_eval_containers.py
@@ -300,7 +300,7 @@ def _iso_to_unix_ns(value: Any) -> int | None:
 
     Needed to anchor time-to-first-call: the span clock is unix-epoch
     nanoseconds, so the task's own start has to be expressed in the same units.
-    Returns None on anything unparseable, so the metric is blanked rather than
+    Returns None on anything unparsable, so the metric is blanked rather than
     guessed.
     """
     if value is None:

--- a/tests/fixtures/single_stack_overrides.yaml
+++ b/tests/fixtures/single_stack_overrides.yaml
@@ -1,6 +1,6 @@
 # Test-only single-stack scenario, owned by tests/test_cli_set_overrides.py.
 # Sibling of multi_stack_overrides.yaml; same reasoning -- scenarios under
-# config/scenarios/ ship to users and get retuned freely, so a suite that
+# config/scenarios/ ship to users and get modified freely, so a suite that
 # asserts on their literals fails for reasons unrelated to the code.
 #
 # Everything below is load-bearing for an assertion. The contract:

--- a/tests/test_cli_set_overrides.py
+++ b/tests/test_cli_set_overrides.py
@@ -44,7 +44,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATES = PROJECT_ROOT / "config" / "templates" / "jinja"
 DEFAULTS = PROJECT_ROOT / "config" / "templates" / "values" / "defaults.yaml"
 # Test-owned fixtures, deliberately NOT scenarios under config/scenarios/.
-# Those ship to users and get retuned freely -- replicas, resources, model
+# Those ship to users and get modified freely -- replicas, resources, model
 # choice, pool names -- and the tests below assert on literal stack names
 # and values. Pointing them at a shipped scenario makes an ordinary config
 # edit fail the suite for a reason that has nothing to do with the code


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request
---

## Description

Correct the three words reported by the nightly typo scanner. The two configuration comments now use "modified" instead of the scanner's suggested "returned" so their original meaning remains intact, and the analysis docstring uses the standard spelling "unparsable".

No new dependencies are required.

Fixes #1793

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- `typos .`
- `pre-commit run --files llmdbenchmark/analysis/aggregate_eval_containers.py tests/fixtures/single_stack_overrides.yaml tests/test_cli_set_overrides.py`
- `.venv/bin/python -m pytest tests/test_cli_set_overrides.py -q` (150 passed)
- `.venv/bin/python -m pytest tests/test_aggregate_eval_containers.py -q` (23 passed)

### Test Configuration

- Kubernetes version: N/A (comment and docstring corrections do not require a cluster)

## Checklist

- [x] My changes follows the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [ ] I confirm that a full `./setup/standup.sh` -> `run.sh` -> `./setup/teardown.sh` sequence completed successfully — N/A for comment-only typo corrections
- [x] I confirm that `pre-commit run` was run and all checks passed
- [x] I have updated the documentation accordingly
