### PR TITLE
fix: catch FMA regression errors and verify FMA serving after wakeup

### DIFF
--- a/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
+++ b/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
@@ -2,8 +2,8 @@
 
 Snapshots HPA/ScaledObject/Deployment YAML, events, controller logs, and the
 logs of every pod in the deploy and WVA namespaces to ``results/<exp_id>/``
-— alongside the harness's benchmark output. Skipped only when neither
-+``wva.enabled`` nor ``eppKedaSaturation.enabled`` is set.
+— alongside the harness's benchmark output. Skipped only when none of
+``wva.enabled``, ``eppKedaSaturation.enabled``, or the FMA guide path applies.
 
 Runs AFTER step_09_collect_results so the local results dir already exists
 and won't trip step_09's "skip if results dir non-empty" gate.
@@ -46,6 +46,9 @@ def _kube_logs_with_retry(cmd, *args, attempts: int = 3, backoff: float = 2.0):
     return last
 
 
+_FMA_GUIDE_STACK_NAME = "fast-model-actuation"
+
+
 class CaptureClusterStateStep(Step):
     """Snapshot HPA/ScaledObject/Deployment/events + WVA controller logs to workspace."""
 
@@ -85,14 +88,15 @@ class CaptureClusterStateStep(Step):
             plan_config, "eppKedaSaturation.enabled", default=False
         )
         fma_enabled = self._resolve(plan_config, "fma.enabled", default=False)
-        if not (wva_enabled or epp_keda_enabled):
+        fma_capture = fma_enabled or stack_name == _FMA_GUIDE_STACK_NAME
+        if not (wva_enabled or epp_keda_enabled or fma_capture):
             return StepResult(
                 step_number=self.number,
                 step_name=self.name,
                 success=True,
                 message=(
-                    "wva.enabled and eppKedaSaturation.enabled both false; "
-                    "skipping cluster-state capture"
+                    "wva.enabled, eppKedaSaturation.enabled, and FMA all "
+                    "inactive; skipping cluster-state capture"
                 ),
                 stack_name=stack_name,
             )
@@ -248,8 +252,8 @@ class CaptureClusterStateStep(Step):
         # (wake / create_instance / launcher-create), the signal the hit-rate
         # computation parses. A dedicated high-tail capture (vs. the generic
         # per-pod dump in section 9, which is tail=5000) keeps the full run's
