### PR TITLE
feat(cli): add cleanup subcommand to remove run leftovers from the namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ llmdbenchmark/                Python package
         plan.py               Plan subcommand
         standup.py            Standup subcommand
         teardown.py           Teardown subcommand
+        cleanup.py            Cleanup subcommand (remove run leftovers)
         run.py                Run subcommand
         experiment.py         Experiment subcommand (DoE orchestration)
 
@@ -683,6 +684,9 @@ llmdbenchmark/                Python package
 
     teardown/                 Teardown phase (see teardown/README.md)
         steps/                Step implementations (00-05)
+
+    cleanup/                  Cleanup phase (see cleanup/README.md)
+        steps/                Step implementations (00)
 
     run/                      Run phase (see run/README.md)
         steps/                Step implementations (00-11)

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -120,3 +120,13 @@ llmdbenchmark teardown
 
 > [!NOTE]
 > The scenario can also be indicated as part of the command line options for `llmdbenchmark teardown` (e.g., `llmdbenchmark teardown --spec kubernetes_H200_modelservice_llama-8b`)
+
+`teardown` removes the deployed llm-d stack, but the harness namespace still holds what benchmark runs created there: the data-access pod, the harness service, the benchmark ConfigMaps and the workload PVC (which keeps billing against its storage backend until deleted). Remove all of it with
+
+```
+llmdbenchmark --spec <specification> cleanup
+```
+
+`cleanup` takes the same `--spec` as every other subcommand and reads the resource names from the scenario, so a scenario that overrides `harness.podLabel`, `harness.name`, `labels.app` or `storage.workloadPvc.name` is cleaned correctly. It also reaches both namespaces when the scenario sets `harness.namespace` separately from `namespace.name`.
+
+The command is idempotent -- resources that no longer exist are skipped, and a namespace with no benchmark resources exits 0. Pass `--keep-pvc` to preserve the workload PVC so workload data survives for the next run. `--namespace` overrides the namespaces from the scenario (comma-separated `model,harness`); any other name is overridden the same way as for every other subcommand, e.g. `--set storage.workloadPvc.name=my-pvc`.

--- a/llmdbenchmark/cleanup/README.md
+++ b/llmdbenchmark/cleanup/README.md
@@ -1,0 +1,22 @@
+# llmdbenchmark.cleanup
+
+Cleanup phase of the benchmark lifecycle. Removes what a benchmark run leaves behind in the namespace: leftover harness launcher pods, the benchmark ConfigMaps, the data-access pod, the harness service, and the workload PVC.
+
+## Step Ordering
+
+Steps are registered in `steps/__init__.py` via `get_cleanup_steps()` and execute in order:
+
+| Step | Name | Scope | Description |
+|------|------|-------|-------------|
+| 00 | `CleanupResourcesStep` | global | Delete benchmark leftovers for every rendered stack |
+
+## Step Details
+
+### Step 00 -- Cleanup Resources
+
+For each rendered stack, reads the resource names from its `config.yaml` (`namespace.name`, `harness.namespace`, `harness.podLabel`, `harness.name`, `labels.app`, `storage.workloadPvc.name`) and deletes:
+
+- harness launcher pods and the `<harness.name>-profiles`, `llm-d-benchmark-*` and `llmdbench-harness-scripts` ConfigMaps in the harness namespace
+- the data-access pod, the `labels.app` service and the workload PVC in the workload namespace
+
+The data-access pod is deleted before the PVC so the claim's protection finalizer can clear. `--keep-pvc` preserves the PVC. Stacks that resolve to identical names are cleaned once. The step is idempotent: every delete uses `--ignore-not-found`, so a namespace with nothing in it is a success.

--- a/llmdbenchmark/cleanup/__init__.py
+++ b/llmdbenchmark/cleanup/__init__.py
@@ -1,0 +1,1 @@
+"""llmdbenchmark.cleanup -- Cleanup phase package."""

--- a/llmdbenchmark/cleanup/steps/__init__.py
+++ b/llmdbenchmark/cleanup/steps/__init__.py
@@ -1,0 +1,14 @@
+"""Step registry for the cleanup phase."""
+
+from llmdbenchmark.executor.step import Step
+
+from llmdbenchmark.cleanup.steps.step_00_cleanup_resources import (
+    CleanupResourcesStep,
+)
+
+
+def get_cleanup_steps() -> list[Step]:
+    """Return all cleanup-phase steps in execution order."""
+    return [
+        CleanupResourcesStep(),
+    ]

