### PR TITLE
fix: correct 'retuned' to 'returned' in test files

### DIFF
--- a/tests/fixtures/single_stack_overrides.yaml
+++ b/tests/fixtures/single_stack_overrides.yaml
@@ -1,6 +1,6 @@
 # Test-only single-stack scenario, owned by tests/test_cli_set_overrides.py.
 # Sibling of multi_stack_overrides.yaml; same reasoning -- scenarios under
-# config/scenarios/ ship to users and get retuned freely, so a suite that
+# config/scenarios/ ship to users and get returned freely, so a suite that
 # asserts on their literals fails for reasons unrelated to the code.
 #
 # Everything below is load-bearing for an assertion. The contract:

--- a/tests/test_cli_set_overrides.py
+++ b/tests/test_cli_set_overrides.py
@@ -44,7 +44,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATES = PROJECT_ROOT / "config" / "templates" / "jinja"
 DEFAULTS = PROJECT_ROOT / "config" / "templates" / "values" / "defaults.yaml"
 # Test-owned fixtures, deliberately NOT scenarios under config/scenarios/.
-# Those ship to users and get retuned freely -- replicas, resources, model
+# Those ship to users and get returned freely -- replicas, resources, model
 # choice, pool names -- and the tests below assert on literal stack names
 # and values. Pointing them at a shipped scenario makes an ordinary config
 # edit fail the suite for a reason that has nothing to do with the code


### PR DESCRIPTION
## Summary

Fixed 2 instances of 'retuned' → 'returned' typo in test files:

| File | Line |
|------|------|
| tests/fixtures/single_stack_overrides.yaml | 3 |
| tests/test_cli_set_overrides.py | 47 |

### Issue
- Fixes #1793

### Note
This is a separate fix from PR #1743 which corrected typos in other files (executor/parser/standup/workload/util directories).

---
*Submitted via PR攻关 (Jah-yee)*