### PR TITLE
fix crds

### DIFF
--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -115,7 +115,7 @@ _anchors:
   router_chart_version:              &router_chart_version              v0.10.0
   vllm-openai_version:               &vllm-openai_version               v0.26.0
   llm-d-router-endpoint-picker_version: &llm-d-router-endpoint-picker_version v0.10.0
-  llm-d-routing-sidecar_version:     &llm-d-routing-sidecar_version     v0.10.0
+  llm-d-routing-sidecar_version:     &llm-d-routing-sidecar_version     v0.9.0
   # Just use vllm-openai image for tokenizer
   llm-d-uds-tokenizer_version:       &llm-d-uds-tokenizer_version       v0.26.0
   llm-d-cuda_version:                &llm-d-cuda_version                v0.8.1

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-08-18 04:14:39` (UTC)
-- Generated against git ref: `ba30b34566a53addf8d5959de5cdd3ecf0bb00b8`
+- Generated at: `2026-08-19 22:54:35` (UTC)
+- Generated against git ref: `d6c1e3a1a34294bc58ebfca0922f84868660694a`
 
 ## System Tool Dependencies
 
@@ -62,7 +62,7 @@ generation (and plan) time.
 | **benchmark** | `v0.8.0` | tag | `config/templates/values/defaults.yaml` line 380 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
 | **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 428 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
 | **routerEndpointPicker** | `v0.10.0` | tag | `config/templates/values/defaults.yaml` line 405 (`images.routerEndpointPicker`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) |
-| **routingSidecar** | `v0.10.0` | tag | `config/templates/values/defaults.yaml` line 411 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
+| **routingSidecar** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 411 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
 | **udsTokenizer** | `v0.26.0` | tag | `config/templates/values/defaults.yaml` line 417 (`images.udsTokenizer`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
 | **vllm** | `v0.26.0` | tag | `config/templates/values/defaults.yaml` line 386 (`images.vllm`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
 | **vllmOpenai** | `v0.26.0` | tag | `config/templates/values/defaults.yaml` line 397 (`images.vllmOpenai`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
@@ -89,3 +89,134 @@ captured in the snapshot table below.
 | **PyYAML** | `(unpinned)` | (unpinned) | `pyproject.toml` line 7 | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
 | **requests** | `(unpinned)` | (unpinned) | `pyproject.toml` line 9 | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **transformers** | `(unpinned)` | (unpinned) | `pyproject.toml` line 16 | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+
+
+## Python Package Dependencies (installed snapshot)
+
+Output of `pip freeze` against the project venv (`.venv`). Includes
+every transitive dependency actually installed; direct deps are
+annotated with their `pyproject.toml` line.
+
+<details>
+<summary>Click to expand the full pip-freeze snapshot</summary>
+
+| Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
+|---|---|---|---|---|
+| **aiohappyeyeballs** | `2.7.1` | version | (transitive in `.venv`) | [aiohappyeyeballs (PyPI)](https://pypi.org/project/aiohappyeyeballs/) |
+| **aiohttp** | `3.14.3` | version | (transitive in `.venv`) | [aiohttp (PyPI)](https://pypi.org/project/aiohttp/) |
+| **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
+| **annotated-doc** | `0.0.5` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
+| **annotated-types** | `0.8.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
+| **anyio** | `4.14.2` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
+| **attrs** | `26.1.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
+| **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
+| **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
+| **certifi** | `2026.7.22` | version | (transitive in `.venv`) | [certifi (PyPI)](https://pypi.org/project/certifi/) |
+| **cffi** | `2.1.1` | version | (transitive in `.venv`) | [cffi (PyPI)](https://pypi.org/project/cffi/) |
+| **cfgv** | `3.5.0` | version | (transitive in `.venv`) | [cfgv (PyPI)](https://pypi.org/project/cfgv/) |
+| **chardet** | `6.0.0.post1` | version | (transitive in `.venv`) | [chardet (PyPI)](https://pypi.org/project/chardet/) |
+| **charset-normalizer** | `3.5.1` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
+| **click** | `8.4.2` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
+| **cryptography** | `50.0.0` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
+| **detect_secrets** | `38ba7e335083e0a4db8c53e9be414795b27891e9` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
+| **distlib** | `0.4.3` | version | (transitive in `.venv`) | [distlib (PyPI)](https://pypi.org/project/distlib/) |
+| **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
+| **execnet** | `2.1.2` | version | (transitive in `.venv`) | [execnet (PyPI)](https://pypi.org/project/execnet/) |
+| **fastapi** | `0.141.1` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
+| **filelock** | `3.32.3` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
+| **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
+| **fsspec** | `2026.7.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
+| **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
+| **GitPython** | `3.1.59` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
+| **google-api-core** | `2.34.0` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
+| **google-auth** | `2.56.3` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
+| **google-cloud-core** | `2.6.1` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
+| **google-cloud-storage** | `3.13.1` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
+| **google-crc32c** | `1.8.0` | version | (transitive in `.venv`) | [google-crc32c (PyPI)](https://pypi.org/project/google-crc32c/) |
+| **google-resumable-media** | `2.10.1` | version | (transitive in `.venv`) | [google-resumable-media (PyPI)](https://pypi.org/project/google-resumable-media/) |
+| **googleapis-common-protos** | `1.75.1` | version | (transitive in `.venv`) | [googleapis-common-protos (PyPI)](https://pypi.org/project/googleapis-common-protos/) |
+| **h11** | `0.16.0` | version | (transitive in `.venv`) | [h11 (PyPI)](https://pypi.org/project/h11/) |
+| **hf-xet** | `1.6.0` | version | (transitive in `.venv`) | [hf-xet (PyPI)](https://pypi.org/project/hf-xet/) |
+| **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
+| **httpcore2** | `2.12.0` | version | (transitive in `.venv`) | [httpcore2 (PyPI)](https://pypi.org/project/httpcore2/) |
+| **httptools** | `0.8.0` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
+| **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
+| **httpx2** | `2.12.0` | version | (transitive in `.venv`) | [httpx2 (PyPI)](https://pypi.org/project/httpx2/) |
+| **huggingface_hub** | `1.28.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
+| **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
+| **idna** | `3.19` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
+| **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
+| **Jinja2** | `3.1.6` | version | `pyproject.toml` line 8 (direct) | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
+| **jiter** | `0.16.0` | version | (transitive in `.venv`) | [jiter (PyPI)](https://pypi.org/project/jiter/) |
+| **kubernetes** | `35.0.0` | version | `pyproject.toml` line 11 (direct) | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
+| **kubernetes_asyncio** | `36.1.0` | version | (transitive in `.venv`) | [kubernetes_asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
+| **llm-optimizer** | `bb82d22e8863b762e856be66e831d551d27576b1` | commit SHA | (transitive in `.venv`) | [llm-optimizer (PyPI)](https://pypi.org/project/llm-optimizer/) |
+| **llmdbenchmark** | `editable` | editable | (transitive in `.venv`) | [llmdbenchmark (PyPI)](https://pypi.org/project/llmdbenchmark/) |
+| **markdown-it-py** | `4.2.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
+| **MarkupSafe** | `3.0.3` | version | (transitive in `.venv`) | [MarkupSafe (PyPI)](https://pypi.org/project/markupsafe/) |
+| **mdurl** | `0.1.2` | version | (transitive in `.venv`) | [mdurl (PyPI)](https://pypi.org/project/mdurl/) |
+| **multidict** | `6.7.1` | version | (transitive in `.venv`) | [multidict (PyPI)](https://pypi.org/project/multidict/) |
+| **nodeenv** | `1.10.0` | version | (transitive in `.venv`) | [nodeenv (PyPI)](https://pypi.org/project/nodeenv/) |
+| **numpy** | `2.4.6` | version | (transitive in `.venv`) | [numpy (PyPI)](https://pypi.org/project/numpy/) |
+| **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
+| **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
+| **ollama** | `0.6.2` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
+| **openai** | `3.3.1` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
+| **packaging** | `26.3` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
+| **pandas** | `3.0.3` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
+| **planner** | `9def3abea1720bce19823a4b5ae3ff2015ae77f1` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
+| **platformdirs** | `4.11.3` | version | (transitive in `.venv`) | [platformdirs (PyPI)](https://pypi.org/project/platformdirs/) |
+| **pluggy** | `1.6.0` | version | (transitive in `.venv`) | [pluggy (PyPI)](https://pypi.org/project/pluggy/) |
+| **pre_commit** | `4.6.2` | version | (transitive in `.venv`) | [pre_commit (PyPI)](https://pypi.org/project/pre-commit/) |
+| **propcache** | `0.5.2` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
+| **proto-plus** | `1.28.3` | version | (transitive in `.venv`) | [proto-plus (PyPI)](https://pypi.org/project/proto-plus/) |
+| **protobuf** | `7.35.1` | version | (transitive in `.venv`) | [protobuf (PyPI)](https://pypi.org/project/protobuf/) |
+| **psutil** | `7.2.2` | version | (transitive in `.venv`) | [psutil (PyPI)](https://pypi.org/project/psutil/) |
+| **psycopg2-binary** | `2.9.12` | version | (transitive in `.venv`) | [psycopg2-binary (PyPI)](https://pypi.org/project/psycopg2-binary/) |
+| **pyasn1** | `0.6.4` | version | (transitive in `.venv`) | [pyasn1 (PyPI)](https://pypi.org/project/pyasn1/) |
+| **pyasn1_modules** | `0.4.2` | version | (transitive in `.venv`) | [pyasn1_modules (PyPI)](https://pypi.org/project/pyasn1-modules/) |
+| **pycparser** | `3.0` | version | (transitive in `.venv`) | [pycparser (PyPI)](https://pypi.org/project/pycparser/) |
+| **pydantic** | `2.13.4` | version | `pyproject.toml` line 17 (direct) | [pydantic (PyPI)](https://pypi.org/project/pydantic/) |
+| **pydantic-settings** | `2.14.1` | version | (transitive in `.venv`) | [pydantic-settings (PyPI)](https://pypi.org/project/pydantic-settings/) |
+| **pydantic_core** | `2.46.4` | version | (transitive in `.venv`) | [pydantic_core (PyPI)](https://pypi.org/project/pydantic-core/) |
+| **Pygments** | `2.21.0` | version | (transitive in `.venv`) | [Pygments (PyPI)](https://pypi.org/project/pygments/) |
+| **PyJWT** | `2.13.0` | version | (transitive in `.venv`) | [PyJWT (PyPI)](https://pypi.org/project/pyjwt/) |
+| **pykube-ng** | `23.6.0` | version | `pyproject.toml` line 12 (direct) | [pykube-ng (PyPI)](https://pypi.org/project/pykube-ng/) |
+| **pytest** | `9.1.1` | version | (transitive in `.venv`) | [pytest (PyPI)](https://pypi.org/project/pytest/) |
+| **pytest-xdist** | `3.8.0` | version | (transitive in `.venv`) | [pytest-xdist (PyPI)](https://pypi.org/project/pytest-xdist/) |
+| **python-dateutil** | `2.9.0.post0` | version | (transitive in `.venv`) | [python-dateutil (PyPI)](https://pypi.org/project/python-dateutil/) |
+| **python-discovery** | `1.5.2` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
+| **python-dotenv** | `1.2.3` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
+| **python-multipart** | `0.0.32` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
+| **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
+| **regex** | `2026.7.19` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
+| **requests** | `2.34.2` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
+| **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
+| **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
+| **rich** | `15.0.0` | version | (transitive in `.venv`) | [rich (PyPI)](https://pypi.org/project/rich/) |
+| **ruff** | `0.15.11` | version | (transitive in `.venv`) | [ruff (PyPI)](https://pypi.org/project/ruff/) |
+| **safetensors** | `0.8.0` | version | (transitive in `.venv`) | [safetensors (PyPI)](https://pypi.org/project/safetensors/) |
+| **scipy** | `1.17.1` | version | (transitive in `.venv`) | [scipy (PyPI)](https://pypi.org/project/scipy/) |
+| **shellingham** | `1.5.4` | version | (transitive in `.venv`) | [shellingham (PyPI)](https://pypi.org/project/shellingham/) |
+| **six** | `1.17.0` | version | (transitive in `.venv`) | [six (PyPI)](https://pypi.org/project/six/) |
+| **smmap** | `5.0.3` | version | (transitive in `.venv`) | [smmap (PyPI)](https://pypi.org/project/smmap/) |
+| **sniffio** | `1.3.1` | version | (transitive in `.venv`) | [sniffio (PyPI)](https://pypi.org/project/sniffio/) |
+| **starlette** | `1.6.0` | version | (transitive in `.venv`) | [starlette (PyPI)](https://pypi.org/project/starlette/) |
+| **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
+| **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
+| **tqdm** | `4.70.0` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
+| **transformers** | `5.15.1` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **truststore** | `0.10.4` | version | (transitive in `.venv`) | [truststore (PyPI)](https://pypi.org/project/truststore/) |
+| **typer** | `0.27.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
+| **typing-inspection** | `0.4.4` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
+| **typing_extensions** | `4.16.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
+| **urllib3** | `2.7.0` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
+| **uvicorn** | `0.48.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
+| **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
+| **virtualenv** | `21.7.4` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
+| **watchfiles** | `1.2.0` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
+| **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
+| **websockets** | `17.0.1` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
+| **yarl** | `1.24.5` | version | (transitive in `.venv`) | [yarl (PyPI)](https://pypi.org/project/yarl/) |
+
+</details>

--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from collections.abc import Mapping
+import json
 import re
 
 import yaml
@@ -200,6 +201,7 @@ class AdminPrerequisitesStep(Step):
 
         existing_crds = self._get_existing_crds(cmd, context)
 
+        installed_monitoring_crds = False
         deploy_methods = context.deployed_methods or []
         modelservice_active = "modelservice" in deploy_methods
         gateway_class = (plan_config.get("gateway") or {}).get("className", "")
@@ -238,7 +240,7 @@ class AdminPrerequisitesStep(Step):
                 existing_crds,
             )
 
-            self._install_prometheus_crds_if_needed(
+            installed_monitoring_crds = self._install_prometheus_crds_if_needed(
                 cmd,
                 plan_config,
                 existing_crds,
@@ -246,16 +248,23 @@ class AdminPrerequisitesStep(Step):
 
         # Also install Prometheus CRDs for standalone (outside modelservice block)
         if not modelservice_active:
-            self._install_prometheus_crds_if_needed(
+            installed_monitoring_crds = self._install_prometheus_crds_if_needed(
                 cmd,
                 plan_config,
                 existing_crds,
             )
 
         # After any auto-install attempt, validate that monitoring CRDs are
-        # present when monitoring is enabled.  Re-fetch CRDs so we pick up
-        # anything that was just installed above.
-        refreshed_crds = self._get_existing_crds(cmd, context)
+        # present when monitoring is enabled.  Re-fetch the inventory only when
+        # something was actually installed above -- `kubectl get crd -o json`
+        # ships every CRD's full OpenAPI schema, so an unconditional refetch
+        # spends seconds to minutes re-confirming a set we already hold. When
+        # nothing installed, `existing_crds` is still authoritative.
+        refreshed_crds = (
+            self._get_existing_crds(cmd, context)
+            if installed_monitoring_crds
+            else existing_crds
+        )
         self._validate_monitoring_crds(
             cmd, context, plan_config, refreshed_crds, errors
         )
@@ -296,9 +305,14 @@ class AdminPrerequisitesStep(Step):
         )
         if not result.success or not result.stdout.strip():
             return {}
+        # json.loads, not yaml.safe_load: `-o json` can only emit JSON, and
+        # this payload carries every CRD's full OpenAPI v3 schema -- tens of
+        # MB on a mature cluster. PyYAML's pure-Python parser takes ~200x
+        # longer than json on that input (a minute vs a fraction of a second
+        # for ~600 CRDs), which used to dominate this step's runtime.
         try:
-            items = yaml.safe_load(result.stdout).get("items", [])
-        except (yaml.YAMLError, AttributeError):
+            items = json.loads(result.stdout).get("items", [])
+        except (json.JSONDecodeError, AttributeError):
             return {}
         inventory: dict[str, str | None] = {}
         for item in items:
@@ -607,16 +621,19 @@ class AdminPrerequisitesStep(Step):
         cmd: CommandExecutor,
         plan_config: dict,
         existing_crds: list[str],
-    ):
+    ) -> bool:
         """Install Prometheus Operator CRDs (PodMonitor, ServiceMonitor) if requested.
 
         Only installs when monitoring.installPrometheusCrds is true and the
         CRDs don't already exist. Useful for Kind or vanilla K8s clusters
         that don't have the Prometheus Operator installed.
+
+        Returns True only when CRDs were actually applied, so the caller knows
+        whether its cached CRD inventory is now stale.
         """
         monitoring = plan_config.get("monitoring", {})
         if not monitoring.get("installPrometheusCrds", False):
-            return
+            return False
 
         prometheus_crds = [
             "podmonitors.monitoring.coreos.com",
@@ -628,7 +645,7 @@ class AdminPrerequisitesStep(Step):
                 "✅ Prometheus Operator CRDs already installed "
                 "(podmonitors.monitoring.coreos.com found)"
             )
-            return
+            return False
 
         cmd.logger.log_info(
             "Installing Prometheus Operator CRDs (PodMonitor, ServiceMonitor)..."
@@ -638,18 +655,19 @@ class AdminPrerequisitesStep(Step):
             cmd.logger.log_warning(
                 "monitoring.prometheusCrdUrls is empty -- cannot install CRDs"
             )
-            return
+            return False
         for url in urls:
             result = cmd.kube("apply", "-f", url, check=False)
             if not result.success:
                 cmd.logger.log_warning(
                     f"Failed to install Prometheus CRD from {url}: {result.stderr}"
                 )
-                return
+                return False
 
         cmd.logger.log_info(
             "✅ Prometheus Operator CRDs installed (PodMonitor, ServiceMonitor)"
         )
+        return True
 
     def _validate_monitoring_crds(
         self,


### PR DESCRIPTION
- Step 02 was spending ~2 minutes doing nothing useful

`_get_existing_crds` runs `kubectl get crd -o json`  which returns every CRD's full OpenAPI v3 schema, then parsed it with `yaml.safe_load`. PyYAML's pure-Python parser is ~230x slower than json on that input, despite -o json guaranteeing JSON. It was also called `twice`: once up front, once to "pick up anything just installed", even when nothing installed.


- Decode pods crash-loop on current main

`llm-d-routing-sidecar v0.10.0` renamed `--connector` to `--kv-connector` and `--vllm-port`  to `--model-server-port`, but `llm-d-modelservice v0.4.15` still emits the old names, so the sidecar exits 2 on startup and decode pods sit in Init:CrashLoopBackOff forever. Introduced by [#1817](https://github.com/llm-d/llm-d-benchmark/issues/1817), which bumped the image without a matching chart release.

Quick temp fix is to pin `llm-d-routing-sidecar_version` back to `v0.9.0`. The forward fix isn't ours since the flag names are hardcoded literals in the chart's `_helpers.tpl` with `no args passthrough`, so pinning is the only lever we have. 

Needs a follow-up issue on modelservice. TBD

Note only the sidecar half of [#1817](https://github.com/llm-d/llm-d-benchmark/issues/1817) is reverted; router_chart_version: v0.10.0 stays, and the EPP is healthy on it.