--- a/llmdbenchmark/cleanup/steps/step_00_cleanup_resources.py
+++ b/llmdbenchmark/cleanup/steps/step_00_cleanup_resources.py
@@ -1,0 +1,196 @@
+"""Cleanup Step 00 -- Remove what a benchmark run leaves behind in the namespace."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from llmdbenchmark.executor.step import Step, StepResult, Phase
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.executor.command import CommandExecutor
+from llmdbenchmark.run.steps.step_06_create_profile_configmap import (
+    HARNESS_SCRIPTS_CONFIGMAP,
+)
+from llmdbenchmark.utilities.kube_helpers import (
+    delete_pods_by_label,
+    delete_pods_by_names,
+    find_data_access_pod,
+)
+
+# These ConfigMaps are created by name in the standup/run code rather than
+# from a scenario key, so they are matched by name here as well (same list
+# teardown step_02 and run step_11 use).
+BENCHMARK_CONFIGMAPS = [
+    "llm-d-benchmark-preprocesses",
+    "llm-d-benchmark-run-parameters",
+    "llm-d-benchmark-standup-parameters",
+    HARNESS_SCRIPTS_CONFIGMAP,
+]
+
+
+@dataclass(frozen=True)
+class CleanupTarget:
+    """Resource names one rendered stack leaves behind, read from its config.yaml.
+
+    Harness pods and their ConfigMaps render into ``harness.namespace``
+    (falling back to ``namespace.name``); the workload PVC, harness service
+    and data-access pod render into ``namespace.name``.
+    """
+
+    namespace: str
+    harness_namespace: str
+    pod_label: str
+    service: str
+    pvc_name: str
+    profiles_configmap: str
+
+
+class CleanupResourcesStep(Step):
+    """Delete benchmark leftovers for every rendered stack. Idempotent."""
+
+    def __init__(self):
+        super().__init__(
+            number=0,
+            name="cleanup_resources",
+            description="Remove benchmark leftovers (pods, service, ConfigMaps, PVC)",
+            phase=Phase.CLEANUP,
+            per_stack=False,
+        )
+
+    def should_skip(self, context: ExecutionContext) -> bool:
+        return "nok8s" in (context.deployed_methods or [])
+
+    def execute(
+        self, context: ExecutionContext, stack_path: Path | None = None
+    ) -> StepResult:
+        cmd = context.require_cmd()
+
+        targets: list[CleanupTarget] = []
+        for rendered_stack in context.rendered_stacks:
+            plan_config = self._load_stack_config(rendered_stack)
+            if not plan_config:
+                continue
+            target = self._target_from_config(plan_config)
+            # Multi-stack scenarios routinely share a namespace; clean it once.
+            if target not in targets:
+                targets.append(target)
+
+        if not targets:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="No rendered plan config found.",
+                errors=["plan config (config.yaml) not found"],
+            )
+
+        deleted: list[str] = []
+        errors: list[str] = []
+        for target in targets:
+            self._clean_target(cmd, context, target, deleted, errors)
+
+        namespaces = ", ".join(
+            f'"{ns}"'
+            for ns in dict.fromkeys(
+                ns for t in targets for ns in (t.harness_namespace, t.namespace)
+            )
+        )
+        if errors:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message=f"Cleanup finished with {len(errors)} error(s) in {namespaces}",
+                errors=errors,
+            )
+        if deleted:
+            message = f"Removed {len(deleted)} resource(s) from {namespaces}"
+        else:
+            message = f"No benchmark resources found in {namespaces}"
+        return StepResult(
+            step_number=self.number,
+            step_name=self.name,
+            success=True,
+            message=message,
+        )
+
+    def _target_from_config(self, plan_config: dict) -> CleanupTarget:
+        """Read every resource name from the rendered config -- no fallbacks."""
+        namespace = self._require_config(plan_config, "namespace", "name")
+        return CleanupTarget(
+            namespace=namespace,
+            harness_namespace=(
+                plan_config.get("harness", {}).get("namespace") or namespace
+            ),
+            pod_label=self._require_config(plan_config, "harness", "podLabel"),
+            service=self._require_config(plan_config, "labels", "app"),
+            pvc_name=self._require_config(
+                plan_config, "storage", "workloadPvc", "name"
+            ),
+            profiles_configmap=(
+                f"{self._require_config(plan_config, 'harness', 'name')}-profiles"
+            ),
+        )
+
+    def _clean_target(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        target: CleanupTarget,
+        deleted: list[str],
+        errors: list[str],
+    ) -> None:
+        harness_ns = target.harness_namespace
+        context.logger.log_info(f'Cleaning harness resources in "{harness_ns}"...')
+        delete_pods_by_label(cmd, target.pod_label, harness_ns, context)
+        for cm_name in [target.profiles_configmap, *BENCHMARK_CONFIGMAPS]:
+            self._delete(
+                cmd, context, "configmap", cm_name, harness_ns, deleted, errors
+            )
+
+        namespace = target.namespace
+        context.logger.log_info(f'Cleaning workload resources in "{namespace}"...')
+        # The data-access pod mounts the workload PVC; delete it first so the
+        # claim's protection finalizer clears instead of leaving it Terminating.
+        data_access_pod = find_data_access_pod(cmd, namespace, attempts=1)
+        if data_access_pod:
+            delete_pods_by_names(cmd, [data_access_pod], namespace, context)
+            deleted.append(f"pod/{data_access_pod}")
+        self._delete(
+            cmd, context, "service", target.service, namespace, deleted, errors
+        )
+
+        if context.keep_pvc:
+            context.logger.log_info(
+                f'Keeping PVC "{target.pvc_name}" (--keep-pvc). It keeps billing '
+                "against its storage backend until deleted."
+            )
+        else:
+            self._delete(
+                cmd, context, "pvc", target.pvc_name, namespace, deleted, errors
+            )
+
+    @staticmethod
+    def _delete(
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        kind: str,
+        name: str,
+        namespace: str,
+        deleted: list[str],
+        errors: list[str],
+    ) -> None:
+        """Delete one named resource; a resource that no longer exists is a no-op."""
+        result = cmd.kube(
+            "delete",
+            kind,
+            name,
+            "--namespace",
+            namespace,
+            "--ignore-not-found",
+            check=False,
+        )
+        if not result.success:
+            errors.append(f"Failed to delete {kind}/{name}: {result.stderr}")
+        elif result.stdout.strip():
+            # kubectl only prints "<kind>/<name> deleted" when it removed something.
+            context.logger.log_info(f"Deleted {kind}/{name}", emoji="🗑️")
+            deleted.append(f"{kind}/{name}")

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -34,6 +34,7 @@ from llmdbenchmark.interface import plan, standup, teardown, run
 from llmdbenchmark.interface import smoketest as smoketest_interface
 from llmdbenchmark.interface import experiment as experiment_interface
 from llmdbenchmark.interface import results
+from llmdbenchmark.interface import cleanup as cleanup_interface
 from llmdbenchmark.parser.cli_overrides import (
     GLOBAL_SELECTOR,
     REDACTED,
@@ -53,6 +54,7 @@ from llmdbenchmark.executor.step_executor import StepExecutor
 from llmdbenchmark.standup.steps import get_standup_steps
 from llmdbenchmark.smoketests.steps import get_smoketest_steps
 from llmdbenchmark.teardown.steps import get_teardown_steps
+from llmdbenchmark.cleanup.steps import get_cleanup_steps
 
 from llmdbenchmark.run.steps import get_run_steps
 from llmdbenchmark.executor.command import CommandExecutor
@@ -93,6 +95,7 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
         Command.SMOKETEST.value,
         Command.TEARDOWN.value,
         Command.RUN.value,
+        Command.CLEANUP.value,
     ):
         # Resolve templates, scenarios, and values into the workspace
         try:
@@ -177,6 +180,9 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
 
     if args.command == Command.RUN.value:
         _execute_run(args, logger, render_plan_errors)
+
+    if args.command == Command.CLEANUP.value:
+        _execute_cleanup(args, logger, render_plan_errors)
 
 
 def _render_helm_manifests(plan_dir: Path, logger) -> None:
@@ -864,6 +870,74 @@ def _execute_teardown(args, logger, render_plan_errors):
         f'Namespaces: "{ns}", "{harness_ns}". '
         f"Methods: {', '.join(context.deployed_methods)}. "
         f"Release: {context.release}.",
+        emoji="✅",
+    )
+
+
+def _do_cleanup(args, logger, render_plan_errors):
+    """Core cleanup logic. Returns (context, result). Raises PhaseError on failure."""
+    rendered_paths = getattr(render_plan_errors, "rendered_paths", [])
+    plan_info = _load_plan_info(rendered_paths)
+    deployed_methods = _resolve_deploy_methods(args, plan_info, logger, phase="cleanup")
+
+    namespace, harness_ns = _parse_namespaces(
+        getattr(args, "namespace", None),
+        plan_info,
+    )
+
+    container_only = "nok8s" in deployed_methods
+    if not namespace and not container_only:
+        raise PhaseError(
+            "No namespace specified. Set 'namespace.name' in your scenario "
+            "YAML, defaults.yaml, or pass --namespace on the CLI."
+        )
+
+    context = ExecutionContext(
+        plan_dir=config.plan_dir,
+        workspace=config.workspace,
+        specification_file=getattr(args, "specification_file", None),
+        rendered_stacks=rendered_paths,
+        dry_run=config.dry_run,
+        verbose=config.verbose,
+        non_admin=getattr(args, "non_admin", False),
+        current_phase=Phase.CLEANUP,
+        kubeconfig=getattr(args, "kubeconfig", None),
+        deployed_methods=deployed_methods,
+        container_only=container_only,
+        keep_pvc=getattr(args, "keep_pvc", False),
+        namespace=namespace,
+        harness_namespace=harness_ns,
+        model_name=plan_info.get("model_name"),
+        logger=logger,
+    )
+
+    executor = StepExecutor(
+        steps=get_cleanup_steps(),
+        context=context,
+        logger=logger,
+    )
+
+    result = executor.execute()
+
+    if result.has_errors:
+        raise PhaseError(f"Cleanup failed:\n{result.summary()}")
+
+    return context, result
+
+
+def _execute_cleanup(args, logger, render_plan_errors):
+    """Build execution context and run cleanup steps."""
+    try:
+        context, _result = _do_cleanup(args, logger, render_plan_errors)
+    except PhaseError as e:
+        logger.log_error(str(e))
+        sys.exit(1)
+
+    ns = context.namespace or "unknown"
+    harness_ns = context.harness_namespace or ns
+    logger.line_break()
+    logger.log_info(
+        f'Cleanup complete. Namespaces: "{ns}", "{harness_ns}".',
         emoji="✅",
     )
 
@@ -2039,6 +2113,7 @@ def cli() -> None:
     run.add_subcommands(subparsers, parents=[benchmark_parser])
     experiment_interface.add_subcommands(subparsers, parents=[benchmark_parser])
     results.add_subcommands(subparsers, parents=[])
+    cleanup_interface.add_subcommands(subparsers, parents=[benchmark_parser])
     args = parser.parse_args()
 
     # Merge env vars for boolean flags (store_true can't use default=)

--- a/llmdbenchmark/executor/README.md
+++ b/llmdbenchmark/executor/README.md
@@ -37,6 +37,7 @@ class Phase(Enum):
     SMOKETEST = "smoketest"
     RUN = "run"
     TEARDOWN = "teardown"
+    CLEANUP = "cleanup"
 ```
 
 ### Step ABC

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -36,6 +36,7 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     non_admin: bool = False
     current_phase: Any = None  # Phase enum, set at runtime to avoid circular import
     deep_clean: bool = False  # teardown: wipe all resources in namespaces
+    keep_pvc: bool = False  # cleanup: preserve the workload PVC
     release: str = "llmdbench"  # Helm release name prefix
 
     # Kubernetes connection info (resolved at runtime by step 00)

--- a/llmdbenchmark/executor/step.py
+++ b/llmdbenchmark/executor/step.py
@@ -19,6 +19,7 @@ class Phase(Enum):
     SMOKETEST = "smoketest"
     RUN = "run"
     TEARDOWN = "teardown"
+    CLEANUP = "cleanup"
 
 
 @dataclass

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -14,6 +14,7 @@ interface/
 ├── smoketest.py     -- smoketest subcommand
 ├── run.py           -- run subcommand
 ├── teardown.py      -- teardown subcommand
+├── cleanup.py       -- cleanup subcommand
 └── experiment.py    -- experiment subcommand
 ```
 
@@ -26,6 +27,7 @@ class Command(Enum):
     SMOKETEST = "smoketest"
     RUN = "run"
     TEARDOWN = "teardown"
+    CLEANUP = "cleanup"
     EXPERIMENT = "experiment"
 ```
 

--- a/llmdbenchmark/interface/cleanup.py
+++ b/llmdbenchmark/interface/cleanup.py
@@ -1,0 +1,47 @@
+"""CLI definition for the ``cleanup`` subcommand."""
+
+import argparse
+from llmdbenchmark.interface.commands import Command
+from llmdbenchmark.interface.env import env
+
+
+def add_subcommands(
+    parser: argparse._SubParsersAction, parents: list[argparse.ArgumentParser] = []
+):
+    """Register the ``cleanup`` subcommand and its arguments."""
+    cleanup_parser = parser.add_parser(
+        Command.CLEANUP.value,
+        parents=parents,
+        description=(
+            "The `cleanup` command removes the resources a benchmark run "
+            "leaves behind: leftover harness launcher pods, the benchmark "
+            "ConfigMaps, the data-access pod, the harness service, and the "
+            "workload PVC. Resource names are read from the rendered scenario, "
+            "so --spec is required. It is idempotent: resources that no longer "
+            "exist are skipped, and a namespace with no benchmark resources "
+            "exits 0. Pass --keep-pvc to preserve the workload PVC so workload "
+            "data survives between runs."
+        ),
+        help="Remove benchmark leftovers (pods, service, ConfigMaps, PVC) "
+        "left by a scenario.",
+    )
+    cleanup_parser.add_argument(
+        "-p",
+        "--namespace",
+        default=env("LLMDBENCH_NAMESPACE"),
+        help="Comma-separated namespaces to clean up (model,harness). "
+        "Overrides namespace from the plan config. If only one namespace is "
+        "provided, it is used for both model and harness.",
+    )
+    cleanup_parser.add_argument(
+        "--keep-pvc",
+        action="store_true",
+        help="Preserve the workload PVC so workload data survives for the "
+        "next run. Everything else is still removed.",
+    )
+    cleanup_parser.add_argument(
+        "--kubeconfig",
+        "-k",
+        default=env("LLMDBENCH_KUBECONFIG") or env("KUBECONFIG"),
+        help="Path to kubeconfig file for kubectl commands.",
+    )

--- a/llmdbenchmark/interface/commands.py
+++ b/llmdbenchmark/interface/commands.py
@@ -11,5 +11,6 @@ class Command(Enum):
     SMOKETEST = "smoketest"
     RUN = "run"
     TEARDOWN = "teardown"
+    CLEANUP = "cleanup"
     EXPERIMENT = "experiment"
     RESULTS = "results"

--- a/tests/test_cleanup_command.py
+++ b/tests/test_cleanup_command.py
@@ -1,0 +1,318 @@
+"""Tests for the ``cleanup`` subcommand's step.
+
+``cleanup`` removes the leftovers a benchmark run parks in the namespace
+(harness pods, ConfigMaps, data-access pod, harness service, workload PVC).
+Two properties matter: every resource name comes from the rendered
+``config.yaml`` rather than from hardcoded fallbacks, and the step is
+idempotent -- a namespace with nothing in it is a success, not an error.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+from llmdbenchmark.cleanup.steps import get_cleanup_steps
+from llmdbenchmark.cleanup.steps.step_00_cleanup_resources import (
+    BENCHMARK_CONFIGMAPS,
+    CleanupResourcesStep,
+)
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.utilities.kube_helpers import DATA_ACCESS_LABEL
+
+
+@dataclass
+class _Result:
+    success: bool
+    stdout: str = ""
+    stderr: str = ""
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def log_info(self, msg, **_kwargs):
+        self.messages.append(("info", msg))
+
+    def log_warning(self, msg, **_kwargs):
+        self.messages.append(("warning", msg))
+
+    def log_error(self, msg, **_kwargs):
+        self.messages.append(("error", msg))
+
+
+class _FakeCluster:
+    """Answers kubectl get/delete against an in-memory resource inventory.
+
+    ``resources`` maps namespace -> {"kind/name": set of "key=value" labels}.
+    Mirrors kubectl closely enough for the step: ``get -o jsonpath`` returns
+    the first match, ``delete`` prints one "<kind>/<name> deleted" line per
+    removed resource and nothing for ``--ignore-not-found`` misses.
+    """
+
+    def __init__(self, resources: dict[str, dict[str, set[str]]]):
+        self.resources = {ns: dict(items) for ns, items in resources.items()}
+        self.deleted: list[tuple[str, str]] = []
+
+    def kube(self, *args, check=True, **_kwargs):
+        namespace = args[args.index("--namespace") + 1]
+        verb, kind = args[0], args[1]
+        inventory = self.resources.setdefault(namespace, {})
+        matches = self._match(inventory, kind, args)
+        if verb == "get":
+            return _Result(True, matches[0].split("/", 1)[1] if matches else "")
+        if verb == "delete":
+            for key in matches:
+                del inventory[key]
+                self.deleted.append((namespace, key))
+            return _Result(True, "\n".join(f"{key} deleted" for key in matches))
+        return _Result(False, "", f"unexpected verb {verb}")
+
+    @staticmethod
+    def _match(inventory: dict[str, set[str]], kind: str, args) -> list[str]:
+        if "-l" in args:
+            label = args[args.index("-l") + 1]
+            return [
+                key
+                for key, labels in inventory.items()
+                if key.startswith(f"{kind}/") and label in labels
+            ]
+        name = args[2] if len(args) > 2 and not args[2].startswith("-") else None
+        key = f"{kind}/{name}"
+        return [key] if key in inventory else []
+
+
+def _stack_config(**overrides) -> dict:
+    """A rendered config.yaml carrying everything the step reads."""
+    config = {
+        "namespace": {"name": "bench"},
+        "labels": {"app": "llm-d-benchmark-harness"},
+        "storage": {"workloadPvc": {"name": "workload-pvc"}},
+        "harness": {"name": "inference-perf", "podLabel": "llmdbench-harness-launcher"},
+    }
+    for path, value in overrides.items():
+        node = config
+        keys = path.split("__")
+        for key in keys[:-1]:
+            node = node.setdefault(key, {})
+        node[keys[-1]] = value
+    return config
+
+
+def _inventory(config: dict) -> dict[str, dict[str, set[str]]]:
+    """Everything a run of *config* leaves behind, in both namespaces."""
+    namespace = config["namespace"]["name"]
+    harness_ns = config["harness"].get("namespace") or namespace
+    resources: dict[str, dict[str, set[str]]] = {namespace: {}, harness_ns: {}}
+
+    harness = resources[harness_ns]
+    harness["pod/harness-launcher-1"] = {f"app={config['harness']['podLabel']}"}
+    harness[f"configmap/{config['harness']['name']}-profiles"] = set()
+    for cm_name in BENCHMARK_CONFIGMAPS:
+        harness[f"configmap/{cm_name}"] = set()
+
+    # Same dict as ``harness`` when the scenario leaves harness.namespace unset.
+    workload = resources[namespace]
+    workload["pod/access-to-harness-data-workload-pvc"] = {DATA_ACCESS_LABEL}
+    workload[f"service/{config['labels']['app']}"] = set()
+    workload[f"pvc/{config['storage']['workloadPvc']['name']}"] = set()
+    return resources
+
+
+def _render(tmp_path: Path, *configs: dict) -> list[Path]:
+    """Write one rendered stack directory per config, like RenderPlans does."""
+    paths = []
+    for index, config in enumerate(configs):
+        stack_dir = tmp_path / f"stack-{index}"
+        stack_dir.mkdir()
+        (stack_dir / "config.yaml").write_text(yaml.safe_dump(config))
+        paths.append(stack_dir)
+    return paths
+
+
+def _context(tmp_path: Path, cluster: _FakeCluster, *configs: dict, **kwargs):
+    return ExecutionContext(
+        plan_dir=tmp_path,
+        workspace=tmp_path,
+        rendered_stacks=_render(tmp_path, *configs),
+        logger=_FakeLogger(),
+        cmd=cluster,
+        **kwargs,
+    )
+
+
+def _clean(tmp_path: Path, *configs: dict, **kwargs):
+    """Run the step against a cluster holding every leftover of *configs*."""
+    resources: dict[str, dict[str, set[str]]] = {}
+    for config in configs:
+        for ns, items in _inventory(config).items():
+            resources.setdefault(ns, {}).update(items)
+    cluster = _FakeCluster(resources)
+    result = CleanupResourcesStep().execute(
+        _context(tmp_path, cluster, *configs, **kwargs)
+    )
+    return cluster, result
+
+
+def test_registered_as_the_only_cleanup_step() -> None:
+    assert [type(s) for s in get_cleanup_steps()] == [CleanupResourcesStep]
+
+
+def test_deletes_every_benchmark_resource(tmp_path) -> None:
+    cluster, result = _clean(tmp_path, _stack_config())
+
+    assert result.success, result.errors
+    # Acceptance: nothing benchmark-owned survives in either namespace.
+    assert not any(cluster.resources.values())
+    assert "Removed" in result.message
+
+
+def test_keep_pvc_preserves_only_the_pvc(tmp_path) -> None:
+    cluster, result = _clean(tmp_path, _stack_config(), keep_pvc=True)
+
+    assert result.success, result.errors
+    assert list(cluster.resources["bench"]) == ["pvc/workload-pvc"]
+
+
+def test_empty_namespace_is_a_no_op_success(tmp_path) -> None:
+    cluster = _FakeCluster({})
+
+    result = CleanupResourcesStep().execute(
+        _context(tmp_path, cluster, _stack_config())
+    )
+
+    assert result.success, result.errors
+    assert not cluster.deleted
+    assert "No benchmark resources found" in result.message
+
+
+def test_data_access_pod_deleted_before_pvc(tmp_path) -> None:
+    """The PVC protection finalizer blocks claim deletion while a pod mounts
+    it, so the data-access pod must be deleted before the claim."""
+    cluster, _ = _clean(tmp_path, _stack_config())
+
+    order = [key for _ns, key in cluster.deleted]
+    assert order.index("pod/access-to-harness-data-workload-pvc") < order.index(
+        "pvc/workload-pvc"
+    )
+
+
+def test_resource_names_come_from_the_rendered_config(tmp_path) -> None:
+    """A scenario that renames every configurable resource is still cleaned."""
+    config = _stack_config(
+        harness__podLabel="my-launcher",
+        harness__name="guidellm",
+        labels__app="my-harness",
+        storage__workloadPvc__name="my-workload",
+    )
+
+    cluster, result = _clean(tmp_path, config)
+
+    assert result.success, result.errors
+    assert not any(cluster.resources.values())
+    deleted = {key for _ns, key in cluster.deleted}
+    assert {
+        "pod/harness-launcher-1",
+        "configmap/guidellm-profiles",
+        "service/my-harness",
+        "pvc/my-workload",
+    } <= deleted
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["harness__podLabel", "harness__name", "labels__app", "storage__workloadPvc__name"],
+)
+def test_missing_config_key_is_an_error_not_a_guess(tmp_path, missing) -> None:
+    """No hardcoded fallbacks: a rendered config without a key the step needs
+    fails loudly instead of deleting a guessed name."""
+    config = _stack_config()
+    node = config
+    keys = missing.split("__")
+    for key in keys[:-1]:
+        node = node[key]
+    del node[keys[-1]]
+
+    with pytest.raises(KeyError, match=missing.replace("__", ".")):
+        CleanupResourcesStep().execute(_context(tmp_path, _FakeCluster({}), config))
+
+
+def test_harness_namespace_is_cleaned_alongside_the_workload_namespace(
+    tmp_path,
+) -> None:
+    """Launcher pods and their ConfigMaps render into ``harness.namespace``
+    while the PVC, service and data-access pod render into ``namespace.name``,
+    so one namespace cannot reach both."""
+    cluster, result = _clean(
+        tmp_path, _stack_config(harness__namespace="bench-harness")
+    )
+
+    assert result.success, result.errors
+    assert not any(cluster.resources.values())
+    assert ("bench-harness", "pod/harness-launcher-1") in cluster.deleted
+    assert ("bench", "pvc/workload-pvc") in cluster.deleted
+
+
+def test_every_stack_of_a_multi_stack_scenario_is_cleaned(tmp_path) -> None:
+    cluster, result = _clean(
+        tmp_path,
+        _stack_config(namespace__name="stack-a"),
+        _stack_config(namespace__name="stack-b", harness__name="guidellm"),
+    )
+
+    assert result.success, result.errors
+    assert not any(cluster.resources.values())
+    assert ("stack-a", "configmap/inference-perf-profiles") in cluster.deleted
+    assert ("stack-b", "configmap/guidellm-profiles") in cluster.deleted
+
+
+def test_identical_stacks_are_cleaned_once(tmp_path) -> None:
+    """Multi-stack scenarios routinely share a namespace; cleaning it twice
+    would double every log line for no benefit."""
+    cluster, result = _clean(tmp_path, _stack_config(), _stack_config())
+
+    assert result.success, result.errors
+    assert len(cluster.deleted) == len(set(cluster.deleted))
+    assert sum(1 for _ns, key in cluster.deleted if key == "pvc/workload-pvc") == 1
+
+
+def test_no_rendered_config_is_an_error(tmp_path) -> None:
+    context = ExecutionContext(
+        plan_dir=tmp_path,
+        workspace=tmp_path,
+        rendered_stacks=[tmp_path / "stack-without-config"],
+        logger=_FakeLogger(),
+        cmd=_FakeCluster({}),
+    )
+
+    result = CleanupResourcesStep().execute(context)
+
+    assert not result.success
+    assert result.errors
+
+
+def test_failed_delete_is_reported(tmp_path) -> None:
+    class _FailingCluster(_FakeCluster):
+        def kube(self, *args, **kwargs):
+            if args[0] == "delete" and args[1] == "pvc":
+                return _Result(False, "", "forbidden")
+            return super().kube(*args, **kwargs)
+
+    cluster = _FailingCluster(_inventory(_stack_config()))
+    result = CleanupResourcesStep().execute(
+        _context(tmp_path, cluster, _stack_config())
+    )
+
+    assert not result.success
+    assert any(
+        "pvc/workload-pvc" in err and "forbidden" in err for err in result.errors
+    )
+
+
+def test_nok8s_scenario_is_skipped(tmp_path) -> None:
+    context = _context(tmp_path, _FakeCluster({}), deployed_methods=["nok8s"])
+    assert CleanupResourcesStep().should_skip(context)