-        # actuation events. FMA-only.
-        if fma_enabled:
+        # actuation events. FMA paths only (benchmark fma.enabled or the guide).
+        if fma_capture:
             result = _kube_logs_with_retry(
                 cmd,
                 "-l",

--- a/llmdbenchmark/smoketests/__init__.py
+++ b/llmdbenchmark/smoketests/__init__.py
@@ -3,11 +3,15 @@
 from llmdbenchmark.smoketests.base import BaseSmoketest
 
 
-def get_validator(stack_name: str, is_kustomize: bool = False) -> BaseSmoketest:
+def get_validator(
+    stack_name: str, is_kustomize: bool = False, is_fma: bool = False
+) -> BaseSmoketest:
     """Return the scenario-specific validator, or the base if none exists."""
     from llmdbenchmark.smoketests.validators import VALIDATORS
 
-    if is_kustomize:
+    if is_fma:
+        stack_name = "fma"
+    elif is_kustomize:
         stack_name = "ignore"
 
     cls = VALIDATORS.get(stack_name, BaseSmoketest)

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -109,7 +109,6 @@ class BaseSmoketest:
         Returns (service_ip, gateway_port, is_standalone).
         """
         is_standalone = "standalone" in context.deployed_methods
-        is_fma = "fma" in context.deployed_methods
         is_kustomize = "kustomize" in context.deployed_methods
         namespace = context.require_namespace()
 
@@ -124,8 +123,6 @@ class BaseSmoketest:
             service_ip, _, gateway_port = find_standalone_endpoint(
                 cmd, namespace, inference_port
             )
-        elif is_fma:
-            return None, "0", False
         elif is_kustomize:
             guide_name = _nested_get(plan_config, "kustomize", "guideName") or ""
             if guide_name:
@@ -198,10 +195,6 @@ class BaseSmoketest:
         standalone_role = _nested_get(plan_config, "standalone", "role") or "standalone"
         is_kustomize = "kustomize" in context.deployed_methods
         guide_name = _nested_get(plan_config, "kustomize", "guideName") or ""
-
-        # skip base healh checks for FMA
-        if "fma" in context.deployed_methods:
-            return report
 
         service_ip, gateway_port, is_standalone = self.discover_endpoint(
             cmd,
@@ -612,10 +605,6 @@ class BaseSmoketest:
         plan_config = _load_config(stack_path)
 
         model_name = _nested_get(plan_config, "model", "name") or ""
-
-        # skip base inference test for FMA
-        if "fma" in context.deployed_methods:
-            return report
 
         service_ip, gateway_port, _is_standalone = self.discover_endpoint(
             cmd,

--- a/llmdbenchmark/smoketests/steps/step_00_health_check.py
+++ b/llmdbenchmark/smoketests/steps/step_00_health_check.py
@@ -33,7 +33,8 @@ class HealthCheckStep(Step):
             )
 
         stack_name = stack_path.name
-        validator = get_validator(stack_name)
+        is_fma = "fma" in context.deployed_methods
+        validator = get_validator(stack_name, is_fma=is_fma)
         report = validator.run_health_checks(context, stack_path)
 
         if report.passed:

--- a/llmdbenchmark/smoketests/steps/step_01_inference_test.py
+++ b/llmdbenchmark/smoketests/steps/step_01_inference_test.py
@@ -34,7 +34,8 @@ class InferenceTestStep(Step):
             )
 
         stack_name = stack_path.name
-        validator = get_validator(stack_name)
+        is_fma = "fma" in context.deployed_methods
+        validator = get_validator(stack_name, is_fma=is_fma)
         report = validator.run_inference_test(context, stack_path)
 
         # Clean up ephemeral curl pods left behind by health + inference checks.

--- a/llmdbenchmark/smoketests/validators/__init__.py
+++ b/llmdbenchmark/smoketests/validators/__init__.py
@@ -32,6 +32,7 @@ from llmdbenchmark.smoketests.validators.wva import WvaValidator
 from llmdbenchmark.smoketests.validators.cpu import CpuValidator
 from llmdbenchmark.smoketests.validators.gpu import GpuValidator
 from llmdbenchmark.smoketests.validators.spyre import SpyreValidator
+from llmdbenchmark.smoketests.validators.fma import FmaValidator
 
 
 VALIDATORS: dict[str, type] = {
@@ -39,6 +40,7 @@ VALIDATORS: dict[str, type] = {
     "pd-disaggregation": PdDisaggregationValidator,
     "precise-prefix-cache-aware": PrecisePrefixCacheAwareValidator,
     "optimized-baseline": OptimizedBaselineValidator,
+    "fast-model-actuation": FmaValidator,
     # inference-scheduling-wva reuses the inference-scheduling validator;
     # the WvaSmoketestMixin auto-activates its extra checks when the
     # stack's config has wva.enabled: true.
@@ -51,4 +53,6 @@ VALIDATORS: dict[str, type] = {
     "cpu-example-ms": CpuValidator,
     "gpu-example": GpuValidator,
     "spyre-example": SpyreValidator,
+    # get_validator sets stack_name = "fma" when standup_method is fma.
+    "fma": FmaValidator,
 }

--- a/llmdbenchmark/smoketests/validators/fma.py
+++ b/llmdbenchmark/smoketests/validators/fma.py
@@ -1,0 +1,412 @@
+"""Validator for the FMA (fast-model-actuation) standup path.
+
+FMA (``standup_method: fma``) has no Service/gateway/EPP and no decode/prefill
+Deployments: a launcher pod hosts vLLM directly and binds to a requester on
+demand. This validator overrides the health check and inference test to probe
+the bound launcher pod instead of the generic role-based path in
+``BaseSmoketest``.
+
+Registered in the ``VALIDATORS`` map under the sentinel key ``"fma"``.
+"""
+
+import json
+import time
+from pathlib import Path
+
+from llmdbenchmark.executor.command import CommandExecutor
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.smoketests.base import BaseSmoketest, _load_config, _nested_get
+from llmdbenchmark.smoketests.report import CheckResult, SmoketestReport
+from llmdbenchmark.utilities.kube_helpers import _pod_crash_details
+
+# --- FMA serving signals -----------------------------------------------------
+# When the dual-pods controller BINDS a launcher to a requester it stamps the
+# launcher pod with binding labels it manages itself -- `dual-pods.llm-d.ai/dual`
+# (the bound requester pod name) and `dual-pods.llm-d.ai/sleeping` -- and it ADDS
+# the InferenceServerConfig.modelServerConfig routing labels. It strips the
+# binding labels again on unbind.
+#
+# NOTE the guide runs a POOL of launchers (LauncherPopulationPolicy
+# launcherCount=1 per GPU node), not a single launcher; with requester
+# replicas=N there are N bound launchers. Any bound launcher serves the same
+# model, so probing pods[0] of the `dual`-selected set is sufficient.
+_FMA_LAUNCHER_COMPONENT_SELECTOR = "app.kubernetes.io/component=launcher"
+# Set by the controller on a launcher when it binds to a requester; removed on
+# unbind.
+_FMA_BOUND_LABEL = "dual-pods.llm-d.ai/dual"
+# Written onto the launcher pod by the state-change-reflector sidecar
+_FMA_SIGNATURE_ANNOTATION = "dual-pods.llm-d.ai/vllm-instance-signature"
+# FYI-only signal set by the controller on the launcher pod; it trails
+# the actual /sleep and /wake_up calls
+_FMA_SLEEPING_LABEL = "dual-pods.llm-d.ai/sleeping"
+
+
+def _fma_serving_selector() -> str:
+    """Selector matching a launcher pod bound to a requester (serving)."""
+    return f"{_FMA_LAUNCHER_COMPONENT_SELECTOR},{_FMA_BOUND_LABEL}"
+
+
+def _fma_pods(cmd, namespace: str, selector: str) -> list[dict]:
+    """Pod items (from ``kubectl get pods -o json``) matching *selector*."""
+    result = cmd.kube(
+        "get",
+        "pods",
+        "-l",
+        selector,
+        "--namespace",
+        namespace,
+        "-o",
+        "json",
+        check=False,
+    )
+    if not result.success or not (result.stdout or "").strip():
+        return []
+    try:
+        return json.loads(result.stdout).get("items", [])
+    except json.JSONDecodeError:
+        return []
+
+
+def _fma_serving_pod(cmd, namespace: str) -> dict | None:
+    """The launcher pod currently bound and serving, if any."""
+    pods = _fma_pods(cmd, namespace, _fma_serving_selector())
+    return pods[0] if pods else None
+
+
+def _fma_pod_ip(pod: dict | None) -> str:
+    """status.podIP of *pod*, or "" if absent."""
+    return ((pod or {}).get("status", {}) or {}).get("podIP", "") or ""
+
+
+class FmaValidator(BaseSmoketest):
+    """Smoketest for the FMA (fast-model-actuation) standup path."""
+
+    # How long to wait for the launcher to (un)bind after a scale change.
+    _FMA_SERVING_TIMEOUT = 300
+    # How long to wait for the state-change-reflector sidecar to write its
+    # signature annotation.
+    _FMA_ANNOTATION_TIMEOUT = 90
+    # Shared poll interval for both waits above.
+    _FMA_POLL = 5
+
+    def _launcher_created_on_demand(
+        self,
+        context: ExecutionContext,
+        cmd: CommandExecutor,
+        plan_config: dict,
+    ) -> bool:
+        """True when no bound launcher is expected at smoketest time."""
+        if cmd.dry_run:
+            return False
+        if "fma" not in (context.deployed_methods or []):
+            return False
+        requester_replicas = _nested_get(plan_config, "fma", "requester", "replicas")
+        return (requester_replicas or 0) == 0
+
+    @staticmethod
+    def _fma_skip_report(check_name: str) -> SmoketestReport:
+        """A passing report recording that launcher checks were skipped because
+        no launcher is expected at smoketest (benchmark fma, requester=0)."""
+        report = SmoketestReport()
+        report.add(
+            CheckResult(
+                check_name,
+                True,
+                message=("No bound launcher at smoketest"),
+            )
+        )
+        return report
+
+    def run_health_checks(
+        self,
+        context: ExecutionContext,
+        stack_path: Path,
+    ) -> SmoketestReport:
+        """Health checks against the bound launcher pod.
+
+        FMA has no Service/gateway; a launcher pod hosts vLLM and is bound to a
+        requester on demand. We assert three things the generic path misses:
+          1. No launcher pod is in a container-level crash state
+             (OOMKilled/CrashLoopBackOff/image-pull/non-zero exit).
+          2. The bound launcher carries the state-change-reflector's signature
+             annotation.
+          3. vLLM answers /v1/models on the launcher pod IP:port.
+        """
+        report = SmoketestReport()
+        cmd = context.require_cmd()
+        namespace = context.require_namespace()
+        plan_config = _load_config(stack_path)
+
+        model_name = _nested_get(plan_config, "model", "name") or ""
+        port = str(_nested_get(plan_config, "vllmCommon", "inferencePort") or "8000")
+
+        if self._launcher_created_on_demand(context, cmd, plan_config):
+            return self._fma_skip_report("fma_health_skipped_no_launcher")
+
+        # 1. No launcher pod in a CONTAINER-level crash state. Catches a
+        #    container OOMKill (kernel), CrashLoopBackOff, image-pull failure, or
+        #    non-zero exit.
+        launcher_pods = _fma_pods(cmd, namespace, _FMA_LAUNCHER_COMPONENT_SELECTOR)
+        if not launcher_pods and not cmd.dry_run:
+            report.add(
+                CheckResult(
+                    "fma_launcher_pods_exist",
+                    False,
+                    message=(
+                        f"No launcher pods found "
+                        f"(selector '{_FMA_LAUNCHER_COMPONENT_SELECTOR}')"
+                    ),
+                )
+            )
+            return report
+        crashed: list[str] = []
+        for pod in launcher_pods:
+            crashed.extend(_pod_crash_details(pod))
+        report.add(
+            CheckResult(
+                "fma_launcher_no_crash",
+                not crashed,
+                message=(
+                    "Launcher pods healthy (no container crash states)"
+                    if not crashed
+                    else f"Launcher pod(s) in a container crash state: {'; '.join(crashed)}"
+                ),
+            )
+        )
+
+        # 2. The bound launcher must be serving and carry the signature annotation.
+        serving_pod = self._fma_wait_serving(cmd, context, namespace)
+        if serving_pod is None:
+            report.add(
+                CheckResult(
+                    "fma_launcher_bound",
+                    False,
+                    message=(
+                        f"No launcher pod became bound/serving for model "
+                        f"'{model_name}' within {self._FMA_SERVING_TIMEOUT}s "
+                        f"(selector '{_fma_serving_selector()}')"
+                    ),
+                )
+            )
+            return report
+
+        pod_name = serving_pod.get("metadata", {}).get("name", "")
+        self._log_fma_sleeping(context, serving_pod)
+        annotation_ok = self._fma_wait_signature_annotation(
+            cmd, context, namespace, pod_name
+        )
+        report.add(
+            CheckResult(
+                "fma_signature_annotation",
+                annotation_ok,
+                message=(
+                    f"Signature annotation '{_FMA_SIGNATURE_ANNOTATION}' present on {pod_name}"
+                    if annotation_ok
+                    else (
+                        f"Signature annotation '{_FMA_SIGNATURE_ANNOTATION}' missing on "
+                        f"{pod_name} after {self._FMA_ANNOTATION_TIMEOUT}s"
+                    )
+                ),
+            )
+        )
+
+        # 3. vLLM answers /v1/models on the launcher pod IP:port. This is the
+        #    reliable catch-all gate for the shared "launcher stopped" signature.
+        pod_ip = _fma_pod_ip(serving_pod)
+        if not pod_ip and not cmd.dry_run:
+            report.add(
+                CheckResult(
+                    "fma_launcher_ip",
+                    False,
+                    message=f"Bound launcher pod {pod_name} has no status.podIP",
+                )
+            )
+            return report
+        err = self._wait_for_model_ready(
+            cmd,
+            context,
+            namespace,
+            pod_ip or "<dry-run-ip>",
+            port,
+            model_name,
+            plan_config,
+        )
+        report.add(
+            CheckResult(
+                "fma_model_ready",
+                err is None,
+                message=(
+                    f"vLLM serving '{model_name}' at {pod_ip}:{port}"
+                    if err is None
+                    else err
+                ),
+            )
+        )
+        return report
+
+    def run_inference_test(
+        self,
+        context: ExecutionContext,
+        stack_path: Path,
+    ) -> SmoketestReport:
+        """Baseline inference check against the bound launcher pod.
+
+        Sends one request to the bound launcher pod as a fail-fast serving gate
+        before the (expensive) run phase.
+        """
+        report = SmoketestReport()
+        cmd = context.require_cmd()
+        namespace = context.require_namespace()
+        plan_config = _load_config(stack_path)
+
+        model_name = _nested_get(plan_config, "model", "name") or ""
+        port = str(_nested_get(plan_config, "vllmCommon", "inferencePort") or "8000")
+
+        if self._launcher_created_on_demand(context, cmd, plan_config):
+            return self._fma_skip_report("fma_inference_skipped_no_launcher")
+
+        # The launcher must be bound+serving before we send the baseline request.
+        pod = self._fma_wait_serving(cmd, context, namespace)
+        if pod is None:
+            report.add(
+                CheckResult(
+                    "fma_inference_endpoint",
+                    False,
+                    message=(
+                        f"No bound launcher pod serving '{model_name}' "
+                        f"for the inference test"
+                    ),
+                )
+            )
+            return report
+
+        ok, msg = self._fma_request_once(
+            cmd,
+            context,
+            namespace,
+            _fma_pod_ip(pod),
+            port,
+            model_name,
+            plan_config,
+            label="baseline",
+        )
+        report.add(CheckResult("fma_inference_baseline", ok, message=msg))
+        return report
+
+    def _fma_request_once(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        namespace: str,
+        pod_ip: str,
+        port: str,
+        model_name: str,
+        plan_config: dict,
+        *,
+        label: str,
+    ) -> tuple[bool, str]:
+        """Send one /v1/completions (falling back to /v1/chat/completions) to the
+        launcher pod IP:port. Returns (passed, message)."""
+        if not pod_ip and not cmd.dry_run:
+            return False, f"FMA {label} request: launcher pod has no IP"
+        base_url = f"http://{pod_ip or '<dry-run-ip>'}:{port}"
+        context.logger.log_info(f"FMA {label} inference against {base_url}...")
+        result = self._try_completions(
+            cmd, context, namespace, base_url, model_name, plan_config
+        )
+        if result.get("success"):
+            return True, (
+                f"FMA {label} inference passed via /v1/completions -- "
+                f'Generated: "{result.get("generated_text", "")}"'
+            )
+        if result.get("should_fallback"):
+            chat = self._try_chat_completions(
+                cmd, context, namespace, base_url, model_name, plan_config
+            )
+            if chat.get("success"):
+                return True, (
+                    f"FMA {label} inference passed via /v1/chat/completions -- "
+                    f'Generated: "{chat.get("generated_text", "")}"'
+                )
+            return False, (
+                f"FMA {label} inference failed: /v1/completions: "
+                f"{result.get('error')}; /v1/chat/completions: {chat.get('error')}"
+            )
+        return False, (
+            f"FMA {label} inference failed: {result.get('error', 'unknown error')}"
+        )
+
+    def _fma_wait_serving(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        namespace: str,
+        timeout: int | None = None,
+    ) -> dict | None:
+        """Poll until a launcher pod is bound+serving (routing labels present +
+        a podIP). Returns the pod dict, or None on timeout."""
+        timeout = timeout or self._FMA_SERVING_TIMEOUT
+        start = time.time()
+        while True:
+            pod = _fma_serving_pod(cmd, namespace)
+            if cmd.dry_run:
+                return {
+                    "metadata": {"name": "<dry-run-launcher>"},
+                    "status": {"podIP": "<dry-run-ip>"},
+                }
+            if pod is not None and _fma_pod_ip(pod):
+                return pod
+            elapsed = time.time() - start
+            if elapsed > timeout:
+                return None
+            context.logger.log_info(
+                f"Waiting for a launcher to bind+serve ({int(elapsed)}s/{timeout}s)..."
+            )
+            time.sleep(self._FMA_POLL)
+
+    def _fma_wait_signature_annotation(
+        self,
+        cmd: CommandExecutor,
+        context: ExecutionContext,
+        namespace: str,
+        pod_name: str,
+        timeout: int | None = None,
+    ) -> bool:
+        """Poll for the state-change-reflector's signature annotation on the
+        launcher pod. Returns True once present, False on timeout."""
+        timeout = timeout or self._FMA_ANNOTATION_TIMEOUT
+        start = time.time()
+        while True:
+            result = cmd.kube(
+                "get",
+                "pod",
+                pod_name,
+                "--namespace",
+                namespace,
+                "-o",
+                "json",
+                check=False,
+            )
+            if cmd.dry_run:
+                return True
+            if result.success and (result.stdout or "").strip():
+                try:
+                    pod = json.loads(result.stdout)
+                except json.JSONDecodeError:
+                    pod = {}
+                if _FMA_SIGNATURE_ANNOTATION in self.get_pod_annotations(pod):
+                    return True
+            if time.time() - start > timeout:
+                return False
+            time.sleep(self._FMA_POLL)
+
+    @staticmethod
+    def _log_fma_sleeping(context: ExecutionContext, pod: dict) -> None:
+        """Log the FYI-only dual-pods sleeping label (trails the real /sleep,
+        /wake_up calls, so it is never asserted on)."""
+        labels = (pod or {}).get("metadata", {}).get("labels", {}) or {}
+        if _FMA_SLEEPING_LABEL in labels:
+            context.logger.log_info(
+                f"[FYI] {_FMA_SLEEPING_LABEL}={labels[_FMA_SLEEPING_LABEL]} on "
+                f"{pod.get('metadata', {}).get('name', '')}"
+            )

--- a/workload/harnesses/nop-llm-d-benchmark.py
+++ b/workload/harnesses/nop-llm-d-benchmark.py
@@ -8,6 +8,7 @@ Benchmark 'nop' harness
 from __future__ import annotations
 from datetime import datetime, timezone
 import os
+import sys
 import logging
 from pathlib import Path
 import yaml
@@ -135,6 +136,7 @@ def main():
     benchmark_result = BenchmarkResult()
     benchmark_result.scenario.deploy_methods = ",".join(deploy_methods)
     benchmark_result.scenario.max_instances = fma_max_instances
+    fma_error: Exception | None = None
     if fma_enabled:
         try:
             logger.info("Benchmark FMA launcher start...")
@@ -153,8 +155,9 @@ def main():
                 MAX_VLLM_WAIT,
                 write_log_per_process,
             )
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.exception("error on benchmark FMA launcher")
+            fma_error = exc
         finally:
             logger.info("Benchmark FMA launcher end")
     else:
@@ -187,6 +190,15 @@ def main():
     os.makedirs(benchmark_report_filepath, exist_ok=True)
     benchmark_report_filepath = os.path.join(benchmark_report_filepath, "result.yaml")
     convert_result(result_filepath, benchmark_report_filepath, start_time, stop_time)
+
+    # An FMA benchmark failure must fail the run. Exit non-zero AFTER results and
+    # logs are persisted above: SystemExit is not an Exception, so it is not
+    # swallowed by the broad `except Exception` in benchmark_fma or in the
+    # __main__ guard below -- the harness pod goes to Failed and step_08
+    # (wait_completion) marks the nightly failed.
+    if fma_error is not None:
+        logger.error("FMA benchmark failed; harness exiting non-zero to fail the run")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Problem**

Two scheduled nightlies exercise FMA, and both stayed green through three real regressions:

- #1791 — launcher OOM from config-driven memory knobs
- #1799 — state-change-reflector sidecar got a 403 patching its own pod, so the dual-pods.llm-d.ai/vllm-instance-signature annotation never landed
- https://github.com/llm-d-incubation/llm-d-fast-model-actuation/issues/712, https://github.com/llm-d-incubation/llm-d-fast-model-actuation/issues/720 — cold-compile-vs-recycle wake race (launcher fails to wake after sleep)

They missed all three because the verification was too thin:

- https://github.com/llm-d/llm-d-benchmark/actions/workflows/ci-nightly-benchmark-ocp-fma.yaml does zero serving verification — the fma branches in `smoketests/base.py` early-returned from endpoint discovery, health checks, and the inference test. 

- **Even when this benchmark raise an error, the `nop` harness swallowed it twice (a broad except in main() and another in the __main__ guard) → process always exited 0 → pod Succeeded → nightly green regardless.**

**Changes**

1. New `smoketests/validators/fma.py` (FmaValidator) — a dedicated validator for the FMA standup path. It runs the checks the generic path missed:
  - health: no launcher pod in a crash state ; the bound launcher carries the signature annotation, polled with a short retry; vLLM answers `/v1/models` on the launcher pod IP:port
  - inference: one fail-fast baseline request to the bound launcher

2. `smoketests/validators/__init__.py` — registered FmaValidator under both the "fma" sentinel and the "fast-model-actuation" guide stack name, so the llm-d guide kustomize nightly runs the same checks. To make one validator serve both paths, FmaValidator's serving selector is now model-label-agnostic: it matches the guide's static ISC label  as well as the benchmark's hashed model_id_label, since both configs run a single launcher.

3. `workload/harnesses/nop-llm-d-benchmark.py` — make FMA failures fail the run. 

4. `run/steps/step_09a_capture_cluster_state.py` — open the cluster-state capture gate for the FMA guide via a stack-name signal.