### PR TITLE
feat: Allow for Pods to Automatically Restart if in Error State

### DIFF
--- a/docs/standup.md
+++ b/docs/standup.md
@@ -184,6 +184,55 @@ Three things overrides cannot do:
 ## Multiple steps
 The full standup of a stack is a multi-step process. The [lifecycle](lifecycle.md) document go into more details explaning the meaning of each different individual step.
 
+## Recovering from crashed pods (`--pod-restart-budget`)
+
+Some pods come up broken and only recover once deleted -- the replacement the
+controller creates is healthy. By default a pod that lands in a crash state
+fails the readiness wait immediately, and with it the whole standup.
+
+`--pod-restart-budget N` lets standup absorb that:
+
+```bash
+llmdbenchmark standup --spec <spec> --pod-restart-budget 3
+```
+
+```bash
+LLMDBENCH_POD_RESTART_BUDGET=3 llmdbenchmark standup --spec <spec>
+```
+
+The budget is a **single total for the whole standup** -- shared by every pod,
+every readiness wait, and every stack, not a per-pod allowance. `3` means at
+most three pod deletions in total, whether they all hit one stubborn decode
+pod or one each across three stacks.
+
+Only failures a restart can plausibly fix are retried:
+
+| Situation | Behavior |
+|---|---|
+| `CrashLoopBackOff`, `Error`, `OOMKilled`, pod phase `Failed` | Deleted and retried while budget remains |
+| `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `CreateContainerConfigError` | Fails immediately -- an identical replacement fails identically |
+| Pod with no controller to recreate it | Fails immediately -- deleting it means it never comes back |
+| Pod already `Terminating` | Left alone; never charged twice |
+| Budget exhausted | Fails with `Pod restart budget exhausted (N/N)` |
+
+Each restart adds `--pod-restart-grace` seconds (default `300`) to that wait's
+deadline, since the replacement pod re-pulls its image and reloads the model
+from scratch. Without it, a crash late in a wait would leave the replacement
+no time to become Ready.
+
+Before a pod is deleted, its `describe` output, current logs,
+previous-container logs, and events are written to
+`<workspace>/setup/logs/pod-restarts/`. Every consumed restart is reported at
+the end of standup, so a run that only converged after deleting pods does not
+look identical to one that came up clean.
+
+Default is `0` (disabled), which behaves exactly as standup always has.
+
+> [!TIP]
+> If you find yourself needing a large budget, the pods are probably failing
+> for a structural reason. Check the captured diagnostics before raising it --
+> the previous-container logs are usually the ones that explain a crash loop.
+
 ## Use
 A scenario file has to be manually crafted as a YAML file. Once crafted, it can be used by `llmdbenchmark standup`, `llmdbenchmark run` or `llmdbenchmark teardown` commands. Its access is controlled by the following parameters.
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -530,6 +530,8 @@ def _do_standup(args, logger, render_plan_errors):
         kustomize_deploy_timeout=int(
             getattr(args, "kustomize_deploy_timeout", 900) or 900
         ),
+        pod_restart_budget=max(0, int(getattr(args, "pod_restart_budget", 0) or 0)),
+        pod_restart_grace=int(getattr(args, "pod_restart_grace", 300) or 300),
         llmd_repo_path=getattr(args, "llmd_repo_path", None),
         kustomize_skip_infra=not getattr(args, "full_infra", False),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
@@ -547,10 +549,35 @@ def _do_standup(args, logger, render_plan_errors):
     step_spec = getattr(args, "step", None)
     result = executor.execute(step_spec=step_spec)
 
+    # Reported before the failure check so a standup that died *after*
+    # spending restarts still says what it spent them on.
+    _report_pod_restarts(context, logger)
+
     if result.has_errors:
         raise PhaseError(f"Standup failed:\n{result.summary()}")
 
     return context, result
+
+
+def _report_pod_restarts(context, logger):
+    """Log which pods were restarted, if any.
+
+    A standup that only converged after deleting pods must not read the same
+    as one that came up clean -- especially in CI, where nobody watched it.
+    """
+    from llmdbenchmark.utilities.podstate import evidence_dir, render_restart_summary
+
+    budget = context.restart_budget
+    lines = render_restart_summary(budget)
+    if not lines:
+        return
+
+    logger.log_warning("")
+    for line in lines:
+        logger.log_warning(line)
+    logger.log_warning(
+        f"  Diagnostics for each restarted pod: {evidence_dir(context.workspace)}"
+    )
 
 
 def _execute_standup(args, logger, render_plan_errors):
@@ -1707,6 +1734,14 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_KUSTOMIZE_DEPLOY_TIMEOUT": (
             "kustomize_deploy_timeout",
             "--kustomize-deploy-timeout",
+        ),
+        "LLMDBENCH_POD_RESTART_BUDGET": (
+            "pod_restart_budget",
+            "--pod-restart-budget",
+        ),
+        "LLMDBENCH_POD_RESTART_GRACE": (
+            "pod_restart_grace",
+            "--pod-restart-grace",
         ),
     }
 

--- a/llmdbenchmark/executor/README.md
+++ b/llmdbenchmark/executor/README.md
@@ -105,8 +105,15 @@ class CommandExecutor:
         kubeconfig=None,
         kube_context=None,
         openshift=False,
+        pod_restart_budget=None,
+        pod_restart_grace=300.0,
     ): ...
 ```
+
+`pod_restart_budget` is a `utilities.podstate.RestartBudget` owned by the
+caller (`ExecutionContext.restart_budget`), not built here -- the executor is
+rebuilt mid-phase after cluster detection, and a budget created here would
+silently reset its counter on every rebuild.
 
 ### Core Methods
 
@@ -119,7 +126,7 @@ class CommandExecutor:
 
 All wait helpers show live terminal progress with progress bars and pod status. In dry-run mode, they log the would-be command and return success immediately.
 
-- `wait_for_pods(label, namespace, timeout=300, poll_interval=10, description="") -> CommandResult` -- Poll pods by label until all are Ready. Detects and aborts on terminal states (`CrashLoopBackOff`, `OOMKilled`, `ImagePullBackOff`, etc.).
+- `wait_for_pods(label, namespace, timeout=300, poll_interval=10, description="") -> CommandResult` -- Poll pods by label until all are Ready. Detects and aborts on terminal states (`CrashLoopBackOff`, `OOMKilled`, `ImagePullBackOff`, etc.). When the executor is built with a `pod_restart_budget` (see `--pod-restart-budget`), pods failing in a way a restart may clear are deleted and retried instead of aborting, and the deadline is extended per restart; states a restart cannot fix still fail fast. Remediation is pluggable via `_pod_policies` -- see [utilities/podstate](../utilities/podstate/README.md).
 - `wait_for_job(job_name, namespace, timeout=3600, poll_interval=15, description="") -> CommandResult` -- Poll a Job until it completes or fails. Tracks active/succeeded/failed counts.
 - `wait_for_pvc(pvc_name, namespace, timeout=300, poll_interval=10, description="") -> CommandResult` -- Poll a PVC until it reaches `Bound` phase. Short-circuits to success when the StorageClass uses `volumeBindingMode: WaitForFirstConsumer` (such PVCs stay `Pending` until a consumer pod schedules), returning `wait_skipped=True` so a caller with a tighter next wait can add this `timeout` to it.
 

--- a/llmdbenchmark/executor/command.py
+++ b/llmdbenchmark/executor/command.py
@@ -9,45 +9,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from llmdbenchmark.exceptions.exceptions import ExecutionError
-from llmdbenchmark.utilities.kube_helpers import CRASH_STATES
-
-
-def _summarize_container_status(not_ready: list[dict]) -> str:
-    """Return the 'worst' container state among *not_ready*.
-
-    Priority: terminated with a CRASH_STATES reason > any terminated >
-    waiting with a CRASH_STATES reason > any waiting > "NotReady".
-
-    This is what surfaces to ``wait_for_pods``' crash detector, so
-    pushing crash reasons to the front means a CrashLoopBackOff on one
-    container of a multi-container pod aborts the wait immediately
-    instead of getting masked by a "Waiting" sibling.
-    """
-    if not not_ready:
-        return "NotReady"
-
-    def _state_reason(cs: dict, key: str) -> str:
-        return (cs.get("state", {}).get(key) or {}).get("reason", "") or ""
-
-    # Terminal crash states first.
-    for cs in not_ready:
-        reason = _state_reason(cs, "terminated")
-        if reason in CRASH_STATES:
-            return reason
-
-    # Waiting with a crash reason (e.g. CrashLoopBackOff, ImagePullBackOff).
-    for cs in not_ready:
-        reason = _state_reason(cs, "waiting")
-        if reason in CRASH_STATES:
-            return reason
-
-    # Non-terminal but informative.
-    for cs in not_ready:
-        reason = _state_reason(cs, "waiting") or _state_reason(cs, "terminated")
-        if reason:
-            return reason
-
-    return "NotReady"
+from llmdbenchmark.utilities.podstate import (
+    PodState,
+    RestartBudget,
+    RestartBudgetPolicy,
+    Verdict,
+    WaitContext,
+    capture_pod_evidence,
+    evidence_dir,
+    parse_pod_list,
+)
 
 
 @dataclass
@@ -117,6 +88,8 @@ class CommandExecutor:
         kubeconfig: str | None = None,
         kube_context: str | None = None,
         openshift: bool = False,
+        pod_restart_budget: RestartBudget | None = None,
+        pod_restart_grace: float = 300.0,
     ):
         self.work_dir = work_dir
         self.dry_run = dry_run
@@ -128,6 +101,18 @@ class CommandExecutor:
         self._kube_bin = "oc" if openshift else "kubectl"
         self._commands_dir = work_dir / "setup" / "commands"
         self._commands_dir.mkdir(parents=True, exist_ok=True)
+        # Owned by the caller, not built here: this executor is rebuilt
+        # mid-phase (after cluster/OpenShift detection), and a budget created
+        # here would silently reset its counter on every rebuild.
+        self.pod_restart_budget = pod_restart_budget
+        self._pod_policies: list = []
+        if pod_restart_budget is not None and pod_restart_budget.enabled:
+            self._pod_policies.append(
+                RestartBudgetPolicy(
+                    budget=pod_restart_budget,
+                    grace_seconds=pod_restart_grace,
+                )
+            )
 
     def execute(  # pylint: disable=too-many-arguments
         self,
@@ -322,7 +307,13 @@ class CommandExecutor:
         poll_interval: int = 10,
         description: str = "",
     ) -> CommandResult:
