### PR TITLE
fix: correct unparseable -> unparsable in aggregate_eval_containers.py

### DIFF
--- a/llmdbenchmark/analysis/aggregate_eval_containers.py
+++ b/llmdbenchmark/analysis/aggregate_eval_containers.py
@@ -300,7 +300,7 @@ def _iso_to_unix_ns(value: Any) -> int | None:
 
     Needed to anchor time-to-first-call: the span clock is unix-epoch
     nanoseconds, so the task's own start has to be expressed in the same units.
-    Returns None on anything unparseable, so the metric is blanked rather than
+    Returns None on anything unparsable, so the metric is blanked rather than
     guessed.
     """
     if value is None:


### PR DESCRIPTION
Fixes llm-d/llm-d-benchmark#1793

Fixes the unparseable -> unparsable report from the 2026-08-14 scan.
The two retuned reports from the original scan are not reproducible with typos-cli 1.49.0 - typos . on main reports only the unparseable instance. They also look like false positives regardless: both comments mean "re-tuned" (adjusted again), not "returned" (config/scenarios/ ship to users and get retuned freely). Left unchanged, and no _typos.toml entry added since nothing currently flags them.