### PR TITLE
[Standup] Update `llm-d-router` version to `v0.10.0`

### DIFF
--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -115,10 +115,10 @@ _anchors:
   router_chart_version:              &router_chart_version              v0.10.0
   vllm-openai_version:               &vllm-openai_version               v0.26.0
   llm-d-router-endpoint-picker_version: &llm-d-router-endpoint-picker_version v0.10.0
-  llm-d-routing-sidecar_version:     &llm-d-routing-sidecar_version     v0.9.0
+  llm-d-routing-sidecar_version:     &llm-d-routing-sidecar_version     v0.10.0
   # Just use vllm-openai image for tokenizer
   llm-d-uds-tokenizer_version:       &llm-d-uds-tokenizer_version       v0.26.0
-  llm-d-cuda_version:                &llm-d-cuda_version                v0.8.1
+  llm-d-cuda_version:                &llm-d-cuda_version                v0.9.0
   llm-d-inference-sim_version:       &llm-d-inference-sim_version       v0.10.2
   llm-d-benchmark_version:           &llm-d-benchmark_version           v0.8.0
 


### PR DESCRIPTION
`llm-d-modelservice` was fixed already (`v0.4.16`)