### PR TITLE
Add strat and retuned as typos scanner false positives

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -34,6 +34,10 @@ ba = "ba"
 nam = "nam"
 # Parameter abbreviation used in code
 parm = "parm"
+# Local variable abbreviation for `strategy` (guidellm_native.py)
+strat = "strat"
+# "re-tuned" as in adjusted/tweaked freely (comments in fixtures + tests)
+retuned = "retuned"
 
 # OpenShift Data Foundation
 ODF = "ODF"


### PR DESCRIPTION
Fixes #1810

The nightly typos scanner flagged 6 occurrences across 3 files. After reviewing the context, all 6 are false positives:
- `strat` (4× in `llmdbenchmark/analysis/benchmark_report/guidellm_native.py`): an intentional local variable abbreviation for `strategy`. Replacing it with `start` would break the code.
- `retuned` (2× in `tests/fixtures/single_stack_overrides.yaml` and `tests/test_cli_set_overrides.py`): intentional use of "re-tuned" meaning "adjusted/tweaked freely". Replacing it with `returned` would make the comments nonsensical.
  
Both words are added to `_typos.toml` under `[default.extend-words]` with inline comments explaining the rationale, consistent with existing entries in that file.