### PR TITLE
Run FMA+KEDA and FMA+WVA benchmarks with cluster-admin privileges

### DIFF
--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -123,6 +123,13 @@ on:
         required: false
         default: '5400'
         type: 'string'
+      admin_privileges:
+        # Keep 'true': 'false' adds --non-admin, which skips the decode SCC
+        # grant (pods never admit) and the KEDA prometheus-auth Secret (no HPA).
+        description: 'Run with cluster-admin privileges (required for SCC grants and KEDA Prometheus auth)'
+        required: false
+        default: 'true'
+        type: 'string'
 
 jobs:
   # =========================================================================
@@ -158,6 +165,7 @@ jobs:
       harness: ${{ inputs.harness || 'inference-perf' }}
       workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '5400' }}
+      admin_privileges: ${{ inputs.admin_privileges || 'true' }}
     secrets: inherit
 
   # =========================================================================
@@ -199,6 +207,7 @@ jobs:
       harness: ${{ inputs.harness || 'inference-perf' }}
       workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '5400' }}
+      admin_privileges: ${{ inputs.admin_privileges || 'true' }}
     secrets: inherit
 
   # =========================================================================
@@ -236,6 +245,7 @@ jobs:
       harness: ${{ inputs.harness || 'inference-perf' }}
       workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '7200' }}
+      admin_privileges: ${{ inputs.admin_privileges || 'true' }}
     secrets: inherit
 
   # =========================================================================

--- a/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
@@ -127,6 +127,13 @@ on:
         required: false
         default: '5400'
         type: 'string'
+      admin_privileges:
+        # Keep 'true': 'false' adds --non-admin, which skips the decode SCC
+        # grant (pods never admit) and the prometheus-auth Secret (no HPA).
+        description: 'Run with cluster-admin privileges (required for SCC grants and Prometheus auth)'
+        required: false
+        default: 'true'
+        type: 'string'
 
 jobs:
   # =========================================================================
@@ -161,6 +168,7 @@ jobs:
       harness: ${{ inputs.harness || 'inference-perf' }}
       workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '5400' }}
+      admin_privileges: ${{ inputs.admin_privileges || 'true' }}
     secrets: inherit
 
   # =========================================================================
@@ -202,6 +210,7 @@ jobs:
       harness: ${{ inputs.harness || 'inference-perf' }}
       workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '5400' }}
+      admin_privileges: ${{ inputs.admin_privileges || 'true' }}
     secrets: inherit
 
   # =========================================================================
@@ -239,6 +248,7 @@ jobs:
       harness: ${{ inputs.harness || 'inference-perf' }}
       workload: ${{ inputs.workload || 'shared_prefix_synthetic_heavy.yaml' }}
       wait_timeout: ${{ inputs.wait_timeout || '7200' }}
+      admin_privileges: ${{ inputs.admin_privileges || 'true' }}
     secrets: inherit
 
   # =========================================================================


### PR DESCRIPTION
### Summary

Adds an admin_privileges input (default 'true') to the `FMA+KEDA` and `FMA+WVA` benchmark workflows and passes it to all three jobs in each. Both workflows previously inherited the reusable workflow's admin_privileges: 'false' default, which caused standup to fail before any benchmark ran.

### Problem

The Baseline (EPP+KEDA, no FMA) job failed at step 09 after a 25-minute wait:
```
⏱️  No pods found for decode pods after 1500s
❌ Decode pods not ready: Timed out after 1500s waiting for decode pods -- no pods found

The decode Deployment was created and scaled to 1, but the ReplicaSet could never admit a pod:

Normal   ScalingReplicaSet  deployment/...-decode  Scaled up replica set ... from 0 to 1
Warning  FailedCreate       replicaset/...-decode-9ff7b4f4d
  Error creating: pods "...-decode-9ff7b4f4d-" is forbidden: unable to validate against any security context constraint:
    provider restricted-v2: .containers[0].runAsUser: Invalid value: 0: must be in the ranges: [1003630000, 1003639999]
    provider restricted-v2: .containers[0].capabilities.add: Invalid value: "IPC_LOCK": capability may not be added
    provider "anyuid":     Forbidden: not usable by user or serviceaccount
    provider "privileged": Forbidden: not usable by user or serviceaccount
```
Because `admin_privileges` was false, the reusable workflow passed `--non-admin`, which disables two things these scenarios depend on.

### Changes

Identical in `ci-benchmark-ocp-fma-keda.yaml` and `ci-benchmark-ocp-fma-wva.yaml`:

- New admin_privileges workflow_dispatch input, `default: 'true'`, with a two-line comment on why it must stay true.
- admin_privileges: `${{ inputs.admin_privileges || 'true' }}` added to the with: block of the baseline, nightly, and hotstart jobs.