-        """Poll pods matching a label selector until all are Ready, showing live progress."""
+        """Poll pods matching a label selector until all are Ready, showing live progress.
+
+        When a restart budget is configured (``--pod-restart-budget``), pods
+        that fail in a way a restart may clear are deleted and given another
+        chance instead of aborting the wait outright. Failures a restart
+        cannot clear (a bad image reference, a broken config) still fail fast.
+        """
         desc = description or label
         kc_args = " ".join(self._kubeconfig_args())
         cmd_repr = (
@@ -336,32 +327,38 @@ class CommandExecutor:
         start = time.time()
         last_status_line = ""
         ever_found_pods = False
+        # Extended by the restart policy: a replacement pod re-pulls its image
+        # and reloads the model from zero, so it needs budget of its own.
+        deadline = float(timeout)
 
         while True:
             elapsed = time.time() - start
-            remaining = max(0, timeout - elapsed)  # noqa: F841
 
-            if elapsed > timeout:
+            if elapsed > deadline:
                 self._clear_progress_line(last_status_line)
+                budget_note = self._restart_budget_note()
                 if not ever_found_pods:
                     self.logger.log_warning(
-                        f"⏱️  No pods found for {desc} after {timeout}s"
+                        f"⏱️  No pods found for {desc} after {int(deadline)}s"
                     )
                     return CommandResult(
                         command=cmd_repr,
                         exit_code=1,
-                        stderr=f"Timed out after {timeout}s waiting for {desc} -- no pods found",
+                        stderr=(
+                            f"Timed out after {int(deadline)}s waiting for {desc} "
+                            f"-- no pods found{budget_note}"
+                        ),
                     )
                 self.logger.log_error(
-                    f"⏱️  Timed out waiting for {desc} after {timeout}s"
+                    f"⏱️  Timed out waiting for {desc} after {int(deadline)}s"
                 )
                 return CommandResult(
                     command=cmd_repr,
                     exit_code=1,
-                    stderr=f"Timed out after {timeout}s waiting for {desc}",
+                    stderr=f"Timed out after {int(deadline)}s waiting for {desc}{budget_note}",
                 )
 
-            pods = self._get_pod_statuses(label, namespace)
+            pods = self._observe_pods(label, namespace)
 
             if pods is None:
                 time.sleep(poll_interval)
@@ -371,7 +368,7 @@ class CommandExecutor:
                 status_line = self._format_progress(
                     desc,
                     elapsed,
-                    timeout,
+                    deadline,
                     "no pods found yet",
                     0,
                     0,
@@ -383,14 +380,14 @@ class CommandExecutor:
 
             ever_found_pods = True
 
-            ready_count = sum(1 for p in pods if p["ready"])
+            ready_count = sum(1 for p in pods if p.ready)
             total = len(pods)
-            pod_summaries = [f"{p['name'][:30]}:{p['status']}" for p in pods]
+            pod_summaries = [f"{p.name[:30]}:{p.summary}" for p in pods]
 
             status_line = self._format_progress(
                 desc,
                 elapsed,
-                timeout,
+                deadline,
                 " | ".join(pod_summaries),
                 ready_count,
                 total,
@@ -398,11 +395,39 @@ class CommandExecutor:
             self._print_progress(status_line, last_status_line)
             last_status_line = status_line
 
-            crashing = [p for p in pods if p["status"] in CRASH_STATES]
+            remedy = self._apply_pod_policies(
+                pods,
+                WaitContext(
+                    description=desc,
+                    namespace=namespace,
+                    elapsed=elapsed,
+                    timeout=deadline,
+                ),
+                last_status_line,
+            )
+            if remedy is not None:
+                if remedy.verdict is Verdict.ABORT:
+                    self._clear_progress_line(last_status_line)
+                    return CommandResult(
+                        command=cmd_repr,
+                        exit_code=1,
+                        stderr=remedy.message or f"Aborting wait for {desc}",
+                    )
+                if remedy.extend_deadline:
+                    deadline += remedy.extend_deadline
+                if remedy.message or remedy.delete_pods:
+                    # The policy logged something, so the progress line was
+                    # cleared; a silent remedy leaves it on screen to be
+                    # overwritten by the next tick.
+                    last_status_line = ""
+                time.sleep(poll_interval)
+                continue
+
+            crashing = [p for p in pods if p.crashing]
             if crashing:
                 self._clear_progress_line(last_status_line)
                 crash_details = ", ".join(
-                    f"{p['name'][:30]}={p['status']}" for p in crashing
+                    f"{p.name[:30]}={p.summary}" for p in crashing
                 )
                 self.logger.log_error(
                     f"❌ {desc}: pod(s) in terminal failure state: {crash_details}"
@@ -412,7 +437,7 @@ class CommandExecutor:
                     exit_code=1,
                     stderr=(
                         f"Pod(s) in terminal failure state: {crash_details}. "
-                        f"Aborting wait for {desc}."
+                        f"Aborting wait for {desc}.{self._restart_budget_note()}"
                     ),
                 )
 
@@ -424,6 +449,93 @@ class CommandExecutor:
                 return CommandResult(command=cmd_repr, exit_code=0)
 
             time.sleep(poll_interval)
+
+    def _restart_budget_note(self) -> str:
+        """Suffix explaining budget state, for failure messages ('' when unused)."""
+        budget = self.pod_restart_budget
+        if budget is None or not budget.enabled:
+            return ""
+        if budget.exhausted:
+            return (
+                f" Pod restart budget exhausted ({budget.status()}); "
+                "raise --pod-restart-budget to allow more restart attempts."
+            )
+        return f" Pod restart budget used: {budget.status()}."
+
+    def _apply_pod_policies(
+        self,
+        pods: list[PodState],
+        ctx: WaitContext,
+        last_status_line: str,
+    ):
+        """Run the configured policies and perform the side effects they ask for.
+
+        Returns the Remedy that was acted on, or ``None`` when no policy had
+        anything to say and the caller should apply its normal rules.
+        """
+        for policy in self._pod_policies:
+            remedy = policy.observe(pods, ctx)
+            if remedy is None:
+                continue
+
+            granted = getattr(policy, "take_granted", lambda: [])()
+            if not remedy.message and not granted:
+                # A silent "keep waiting" (e.g. a replacement pod that has not
+                # appeared yet): leave the progress line alone.
+                return remedy
+
+            self._clear_progress_line(last_status_line)
+            if remedy.message:
+                self.logger.log_warning(f"♻️  {ctx.description}: {remedy.message}")
+
+            for grant in granted:
+                self._capture_and_delete(grant.pod, ctx, grant.event.sequence)
+
+            if remedy.extend_deadline:
+                self.logger.log_info(
+                    f"   Extending wait for {ctx.description} by "
+                    f"{int(remedy.extend_deadline)}s to cover the restart"
+                )
+            return remedy
+        return None
+
+    def _capture_and_delete(
+        self, pod: PodState, ctx: WaitContext, sequence: int
+    ) -> None:
+        """Snapshot a failing pod's diagnostics, then delete it.
+
+        Evidence first: once the pod object is gone its logs and events go with
+        it, and a standup that silently restarted pods would be undebuggable.
+        """
+        try:
+            capture_pod_evidence(
+                self,
+                pod,
+                evidence_dir(self.work_dir),
+                prefix=f"{sequence:02d}-",
+                logger=self.logger,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            self.logger.log_warning(
+                f"Could not capture diagnostics for pod '{pod.name}': {exc}"
+            )
+
+        result = self.kube(
+            "delete",
+            "pod",
+            pod.name,
+            "--namespace",
+            pod.namespace or ctx.namespace,
+            "--ignore-not-found",
+            "--wait=false",
+            check=False,
+        )
+        if result.success:
+            self.logger.log_info(f"   Deleted pod '{pod.name}' -- awaiting replacement")
+        else:
+            self.logger.log_warning(
+                f"Could not delete pod '{pod.name}': {result.stderr}"
+            )
 
     def wait_for_job(
         self,
@@ -769,8 +881,15 @@ class CommandExecutor:
         except OSError:
             return ""
 
-    def _get_pod_statuses(self, label: str, namespace: str) -> list[dict] | None:
-        """Query pod statuses via kubectl/oc get pods -o json."""
+    def _observe_pods(self, label: str, namespace: str) -> list[PodState] | None:
+        """Query pods matching *label* and return their structured state.
+
+        Returns ``None`` when the query itself failed, so a poll loop can tell
+        an apiserver hiccup apart from "the deployment has no pods".
+
+        Deliberately bypasses :meth:`execute`: this runs on every poll tick and
+        would otherwise write a log file per query.
+        """
         parts = [self._kube_bin]
         parts.extend(self._kubeconfig_args())
         parts.extend(
@@ -796,60 +915,24 @@ class CommandExecutor:
             )
             if result.returncode != 0:
                 return None
-
-            data = json.loads(result.stdout)
-            pods = []
-            for item in data.get("items", []):
-                name = item.get("metadata", {}).get("name", "?")
-                phase = item.get("status", {}).get("phase", "Unknown")
-
-                status = phase
-                ready = False
-                container_statuses = item.get("status", {}).get("containerStatuses", [])
-                if container_statuses:
-                    # A pod is Ready only when ALL of its containers are
-                    # Ready. Previously we only looked at containerStatuses[0]
-                    # which, for multi-container pods (e.g. modelservice's
-                    # decode pod with its routing sidecar), could show
-                    # "Ready" while the actual serving container was in
-                    # CrashLoopBackOff — causing step_09's wait to return
-                    # success on a broken deployment.
-                    if all(cs.get("ready", False) for cs in container_statuses):
-                        ready = True
-                        status = "Ready"
-                    else:
-                        # Surface the worst-looking not-ready container so the
-                        # caller can match against CRASH_STATES. Prefer a
-                        # crashing/terminated container over a merely-waiting
-                        # one so terminal failures bubble up first.
-                        not_ready = [
-                            cs
-                            for cs in container_statuses
-                            if not cs.get("ready", False)
-                        ]
-                        status = _summarize_container_status(not_ready)
-                elif phase == "Pending":
-                    conditions = item.get("status", {}).get("conditions", [])
-                    for cond in conditions:
-                        if (
-                            cond.get("type") == "PodScheduled"
-                            and cond.get("status") == "False"
-                        ):
-                            reason = cond.get("reason", "Unschedulable")
-                            status = reason
-                            break
-
-                pods.append(
-                    {
-                        "name": name,
-                        "status": status,
-                        "ready": ready,
-                        "phase": phase,
-                    }
-                )
-            return pods
-        except (json.JSONDecodeError, OSError):
+            return parse_pod_list(result.stdout, namespace=namespace)
+        except OSError:
             return None
+
+    def _get_pod_statuses(self, label: str, namespace: str) -> list[dict] | None:
+        """Query pod statuses as plain dicts (name/status/ready/phase)."""
+        pods = self._observe_pods(label, namespace)
+        if pods is None:
+            return None
+        return [
+            {
+                "name": pod.name,
+                "status": pod.summary,
+                "ready": pod.ready,
+                "phase": pod.phase,
+            }
+            for pod in pods
+        ]
 
     def _get_job_status(self, job_name: str, namespace: str) -> dict | None:
         """Query job status via kubectl/oc get job -o json."""

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -137,6 +137,19 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # namespace creation).  Override with --full-infra on the CLI.
     kustomize_skip_infra: bool = True
 
+    # Total pod deletions allowed across a phase when a pod lands in a failure
+    # state a restart may clear (CrashLoopBackOff, Error, OOMKilled). Some pods
+    # come up broken and only recover once deleted, so this trades a bounded
+    # amount of churn for a standup that survives it. Deliberately a single
+    # phase-wide total rather than per-pod: the cap is on how much churn the
+    # phase is allowed, not on how stubborn any one pod may be.
+    # 0 (default) disables the mechanism -- a crashing pod fails the wait
+    # immediately, as it always has.
+    pod_restart_budget: int = 0
+    # Seconds added to the wait deadline per restart, covering the replacement
+    # pod's image pull and model load.
+    pod_restart_grace: int = 300
+
     # Standup pod deployment timeouts
     kustomize_deploy_timeout: int = 900
     standalone_deploy_timeout: int = 900
@@ -163,6 +176,10 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
 
     logger: LoggerProtocol | None = field(default=None, repr=False)
 
+    # Built once on first use and shared by every CommandExecutor rebuild, so
+    # the count survives the executor being recreated mid-phase.
+    _restart_budget: Any = field(default=None, repr=False)
+
     # Call rebuild_cmd() after changing kubeconfig or is_openshift.
     cmd: CommandExecutor | None = field(default=None, repr=False)
 
@@ -173,6 +190,15 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     helm_cmd: str = "helm"
     helmfile_cmd: str = "helmfile"
     python_cmd: str = "python3"
+
+    @property
+    def restart_budget(self):
+        """The phase-wide pod restart budget, created on first access."""
+        if self._restart_budget is None:
+            from llmdbenchmark.utilities.podstate import RestartBudget
+
+            self._restart_budget = RestartBudget(self.pod_restart_budget)
+        return self._restart_budget
 
     def rebuild_cmd(self) -> CommandExecutor:
         """Create or recreate the shared CommandExecutor from current context fields."""
@@ -186,6 +212,8 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
             kubeconfig=self.kubeconfig,
             kube_context=self.context_name,
             openshift=self.is_openshift,
+            pod_restart_budget=self.restart_budget,
+            pod_restart_grace=float(self.pod_restart_grace),
         )
         return self.cmd
 

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -158,6 +158,33 @@ def add_subcommands(
         "(some dynamic provisioners take 1-3 minutes per volume).",
     )
     standup_parser.add_argument(
+        "--pod-restart-budget",
+        type=int,
+        default=env_int("LLMDBENCH_POD_RESTART_BUDGET"),
+        help="Total number of pod restarts (deletions) allowed across the "
+        "whole standup when a pod lands in a failure state a restart may "
+        "clear (CrashLoopBackOff, Error, OOMKilled). Some pods come up broken "
+        "and only recover once deleted; this lets standup absorb that instead "
+        "of failing. The budget is a single phase-wide total shared by every "
+        "pod and every stack -- not a per-pod allowance. Failures a restart "
+        "cannot fix (ImagePullBackOff, InvalidImageName, "
+        "CreateContainerConfigError) still fail immediately, as do pods with "
+        "no controller to recreate them. Each restarted pod's logs, events, "
+        "and description are saved under "
+        "<workspace>/setup/logs/pod-restarts/ before deletion. "
+        "Default: 0 (disabled).",
+    )
+    standup_parser.add_argument(
+        "--pod-restart-grace",
+        type=int,
+        default=env_int("LLMDBENCH_POD_RESTART_GRACE"),
+        help="Seconds added to a pod readiness wait for each restart "
+        "consumed, covering the replacement pod's image pull and model load. "
+        "Without it, a crash late in the wait would leave the replacement no "
+        "time to become Ready. Only used when --pod-restart-budget > 0. "
+        "Default: 300.",
+    )
+    standup_parser.add_argument(
         "--data-access-timeout",
         type=int,
         default=env_int("LLMDBENCH_DATA_ACCESS_TIMEOUT"),

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -50,12 +50,61 @@ When passed, `--monitoring` enables monitoring infrastructure during standup:
 
 This is separate from the run-phase `--monitoring` flag, which controls metrics scraping and log capture during benchmark execution.
 
+## Pod Restarts During Standup (`--pod-restart-budget`)
+
+Some pods come up broken and only recover once deleted -- the replacement the
+controller creates is fine. By default a pod in a crash state fails the
+readiness wait immediately, which fails the whole standup.
+
+`--pod-restart-budget N` (env `LLMDBENCH_POD_RESTART_BUDGET`) lets standup
+absorb that: when a pod lands in a failure state a restart may clear, it is
+deleted and given another chance.
+
+```bash
+llmdbenchmark standup --spec <spec> --pod-restart-budget 3
+```
+
+The budget is a **single total for the whole standup**, shared by every pod,
+every wait, and every stack -- not a per-pod allowance. Three restarts means
+three pod deletions in total, whether they all hit one decode pod or one each
+across three stacks.
+
+What is and is not restarted:
+
+| Situation | Behavior |
+|---|---|
+| `CrashLoopBackOff`, `Error`, `OOMKilled`, pod phase `Failed` | Deleted and retried while budget remains |
+| `ImagePullBackOff`, `ErrImagePull`, `InvalidImageName`, `CreateContainerConfigError` | Fails immediately -- an identical replacement would fail identically |
+| Pod with no controller to recreate it | Fails immediately -- deleting it means it never comes back |
+| Pod already `Terminating` | Left alone; it is not charged twice |
+| Budget exhausted | Fails with `Pod restart budget exhausted (N/N)` |
+
+Each restart adds `--pod-restart-grace` seconds (default 300) to that wait's
+deadline, because the replacement pod re-pulls its image and reloads the model
+from zero.
+
+**Diagnostics are captured before deletion** -- `describe`, current logs,
+previous-container logs, and events are written to
+`<workspace>/setup/logs/pod-restarts/` so a restarted pod can still be
+debugged after the fact. At the end of standup, every consumed restart is
+reported, so a standup that only converged after deleting pods does not read
+the same as one that came up clean.
+
+Applies to every readiness wait in standup: the data-access pod, standalone /
+kustomize / FMA deploys, the gateway, and decode / prefill / inference-pool
+pods. Default is `0` -- disabled, with behavior identical to before the flag
+existed.
+
+Implemented by `llmdbenchmark.utilities.podstate`; see
+[its README](../utilities/podstate/README.md) to add other reactions to pod
+state.
+
 ## Dry-Run Behavior
 
 In dry-run mode:
 
 - Step 00 still connects to the cluster and resolves metadata (needed for subsequent commands).
-- Steps 02-09 log the commands they would execute without applying them. Commands wrapped in `cmd.kube()`, `cmd.helm()`, and `cmd.execute()` return dry-run `CommandResult` objects. Wait helpers (`wait_for_pods`, `wait_for_pvc`) return success immediately.
+- Steps 02-09 log the commands they would execute without applying them. Commands wrapped in `cmd.kube()`, `cmd.helm()`, and `cmd.execute()` return dry-run `CommandResult` objects. Wait helpers (`wait_for_pods`, `wait_for_pvc`) return success immediately, so no pod is ever deleted by the restart budget in dry-run mode.
 
 ## preprocess/ Subdirectory
 

--- a/llmdbenchmark/utilities/README.md
+++ b/llmdbenchmark/utilities/README.md
@@ -14,11 +14,20 @@ utilities/
 ├── cloud_upload.py        -- GCS/S3 upload
 ├── huggingface.py         -- HuggingFace Hub access checks
 ├── profile_renderer.py    -- Workload profile template renderer
+├── podstate/
+│   ├── __init__.py        -- Public API re-exports
+│   ├── state.py           -- PodState / ContainerState / Health model
+│   ├── observer.py        -- The single `get pods -o json` parser
+│   ├── policy.py          -- PodPolicy seam + RestartBudget(Policy)
+│   └── diagnostics.py     -- Evidence capture and restart reporting
 └── os/
     ├── __init__.py        -- Empty package marker
     ├── filesystem.py      -- Filesystem utilities
     └── platform.py        -- Platform detection
 ```
+
+See [podstate/README.md](podstate/README.md) for the pod state model, the
+`Health` grading, and how to add a remediation policy.
 
 ## cluster.py -- Cluster Connectivity and Platform Detection
 

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -13,19 +13,16 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from llmdbenchmark.utilities.podstate import PodState
+from llmdbenchmark.utilities.podstate import CRASH_STATES as _CRASH_STATES
+
 if TYPE_CHECKING:
     from llmdbenchmark.executor.context import ExecutionContext
 
-# Container states that indicate a pod will never succeed.
-CRASH_STATES = {
-    "CrashLoopBackOff",
-    "Error",
-    "OOMKilled",
-    "CreateContainerConfigError",
-    "ImagePullBackOff",
-    "ErrImagePull",
-    "InvalidImageName",
-}
+# Container states that indicate a pod will never succeed. Re-exported from
+# llmdbenchmark.utilities.podstate, which also splits them into the states a
+# restart may clear (DEGRADED_STATES) and those it cannot (TERMINAL_STATES).
+CRASH_STATES = _CRASH_STATES
 
 DATA_ACCESS_LABEL = "role=llm-d-benchmark-data-access"
 
@@ -36,64 +33,14 @@ DATA_ACCESS_LOOKUP_ATTEMPTS = 5
 DATA_ACCESS_LOOKUP_DELAY_SECONDS = 3.0
 
 
-def _terminated_state_detail(prefix: str, state: dict) -> str:
-    """Format a terminated container state for a user-facing error."""
-    reason = state.get("reason") or "unknown reason"
-    detail = f"{prefix}{reason}"
-    if state.get("exitCode") is not None:
-        detail += f", exit_code={state['exitCode']}"
-    return detail
-
-
 def _pod_crash_details(pod: dict) -> list[str]:
-    """Return concrete crash details for containers in a pod."""
-    metadata = pod.get("metadata", {})
-    status = pod.get("status", {})
-    pod_name = metadata.get("name", "unknown-pod")
-    failures: list[str] = []
+    """Return concrete crash details for containers in a pod.
 
-    status_groups = (
-        status.get("initContainerStatuses", []),
-        status.get("containerStatuses", []),
-        status.get("ephemeralContainerStatuses", []),
-    )
-    for container_statuses in status_groups:
-        for container_status in container_statuses or []:
-            state = container_status.get("state", {})
-            details: list[str] = []
-
-            waiting = state.get("waiting") or {}
-            waiting_reason = waiting.get("reason")
-            if waiting_reason in CRASH_STATES:
-                details.append(waiting_reason)
-
-            terminated = state.get("terminated") or {}
-            terminated_reason = terminated.get("reason")
-            terminated_exit_code = terminated.get("exitCode")
-            if terminated and (
-                terminated_reason in CRASH_STATES
-                or (terminated_exit_code is not None and terminated_exit_code != 0)
-            ):
-                details.append(_terminated_state_detail("terminated: ", terminated))
-
-            if not details:
-                continue
-
-            last_terminated = (container_status.get("lastState") or {}).get(
-                "terminated"
-            )
-            if last_terminated:
-                details.append(
-                    _terminated_state_detail("last terminated: ", last_terminated)
-                )
-
-            container_name = container_status.get("name", "unknown-container")
-            failures.append(f"{pod_name}/{container_name} ({', '.join(details)})")
-
-    if not failures and status.get("reason") in CRASH_STATES:
-        failures.append(f"{pod_name} ({status['reason']})")
-
-    return failures
+    Thin wrapper over :attr:`PodState.crash_details`; kept as a module-level
+    function because callers outside this module (the FMA validator) import it
+    by name.
+    """
+    return PodState.from_api(pod).crash_details
 
 
 # ---------------------------------------------------------------------------

--- a/llmdbenchmark/utilities/podstate/README.md
+++ b/llmdbenchmark/utilities/podstate/README.md
@@ -1,0 +1,72 @@
+# llmdbenchmark.utilities.podstate
+
+Structured pod state, observation, remediation policy, and diagnostics.
+
+Before this package, "what is this pod doing?" was re-derived from raw
+`kubectl get pods -o json` payloads in four places, each covering a slightly
+different slice and disagreeing at the edges. This is the one parser and the
+one model.
+
+## Modules
+
+| Module | Responsibility |
+|---|---|
+| `state.py` | `PodState` / `ContainerState` / `Health` -- the data model and its classification rules |
+| `observer.py` | `parse_pod_list()` / `observe_pods()` -- the single `get pods -o json` parser |
+| `policy.py` | `PodPolicy` protocol, `Remedy`, `RestartBudget`, `RestartBudgetPolicy` |
+| `diagnostics.py` | Evidence capture before destructive remediation, plus end-of-phase reporting |
+
+## The `Health` grading
+
+The key distinction the model adds over a flat "is it crashing?" set:
+
+| Health | Meaning | Example |
+|---|---|---|
+| `HEALTHY` | Every container Ready | -- |
+| `STARTING` | Not Ready, no failure signal | `PodInitializing`, `Unschedulable` |
+| `DEGRADED` | Failing in a way a restart **may** clear | `CrashLoopBackOff`, `Error`, `OOMKilled`, pod phase `Failed` |
+| `TERMINAL` | Failing in a way a restart **cannot** clear | `ImagePullBackOff`, `InvalidImageName`, `CreateContainerConfigError` |
+
+`CRASH_STATES` (`DEGRADED_STATES | TERMINAL_STATES`) is preserved as the
+historical flat set and re-exported from `kube_helpers` for existing callers.
+
+## The policy seam
+
+A waiter observes pods; a *policy* decides what to do about what it saw.
+
+```python
+class PodPolicy(Protocol):
+    def observe(self, pods: Sequence[PodState], ctx: WaitContext) -> Remedy | None: ...
+```
+
+Policies are **pure**: they return a `Remedy` describing what should happen
+(`verdict`, `delete_pods`, `extend_deadline`, `message`) and the caller
+performs the side effects. That keeps them testable without a cluster and
+keeps pod deletion in one audited place.
+
+`RestartBudgetPolicy` is the first implementation. New reactions -- capture
+diagnostics on first failure, react to node pressure, give up early on a
+stalled rollout -- plug into the same seam without touching the wait loop.
+
+## `RestartBudget`
+
+A **total, phase-wide** allowance of pod deletions, deliberately not per-pod:
+the cap is on how much churn a phase is allowed, so one pathologically broken
+pod cannot consume unbounded restarts by staying under its own limit.
+
+Thread-safe, because standup deploys stacks in parallel through a single
+shared `CommandExecutor`. Charges are keyed on pod **UID**, so a pod lingering
+in `Terminating` is never re-charged while its replacement still can be.
+
+## Adding a policy
+
+1. Implement `observe(pods, ctx) -> Remedy | None`.
+2. Return `None` when you have nothing to say -- the caller then applies its
+   normal rules.
+3. Return `Remedy(verdict=Verdict.CONTINUE, ...)` to keep waiting, optionally
+   asking for deletions or a deadline extension; `Verdict.ABORT` to stop.
+4. Append it to `CommandExecutor._pod_policies`.
+
+If a policy asks for a deletion, capture evidence first --
+`diagnostics.capture_pod_evidence()`. Deleting a pod destroys its logs and
+events, and an unexplained restart is worse than a clean failure.

--- a/llmdbenchmark/utilities/podstate/__init__.py
+++ b/llmdbenchmark/utilities/podstate/__init__.py
@@ -1,0 +1,69 @@
+"""Structured pod state, observation, remediation policy, and diagnostics.
+
+Public surface:
+
+* :class:`PodState` / :class:`ContainerState` -- what a pod is doing.
+* :class:`Health` -- a graded verdict (healthy / starting / degraded /
+  terminal) that distinguishes failures a restart can clear from those it
+  cannot.
+* :func:`parse_pod_list` / :func:`observe_pods` -- the single parser for
+  ``kubectl get pods -o json``.
+* :class:`PodPolicy` / :class:`Remedy` -- the seam for reacting to unhealthy
+  pods; :class:`RestartBudgetPolicy` is the first implementation.
+* :mod:`diagnostics` -- evidence capture and end-of-phase reporting.
+"""
+
+from llmdbenchmark.utilities.podstate.diagnostics import (
+    capture_pod_evidence,
+    evidence_dir,
+    render_restart_summary,
+)
+from llmdbenchmark.utilities.podstate.observer import observe_pods, parse_pod_list
+from llmdbenchmark.utilities.podstate.policy import (
+    GrantedRestart,
+    PodPolicy,
+    Remedy,
+    RestartBudget,
+    RestartBudgetPolicy,
+    RestartEvent,
+    Verdict,
+    WaitContext,
+)
+from llmdbenchmark.utilities.podstate.state import (
+    CRASH_STATES,
+    DEGRADED_STATES,
+    TERMINAL_STATES,
+    ContainerKind,
+    ContainerState,
+    Health,
+    OwnerRef,
+    PodState,
+    Termination,
+    summarize_container_states,
+)
+
+__all__ = [
+    "CRASH_STATES",
+    "DEGRADED_STATES",
+    "TERMINAL_STATES",
+    "ContainerKind",
+    "ContainerState",
+    "GrantedRestart",
+    "Health",
+    "OwnerRef",
+    "PodPolicy",
+    "PodState",
+    "Remedy",
+    "RestartBudget",
+    "RestartBudgetPolicy",
+    "RestartEvent",
+    "Termination",
+    "Verdict",
+    "WaitContext",
+    "capture_pod_evidence",
+    "evidence_dir",
+    "observe_pods",
+    "parse_pod_list",
+    "render_restart_summary",
+    "summarize_container_states",
+]

--- a/llmdbenchmark/utilities/podstate/diagnostics.py
+++ b/llmdbenchmark/utilities/podstate/diagnostics.py
@@ -1,0 +1,125 @@
+"""Evidence capture and reporting for unhealthy pods.
+
+Restarting a pod destroys the evidence of why it failed: once the pod object
+is gone, so are its logs and its events.  Anything that deletes a pod as a
+remediation should capture that evidence first, or the standup that needed
+three restarts becomes undebuggable after the fact.
+
+Every function here is best-effort by construction: diagnostics must never be
+the reason a phase fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmdbenchmark.utilities.podstate.policy import RestartBudget
+from llmdbenchmark.utilities.podstate.state import PodState
+
+# Bounded so a chatty crash-looping container cannot fill the workspace.
+DEFAULT_LOG_TAIL = 2000
+
+EVIDENCE_DIRNAME = "pod-restarts"
+
+
+def _write(dest: Path, content: str) -> Path | None:
+    """Write *content*, swallowing filesystem errors."""
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+        return dest
+    except OSError:
+        return None
+
+
+def capture_pod_evidence(
+    cmd,
+    pod: PodState,
+    dest_dir: Path,
+    *,
+    prefix: str = "",
+    log_tail: int = DEFAULT_LOG_TAIL,
+    logger=None,
+) -> list[Path]:
+    """Snapshot a pod's description, logs, and events before it is deleted.
+
+    Returns the files actually written.  Never raises.
+    """
+    written: list[Path] = []
+    stem = f"{prefix}{pod.name}" if prefix else pod.name
+    namespace = pod.namespace
+
+    probes = (
+        ("describe", ("describe", "pod", pod.name)),
+        (
+            "logs",
+            ("logs", pod.name, "--all-containers=true", f"--tail={log_tail}"),
+        ),
+        (
+            "previous",
+            (
+                "logs",
+                pod.name,
+                "--all-containers=true",
+                "--previous",
+                f"--tail={log_tail}",
+            ),
+        ),
+        (
+            "events",
+            (
+                "get",
+                "events",
+                "--field-selector",
+                f"involvedObject.name={pod.name}",
+                "--sort-by=.lastTimestamp",
+            ),
+        ),
+    )
+
+    for kind, args in probes:
+        try:
+            result = cmd.kube(*args, namespace=namespace, check=False)
+        except Exception:  # pylint: disable=broad-except
+            continue
+        if not getattr(result, "success", False):
+            continue
+        output = (result.stdout or "").strip()
+        if not output:
+            continue
+        path = _write(dest_dir / f"{stem}-{kind}.txt", output)
+        if path is not None:
+            written.append(path)
+
+    if written and logger is not None:
+        logger.log_info(
+            f"   Captured {len(written)} diagnostic file(s) for {pod.name} "
+            f"-> {dest_dir}"
+        )
+
+    return written
+
+
+def evidence_dir(work_dir: Path) -> Path:
+    """Directory where restart evidence is stored for a workspace."""
+    return Path(work_dir) / "setup" / "logs" / EVIDENCE_DIRNAME
+
+
+def render_restart_summary(budget: RestartBudget) -> list[str]:
+    """Lines describing what the budget was spent on ([] when untouched).
+
+    A standup that only converged after deleting pods must not read the same
+    as one that came up clean, so this is surfaced even on success.
+    """
+    if not budget.events:
+        return []
+
+    lines = [
+        f"Pod restart budget: {budget.status()} consumed during this phase",
+    ]
+    lines.extend(budget.summary_lines())
+    if budget.exhausted:
+        lines.append(
+            "  Budget is now exhausted -- further pod failures will fail the phase."
+        )
+    return lines

--- a/llmdbenchmark/utilities/podstate/observer.py
+++ b/llmdbenchmark/utilities/podstate/observer.py
@@ -1,0 +1,57 @@
+"""Turn ``kubectl get pods -o json`` payloads into :class:`PodState` objects.
+
+Every consumer of pod state in the codebase should route through here, so
+there is one parser to fix when the API shape or our interpretation of it
+changes.
+"""
+
+from __future__ import annotations
+
+import json
+
+from llmdbenchmark.utilities.podstate.state import PodState
+
+
+def parse_pod_list(payload: str, namespace: str = "") -> list[PodState] | None:
+    """Parse a pod list payload.
+
+    Returns ``None`` (rather than an empty list) when the payload is unusable,
+    so callers can distinguish "the query failed" from "no pods matched" -- a
+    poll loop must not treat an apiserver hiccup as "the deployment vanished".
+    """
+    if not payload:
+        return None
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    return [
+        PodState.from_api(item, namespace=namespace)
+        for item in data.get("items", []) or []
+    ]
+
+
+def observe_pods(
+    cmd,
+    namespace: str,
+    label: str | None = None,
+    field_selector: str | None = None,
+) -> list[PodState] | None:
+    """Query pods through a CommandExecutor and return their parsed state.
+
+    Returns ``None`` when the query itself failed.  Uses ``check=False`` so a
+    transient failure surfaces as ``None`` instead of raising.
+    """
+    args = ["get", "pods", "--namespace", namespace, "-o", "json"]
+    if label:
+        args.extend(["-l", label])
+    if field_selector:
+        args.extend(["--field-selector", field_selector])
+
+    result = cmd.kube(*args, check=False)
+    if not getattr(result, "success", False):
+        return None
+    return parse_pod_list(result.stdout or "", namespace=namespace)

--- a/llmdbenchmark/utilities/podstate/policy.py
+++ b/llmdbenchmark/utilities/podstate/policy.py
@@ -1,0 +1,268 @@
+"""Pluggable responses to unhealthy pods observed during a readiness wait.
+
+A waiter observes pods; a *policy* decides what -- if anything -- to do about
+what was observed.  Keeping that decision behind :class:`PodPolicy` means new
+reactions (capture diagnostics on first failure, react to node pressure, give
+up early on a stalled rollout) can be added without touching the wait loop.
+
+Policies are pure: they return a :class:`Remedy` describing what should
+happen, and the caller performs the side effects.  That keeps them testable
+without a cluster and keeps deletion in one audited place.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from llmdbenchmark.utilities.podstate.state import Health, PodState
+
+
+class Verdict(Enum):
+    """What the wait loop should do next."""
+
+    CONTINUE = "continue"
+    ABORT = "abort"
+
+
+@dataclass(frozen=True)
+class Remedy:
+    """A policy's answer: what to do, and why."""
+
+    verdict: Verdict = Verdict.CONTINUE
+    delete_pods: tuple[str, ...] = ()
+    extend_deadline: float = 0.0
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class WaitContext:
+    """What the wait loop knows about itself, passed to policies."""
+
+    description: str
+    namespace: str
+    elapsed: float
+    timeout: float
+
+    @property
+    def remaining(self) -> float:
+        """Seconds left on the current deadline (never negative)."""
+        return max(0.0, self.timeout - self.elapsed)
+
+
+@runtime_checkable
+class PodPolicy(Protocol):
+    """Reacts to a set of observed pods."""
+
+    def observe(
+        self, pods: Sequence[PodState], ctx: WaitContext
+    ) -> Remedy | None:  # pragma: no cover - protocol
+        """Return a Remedy to act on, or None to leave the wait untouched."""
+        ...
+
+
+@dataclass(frozen=True)
+class RestartEvent:
+    """One consumed restart, for end-of-phase reporting."""
+
+    pod: str
+    namespace: str
+    reason: str
+    sequence: int
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class GrantedRestart:
+    """A pod the budget agreed to spend a restart on."""
+
+    pod: PodState
+    event: RestartEvent
+
+
+class RestartBudget:
+    """A total, phase-wide allowance of pod deletions.
+
+    Deliberately *not* per-pod: the point of the knob is to cap how much
+    churn a standup is allowed in total, so one pathologically broken pod
+    cannot consume an unbounded number of restarts just because each
+    individual pod stayed under its own limit.
+
+    Shared across threads: standup deploys stacks in parallel through a single
+    CommandExecutor, so several waits can claim from this concurrently.
+    """
+
+    def __init__(self, limit: int = 0) -> None:
+        self._limit = max(0, int(limit))
+        self._used = 0
+        self._lock = threading.Lock()
+        self._events: list[RestartEvent] = []
+        self._claimed_keys: set[str] = set()
+
+    @property
+    def limit(self) -> int:
+        """Total restarts allowed."""
+        return self._limit
+
+    @property
+    def used(self) -> int:
+        """Restarts consumed so far."""
+        with self._lock:
+            return self._used
+
+    @property
+    def remaining(self) -> int:
+        """Restarts still available."""
+        with self._lock:
+            return max(0, self._limit - self._used)
+
+    @property
+    def enabled(self) -> bool:
+        """True when the budget allows any restart at all."""
+        return self._limit > 0
+
+    @property
+    def exhausted(self) -> bool:
+        """True when the budget is enabled but fully spent."""
+        with self._lock:
+            return self._limit > 0 and self._used >= self._limit
+
+    @property
+    def events(self) -> list[RestartEvent]:
+        """Chronological record of consumed restarts."""
+        with self._lock:
+            return list(self._events)
+
+    @staticmethod
+    def _key(pod: PodState) -> str:
+        """Identity used to avoid charging the same pod instance twice.
+
+        A deleted pod lingers in ``Terminating`` for several poll cycles; the
+        replacement carries a new UID.  Keying on UID means the old instance is
+        never re-charged while the new one still can be.  Pods with no UID
+        (synthetic payloads) fall back to their name.
+        """
+        return pod.uid or f"{pod.namespace}/{pod.name}"
+
+    def claim(
+        self,
+        pods: Sequence[PodState],
+        *,
+        description: str = "",
+    ) -> list[GrantedRestart]:
+        """Reserve restarts for *pods*, atomically.
+
+        Returns the subset granted (possibly empty), each with its 1-based
+        sequence number.  Pods already charged for are skipped and do not
+        count against the budget.
+        """
+        granted: list[GrantedRestart] = []
+        with self._lock:
+            for pod in pods:
+                if self._used >= self._limit:
+                    break
+                key = self._key(pod)
+                if key in self._claimed_keys:
+                    continue
+                self._claimed_keys.add(key)
+                self._used += 1
+                event = RestartEvent(
+                    pod=pod.name,
+                    namespace=pod.namespace,
+                    reason=pod.reason,
+                    sequence=self._used,
+                    description=description,
+                )
+                self._events.append(event)
+                granted.append(GrantedRestart(pod=pod, event=event))
+        return granted
+
+    def claimed(self, pod: PodState) -> bool:
+        """True when a restart was already spent on this exact pod instance."""
+        with self._lock:
+            return self._key(pod) in self._claimed_keys
+
+    def status(self) -> str:
+        """Human-readable ``used/limit`` string."""
+        return f"{self.used}/{self._limit}"
+
+    def summary_lines(self) -> list[str]:
+        """One line per consumed restart, for an end-of-phase report."""
+        lines = []
+        for event in self.events:
+            where = f"{event.namespace}/{event.pod}" if event.namespace else event.pod
+            suffix = f" during {event.description}" if event.description else ""
+            lines.append(
+                f"  [{event.sequence}/{self._limit}] {where} ({event.reason}){suffix}"
+            )
+        return lines
+
+
+@dataclass
+class RestartBudgetPolicy:
+    """Delete degraded, controller-owned pods while the budget allows it.
+
+    Eligibility is deliberately narrow:
+
+    * ``Health.DEGRADED`` only -- a wrong image name is not fixed by a restart.
+    * Controller-owned only -- deleting a bare pod (``--restart=Never``, as
+      the smoketests create) means it never comes back.
+    * Not already terminating -- otherwise a Terminating pod is re-deleted
+      every poll.
+    """
+
+    budget: RestartBudget
+    grace_seconds: float = 300.0
+    _pending: list[GrantedRestart] = field(default_factory=list, repr=False)
+
+    def eligible(self, pods: Sequence[PodState]) -> list[PodState]:
+        """Pods this policy would restart if the budget allowed."""
+        return [
+            pod
+            for pod in pods
+            if pod.health is Health.DEGRADED and pod.controlled and not pod.deleting
+        ]
+
+    def observe(self, pods: Sequence[PodState], ctx: WaitContext) -> Remedy | None:
+        """Claim restarts for degraded pods; None when nothing to do."""
+        if not self.budget.enabled:
+            return None
+
+        candidates = self.eligible(pods)
+        if not candidates:
+            return None
+
+        granted = self.budget.claim(candidates, description=ctx.description)
+        if not granted:
+            # Nothing new to claim. If the pods that still look broken are ones
+            # we already deleted, their replacements simply have not appeared
+            # yet -- deletion is asynchronous and a pod lingers in Terminating
+            # for several polls. Hold the wait open rather than letting the
+            # caller abort on a pod we deliberately restarted.
+            if any(not pod.ready and self.budget.claimed(pod) for pod in pods):
+                return Remedy(verdict=Verdict.CONTINUE)
+            return None
+
+        self._pending = granted
+        details = ", ".join(
+            f"{g.pod.name} ({g.pod.reason}) "
+            f"[restart {g.event.sequence}/{self.budget.limit}]"
+            for g in granted
+        )
+        return Remedy(
+            verdict=Verdict.CONTINUE,
+            delete_pods=tuple(g.pod.name for g in granted),
+            # A replacement pod starts its own image pull and model load from
+            # zero. Without extra budget a crash late in the wait guarantees
+            # the restart times out, making the restart pointless.
+            extend_deadline=self.grace_seconds * len(granted),
+            message=f"restarting {details}",
+        )
+
+    def take_granted(self) -> list[GrantedRestart]:
+        """Consume and return the pods granted by the last observe() call."""
+        granted, self._pending = self._pending, []
+        return granted

--- a/llmdbenchmark/utilities/podstate/state.py
+++ b/llmdbenchmark/utilities/podstate/state.py
@@ -1,0 +1,337 @@
+"""Structured pod state derived from the Kubernetes API.
+
+Single source of truth for the question "what is this pod doing, and can it
+recover?".  Before this module the answer was re-derived in four places from
+raw ``kubectl get pods -o json`` payloads (the executor's poll loop, the
+harness wait helper, the WVA validator, the smoketest phase check), each
+covering a slightly different slice and disagreeing on the edges.
+
+The important distinction this model adds over a flat "is it crashing?" set is
+:class:`Health`: a pod stuck on ``ImagePullBackOff`` and a pod stuck on
+``CrashLoopBackOff`` are both broken, but only the second one can plausibly be
+fixed by deleting it and letting its controller build a new one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+# Container/pod states that a restart may plausibly clear: a bad roll of the
+# dice on startup, a transient OOM, a dependency that was not up yet.
+DEGRADED_STATES = frozenset(
+    {
+        "CrashLoopBackOff",
+        "Error",
+        "OOMKilled",
+    }
+)
+
+# States that describe a broken *specification* rather than a broken run.
+# Deleting the pod produces an identical pod that fails identically, so these
+# fail fast instead of consuming a restart budget.
+TERMINAL_STATES = frozenset(
+    {
+        "CreateContainerConfigError",
+        "ImagePullBackOff",
+        "ErrImagePull",
+        "InvalidImageName",
+    }
+)
+
+# Kept as the historical flat set: every state that means "this pod will not
+# become Ready on its own". Imported by kube_helpers for backwards
+# compatibility with existing callers.
+CRASH_STATES = frozenset(DEGRADED_STATES | TERMINAL_STATES)
+
+
+class Health(Enum):
+    """Graded verdict on a pod, ordered from good to unrecoverable."""
+
+    HEALTHY = "healthy"  # every container Ready
+    STARTING = "starting"  # not Ready, but no failure signal yet
+    DEGRADED = "degraded"  # failing in a way a restart may clear
+    TERMINAL = "terminal"  # failing in a way a restart cannot clear
+
+
+class ContainerKind(Enum):
+    """Which of a pod's three container lists a status came from."""
+
+    INIT = "init"
+    APP = "app"
+    EPHEMERAL = "ephemeral"
+
+
+@dataclass(frozen=True)
+class OwnerRef:
+    """The controller that owns a pod (Deployment/ReplicaSet/StatefulSet/...)."""
+
+    kind: str
+    name: str
+
+
+@dataclass(frozen=True)
+class Termination:
+    """A container's terminated state, current or previous."""
+
+    reason: str = ""
+    exit_code: int | None = None
+
+    def describe(self, prefix: str = "") -> str:
+        """Format for a user-facing failure line."""
+        detail = f"{prefix}{self.reason or 'unknown reason'}"
+        if self.exit_code is not None:
+            detail += f", exit_code={self.exit_code}"
+        return detail
+
+
+@dataclass(frozen=True)
+class ContainerState:
+    """One container's status, flattened from the API's nested state union."""
+
+    name: str
+    kind: ContainerKind = ContainerKind.APP
+    ready: bool = False
+    restart_count: int = 0
+    waiting_reason: str = ""
+    terminated: Termination | None = None
+    last_terminated: Termination | None = None
+
+    @property
+    def terminated_reason(self) -> str:
+        """Reason from the current terminated state ('' when not terminated)."""
+        return self.terminated.reason if self.terminated else ""
+
+    @property
+    def reason(self) -> str:
+        """Best single-token description of why this container is not Ready."""
+        return self.waiting_reason or self.terminated_reason
+
+    @property
+    def failure_details(self) -> list[str]:
+        """Crash descriptions for this container, empty when it looks fine.
+
+        A container counts as failing when it is waiting on a crash state, or
+        when it terminated either with a crash reason or a non-zero exit code.
+        """
+        details: list[str] = []
+
+        if self.waiting_reason in CRASH_STATES:
+            details.append(self.waiting_reason)
+
+        if self.terminated is not None and (
+            self.terminated.reason in CRASH_STATES
+            or (
+                self.terminated.exit_code is not None and self.terminated.exit_code != 0
+            )
+        ):
+            details.append(self.terminated.describe("terminated: "))
+
+        if not details:
+            return []
+
+        if self.last_terminated is not None:
+            details.append(self.last_terminated.describe("last terminated: "))
+
+        return details
+
+
+def _parse_termination(state: dict, key: str) -> Termination | None:
+    """Build a Termination from ``state[key]`` when present."""
+    raw = state.get(key)
+    if not raw:
+        return None
+    return Termination(
+        reason=raw.get("reason") or "",
+        exit_code=raw.get("exitCode"),
+    )
+
+
+def _parse_container(status: dict, kind: ContainerKind) -> ContainerState:
+    """Flatten one entry of a *ContainerStatuses list."""
+    state = status.get("state") or {}
+    waiting = state.get("waiting") or {}
+    last_state = status.get("lastState") or {}
+
+    return ContainerState(
+        name=status.get("name", "unknown-container"),
+        kind=kind,
+        ready=bool(status.get("ready", False)),
+        restart_count=int(status.get("restartCount", 0) or 0),
+        waiting_reason=waiting.get("reason") or "",
+        terminated=_parse_termination(state, "terminated"),
+        last_terminated=_parse_termination(last_state, "terminated"),
+    )
+
+
+def summarize_container_states(not_ready: list[ContainerState]) -> str:
+    """Return the 'worst' state among *not_ready* containers.
+
+    Priority: terminated with a crash reason > waiting with a crash reason >
+    any reason at all > ``NotReady``.  Pushing crash reasons to the front means
+    a CrashLoopBackOff on one container of a multi-container pod surfaces
+    immediately instead of being masked by a merely-Waiting sibling.
+    """
+    if not not_ready:
+        return "NotReady"
+
+    for container in not_ready:
+        if container.terminated_reason in CRASH_STATES:
+            return container.terminated_reason
+
+    for container in not_ready:
+        if container.waiting_reason in CRASH_STATES:
+            return container.waiting_reason
+
+    for container in not_ready:
+        if container.reason:
+            return container.reason
+
+    return "NotReady"
+
+
+@dataclass(frozen=True)
+class PodState:
+    """A pod's observable state at one point in time."""
+
+    name: str
+    namespace: str = ""
+    uid: str = ""
+    phase: str = "Unknown"
+    deleting: bool = False
+    owner: OwnerRef | None = None
+    containers: tuple[ContainerState, ...] = ()
+    init_containers: tuple[ContainerState, ...] = ()
+    ephemeral_containers: tuple[ContainerState, ...] = ()
+    status_reason: str = ""
+    scheduling_reason: str = ""
+
+    @classmethod
+    def from_api(cls, item: dict, namespace: str = "") -> PodState:
+        """Build a PodState from one item of a ``kubectl get pods -o json`` list."""
+        metadata = item.get("metadata", {}) or {}
+        status = item.get("status", {}) or {}
+
+        owner = None
+        for ref in metadata.get("ownerReferences", []) or []:
+            if ref.get("controller"):
+                owner = OwnerRef(kind=ref.get("kind", ""), name=ref.get("name", ""))
+                break
+
+        scheduling_reason = ""
+        for cond in status.get("conditions", []) or []:
+            if cond.get("type") == "PodScheduled" and cond.get("status") == "False":
+                scheduling_reason = cond.get("reason", "Unschedulable")
+                break
+
+        def _group(key: str, kind: ContainerKind) -> tuple[ContainerState, ...]:
+            return tuple(_parse_container(cs, kind) for cs in status.get(key, []) or [])
+
+        return cls(
+            name=metadata.get("name", "?"),
+            namespace=metadata.get("namespace", "") or namespace,
+            uid=metadata.get("uid", "") or "",
+            phase=status.get("phase", "Unknown"),
+            deleting=bool(metadata.get("deletionTimestamp")),
+            owner=owner,
+            containers=_group("containerStatuses", ContainerKind.APP),
+            init_containers=_group("initContainerStatuses", ContainerKind.INIT),
+            ephemeral_containers=_group(
+                "ephemeralContainerStatuses", ContainerKind.EPHEMERAL
+            ),
+            status_reason=status.get("reason", "") or "",
+            scheduling_reason=scheduling_reason,
+        )
+
+    @property
+    def all_containers(self) -> tuple[ContainerState, ...]:
+        """Every container status, ordered init -> app -> ephemeral."""
+        return self.init_containers + self.containers + self.ephemeral_containers
+
+    @property
+    def ready(self) -> bool:
+        """True when the pod reports containers and all of them are Ready.
+
+        All of them: a multi-container pod (e.g. a decode pod with its routing
+        sidecar) must not read as Ready while its serving container is
+        crash-looping.
+        """
+        return bool(self.containers) and all(c.ready for c in self.containers)
+
+    @property
+    def summary(self) -> str:
+        """One-token status suitable for progress lines and crash matching."""
+        if not self.containers:
+            if self.phase == "Pending" and self.scheduling_reason:
+                return self.scheduling_reason
+            return self.phase
+
+        if self.ready:
+            return "Ready"
+
+        return summarize_container_states([c for c in self.containers if not c.ready])
+
+    @property
+    def crashing(self) -> bool:
+        """True when this pod's container-level summary is a known crash state."""
+        return self.summary in CRASH_STATES
+
+    @property
+    def health(self) -> Health:
+        """Graded verdict, including pod-level failures with no container status.
+
+        A pod whose containers never started (phase ``Failed``, reason
+        ``Error``) reports no containerStatuses at all, so ``summary`` cannot
+        see it -- but it is exactly the case a restart clears.
+        """
+        if self.ready:
+            return Health.HEALTHY
+
+        summary = self.summary
+        if summary in TERMINAL_STATES:
+            return Health.TERMINAL
+        if summary in DEGRADED_STATES:
+            return Health.DEGRADED
+
+        if not self.containers:
+            if self.status_reason in TERMINAL_STATES:
+                return Health.TERMINAL
+            if self.status_reason in DEGRADED_STATES or self.phase == "Failed":
+                return Health.DEGRADED
+
+        return Health.STARTING
+
+    @property
+    def controlled(self) -> bool:
+        """True when a controller owns this pod and would recreate it."""
+        return self.owner is not None
+
+    @property
+    def total_restarts(self) -> int:
+        """Sum of restartCount across every container in the pod."""
+        return sum(c.restart_count for c in self.all_containers)
+
+    def restarts_for(self, container_name: str) -> int:
+        """restartCount for one named container (0 when absent)."""
+        return sum(
+            c.restart_count for c in self.all_containers if c.name == container_name
+        )
+
+    @property
+    def crash_details(self) -> list[str]:
+        """Concrete per-container crash descriptions for user-facing errors."""
+        failures = [
+            f"{self.name}/{container.name} ({', '.join(details)})"
+            for container in self.all_containers
+            if (details := container.failure_details)
+        ]
+
+        if not failures and self.status_reason in CRASH_STATES:
+            failures.append(f"{self.name} ({self.status_reason})")
+
+        return failures
+
+    @property
+    def reason(self) -> str:
+        """Short reason for the pod's current state, for logs and ledgers."""
+        return self.summary if self.containers else (self.status_reason or self.phase)

--- a/tests/test_pod_restart_wait.py
+++ b/tests/test_pod_restart_wait.py
@@ -1,0 +1,537 @@
+"""End-to-end behavior of the restart budget inside CommandExecutor.wait_for_pods."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from llmdbenchmark.executor.command import CommandExecutor, CommandResult
+from llmdbenchmark.utilities.podstate import PodState, RestartBudget
+
+
+class _Logger:
+    def __init__(self):
+        self.messages: list[tuple[str, str]] = []
+
+    def set_indent(self, level: int) -> None:
+        pass
+
+    def _add(self, level, msg):
+        self.messages.append((level, str(msg)))
+
+    def log_info(self, msg, **_):
+        self._add("info", msg)
+
+    def log_debug(self, msg, **_):
+        self._add("debug", msg)
+
+    def log_warning(self, msg, **_):
+        self._add("warning", msg)
+
+    def log_error(self, msg, **_):
+        self._add("error", msg)
+
+    def text(self) -> str:
+        return "\n".join(m for _, m in self.messages)
+
+
+def _pod(name, *, ready=False, reason="CrashLoopBackOff", uid=None, owned=True):
+    item = {
+        "metadata": {"name": name, "uid": uid or f"uid-{name}", "namespace": "ns"},
+        "status": {"phase": "Running", "containerStatuses": []},
+    }
+    if owned:
+        item["metadata"]["ownerReferences"] = [
+            {"kind": "ReplicaSet", "name": "rs", "controller": True}
+        ]
+    if ready:
+        item["status"]["containerStatuses"] = [
+            {"name": "vllm", "ready": True, "state": {}}
+        ]
+    else:
+        item["status"]["containerStatuses"] = [
+            {"name": "vllm", "ready": False, "state": {"waiting": {"reason": reason}}}
+        ]
+    return PodState.from_api(item)
+
+
+def _executor(tmp_path, monkeypatch, polls, budget=None):
+    """Build an executor whose pod observations follow the scripted *polls*."""
+    logger = _Logger()
+    cmd = CommandExecutor(
+        work_dir=tmp_path,
+        dry_run=False,
+        verbose=False,
+        logger=logger,
+        pod_restart_budget=budget,
+    )
+
+    observed = iter(polls)
+    cmd.observed_calls = 0
+
+    def _observe(_label, _namespace):
+        cmd.observed_calls += 1
+        try:
+            return next(observed)
+        except StopIteration:
+            return polls[-1]
+
+    monkeypatch.setattr(cmd, "_observe_pods", _observe)
+
+    calls: list[tuple[str, ...]] = []
+
+    def _kube(*args: str, **_: Any) -> CommandResult:
+        calls.append(args)
+        return CommandResult(command=" ".join(args), exit_code=0, stdout="")
+
+    monkeypatch.setattr(cmd, "kube", _kube)
+    monkeypatch.setattr("llmdbenchmark.executor.command.time.sleep", lambda _s: None)
+
+    cmd.kube_calls = calls
+    cmd.test_logger = logger
+    return cmd
+
+
+def _deletions(cmd) -> list[str]:
+    return [c[2] for c in cmd.kube_calls if c[:2] == ("delete", "pod")]
+
+
+# ---------------------------------------------------------------------------
+# Default (disabled) behavior -- must be byte-for-byte what it always was
+# ---------------------------------------------------------------------------
+
+
+def test_without_budget_a_crashing_pod_still_fails_immediately(tmp_path, monkeypatch):
+    cmd = _executor(tmp_path, monkeypatch, [[_pod("decode-0")]])
+    result = cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+
+    assert result.success is False
+    assert "terminal failure state" in result.stderr
+    assert "decode-0=CrashLoopBackOff" in result.stderr
+    assert _deletions(cmd) == []
+    # No budget configured -> no budget noise in the message.
+    assert "restart budget" not in result.stderr
+
+
+def test_without_budget_ready_pods_succeed(tmp_path, monkeypatch):
+    cmd = _executor(tmp_path, monkeypatch, [[_pod("decode-0", ready=True)]])
+    assert cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1).success
+
+
+def test_zero_budget_object_behaves_like_no_budget(tmp_path, monkeypatch):
+    cmd = _executor(
+        tmp_path, monkeypatch, [[_pod("decode-0")]], budget=RestartBudget(0)
+    )
+    result = cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+    assert result.success is False
+    assert _deletions(cmd) == []
+
+
+# ---------------------------------------------------------------------------
+# Restart behavior
+# ---------------------------------------------------------------------------
+
+
+def test_crashing_pod_is_deleted_and_wait_recovers(tmp_path, monkeypatch):
+    budget = RestartBudget(3)
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [
+            [_pod("decode-0")],  # crash detected -> delete
+            [],  # replacement not created yet
+            [_pod("decode-0", ready=True, uid="uid-new")],  # recovered
+        ],
+        budget=budget,
+    )
+
+    result = cmd.wait_for_pods(
+        "app=x", "ns", timeout=600, poll_interval=1, description="decode pods"
+    )
+
+    assert result.success is True
+    assert _deletions(cmd) == ["decode-0"]
+    assert budget.used == 1
+    assert "♻️" in cmd.test_logger.text()
+
+
+def test_deletion_uses_ignore_not_found_and_does_not_block(tmp_path, monkeypatch):
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [[_pod("decode-0")], [_pod("decode-0", ready=True, uid="new")]],
+        budget=RestartBudget(1),
+    )
+    cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+
+    (delete_call,) = [c for c in cmd.kube_calls if c[:2] == ("delete", "pod")]
+    assert "--ignore-not-found" in delete_call
+    assert "--wait=false" in delete_call
+
+
+def test_diagnostics_are_captured_before_deletion(tmp_path, monkeypatch):
+    """Deleting a pod destroys its logs, so evidence must be gathered first."""
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [[_pod("decode-0")], [_pod("decode-0", ready=True, uid="new")]],
+        budget=RestartBudget(1),
+    )
+    cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+
+    verbs = [c[0] for c in cmd.kube_calls]
+    assert verbs.index("describe") < verbs.index("delete")
+    assert "logs" in verbs
+    previous = [c for c in cmd.kube_calls if c[0] == "logs" and "--previous" in c]
+    assert previous, "previous-container logs are the ones that explain a crash loop"
+
+
+def test_budget_exhaustion_fails_with_an_actionable_message(tmp_path, monkeypatch):
+    budget = RestartBudget(1)
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [
+            [_pod("decode-0", uid="uid-1")],  # restart 1/1
+            [_pod("decode-0", uid="uid-2")],  # crashes again, no budget left
+        ],
+        budget=budget,
+    )
+
+    result = cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+
+    assert result.success is False
+    assert "restart budget exhausted (1/1)" in result.stderr
+    assert "--pod-restart-budget" in result.stderr
+    assert _deletions(cmd) == ["decode-0"]
+
+
+def test_terminal_failure_is_not_restarted_even_with_budget(tmp_path, monkeypatch):
+    budget = RestartBudget(5)
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [[_pod("decode-0", reason="ImagePullBackOff")]],
+        budget=budget,
+    )
+
+    result = cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+
+    assert result.success is False
+    assert "ImagePullBackOff" in result.stderr
+    assert _deletions(cmd) == []
+    assert budget.used == 0
+
+
+def test_uncontrolled_pod_is_not_deleted(tmp_path, monkeypatch):
+    budget = RestartBudget(5)
+    cmd = _executor(
+        tmp_path, monkeypatch, [[_pod("bare-pod", owned=False)]], budget=budget
+    )
+
+    result = cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+
+    assert result.success is False
+    assert _deletions(cmd) == []
+    assert budget.used == 0
+
+
+def test_multiple_pods_each_consume_one_restart(tmp_path, monkeypatch):
+    budget = RestartBudget(5)
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [
+            [_pod("decode-0"), _pod("decode-1")],
+            [
+                _pod("decode-0", ready=True, uid="n0"),
+                _pod("decode-1", ready=True, uid="n1"),
+            ],
+        ],
+        budget=budget,
+    )
+
+    assert cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1).success
+    assert sorted(_deletions(cmd)) == ["decode-0", "decode-1"]
+    assert budget.used == 2
+
+
+def test_terminating_pod_is_not_repeatedly_deleted(tmp_path, monkeypatch):
+    """The replacement takes several polls to appear; budget must not drain."""
+    budget = RestartBudget(5)
+    crashing = _pod("decode-0", uid="uid-1")
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [
+            [crashing],
+            [crashing],
+            [crashing],
+            [_pod("decode-0", ready=True, uid="uid-2")],
+        ],
+        budget=budget,
+    )
+
+    assert cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1).success
+    assert budget.used == 1
+    assert _deletions(cmd) == ["decode-0"]
+
+
+def test_pod_that_is_simply_in_error_phase_is_restarted(tmp_path, monkeypatch):
+    """The reported case: a pod sitting in Error that only recovers if deleted."""
+    failed = PodState.from_api(
+        {
+            "metadata": {
+                "name": "decode-0",
+                "uid": "uid-1",
+                "namespace": "ns",
+                "ownerReferences": [
+                    {"kind": "ReplicaSet", "name": "rs", "controller": True}
+                ],
+            },
+            "status": {"phase": "Failed", "reason": "Error"},
+        }
+    )
+    budget = RestartBudget(2)
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [[failed], [_pod("decode-0", ready=True, uid="uid-2")]],
+        budget=budget,
+    )
+
+    assert cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1).success
+    assert _deletions(cmd) == ["decode-0"]
+
+
+def test_restart_extends_the_deadline(tmp_path, monkeypatch):
+    """A replacement pod re-pulls and reloads; it needs time budget of its own."""
+    clock = {"t": 0.0}
+    monkeypatch.setattr("llmdbenchmark.executor.command.time.time", lambda: clock["t"])
+
+    budget = RestartBudget(1)
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [[_pod("decode-0")], [_pod("decode-0", ready=True, uid="new")]],
+        budget=budget,
+    )
+
+    original = cmd._observe_pods
+
+    def _advance(label, namespace):
+        # Crash surfaces at t=90s of a 100s wait; without the grace extension
+        # the replacement would never get a chance.
+        clock["t"] += 90.0
+        return original(label, namespace)
+
+    monkeypatch.setattr(cmd, "_observe_pods", _advance)
+
+    result = cmd.wait_for_pods("app=x", "ns", timeout=100, poll_interval=1)
+    assert result.success is True
+
+
+def test_timeout_message_reports_budget_usage(tmp_path, monkeypatch):
+    clock = {"t": 0.0}
+    monkeypatch.setattr("llmdbenchmark.executor.command.time.time", lambda: clock["t"])
+    budget = RestartBudget(4)
+    cmd = _executor(
+        tmp_path,
+        monkeypatch,
+        [[_pod("decode-0")], [_pod("decode-0", uid="u2")]],
+        budget=budget,
+    )
+    original = cmd._observe_pods
+
+    def _advance(label, namespace):
+        clock["t"] += 400.0
+        return original(label, namespace)
+
+    monkeypatch.setattr(cmd, "_observe_pods", _advance)
+
+    result = cmd.wait_for_pods("app=x", "ns", timeout=100, poll_interval=1)
+    assert result.success is False
+    assert "Timed out" in result.stderr
+    assert "restart budget used: 2/4" in result.stderr.lower()
+
+
+def test_dry_run_never_deletes(tmp_path):
+    logger = _Logger()
+    cmd = CommandExecutor(
+        work_dir=tmp_path,
+        dry_run=True,
+        verbose=False,
+        logger=logger,
+        pod_restart_budget=RestartBudget(5),
+    )
+    result = cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+    assert result.dry_run is True
+    assert "would have executed" in logger.text()
+
+
+@pytest.mark.parametrize("limit", [1, 2, 3])
+def test_budget_caps_total_restarts_across_waits(tmp_path, monkeypatch, limit):
+    """The cap is phase-wide: repeated waits draw from the same pool."""
+    budget = RestartBudget(limit)
+    for i in range(limit + 2):
+        cmd = _executor(
+            tmp_path,
+            monkeypatch,
+            [
+                [_pod("decode-0", uid=f"uid-{i}")],
+                [_pod("decode-0", ready=True, uid=f"ready-{i}")],
+            ],
+            budget=budget,
+        )
+        cmd.wait_for_pods("app=x", "ns", timeout=600, poll_interval=1)
+    assert budget.used == limit
+
+
+# ---------------------------------------------------------------------------
+# Full chain: real kubectl JSON -> parse -> policy -> delete
+# ---------------------------------------------------------------------------
+
+
+def _kubectl_payload(name, *, ready, reason="CrashLoopBackOff", uid="uid-1"):
+    container = (
+        {"name": "vllm", "ready": True, "restartCount": 0, "state": {"running": {}}}
+        if ready
+        else {
+            "name": "vllm",
+            "ready": False,
+            "restartCount": 4,
+            "state": {"waiting": {"reason": reason, "message": "back-off 5m0s"}},
+            "lastState": {"terminated": {"reason": "Error", "exitCode": 1}},
+        }
+    )
+    return {
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "metadata": {
+                    "name": name,
+                    "namespace": "llmdbench",
+                    "uid": uid,
+                    "ownerReferences": [
+                        {
+                            "apiVersion": "apps/v1",
+                            "kind": "ReplicaSet",
+                            "name": "decode-7f9",
+                            "uid": "rs-uid",
+                            "controller": True,
+                            "blockOwnerDeletion": True,
+                        }
+                    ],
+                },
+                "status": {
+                    "phase": "Running",
+                    "containerStatuses": [container],
+                },
+            }
+        ],
+    }
+
+
+def test_full_chain_from_kubectl_json_to_deletion(tmp_path, monkeypatch):
+    """Exercises the real parse path, not a stubbed observer."""
+    import json
+    import subprocess as _sp
+
+    payloads = [
+        json.dumps(_kubectl_payload("decode-0", ready=False, uid="uid-1")),
+        json.dumps(_kubectl_payload("decode-0", ready=True, uid="uid-2")),
+    ]
+    seen = []
+
+    class _Completed:
+        def __init__(self, stdout):
+            self.returncode = 0
+            self.stdout = stdout
+            self.stderr = ""
+
+    def _run(cmd_str, **_):
+        seen.append(cmd_str)
+        return _Completed(payloads[min(len(seen) - 1, len(payloads) - 1)])
+
+    monkeypatch.setattr(_sp, "run", _run)
+    monkeypatch.setattr("llmdbenchmark.executor.command.time.sleep", lambda _s: None)
+
+    logger = _Logger()
+    budget = RestartBudget(2)
+    cmd = CommandExecutor(
+        work_dir=tmp_path,
+        dry_run=False,
+        verbose=False,
+        logger=logger,
+        pod_restart_budget=budget,
+    )
+
+    deletes = []
+    real_kube = cmd.kube
+
+    def _kube(*args, **kwargs):
+        if args[:2] == ("delete", "pod"):
+            deletes.append(args[2])
+            return CommandResult(command="delete", exit_code=0)
+        return real_kube(*args, **kwargs)
+
+    monkeypatch.setattr(cmd, "kube", _kube)
+
+    result = cmd.wait_for_pods(
+        "llm-d.ai/role=decode",
+        "llmdbench",
+        timeout=600,
+        poll_interval=1,
+        description="decode pods",
+    )
+
+    assert result.success is True
+    assert deletes == ["decode-0"]
+    assert budget.used == 1
+    assert "-l llm-d.ai/role=decode" in seen[0]
+
+
+def test_get_pod_statuses_keeps_its_legacy_dict_shape(tmp_path, monkeypatch):
+    """wait_for_job and other callers still consume plain dicts."""
+    import json
+    import subprocess as _sp
+
+    class _Completed:
+        returncode = 0
+        stderr = ""
+        stdout = json.dumps(_kubectl_payload("decode-0", ready=False))
+
+    monkeypatch.setattr(_sp, "run", lambda *_a, **_k: _Completed())
+
+    cmd = CommandExecutor(
+        work_dir=tmp_path, dry_run=False, verbose=False, logger=_Logger()
+    )
+    statuses = cmd._get_pod_statuses("app=x", "ns")
+
+    assert statuses == [
+        {
+            "name": "decode-0",
+            "status": "CrashLoopBackOff",
+            "ready": False,
+            "phase": "Running",
+        }
+    ]
+
+
+def test_get_pod_statuses_returns_none_when_query_fails(tmp_path, monkeypatch):
+    """A failed query must not read as 'the deployment has no pods'."""
+    import subprocess as _sp
+
+    class _Failed:
+        returncode = 1
+        stdout = ""
+        stderr = "the server was unable to return a response"
+
+    monkeypatch.setattr(_sp, "run", lambda *_a, **_k: _Failed())
+
+    cmd = CommandExecutor(
+        work_dir=tmp_path, dry_run=False, verbose=False, logger=_Logger()
+    )
+    assert cmd._get_pod_statuses("app=x", "ns") is None

--- a/tests/test_podstate_policy.py
+++ b/tests/test_podstate_policy.py
@@ -1,0 +1,221 @@
+"""Tests for the restart budget and the pod remediation policy seam."""
+
+from __future__ import annotations
+
+import threading
+
+from llmdbenchmark.utilities.podstate import (
+    Health,
+    PodState,
+    RestartBudget,
+    RestartBudgetPolicy,
+    Verdict,
+    WaitContext,
+)
+
+
+def _pod(name, uid=None, reason="CrashLoopBackOff", owned=True, deleting=False):
+    item = {
+        "metadata": {"name": name, "uid": uid or f"uid-{name}", "namespace": "ns"},
+        "status": {
+            "phase": "Running",
+            "containerStatuses": [
+                {
+                    "name": "vllm",
+                    "ready": False,
+                    "state": {"waiting": {"reason": reason}},
+                }
+            ],
+        },
+    }
+    if owned:
+        item["metadata"]["ownerReferences"] = [
+            {"kind": "ReplicaSet", "name": "rs", "controller": True}
+        ]
+    if deleting:
+        item["metadata"]["deletionTimestamp"] = "2026-08-19T12:00:00Z"
+    return PodState.from_api(item)
+
+
+def _ctx(description="decode pods", elapsed=10.0, timeout=600.0):
+    return WaitContext(
+        description=description, namespace="ns", elapsed=elapsed, timeout=timeout
+    )
+
+
+# ---------------------------------------------------------------------------
+# Budget accounting
+# ---------------------------------------------------------------------------
+
+
+def test_zero_budget_is_disabled():
+    budget = RestartBudget(0)
+    assert budget.enabled is False
+    assert budget.claim([_pod("a")]) == []
+
+
+def test_negative_budget_clamps_to_zero():
+    assert RestartBudget(-5).limit == 0
+
+
+def test_budget_grants_up_to_limit_then_stops():
+    budget = RestartBudget(2)
+    granted = budget.claim([_pod("a"), _pod("b"), _pod("c")])
+    assert [g.pod.name for g in granted] == ["a", "b"]
+    assert [g.event.sequence for g in granted] == [1, 2]
+    assert budget.exhausted is True
+    assert budget.remaining == 0
+
+
+def test_budget_is_global_not_per_pod():
+    """The whole point of the knob: one pod can consume the entire allowance."""
+    budget = RestartBudget(3)
+    for i in range(3):
+        assert len(budget.claim([_pod("decode-0", uid=f"uid-{i}")])) == 1
+    assert budget.claim([_pod("prefill-0", uid="other")]) == []
+
+
+def test_budget_is_shared_across_separate_waits():
+    budget = RestartBudget(2)
+    policy_a = RestartBudgetPolicy(budget=budget)
+    policy_b = RestartBudgetPolicy(budget=budget)
+    assert policy_a.observe([_pod("a")], _ctx()) is not None
+    assert policy_b.observe([_pod("b")], _ctx()) is not None
+    assert policy_a.observe([_pod("c")], _ctx()) is None
+    assert budget.status() == "2/2"
+
+
+def test_same_pod_instance_is_charged_only_once():
+    """A deleted pod lingers in Terminating; it must not drain the budget."""
+    budget = RestartBudget(5)
+    pod = _pod("decode-0", uid="uid-stable")
+    assert len(budget.claim([pod])) == 1
+    assert budget.claim([pod]) == []
+    assert budget.used == 1
+
+
+def test_replacement_pod_with_new_uid_can_be_charged_again():
+    budget = RestartBudget(5)
+    assert len(budget.claim([_pod("decode-0", uid="uid-1")])) == 1
+    assert len(budget.claim([_pod("decode-0", uid="uid-2")])) == 1
+    assert budget.used == 2
+
+
+def test_events_record_pod_reason_and_sequence():
+    budget = RestartBudget(2)
+    budget.claim([_pod("decode-0")], description="decode pods")
+    (event,) = budget.events
+    assert (event.pod, event.reason, event.sequence) == (
+        "decode-0",
+        "CrashLoopBackOff",
+        1,
+    )
+    assert event.description == "decode pods"
+
+
+def test_concurrent_claims_never_exceed_the_limit():
+    """Standup deploys stacks in parallel through one shared executor."""
+    budget = RestartBudget(10)
+    barrier = threading.Barrier(8)
+    results = []
+
+    def worker(n):
+        barrier.wait()
+        pods = [_pod(f"pod-{n}-{i}", uid=f"uid-{n}-{i}") for i in range(5)]
+        results.append(len(budget.claim(pods)))
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(results) == 10
+    assert budget.used == 10
+    assert len({e.sequence for e in budget.events}) == 10
+
+
+# ---------------------------------------------------------------------------
+# Policy eligibility
+# ---------------------------------------------------------------------------
+
+
+def test_policy_restarts_degraded_owned_pod():
+    budget = RestartBudget(1)
+    remedy = RestartBudgetPolicy(budget=budget).observe([_pod("decode-0")], _ctx())
+    assert remedy is not None
+    assert remedy.verdict is Verdict.CONTINUE
+    assert remedy.delete_pods == ("decode-0",)
+    assert remedy.extend_deadline == 300.0
+
+
+def test_policy_ignores_terminal_failures():
+    """ImagePullBackOff produces an identical replacement; do not spend budget."""
+    budget = RestartBudget(3)
+    pod = _pod("decode-0", reason="ImagePullBackOff")
+    assert pod.health is Health.TERMINAL
+    assert RestartBudgetPolicy(budget=budget).observe([pod], _ctx()) is None
+    assert budget.used == 0
+
+
+def test_policy_ignores_uncontrolled_pods():
+    """A bare pod would never come back after deletion."""
+    budget = RestartBudget(3)
+    pod = _pod("smoketest-curl", owned=False)
+    assert RestartBudgetPolicy(budget=budget).observe([pod], _ctx()) is None
+    assert budget.used == 0
+
+
+def test_policy_ignores_already_terminating_pods():
+    budget = RestartBudget(3)
+    pod = _pod("decode-0", deleting=True)
+    assert RestartBudgetPolicy(budget=budget).observe([pod], _ctx()) is None
+    assert budget.used == 0
+
+
+def test_policy_ignores_healthy_pods():
+    budget = RestartBudget(3)
+    item = {
+        "metadata": {"name": "ok", "uid": "u", "namespace": "ns"},
+        "status": {
+            "phase": "Running",
+            "containerStatuses": [{"name": "vllm", "ready": True, "state": {}}],
+        },
+    }
+    assert (
+        RestartBudgetPolicy(budget=budget).observe([PodState.from_api(item)], _ctx())
+        is None
+    )
+
+
+def test_policy_is_inert_when_budget_disabled():
+    budget = RestartBudget(0)
+    assert (
+        RestartBudgetPolicy(budget=budget).observe([_pod("decode-0")], _ctx()) is None
+    )
+
+
+def test_policy_returns_none_once_budget_exhausted():
+    budget = RestartBudget(1)
+    policy = RestartBudgetPolicy(budget=budget)
+    assert policy.observe([_pod("a")], _ctx()) is not None
+    assert policy.observe([_pod("b")], _ctx()) is None
+
+
+def test_deadline_extension_scales_with_pods_restarted():
+    budget = RestartBudget(3)
+    policy = RestartBudgetPolicy(budget=budget, grace_seconds=120.0)
+    remedy = policy.observe([_pod("a"), _pod("b")], _ctx())
+    assert remedy.extend_deadline == 240.0
+
+
+def test_take_granted_is_consumed_once():
+    budget = RestartBudget(2)
+    policy = RestartBudgetPolicy(budget=budget)
+    policy.observe([_pod("a")], _ctx())
+    assert [g.pod.name for g in policy.take_granted()] == ["a"]
+    assert policy.take_granted() == []
+
+
+def test_wait_context_remaining_is_never_negative():
+    assert WaitContext("d", "ns", elapsed=700.0, timeout=600.0).remaining == 0.0

--- a/tests/test_podstate_state.py
+++ b/tests/test_podstate_state.py
@@ -1,0 +1,454 @@
+"""Tests for the structured pod state model (llmdbenchmark.utilities.podstate.state).
+
+Includes an oracle check: the pre-refactor implementations of
+``_summarize_container_status``, the ``_get_pod_statuses`` status/ready
+derivation, and ``_pod_crash_details`` are reproduced verbatim here and
+asserted to agree with the new model on a corpus of payloads.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmdbenchmark.utilities.podstate import (
+    CRASH_STATES,
+    DEGRADED_STATES,
+    TERMINAL_STATES,
+    Health,
+    PodState,
+    summarize_container_states,
+)
+from llmdbenchmark.utilities.kube_helpers import _pod_crash_details
+
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+
+def _cs(name, ready=False, waiting=None, terminated=None, last=None, restarts=0):
+    status = {"name": name, "ready": ready, "restartCount": restarts, "state": {}}
+    if waiting is not None:
+        status["state"]["waiting"] = waiting
+    if terminated is not None:
+        status["state"]["terminated"] = terminated
+    if last is not None:
+        status["lastState"] = {"terminated": last}
+    return status
+
+
+def _pod(name="pod-a", phase="Running", containers=None, **status_extra):
+    item = {
+        "metadata": {"name": name, "uid": f"uid-{name}"},
+        "status": {"phase": phase},
+    }
+    if containers is not None:
+        item["status"]["containerStatuses"] = containers
+    item["status"].update(status_extra)
+    return item
+
+
+def _owned(item, kind="ReplicaSet", name="rs-1"):
+    item["metadata"]["ownerReferences"] = [
+        {"kind": kind, "name": name, "controller": True}
+    ]
+    return item
+
+
+# ---------------------------------------------------------------------------
+# State sets
+# ---------------------------------------------------------------------------
+
+
+def test_crash_states_is_exactly_degraded_plus_terminal():
+    assert CRASH_STATES == DEGRADED_STATES | TERMINAL_STATES
+    assert not DEGRADED_STATES & TERMINAL_STATES
+
+
+def test_crash_states_matches_historical_set():
+    """The flat set predates the split; existing callers must see it unchanged."""
+    assert set(CRASH_STATES) == {
+        "CrashLoopBackOff",
+        "Error",
+        "OOMKilled",
+        "CreateContainerConfigError",
+        "ImagePullBackOff",
+        "ErrImagePull",
+        "InvalidImageName",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Readiness and summary
+# ---------------------------------------------------------------------------
+
+
+def test_pod_ready_only_when_all_containers_ready():
+    pod = PodState.from_api(
+        _pod(containers=[_cs("vllm", ready=True), _cs("sidecar", ready=True)])
+    )
+    assert pod.ready is True
+    assert pod.summary == "Ready"
+    assert pod.health is Health.HEALTHY
+
+
+def test_multi_container_crash_not_masked_by_ready_sibling():
+    """A ready routing sidecar must not hide a crash-looping serving container."""
+    pod = PodState.from_api(
+        _pod(
+            containers=[
+                _cs("routing-proxy", ready=True),
+                _cs("vllm", waiting={"reason": "CrashLoopBackOff"}),
+            ]
+        )
+    )
+    assert pod.ready is False
+    assert pod.summary == "CrashLoopBackOff"
+    assert pod.crashing is True
+
+
+def test_no_container_statuses_falls_back_to_phase():
+    pod = PodState.from_api(_pod(phase="Pending"))
+    assert pod.summary == "Pending"
+    assert pod.ready is False
+
+
+def test_unschedulable_pod_surfaces_scheduling_reason():
+    pod = PodState.from_api(
+        _pod(
+            phase="Pending",
+            conditions=[
+                {"type": "PodScheduled", "status": "False", "reason": "Unschedulable"}
+            ],
+        )
+    )
+    assert pod.summary == "Unschedulable"
+    assert pod.health is Health.STARTING
+
+
+def test_summarize_prefers_terminated_crash_over_waiting():
+    pod = PodState.from_api(
+        _pod(
+            containers=[
+                _cs("a", waiting={"reason": "PodInitializing"}),
+                _cs("b", terminated={"reason": "OOMKilled", "exitCode": 137}),
+            ]
+        )
+    )
+    assert pod.summary == "OOMKilled"
+
+
+def test_summarize_empty_list_is_not_ready():
+    assert summarize_container_states([]) == "NotReady"
+
+
+def test_summarize_falls_back_to_notready_without_reasons():
+    pod = PodState.from_api(_pod(containers=[_cs("a"), _cs("b")]))
+    assert pod.summary == "NotReady"
+
+
+# ---------------------------------------------------------------------------
+# Health grading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reason", sorted(DEGRADED_STATES))
+def test_degraded_states_grade_as_degraded(reason):
+    pod = PodState.from_api(_pod(containers=[_cs("vllm", waiting={"reason": reason})]))
+    assert pod.health is Health.DEGRADED
+
+
+@pytest.mark.parametrize("reason", sorted(TERMINAL_STATES))
+def test_terminal_states_grade_as_terminal(reason):
+    """A wrong image name is not fixed by deleting the pod."""
+    pod = PodState.from_api(_pod(containers=[_cs("vllm", waiting={"reason": reason})]))
+    assert pod.health is Health.TERMINAL
+
+
+def test_failed_pod_without_container_statuses_is_degraded():
+    """The 'pod is just in Error' case: no containerStatuses to inspect."""
+    pod = PodState.from_api(_pod(phase="Failed", reason="Error"))
+    assert pod.health is Health.DEGRADED
+    # ...but the legacy container-level crash test still does not fire, so the
+    # historical wait behavior is unchanged when no budget is configured.
+    assert pod.crashing is False
+
+
+def test_evicted_pod_is_degraded_via_phase():
+    pod = PodState.from_api(_pod(phase="Failed", reason="Evicted"))
+    assert pod.health is Health.DEGRADED
+
+
+def test_starting_pod_is_not_degraded():
+    pod = PodState.from_api(
+        _pod(
+            phase="Pending",
+            containers=[_cs("vllm", waiting={"reason": "PodInitializing"})],
+        )
+    )
+    assert pod.health is Health.STARTING
+
+
+# ---------------------------------------------------------------------------
+# Ownership, identity, restarts
+# ---------------------------------------------------------------------------
+
+
+def test_controlled_requires_controller_owner_reference():
+    assert PodState.from_api(_pod()).controlled is False
+    assert PodState.from_api(_owned(_pod())).controlled is True
+
+
+def test_non_controller_owner_reference_does_not_count():
+    item = _pod()
+    item["metadata"]["ownerReferences"] = [{"kind": "Node", "name": "n1"}]
+    assert PodState.from_api(item).controlled is False
+
+
+def test_deletion_timestamp_marks_pod_deleting():
+    item = _pod()
+    item["metadata"]["deletionTimestamp"] = "2026-08-19T12:00:00Z"
+    assert PodState.from_api(item).deleting is True
+
+
+def test_total_restarts_spans_init_and_app_containers():
+    item = _pod(containers=[_cs("vllm", restarts=3), _cs("sidecar", restarts=1)])
+    item["status"]["initContainerStatuses"] = [_cs("wait-for-model", restarts=2)]
+    pod = PodState.from_api(item)
+    assert pod.total_restarts == 6
+    assert pod.restarts_for("vllm") == 3
+
+
+# ---------------------------------------------------------------------------
+# Crash details
+# ---------------------------------------------------------------------------
+
+
+def test_crash_details_reports_current_and_previous_failure():
+    pod = PodState.from_api(
+        _pod(
+            name="inference-perf-abc",
+            containers=[
+                _cs(
+                    "harness",
+                    waiting={"reason": "CrashLoopBackOff"},
+                    last={"reason": "OOMKilled", "exitCode": 137},
+                )
+            ],
+        )
+    )
+    (detail,) = pod.crash_details
+    assert "inference-perf-abc/harness" in detail
+    assert "CrashLoopBackOff" in detail
+    assert "last terminated: OOMKilled, exit_code=137" in detail
+
+
+def test_crash_details_flags_nonzero_exit_without_crash_reason():
+    pod = PodState.from_api(
+        _pod(
+            containers=[
+                _cs("harness", terminated={"reason": "Completed", "exitCode": 2})
+            ]
+        )
+    )
+    assert "exit_code=2" in pod.crash_details[0]
+
+
+def test_crash_details_ignores_clean_exit():
+    pod = PodState.from_api(
+        _pod(
+            containers=[
+                _cs("harness", terminated={"reason": "Completed", "exitCode": 0})
+            ]
+        )
+    )
+    assert pod.crash_details == []
+
+
+def test_crash_details_falls_back_to_pod_reason():
+    pod = PodState.from_api(_pod(name="p1", phase="Failed", reason="Error"))
+    assert pod.crash_details == ["p1 (Error)"]
+
+
+def test_crash_details_covers_init_containers():
+    item = _pod(containers=[_cs("vllm", ready=True)])
+    item["status"]["initContainerStatuses"] = [
+        _cs("fetch-model", terminated={"reason": "Error", "exitCode": 1})
+    ]
+    assert "fetch-model" in PodState.from_api(item).crash_details[0]
+
+
+# ---------------------------------------------------------------------------
+# Oracle: the pre-refactor implementations, reproduced verbatim
+# ---------------------------------------------------------------------------
+
+
+def _legacy_summarize(not_ready):
+    def _state_reason(cs, key):
+        return (cs.get("state", {}).get(key) or {}).get("reason", "") or ""
+
+    if not not_ready:
+        return "NotReady"
+    for cs in not_ready:
+        reason = _state_reason(cs, "terminated")
+        if reason in CRASH_STATES:
+            return reason
+    for cs in not_ready:
+        reason = _state_reason(cs, "waiting")
+        if reason in CRASH_STATES:
+            return reason
+    for cs in not_ready:
+        reason = _state_reason(cs, "waiting") or _state_reason(cs, "terminated")
+        if reason:
+            return reason
+    return "NotReady"
+
+
+def _legacy_status_and_ready(item):
+    phase = item.get("status", {}).get("phase", "Unknown")
+    status = phase
+    ready = False
+    container_statuses = item.get("status", {}).get("containerStatuses", [])
+    if container_statuses:
+        if all(cs.get("ready", False) for cs in container_statuses):
+            ready = True
+            status = "Ready"
+        else:
+            not_ready = [cs for cs in container_statuses if not cs.get("ready", False)]
+            status = _legacy_summarize(not_ready)
+    elif phase == "Pending":
+        for cond in item.get("status", {}).get("conditions", []):
+            if cond.get("type") == "PodScheduled" and cond.get("status") == "False":
+                status = cond.get("reason", "Unschedulable")
+                break
+    return status, ready
+
+
+def _legacy_terminated_detail(prefix, state):
+    reason = state.get("reason") or "unknown reason"
+    detail = f"{prefix}{reason}"
+    if state.get("exitCode") is not None:
+        detail += f", exit_code={state['exitCode']}"
+    return detail
+
+
+def _legacy_crash_details(pod):
+    metadata = pod.get("metadata", {})
+    status = pod.get("status", {})
+    pod_name = metadata.get("name", "unknown-pod")
+    failures = []
+    status_groups = (
+        status.get("initContainerStatuses", []),
+        status.get("containerStatuses", []),
+        status.get("ephemeralContainerStatuses", []),
+    )
+    for container_statuses in status_groups:
+        for container_status in container_statuses or []:
+            state = container_status.get("state", {})
+            details = []
+            waiting = state.get("waiting") or {}
+            waiting_reason = waiting.get("reason")
+            if waiting_reason in CRASH_STATES:
+                details.append(waiting_reason)
+            terminated = state.get("terminated") or {}
+            terminated_reason = terminated.get("reason")
+            terminated_exit_code = terminated.get("exitCode")
+            if terminated and (
+                terminated_reason in CRASH_STATES
+                or (terminated_exit_code is not None and terminated_exit_code != 0)
+            ):
+                details.append(_legacy_terminated_detail("terminated: ", terminated))
+            if not details:
+                continue
+            last_terminated = (container_status.get("lastState") or {}).get(
+                "terminated"
+            )
+            if last_terminated:
+                details.append(
+                    _legacy_terminated_detail("last terminated: ", last_terminated)
+                )
+            container_name = container_status.get("name", "unknown-container")
+            failures.append(f"{pod_name}/{container_name} ({', '.join(details)})")
+    if not failures and status.get("reason") in CRASH_STATES:
+        failures.append(f"{pod_name} ({status['reason']})")
+    return failures
+
+
+def _corpus():
+    pods = [
+        _pod(containers=[_cs("a", ready=True)]),
+        _pod(containers=[_cs("a", ready=True), _cs("b", ready=True)]),
+        _pod(
+            containers=[
+                _cs("a", ready=True),
+                _cs("b", waiting={"reason": "CrashLoopBackOff"}),
+            ]
+        ),
+        _pod(containers=[_cs("a", waiting={"reason": "PodInitializing"})]),
+        _pod(containers=[_cs("a", waiting={"reason": "ImagePullBackOff"})]),
+        _pod(
+            containers=[_cs("a", terminated={"reason": "OOMKilled", "exitCode": 137})]
+        ),
+        _pod(containers=[_cs("a", terminated={"reason": "Completed", "exitCode": 0})]),
+        _pod(containers=[_cs("a", terminated={"exitCode": 3})]),
+        _pod(containers=[_cs("a")]),
+        _pod(
+            containers=[
+                _cs("a", waiting={"reason": "PodInitializing"}),
+                _cs("b", terminated={"reason": "Error", "exitCode": 1}),
+            ]
+        ),
+        _pod(
+            containers=[
+                _cs(
+                    "a",
+                    waiting={"reason": "CrashLoopBackOff"},
+                    last={"reason": "OOMKilled", "exitCode": 137},
+                )
+            ]
+        ),
+        _pod(containers=[_cs("a", waiting={"reason": "CrashLoopBackOff"}, last={})]),
+        _pod(phase="Pending"),
+        _pod(phase="Failed", reason="Error"),
+        _pod(phase="Succeeded"),
+        _pod(
+            phase="Pending",
+            conditions=[
+                {"type": "PodScheduled", "status": "False", "reason": "Unschedulable"}
+            ],
+        ),
+        _pod(phase="Pending", conditions=[{"type": "PodScheduled", "status": "False"}]),
+        _pod(phase="Pending", conditions=[{"type": "Ready", "status": "False"}]),
+    ]
+    with_init = _pod(containers=[_cs("a", ready=True)])
+    with_init["status"]["initContainerStatuses"] = [
+        _cs("init", terminated={"reason": "Error", "exitCode": 1})
+    ]
+    pods.append(with_init)
+
+    with_ephemeral = _pod(containers=[_cs("a", ready=True)])
+    with_ephemeral["status"]["ephemeralContainerStatuses"] = [
+        _cs("debug", waiting={"reason": "CrashLoopBackOff"})
+    ]
+    pods.append(with_ephemeral)
+    return pods
+
+
+@pytest.mark.parametrize("item", _corpus())
+def test_matches_legacy_status_and_ready(item):
+    pod = PodState.from_api(item)
+    legacy_status, legacy_ready = _legacy_status_and_ready(item)
+    assert (pod.summary, pod.ready) == (legacy_status, legacy_ready)
+
+
+@pytest.mark.parametrize("item", _corpus())
+def test_matches_legacy_crash_details(item):
+    assert PodState.from_api(item).crash_details == _legacy_crash_details(item)
+    assert _pod_crash_details(item) == _legacy_crash_details(item)
+
+
+@pytest.mark.parametrize("item", _corpus())
+def test_legacy_crash_matching_is_unchanged(item):
+    """The historical abort rule (`status in CRASH_STATES`) must be preserved."""
+    legacy_status, _ = _legacy_status_and_ready(item)
+    assert PodState.from_api(item).crashing == (legacy_status in CRASH_STATES)


### PR DESCRIPTION
# Configurable pod restart budget for standup

## Problem

Some pods come up broken and only recover once deleted. The replacement the controller creates is usually healthy. Today the first pod to land in a crash state aborts the readiness wait immediately, which fails the entire `standup`. On a
long standup that means throwing away everything already provisioned if a user is not aware of this issue.

## What this adds

A phase-wide **pod restart budget**, off by default:

```bash
# Can also use --pod-restart-grace for grace period restart
llmdbenchmark standup --spec <spec> --pod-restart-budget 3
```
When a pod fails in a way a restart may clear, it is deleted and given another chance. The budget is a single total for the whole `standup` and it is shared across every pod, every readiness wait, and every stack, not a per-pod allowance.

Each restart extends that wait's deadline by `--pod-restart-grace,` because the replacement re-pulls its image and reloads the model from zero. Without that, a crash late in a wait guarantees the restart times out anyway.

## Current Config

Default is 0, aka disabled. The "wait" and "restart" behaves exactly as before, including identical failure messages. 