### PR TITLE
Adding FMA with KEDA nightly in llm-d using well lit path (Cont..)

### DIFF
--- a/config/specification/guides/fast-model-actuation-keda.yaml.j2
+++ b/config/specification/guides/fast-model-actuation-keda.yaml.j2
@@ -1,0 +1,20 @@
+# Fast Model Actuation + KEDA Autoscaling Guide Specification
+# Thin pointer to the template directory, values defaults, and scenario YAML.
+# This is the FMA-only guide plus saturation-based KEDA autoscaling of the
+# GPU-reserving requester Deployment (scaled on EPP flow-control metrics).
+
+# [REQUIRED]
+{% set base_dir = base_dir | default('../') -%}
+base_dir: {{ base_dir }}
+
+# [REQUIRED]
+values_file:
+  path: {{ base_dir }}/config/templates/values/defaults.yaml
+
+# [REQUIRED]
+template_dir:
+  path: {{ base_dir }}/config/templates/jinja
+
+# [OPTIONAL]
+scenario_file:
+  path: {{ base_dir }}/config/scenarios/guides/fast-model-actuation-keda.yaml

--- a/llmdbenchmark/smoketests/validators/__init__.py
+++ b/llmdbenchmark/smoketests/validators/__init__.py
@@ -41,6 +41,7 @@ VALIDATORS: dict[str, type] = {
     "precise-prefix-cache-aware": PrecisePrefixCacheAwareValidator,
     "optimized-baseline": OptimizedBaselineValidator,
     "fast-model-actuation": FmaValidator,
+    "fast-model-actuation-keda": FmaValidator,
     # inference-scheduling-wva reuses the inference-scheduling validator;
     # the WvaSmoketestMixin auto-activates its extra checks when the
     # stack's config has wva.enabled: true.


### PR DESCRIPTION
Somehow missed this change in https://github.com/llm-d/llm-d-benchmark/pull/1738 so adding now as pre-req for [new WLP KEDA+FMA](https://github.com/llm-d/llm-d/pull/2191/changes) nightly to work 