### PR TITLE
fix(teardown): match the FMA controllers release by chart identity

### DIFF
--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -37,11 +37,18 @@ class UninstallHelmStep(Step):
         }
     )
 
-    # Chart name prefixes used exclusively by modelservice deployments this
-    # tool creates (llm-d-modelservice, llm-d-router-gateway/-standalone).
-    # Used as a fallback match on full-scenario teardowns -- see
-    # _release_matches.
-    _MANAGED_CHART_PREFIXES = ("llm-d-modelservice", "llm-d-router-")
+    # Chart name prefixes used exclusively by deployments this tool creates:
+    # modelservice (llm-d-modelservice, llm-d-router-gateway/-standalone) and
+    # the FMA controllers (fma-controllers, from fma.chart.url). Used as a
+    # fallback match on full-scenario teardowns -- see _release_matches. The
+    # FMA release is named <model_id_label>-fma-dp but the chart itself is
+    # model-agnostic, so without this entry it has no safety net when the
+    # model labels re-derived at teardown do not match standup's.
+    _MANAGED_CHART_PREFIXES = (
+        "llm-d-modelservice",
+        "llm-d-router-",
+        "fma-controllers",
+    )
 
     def __init__(self):
         super().__init__(
@@ -405,10 +412,11 @@ class UninstallHelmStep(Step):
 
         On a full-scenario teardown (``full_teardown``, i.e. no --stack
         filter), we also match by chart identity: any release using one of
-        our managed charts (llm-d-modelservice, llm-d-router-*) belongs to
-        this deployment regardless of model-label mismatches, since a full
-        teardown is meant to wipe everything this tool deployed in the
-        namespace anyway. A --stack-filtered (partial) teardown must not
+        our managed charts (llm-d-modelservice, llm-d-router-*,
+        fma-controllers) belongs to this deployment regardless of
+        model-label mismatches, since a full teardown is meant to wipe
+        everything this tool deployed in the namespace anyway. A
+        --stack-filtered (partial) teardown must not
         use this broader match -- sibling stacks in the same namespace can
         use the same charts and must be preserved.
         """

--- a/tests/test_teardown_fma_release_match.py
+++ b/tests/test_teardown_fma_release_match.py
@@ -1,0 +1,113 @@
+"""Tests for FMA controller Helm release matching during teardown.
+
+Regression coverage for: a full-scenario teardown reporting success while
+leaving the FMA controllers Helm release (``<model_id_label>-fma-dp``)
+behind, so the next same-model standup no-ops on it and the controller pod
+never redeploys.
+
+``UninstallHelmStep._release_matches`` identifies a release three ways:
+by ``--release`` substring, by the model labels re-derived at teardown
+time, and -- on a full-scenario teardown only -- by chart identity. The
+first is cosmetic on the FMA path (the release is keyed on the model
+label, not on ``release``) and the second only fires when teardown is
+given the same model flags as standup. That leaves chart identity as the
+only safety net for a release whose chart is model-agnostic, and
+``fma-controllers`` was missing from ``_MANAGED_CHART_PREFIXES``.
+
+The last test here is the one that keeps this honest over time: rather
+than hard-coding the chart name a second time, it reads the chart this
+tool actually installs out of the shipped ``defaults.yaml`` and asserts
+the prefix list covers it. Repointing ``fma.chart.url`` at a differently
+named chart fails that test instead of silently reopening this bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from llmdbenchmark.teardown.steps.step_01_uninstall_helm import UninstallHelmStep
+
+# What `helm list -o json` reports in `chart` for the release created by
+# config/templates/jinja/26_helmfile-fma-controllers.yaml.j2: the chart's
+# own name and version, not the OCI reference it was pulled from.
+FMA_CHART = "fma-controllers-0.6.4"
+
+DEFAULTS_YAML = (
+    Path(__file__).resolve().parents[1]
+    / "config"
+    / "templates"
+    / "values"
+    / "defaults.yaml"
+)
+
+
+class TestFmaReleaseMatchesByChartIdentity:
+    """UninstallHelmStep._release_matches on the FMA controllers release."""
+
+    def test_full_teardown_matches_fma_chart_despite_label_mismatch(self):
+        """The bug: teardown was run without re-supplying the model flags,
+        so the re-derived model label does not match the one standup used
+        and the ``--release`` substring never appears in an FMA release
+        name. Only chart identity can catch it."""
+        assert UninstallHelmStep._release_matches(
+            "qwen-qwe-04b6bb85-fma-dp",
+            "llmdbench",
+            ["some-other-model-label"],
+            FMA_CHART,
+            full_teardown=True,
+        )
+
+    def test_model_label_match_still_works_when_flags_are_symmetric(self):
+        """Nightlies pass the model flags to both standup and teardown,
+        which is why they never hit this; that path must keep working
+        without relying on the chart fallback."""
+        assert UninstallHelmStep._release_matches(
+            "qwen-qwe-04b6bb85-fma-dp",
+            "llmdbench",
+            ["qwen-qwe-04b6bb85"],
+            FMA_CHART,
+            full_teardown=False,
+        )
+
+    def test_partial_stack_teardown_does_not_use_chart_fallback(self):
+        """A --stack-filtered teardown must not sweep up a sibling stack's
+        FMA release in the same namespace just because it shares a chart."""
+        assert not UninstallHelmStep._release_matches(
+            "sibling-model-fma-dp",
+            "llmdbench",
+            ["some-other-model-label"],
+            FMA_CHART,
+            full_teardown=False,
+        )
+
+    def test_unrelated_chart_named_after_fma_does_not_match(self):
+        """Control: broadening the list must not turn every release
+        mentioning FMA into ours. ``startswith`` is the contract."""
+        assert not UninstallHelmStep._release_matches(
+            "someone-elses-fma-dp",
+            "llmdbench",
+            ["some-other-model-label"],
+            "third-party-fma-controllers-1.0.0",
+            full_teardown=True,
+        )
+
+
+class TestManagedChartPrefixesCoverShippedFmaChart:
+    """The prefix list must cover the chart this tool actually installs."""
+
+    def test_shipped_fma_chart_url_is_covered_by_a_managed_prefix(self):
+        defaults = yaml.safe_load(DEFAULTS_YAML.read_text(encoding="utf-8"))
+        chart_url = defaults["fma"]["chart"]["url"]
+        chart_name = chart_url.rsplit("/", 1)[-1]
+        version = str(defaults["fma"]["chart"]["version"])
+
+        # `helm list` reports "<chart name>-<version>".
+        assert f"{chart_name}-{version}".startswith(
+            UninstallHelmStep._MANAGED_CHART_PREFIXES
+        ), (
+            f"fma.chart.url resolves to chart {chart_name!r}, which no entry "
+            f"in _MANAGED_CHART_PREFIXES matches; a full teardown would leave "
+            f"the FMA controllers release behind while reporting success"
+        )


### PR DESCRIPTION
Closes #1820.

Adds `fma-controllers` to `UninstallHelmStep._MANAGED_CHART_PREFIXES` — the fix the issue
asks for — plus a test that keeps that list tied to the chart this tool actually installs.

## The defect, read off `main@87d03da`

`_release_matches` can claim a release three ways, and the FMA controllers release escapes
all three under asymmetric flags:

1. **`release in release_name`** — `26_helmfile-fma-controllers.yaml.j2` names the release
   `{{ model_id_label }}-fma-dp`, so `LLMDBENCH_RELEASE` never appears in it. Cosmetic on
   this path, as the issue says.
2. **`any(label in release_name ...)`** — `_collect_model_labels()` reads `model_id_label`
   out of the stacks rendered *at teardown time*, so a teardown run without re-supplying the
   model flags derives a different label and misses.
3. **`chart.startswith(_MANAGED_CHART_PREFIXES)`** — the model-agnostic safety net, and the
   tuple held only `llm-d-modelservice` and `llm-d-router-`.

`execute()` loops `_uninstall_releases` over every target namespace unconditionally, so the
loop *does* reach the release; it just does not claim it, and teardown returns
`success=True, message="Helm releases uninstalled"` with the release still `deployed`.

## The chart name is measured, not inferred from the URL

The fix turns entirely on what `helm list -o json` puts in `chart`. `fma.chart.url` is an OCI
reference, and an OCI reference is not a chart name, so I pulled the Helm config blob from
GHCR and read it rather than assuming the last path segment:

```
# Helm config blob for
# oci://ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/charts/fma-controllers:0.6.4
{"name":"fma-controllers","version":"0.6.4","apiVersion":"v2","appVersion":"v0.6.4", ...}
```

So `helm list` reports `fma-controllers-0.6.4` and `startswith("fma-controllers")` matches.

## Tests

`tests/test_teardown_fma_release_match.py`, following `tests/test_teardown_gaie_epp_cleanup.py`:

* the failing case — full teardown, label mismatch, chart `fma-controllers-0.6.4`;
* the symmetric-flags case (what the nightlies do) still matching by label, no fallback needed;
* a `--stack`-filtered teardown **not** using the chart fallback, so a sibling stack's FMA
  release in the same namespace is preserved;
* a control that `third-party-fma-controllers-1.0.0` does **not** match — `startswith` is the
  contract, not a substring;
* **a contract test** that reads `fma.chart.url` out of the shipped
  `config/templates/values/defaults.yaml`, derives `<chart name>-<version>`, and asserts the
  prefix list covers it. Repointing that default at a differently named chart fails this test
  instead of silently reopening the bug.

Both positive assertions were proved non-vacuous by mutation — reverting only the constant:

```
FAILED ...::test_full_teardown_matches_fma_chart_despite_label_mismatch
FAILED ...::test_shipped_fma_chart_url_is_covered_by_a_managed_prefix
2 failed, 12 passed
```

and `14 passed` with it restored. The two negative controls pass either way, which is what
makes them controls.

## Two things I am reporting rather than deciding for you

**1. The one case where this broadening changes behaviour beyond what the issue describes.**
`execute()` deletes the FMA CRs and waits out the pod finalizers *before* `_uninstall_releases`,
but only `if is_fma_enabled`. On an FMA teardown that ordering holds and the new match lands
exactly where it should. In the narrow case where this step runs for a **modelservice/WVA**
scenario in a namespace that also holds an FMA release, the release is now uninstalled
*without* that pre-cleanup, where previously it was left behind. Both are wrong; which is less
wrong is your call. If you would rather not take that, the alternative is to gate the FMA
prefix on `is_fma_enabled` and thread it into `_release_matches` — happy to push that instead,
just say so.

**2.** The release also becomes eligible for the `_WEDGED_HELM_STATES` release-secret deletion
path, which is the same treatment `llm-d-modelservice` / `llm-d-router-` releases already get.

## On #1821

You noted that a PR implementing the namespace-scoped, non-model-keyed controller release
would also close this bug. That is true and it is the better fix. This is deliberately the
narrow one, so the false-success is closed now without pre-empting that design; if #1821 lands
the chart entry becomes redundant but stays harmless, and the contract test keeps pointing at
whatever `fma.chart.url` resolves to.

---

Disclosure: I am an AI agent. Every claim above was verified by running it — the code paths
were read at the commit named, the chart metadata was pulled from the registry, and the tests
were proved to fail on the pre-fix shape. If anything here is wrong I would rather hear it
than have it merged.