### PR DESCRIPTION
## What

Adds `llmdbenchmark cleanup --namespace <ns> [--keep-pvc]`, which removes everything a benchmark run leaves behind in the harness namespace:

- leftover harness launcher pods (`app=llmdbench-harness-launcher`)
- the data-access pod (`role=llm-d-benchmark-data-access`)
- `service/llm-d-benchmark-harness`
- ConfigMaps: `llm-d-benchmark-preprocesses`, `llm-d-benchmark-run-parameters`, `llm-d-benchmark-standup-parameters`, `llmdbench-harness-scripts`, and any `*-profiles` workload profile ConfigMaps
- `pvc/workload-pvc` (skipped with `--keep-pvc`; `--pvc-name` covers scenarios that override `storage.workloadPvc.name`)

## Why

Closes #1789. `run` tears down the launcher pod but leaves the rest in the namespace: the PVC bills against its storage backend until deleted, the resource names are CLI internals that consuming docs have to hardcode, and a stale claim wedges retries after a wrong-StorageClass failure.

## Design notes

- **Idempotent**: resources that no longer exist are skipped; a namespace with no benchmark resources (or a namespace that doesn't exist) exits 0, matching the acceptance criteria in the issue.
- **Pods are deleted before the PVC** so the `pvc-protection` finalizer can clear instead of leaving the claim stuck in Terminating.
- **No spec/plan required**: unlike the other subcommands, `cleanup` only needs `--namespace` (env: `LLMDBENCH_NAMESPACE`) — it deletes by name/label, so it works after the user has deleted their scenario or stack. It is dispatched like `results`, before plan rendering.
- The deletion set lives in one place (`llmdbenchmark/interface/cleanup.py`), so llm-d's `helpers/benchmark.md` can replace its hand-maintained `kubectl delete` list with this command. The issue also floats labeling every CLI-created resource (`app.kubernetes.io/managed-by`) and deleting purely by selector; happy to follow up with that if preferred, but name/label-based deletion keeps this PR small and works for resources created by older CLI versions too.

## Testing

- New unit tests in `tests/test_cleanup_command.py` (full deletion set, `--keep-pvc`, empty-namespace no-op, pod-before-PVC ordering, custom PVC name) following the existing fake-executor style.
- Full suite: 1141 passed, 32 skipped.
- `ruff check` / `ruff format --check` (0.15.11, as CI runs) clean.
- Manual `--dry-run` exercises the exact kubectl commands end-to-end.

Docs: added a section to `docs/lifecycle.md` after teardown, and listed `cleanup.py` in the README package layout.