### PR TITLE
Support remote standup and run for no-k8s llm-d stack

### DIFF
--- a/config/scenarios/guides/nok8s.yaml
+++ b/config/scenarios/guides/nok8s.yaml
@@ -48,12 +48,11 @@ scenario:
       runtime: docker            # docker | podman
       # Host whose runtime runs the stack. "localhost" (default) is this
       # machine. To deploy to a bare-metal node, give its address -- a bare IP
-      # or hostname is read as ssh://, and the runtime's own SSH transport
-      # carries every command, so the node needs no daemon reconfiguration and
-      # no tunnel:
+      # or hostname is read as ssh://, and every container command is run on
+      # the node over ssh, so the node needs no daemon reconfiguration, no
+      # tunnel, and this machine needs no docker/podman at all:
       #   connection: 10.0.0.7
       #   connection: ssh://bench@10.0.0.7
-      #   connection: ssh://bench@10.0.0.7/run/user/1000/podman/podman.sock
       # It does need key-based SSH that works without a prompt
       # ("ssh bench@10.0.0.7 true"). Then curl the node, not localhost:
       # http://10.0.0.7:8081. See docs/nok8s.md#remote-host.
@@ -63,6 +62,10 @@ scenario:
       # --set applies to ONE invocation: pass it to run/teardown as well, or a
       # run will benchmark this machine while the stack sits on the node.
       connection: localhost
+      # How a remote runtime is driven. "ssh" (default) runs `ssh <node>
+      # docker ...`; "native" uses `docker -H` / `podman --url`, which needs a
+      # matching client on THIS machine. Ignored when connection is localhost.
+      #   transport: native
       # sshIdentity: /path/to/key   # default: the agent / ~/.ssh keys
       hfTokenEnv: HUGGING_FACE_HUB_TOKEN
       workspaceHostDir: "~/.llmdbench/nok8s"

--- a/config/scenarios/guides/nok8s.yaml
+++ b/config/scenarios/guides/nok8s.yaml
@@ -106,3 +106,9 @@ scenario:
       name: inference-perf
       profile: sanity_random.yaml
       waitTimeout: 1800
+
+    # Where each invocation's workspace (plan, logs, results) is created, as a
+    # timestamped sub-directory. Without this the CLI falls back to a fresh
+    # mkdtemp per invocation, so a standup's container logs land somewhere
+    # different every time -- and nothing accumulates across runs.
+    workDir: "~/data/nok8s"

--- a/config/scenarios/guides/nok8s.yaml
+++ b/config/scenarios/guides/nok8s.yaml
@@ -4,6 +4,12 @@
 # containers on the local host -- no cluster. The benchmark harness also runs
 # as a local container against the Envoy front door (http://localhost:8081).
 #
+# To run the same stack on a bare-metal node instead, set nok8s.connection to
+# its address (see below), or leave this file alone and pass the address per
+# run: --set nok8s.connection=10.0.0.7 (repeat it on standup/run/teardown, or
+# export LLMDBENCH_SET='nok8s.connection=10.0.0.7' once). Nothing else changes,
+# and you never log into the node.
+#
 # Single-GPU friendly (e.g. one H100/H200). Defaults to a small ungated model
 # so a smoke run needs no Hugging Face token. Set the token in your shell so
 # the vLLM container can pull gated models:
@@ -40,6 +46,24 @@ scenario:
     nok8s:
       enabled: true
       runtime: docker            # docker | podman
+      # Host whose runtime runs the stack. "localhost" (default) is this
+      # machine. To deploy to a bare-metal node, give its address -- a bare IP
+      # or hostname is read as ssh://, and the runtime's own SSH transport
+      # carries every command, so the node needs no daemon reconfiguration and
+      # no tunnel:
+      #   connection: 10.0.0.7
+      #   connection: ssh://bench@10.0.0.7
+      #   connection: ssh://bench@10.0.0.7/run/user/1000/podman/podman.sock
+      # It does need key-based SSH that works without a prompt
+      # ("ssh bench@10.0.0.7 true"). Then curl the node, not localhost:
+      # http://10.0.0.7:8081. See docs/nok8s.md#remote-host.
+      # Per-run alternative, no edit needed here:
+      #   llmdbenchmark --spec ... standup --methods nok8s \
+      #     --set nok8s.connection=10.0.0.7
+      # --set applies to ONE invocation: pass it to run/teardown as well, or a
+      # run will benchmark this machine while the stack sits on the node.
+      connection: localhost
+      # sshIdentity: /path/to/key   # default: the agent / ~/.ssh keys
       hfTokenEnv: HUGGING_FACE_HUB_TOKEN
       workspaceHostDir: "~/.llmdbench/nok8s"
       vllm:

--- a/config/templates/jinja/34_nok8s-containers.yaml.j2
+++ b/config/templates/jinja/34_nok8s-containers.yaml.j2
@@ -8,11 +8,15 @@
    lets the step build docker vs podman commands correctly.
    ============================================================================ #}
 runtime: {{ nok8s.runtime }}
-{# Where the containers run. "localhost" keeps every command local; an ssh://
-   value is passed to the runtime client (docker -H / podman --url). clientHost
-   is resolved by RenderPlans._resolve_nok8s_connection so consumers never have
-   to parse the URL. #}
+{# Where the containers run, and how they are reached. "localhost" keeps every
+   command local. For a remote node, transport "ssh" (the default) runs the
+   runtime on the node over plain ssh, and "native" passes the URL to a local
+   client (docker -H / podman --url). Both are recorded so teardown reaches the
+   same daemon standup used. clientHost is resolved by
+   RenderPlans._resolve_nok8s_connection so consumers never have to parse the
+   URL. #}
 connection: "{{ nok8s.connection | default('localhost') }}"
+transport: "{{ nok8s.transport | default('ssh') }}"
 sshIdentity: "{{ nok8s.sshIdentity | default('') }}"
 sshArgs: [{% for a in nok8s.sshArgs | default([]) %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 workspaceHostDir: "{{ nok8s.workspaceHostDir }}"

--- a/config/templates/jinja/34_nok8s-containers.yaml.j2
+++ b/config/templates/jinja/34_nok8s-containers.yaml.j2
@@ -8,11 +8,25 @@
    lets the step build docker vs podman commands correctly.
    ============================================================================ #}
 runtime: {{ nok8s.runtime }}
+{# Where the containers run. "localhost" keeps every command local; an ssh://
+   value is passed to the runtime client (docker -H / podman --url). clientHost
+   is resolved by RenderPlans._resolve_nok8s_connection so consumers never have
+   to parse the URL. #}
+connection: "{{ nok8s.connection | default('localhost') }}"
+sshIdentity: "{{ nok8s.sshIdentity | default('') }}"
+sshArgs: [{% for a in nok8s.sshArgs | default([]) %}"{{ a }}"{% if not loop.last %}, {% endif %}{% endfor %}]
 workspaceHostDir: "{{ nok8s.workspaceHostDir }}"
 hfTokenEnv: {{ nok8s.hfTokenEnv }}
 hfCacheDir: "{{ nok8s.vllm.hfCacheDir }}"
 model: {{ model.name }}
+{# Two endpoints, because two different machines dial the front door:
+   `endpoint` is used from *inside* the daemon host -- the harness container
+   runs there with --network host, and keeping it on the node means the
+   measured latency is the stack's, not the SSH link's.
+   `clientEndpoint` is used from the machine running llmdbenchmark (smoketest,
+   manual curl). They are identical for a local stack. #}
 endpoint: "http://localhost:{{ nok8s.envoy.listenPort }}"
+clientEndpoint: "http://{{ nok8s.clientHost | default('localhost') }}:{{ nok8s.envoy.listenPort }}"
 readiness:
   vllmPorts: [{% for i in range(nok8s.vllm.replicas) %}{{ nok8s.vllm.hostPort + i }}{% if not loop.last %}, {% endif %}{% endfor %}]
   envoyPort: {{ nok8s.envoy.listenPort }}

--- a/config/templates/jinja/34_nok8s-containers.yaml.j2
+++ b/config/templates/jinja/34_nok8s-containers.yaml.j2
@@ -64,4 +64,8 @@ containers:
     image: "{{ nok8s.envoy.image }}:{{ nok8s.envoy.tag }}"
     listenPort: {{ nok8s.envoy.listenPort }}
     configMountPath: {{ nok8s.envoy.configMountPath }}
+{# Hot-restart base ID, resolved by RenderPlans._resolve_nok8s_envoy_base_id.
+   Envoy runs with --network host, so its default base ID of 0 is claimed
+   host-wide and a second Envoy on the node dies before it binds. #}
+    baseId: {{ nok8s.envoy.baseId | default(0) }}
 {% endif %}

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1504,6 +1504,14 @@ nok8s:
     # one host need distinct admin ports as well as distinct listenPorts.
     adminPort: 19000
     configMountPath: /etc/envoy/envoy.yaml
+    # Envoy's hot-restart base ID (--base-id), which names the shared-memory
+    # region and abstract domain socket it claims. Under --network host that
+    # claim is host-wide, so the Envoy default of 0 lets any second Envoy on
+    # the node -- a sibling stack, or one left running by an earlier standup --
+    # exit with errno=98 before it binds listenPort, which looks only like a
+    # readiness timeout. Left at 0 here and resolved per stack from
+    # listenPort (already unique per host); set it to pin a specific value.
+    baseId: 0
 
 # ============================================================================
 # KUSTOMIZE DEPLOYMENT CONFIGURATION

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1412,18 +1412,32 @@ nok8s:
   # Container runtime: "docker" or "podman".
   runtime: docker
   # Host whose container runtime runs the stack.
-  #   localhost                     -- the machine running llmdbenchmark (default)
-  #   ssh://[user@]host[:port][/socket]  -- a remote node, over the runtime's
-  #                                    native SSH transport (docker -H /
-  #                                    podman --url). A bare "10.0.0.7" or
-  #                                    "user@node" is read as ssh://.
+  #   localhost                          -- the machine running llmdbenchmark
+  #                                         (default)
+  #   ssh://[user@]host[:port][/socket]  -- a remote node. A bare "10.0.0.7"
+  #                                         or "user@node" is read as ssh://.
   # Remote standup needs no daemon reconfiguration and no manual ssh tunnel;
   # it does need key-based SSH to work non-interactively. "tcp://" is refused
   # on purpose: an unauthenticated socket is root on that node.
   # Overridable per run without editing any file, on every subcommand:
   #   --set nok8s.connection=10.0.0.7
   connection: localhost
+  # How a *remote* runtime is driven (ignored when connection is localhost):
+  #   ssh     -- run `ssh <node> docker ...`, i.e. the runtime runs on the
+  #              node. Needs NO container client on this machine, and no
+  #              agreement between the two ends: only the node's runtime
+  #              matters. This is the default.
+  #   native  -- the runtimes' own SSH transport (`docker -H ssh://...` /
+  #              `podman --url ssh://...`). Requires a client here of the SAME
+  #              family as the node's daemon (a podman client cannot drive
+  #              dockerd -- it asks for Libpod endpoints dockerd does not
+  #              serve), and authenticates by that client's own rules: podman's
+  #              Go SSH client ignores ~/.ssh/id_rsa, so `ssh node true` can
+  #              succeed while every container command fails.
+  transport: ssh
   # SSH private key for a remote connection (default: the agent / ~/.ssh keys).
+  # Honoured by both transports, though "native" + podman needs the key to be
+  # one podman itself accepts.
   sshIdentity: ""
   # Extra ssh/scp options for a remote connection. Replaces the defaults
   # (BatchMode=yes, ConnectTimeout=10), so re-state those if you override.

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1411,6 +1411,23 @@ nok8s:
   enabled: false
   # Container runtime: "docker" or "podman".
   runtime: docker
+  # Host whose container runtime runs the stack.
+  #   localhost                     -- the machine running llmdbenchmark (default)
+  #   ssh://[user@]host[:port][/socket]  -- a remote node, over the runtime's
+  #                                    native SSH transport (docker -H /
+  #                                    podman --url). A bare "10.0.0.7" or
+  #                                    "user@node" is read as ssh://.
+  # Remote standup needs no daemon reconfiguration and no manual ssh tunnel;
+  # it does need key-based SSH to work non-interactively. "tcp://" is refused
+  # on purpose: an unauthenticated socket is root on that node.
+  # Overridable per run without editing any file, on every subcommand:
+  #   --set nok8s.connection=10.0.0.7
+  connection: localhost
+  # SSH private key for a remote connection (default: the agent / ~/.ssh keys).
+  sshIdentity: ""
+  # Extra ssh/scp options for a remote connection. Replaces the defaults
+  # (BatchMode=yes, ConnectTimeout=10), so re-state those if you override.
+  sshArgs: []
   # Host env var read at standup time and passed to the vLLM container so it
   # can pull gated models from Hugging Face.
   hfTokenEnv: HUGGING_FACE_HUB_TOKEN

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -167,7 +167,7 @@ single-GPU example. Key fields (full defaults in
 | `nok8s.workspaceHostDir` | Host dir where EPP/Envoy configs are staged + bind-mounted |
 | `nok8s.vllm.{image,tag,hostPort,tensorParallel,accelerator,gpus,deviceArgs,shmSize,replicas,extraArgs}` | vLLM worker(s); worker *i* is published on `hostPort + i` (see Accelerators for `accelerator`/`deviceArgs`) |
 | `nok8s.epp.{image,tag,grpcPort,grpcHealthPort,metricsPort}` | Endpoint Picker |
-| `nok8s.envoy.{image,tag,listenPort,adminPort}` | Envoy front door (the run target); `adminPort` is the admin interface, bound on the host (`--network host`) |
+| `nok8s.envoy.{image,tag,listenPort,adminPort,baseId}` | Envoy front door (the run target); `adminPort` is the admin interface, bound on the host (`--network host`). `baseId` is the hot-restart `--base-id`; leave it `0` and it is resolved per stack from `listenPort` |
 | `nok8s.nameSuffix` | Appended to every container name. Filled automatically with `-<stack>` in a multi-stack scenario (see below); leave empty for one stack |
 | `model.{name,huggingfaceId}` | Set both; standup uses `name`, run reads `huggingfaceId` |
 
@@ -636,7 +636,7 @@ distinct ports and container names. Benchmark them one at a time with
 
 A scenario with more than one stack runs every stack's containers on the same
 host, with no namespace to keep them apart, so each stack needs its own
-identity. Two things are automatic and two are on you:
+identity. Three things are automatic and two are on you:
 
 - **Container names** get a `-<stack name>` suffix, e.g. `vllm-0-chat`,
   `epp-chat`, `envoy-chat`. Without this, stack B's idempotency sweep
@@ -645,6 +645,13 @@ identity. Two things are automatic and two are on you:
   punctuation, or a shared explicit `nok8s.nameSuffix`) are a render error.
 - **`nok8s.workspaceHostDir`** gains a per-stack sub-directory, so the staged
   EPP/Envoy configs never overwrite each other.
+- **Envoy's hot-restart base ID** (`--base-id`, seeded from each stack's
+  `listenPort`) is distinct per stack. Envoy runs with `--network host`, and
+  the default base ID of `0` names a shared-memory region and domain socket
+  claimed host-wide, so a second Envoy exits with `errno=98` *before* binding
+  its listener — visible only as a readiness timeout on a port whose vLLM is
+  healthy. This applies to single-stack standups too, where the other claimant
+  is usually an Envoy an earlier run left behind.
 - **Host ports are yours to assign.** They are never derived, because guessing
   would silently bind ports you did not ask for. Two nok8s stacks claiming the
   same port is a render error that names the port and the owning stack, and
@@ -756,6 +763,13 @@ auto-pinning and puts you in control).
   multi-stack scenario). Lower the model size or add
   `--max-model-len`/`--gpu-memory-utilization` via `nok8s.vllm.extraArgs`.
 - **Envoy 503** — a worker isn't up; confirm `curl http://localhost:8000/v1/models`.
+- **`Timed out waiting for http://localhost:<listenPort>/v1/models` while vLLM
+  is healthy** — Envoy never bound. Read
+  `<workspace>/setup/logs/nok8s-envoy*.log`: `unable to bind domain socket with
+  base_id=0` means another Envoy on the host already holds that hot-restart ID.
+  Current renders assign one per stack; a plan rendered before that did not, so
+  re-render it, and `docker rm -f` any Envoy an earlier run left running. The
+  workspace path is printed by the failure itself.
 - **podman + GPU** — ensure the CDI spec exists: `nvidia-ctk cdi list` should show
   `nvidia.com/gpu=all`.
 - **Ports busy** — a stale run; `teardown --methods nok8s`, or change the ports.

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -37,7 +37,7 @@ broken container runtime is fatal, the rest are warnings.
 |-------------|-------|
 | Linux host + NVIDIA GPU(s) | Images/flags are NVIDIA + vLLM specific |
 | NVIDIA driver | `nvidia-smi` must work |
-| Container runtime | **docker** or **podman** (`nok8s.runtime`), on the host named by `nok8s.connection` |
+| Container runtime | **docker** or **podman** (`nok8s.runtime`), on the host named by `nok8s.connection` — for a remote node that means *there*, not here |
 | NVIDIA Container Toolkit | docker: `nvidia-ctk runtime configure --runtime=docker`; podman: `nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml` |
 | Hugging Face token | `export HUGGING_FACE_HUB_TOKEN=hf_...` (only for gated models) |
 | Free host ports | 8000 (vLLM), 8081 (Envoy), 9002/9003/9090 (EPP), 19000 (Envoy admin) |
@@ -45,15 +45,21 @@ broken container runtime is fatal, the rest are warnings.
 | `llmdbenchmark` CLI | `./install.sh` (Python 3.11+) |
 
 Every requirement above applies to the host that runs the containers. For a
-remote `nok8s.connection` the client additionally needs `ssh` and `scp`, and the
-node needs `curl`, `timeout` and a listening-socket tool (`ss` or `lsof`) —
-step 00 checks each one on the side that has to have it.
+remote `nok8s.connection` the split is:
+
+| Side | Needs |
+|------|-------|
+| The machine running `llmdbenchmark` | `ssh`, `scp`, `timeout` — and **no container runtime at all** under the default transport |
+| The node | the container runtime, the GPU stack, `curl`, and `ss` or `lsof` |
+
+Step 00 checks each one on the side that has to have it. `timeout` is a client
+requirement because it bounds the `ssh` command, not something on the node.
 
 **Not required:** Kubernetes, `kubectl`/`oc`, `helm`/`helmfile`, Gateway CRDs,
-PVCs, or any cluster access. For a remote node, also not required: a
-daemon listening on a TCP port, a manually opened SSH tunnel, an agent or
-anything else installed there, or a login session — `llmdbenchmark` never needs
-you to shell into the node.
+PVCs, or any cluster access. For a remote node, also not required: docker or
+podman on your machine, a daemon listening on a TCP port, a manually opened SSH
+tunnel, an agent or anything else installed there, or a login session —
+`llmdbenchmark` never needs you to shell into the node.
 
 Verify GPU-in-container before you start:
 ```bash
@@ -260,7 +266,7 @@ The override is echoed at render time, which is worth reading back:
 A `run` without it starts the harness on *your own* machine against
 `localhost:8081`, where nothing is listening, while the stack sits idle on the
 node — no error, just the wrong machine. The tell is the launch command: a
-remote run reads `docker -H ssh://10.0.0.7/... run -d`, a local one is a bare
+remote run reads `ssh 10.0.0.7 'docker run -d ...'`, a local one is a bare
 `docker run -d`. Likewise a `teardown` without it leaves the node's containers
 running. To set it once for a whole session, use the env var instead:
 
@@ -306,21 +312,60 @@ fails at render with the reason, before anything is launched.
 | `ssh://[user@]host[:port][/socket-path]` | Explicit. `port` is the **SSH** port; `socket-path` is the daemon socket on the node (rootless podman: `/run/user/<uid>/podman/podman.sock`) |
 | `tcp://…` | **Refused**, with an error at render time |
 
-### Why SSH, and why not `tcp://`
+| `nok8s.transport` | Meaning |
+|-------------------|---------|
+| `ssh` (default) | Run the runtime on the node (`ssh <node> docker …`). No container client needed on this machine |
+| `native` | The runtimes' own transport (`docker -H` / `podman --url`). Needs a matching client here — see [How the node is reached](#how-the-node-is-reached-nok8stransport) |
 
-Both runtimes have a native SSH transport, so nothing has to be reconfigured
-on the node and no tunnel has to be opened by hand:
+Ignored when `connection` is `localhost`: there is nothing to transport.
+
+### How the node is reached (`nok8s.transport`)
+
+Nothing has to be reconfigured on the node and no tunnel has to be opened by
+hand. There are two ways to get the commands there, and the default asks the
+least of your machine.
+
+**`transport: ssh` (default)** runs the runtime *on the node*:
 
 ```bash
-docker -H ssh://bench@10.0.0.7 run ...
+ssh bench@10.0.0.7 'docker run -d --name vllm-0 ...'
+```
+
+`llmdbenchmark` needs **no docker or podman installed locally**. Nothing is
+built or run here — every container command is a remote operation — so the only
+runtime that has to exist is the node's, and the only client-side requirement is
+the `ssh` already needed to stage configs.
+
+**`transport: native`** uses the runtimes' own SSH transport instead:
+
+```bash
+docker -H ssh://bench@10.0.0.7/var/run/docker.sock run ...
 podman --url ssh://bench@10.0.0.7/run/user/1000/podman/podman.sock run ...
 ```
 
-`tcp://` is refused on purpose. A docker/podman socket bound to a TCP port with
-no TLS and no authentication grants root on that node to anyone who can reach
-the port — mounting `/` into a privileged container is a one-liner. Since the
-SSH transport needs no daemon changes at all, there is no case where opening
-that port is the better trade.
+This is each runtime's officially supported mechanism, and it is kept for anyone
+who prefers it — but it charges for a local client that only relays, and couples
+the two ends in three ways the default does not:
+
+- **The families must match.** A podman client cannot drive `dockerd`: it asks
+  for Libpod endpoints (`/libpod/_ping`) that dockerd does not serve, and you
+  get `ping response was 404`. So `nok8s.runtime` has to name what is on the
+  *node*, and the local client has to be the same thing. Watch for `docker`
+  being a shim for podman (the `podman-docker` package, or a symlink) — podman
+  names itself from `argv[0]`, so the same binary prints `docker version 5.8.3`
+  under that name, and `docker --version` will not tell you.
+- **Each client authenticates by its own rules.** See
+  [Authentication](#authentication-keys-not-passwords).
+- **The URL carries a socket path**, which differs between docker
+  (`/var/run/docker.sock`) and rootless podman (`/run/user/<uid>/podman/…`).
+
+Under the default, none of that applies: only the node's runtime matters.
+
+`tcp://` is refused on purpose, under either transport. A docker/podman socket
+bound to a TCP port with no TLS and no authentication grants root on that node
+to anyone who can reach the port — mounting `/` into a privileged container is a
+one-liner. Since SSH needs no daemon changes at all, there is no case where
+opening that port is the better trade.
 
 ### Usernames, when yours differs from the node's
 
@@ -345,8 +390,9 @@ Host 10.0.0.7
     IdentityFile ~/.ssh/id_ed25519
 ```
 
-One value is enough — the username reaches all three places that need it: the
-runtime client (`docker -H ssh://remote@10.0.0.7/var/run/docker.sock`), the
+One value is enough — the username reaches every place that needs it: the
+container commands (`ssh remote@10.0.0.7 'docker …'`, or the runtime client's
+`-H ssh://remote@10.0.0.7/var/run/docker.sock` under `transport: native`), the
 `ssh` probes, and `scp` staging.
 
 Note that `~` in `nok8s.workspaceHostDir` and `nok8s.vllm.hfCacheDir` expands
@@ -389,19 +435,58 @@ standup will fail.
   `known_hosts` (`ssh-keyscan -H 10.0.0.7 >> ~/.ssh/known_hosts`), or
   `BatchMode` fails on the confirmation prompt.
 
-> **`sshIdentity` does not reach the `docker` client.** It is applied to every
-> `ssh`/`scp` probe (`-i /path`) and to podman (`podman --url … --identity
-> /path`), but `docker -H ssh://…` takes no `-i` — docker shells out to your
-> system `ssh`, so it reads the key from the agent or `~/.ssh/config`. With
-> docker **and** a non-default key, put it in `~/.ssh/config` as `IdentityFile`;
-> `sshIdentity` alone gives you a passing preflight and failing container
-> commands.
+Under the default `ssh` transport that is all of it: **one** SSH client — your
+system `ssh` — opens every connection, so `sshIdentity`, `sshArgs` and
+`~/.ssh/config` apply uniformly, and `ssh <dest> true` succeeding really does
+mean the tool can work.
 
-`nok8s.sshArgs` replaces the default args, so `BatchMode` *can* be switched off
-(`sshArgs: ["-o", "BatchMode=no", "-o", "ConnectTimeout=10"]`). This is not a
-supported way to use a password -- it affects only the `ssh`/`scp` probes, not
-the `docker -H` / `podman --url` calls, so you get repeated prompts and a
-standup that still stalls. Use keys.
+<details>
+<summary><strong>With <code>transport: native</code>, each client authenticates
+by its own rules</strong></summary>
+
+The runtime client opens its own connection, and the two clients do it
+differently — so `ssh <dest> true` proves nothing about them.
+
+**`sshIdentity` does not reach the `docker` client.** It is applied to every
+`ssh`/`scp` probe (`-i /path`) and to podman (`podman --url … --identity
+/path`), but `docker -H ssh://…` takes no `-i` — docker shells out to your system
+`ssh`, so it reads the key from the agent or `~/.ssh/config`. With docker **and**
+a non-default key, put it in `~/.ssh/config` as `IdentityFile`; `sshIdentity`
+alone gives you a passing preflight and failing container commands.
+
+**`attempted methods [none]` means podman, whatever `docker --version` says.**
+podman's Go SSH client does not fall back to `~/.ssh/id_rsa` the way OpenSSH
+does. With no key from `sshIdentity`, `CONTAINER_SSHKEY`, the agent, or `podman
+system connection add`, it offers *nothing* and the node rejects it. If you see
+that wording, the client that produced it is podman even when `nok8s.runtime` is
+`docker` and `docker --version` reports Docker: `docker` is often a shim (the
+`podman-docker` package, or a symlink — podman names itself from `argv[0]`), and
+podman accepts docker's `-H` as a synonym for `--url`, so the substitution is
+invisible until it fails. Fix both halves at once:
+
+```bash
+--set nok8s.runtime=podman,nok8s.sshIdentity=$HOME/.ssh/id_rsa
+```
+
+`runtime=podman` matters on its own: with `docker` configured, the URL carries
+docker's socket path (`/var/run/docker.sock`), which is not where podman's socket
+lives. Preflight names the client from the error text for this reason, and quotes
+why — docker's CLI has no SSH client of its own, so it can only ever report the
+`ssh` process's exit status, never Go's handshake wording.
+
+But check the *other* end before acting on either: the client and the node's
+daemon must be the same family, so if the node runs Docker, switching to a
+podman client cannot work no matter how it authenticates (you will get
+`ping response was 404`). The default `ssh` transport removes this whole class of
+problem.
+
+`nok8s.sshArgs` also does not reach the runtime clients, so switching
+`BatchMode` off there (`sshArgs: ["-o", "BatchMode=no", "-o",
+"ConnectTimeout=10"]`) still does not let you authenticate with a password --
+it affects only the `ssh`/`scp` probes, so you get repeated prompts plus a
+standup that stalls anyway. Use keys.
+
+</details>
 
 ### What the node needs
 
@@ -430,7 +515,7 @@ a `localhost` means different things on each side:
 
 | | Runs on | Why |
 |---|---------|-----|
-| `llmdbenchmark` itself | Client | It only drives the runtime client |
+| `llmdbenchmark` itself | Client | It only issues commands; under the default transport it needs no container runtime of its own |
 | vLLM / EPP / Envoy | Node | That is the point |
 | **Benchmark harness** | **Node** | Driving load from the client would add the SSH round-trip to every request and report it as the stack's latency |
 | EPP/Envoy configs | Pushed to the node (`scp`) | Bind-mount sources are resolved by the daemon |
@@ -471,16 +556,41 @@ Where things land on the node:
 | `nok8s.vllm.hfCacheDir` (default `~/.cache/huggingface`) | Model weights, so a re-run does not re-download |
 | `~/.llmdbench/nok8s-runs/<stack>/<workspace-name>/` | Per-run harness inputs and results. Kept after the pull, so a failed run stays inspectable |
 
-The Hugging Face token is passed as a valueless `-e HUGGING_FACE_HUB_TOKEN`,
-which both CLIs expand from your **client** environment. It reaches the vLLM
-container without ever being written to the node's disk.
+The Hugging Face token reaches the vLLM container without ever being written to
+the node's disk, but *how* depends on the transport, because `-e VAR` with no
+value is expanded by whoever runs the CLI:
+
+- **`native`** — the CLI runs here, so it expands the variable from your client
+  environment directly.
+- **`ssh`** — the CLI runs on the node, where the variable is unset. The value is
+  therefore carried across explicitly, piped in over **stdin** and read by the
+  remote shell before it execs the runtime. It is deliberately not passed as a
+  `VAR=value` prefix: every command string is written to the workspace
+  `command.log`, and a prefix would leave the token there in cleartext.
 
 ### Remote troubleshooting
 
-- **`Cannot reach the 'docker' daemon at ssh://…`** — step 00 already ran
-  `docker -H … info`, so the connection, not the config, is the problem. Work
-  through `ssh <dest> true`, then whether your user can use the runtime there
-  (`ssh <dest> docker info`).
+- **`Cannot reach the 'docker' daemon at ssh://…`** — step 00 already ran the
+  runtime's `info`, so the connection or the node's daemon is the problem, not
+  the rendered config. Under the default transport that probe *is*
+  `ssh <dest> docker info`, so work it in two halves: `ssh <dest> true` (the SSH
+  side), then `ssh <dest> docker info` (whether your user can use the runtime
+  there — usually the `docker` group, or `systemctl --user enable --now
+  podman.socket` for rootless podman). Under `transport: native` read the rest of
+  the message first: it names the *client* from the error text and tailors the
+  advice, because `ssh <dest> true` succeeding proves nothing about podman (see
+  [Authentication](#authentication-keys-not-passwords)).
+- **One error instead of a list** — when the connection itself is dead, the
+  probes for `timeout`, `curl`, the accelerator and the ports are skipped rather
+  than run down a broken tunnel; you will see `skipping accelerator probe: the
+  node was unreachable`. They would each have failed for the same single reason
+  and reported it as a missing tool on a node that was never reached.
+- **`unable to connect to Podman socket: ping response was 404`** — only
+  possible under `transport: native`: a podman client is talking to `dockerd`,
+  which does not serve the Libpod endpoints podman asks for. The two ends must be
+  the same family. Either install the matching client, or drop the requirement
+  entirely by using the default transport (remove `transport: native`), where
+  only the node's runtime matters.
 - **A prompt appears and the standup fails immediately** — `BatchMode=yes` is
   doing its job. Add the host key (`ssh-keyscan -H <host> >> ~/.ssh/known_hosts`)
   or load the key into your agent. Passwords are not supported at all — see
@@ -505,8 +615,9 @@ container without ever being written to the node's disk.
   means the `--set` path was misspelled, and no line at all means `--set` was
   missing from *this* command (it is per invocation — see
   [Without editing the scenario](#without-editing-the-scenario---set)). A
-  targeted command logs `nok8s target: docker @ ssh://…` and every container
-  command carries `-H ssh://…`.
+  targeted command logs `nok8s target: docker @ ssh://…`, and every container
+  command is an `ssh <dest> 'docker …'` line (or carries `-H ssh://…` under
+  `transport: native`).
 - **The stack is on the node but the benchmark numbers look like localhost** —
   `run` was invoked without the connection, so the harness ran on the client
   against its own port 8081. Re-run `run` with the same `--set` you gave

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -149,6 +149,32 @@ curl -s http://localhost:8081/v1/completions -H 'Content-Type: application/json'
   -d '{"model":"Qwen/Qwen2.5-0.5B-Instruct","prompt":"Hello","max_tokens":32}'
 ```
 
+### Where the logs go (`workDir`)
+
+Each invocation creates its own timestamped workspace — `plan/`, `logs/`, the
+container logs under `setup/logs/`, and the harness results — inside the
+directory the scenario's `workDir` names. The shipped guide uses
+`~/data/nok8s`, so a standup writes something like:
+
+```
+~/data/nok8s/<user>-20260821-173703-475/
+├── setup/logs/nok8s-{vllm-0,epp,envoy}.log   # captured container logs
+├── logs/                                     # the CLI's own logs, per module
+│   └── llmdbenchmark-stdout.log              #   plus this combined stream
+└── plan/                                     # the rendered launch spec
+```
+
+**A scenario with no `workDir` gets a fresh `mkdtemp` per invocation instead**,
+so the logs land somewhere different every time and nothing accumulates. If you
+wrote your own nok8s scenario, give it a `workDir` (in `shared:` for a
+multi-stack one, since the workspace is scenario-wide). `--ws <dir>` or
+`LLMDBENCH_WORKSPACE` overrides it per invocation.
+
+The `latest` symlink beside the timestamped dirs is repointed by **every**
+subcommand, so after `standup` then `run` it names the *run*. It means "most
+recent invocation", not "most recent standup" — for a specific phase, sort the
+dirs by name (they are chronological) and look at their contents.
+
 ## Configuration
 
 Selected by `nok8s.enabled: true` in a scenario (mutually exclusive with
@@ -170,6 +196,7 @@ single-GPU example. Key fields (full defaults in
 | `nok8s.envoy.{image,tag,listenPort,adminPort,baseId}` | Envoy front door (the run target); `adminPort` is the admin interface, bound on the host (`--network host`). `baseId` is the hot-restart `--base-id`; leave it `0` and it is resolved per stack from `listenPort` |
 | `nok8s.nameSuffix` | Appended to every container name. Filled automatically with `-<stack>` in a multi-stack scenario (see below); leave empty for one stack |
 | `model.{name,huggingfaceId}` | Set both; standup uses `name`, run reads `huggingfaceId` |
+| `workDir` | Directory the per-invocation workspace (plan, logs, results) is created in. Omitting it falls back to a fresh temp dir each run — see [Where the logs go](#where-the-logs-go-workdir) |
 
 Sizing (fp16, single GPU): ~16 GB → 7–8B · ~24 GB → 8B · ~40 GB → 14B ·
 ~80 GB → 32B. For bigger models use `nok8s.vllm.extraArgs`

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -301,7 +301,8 @@ fails at render with the reason, before anything is launched.
 | `nok8s.connection` | Meaning |
 |--------------------|---------|
 | `localhost` (default), `local`, `127.0.0.1`, a `unix://` or `/…` socket path | The local runtime — commands are byte-identical to a pre-`connection` release |
-| `10.0.0.7`, `node1`, `bench@node1` | Read as `ssh://` — the "just give it the IP" case |
+| `10.0.0.7`, `node1` | Read as `ssh://` with **no username**, so SSH picks one — see [Usernames](#usernames-when-yours-differs-from-the-nodes) |
+| `bench@node1`, `remote@10.0.0.7` | Read as `ssh://` with an explicit username |
 | `ssh://[user@]host[:port][/socket-path]` | Explicit. `port` is the **SSH** port; `socket-path` is the daemon socket on the node (rootless podman: `/run/user/<uid>/podman/podman.sock`) |
 | `tcp://…` | **Refused**, with an error at render time |
 
@@ -321,6 +322,87 @@ the port — mounting `/` into a privileged container is a one-liner. Since the
 SSH transport needs no daemon changes at all, there is no case where opening
 that port is the better trade.
 
+### Usernames, when yours differs from the node's
+
+`nok8s.connection` carries the username, and a **bare** address carries *none* —
+it is not silently your local one:
+
+```bash
+--set nok8s.connection=10.0.0.7           # no username: ssh decides
+--set nok8s.connection=remote@10.0.0.7    # explicit
+--set nok8s.connection=ssh://remote@10.0.0.7:2222   # explicit, non-default SSH port
+```
+
+With no username, `ssh` applies its own resolution order — a matching `Host`
+block in `~/.ssh/config` first, then `$USER`. So if you are `local` here and the
+node only knows `remote`, a bare `10.0.0.7` tries `local@10.0.0.7` and fails
+authentication. Either name the user in the connection, or let `~/.ssh/config`
+supply it:
+
+```
+Host 10.0.0.7
+    User remote
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+One value is enough — the username reaches all three places that need it: the
+runtime client (`docker -H ssh://remote@10.0.0.7/var/run/docker.sock`), the
+`ssh` probes, and `scp` staging.
+
+Note that `~` in `nok8s.workspaceHostDir` and `nok8s.vllm.hfCacheDir` expands
+against the **node's** `$HOME` (read live with `ssh … printenv HOME`), so it
+becomes `/home/remote/…`, never your local `/Users/local/…`. A `~other/path`
+names a specific other user and is left alone.
+
+### Authentication: keys, not passwords
+
+Password authentication is not supported. The connection is opened with
+`-o BatchMode=yes`, which disables every prompt, because a standup issues dozens
+of commands — a password would be asked for repeatedly, and a prompt nobody can
+see is indistinguishable from a hang.
+
+Preflight (step 00) turns that into an actionable failure rather than a timeout:
+
+```
+Cannot reach the 'docker' daemon at ssh://remote@10.0.0.7/var/run/docker.sock: …
+Check that 'ssh remote@10.0.0.7 true' succeeds without a prompt (key-based auth,
+key in the agent or nok8s.sshIdentity, host key already known) and that 'docker'
+is running there.
+```
+
+One-time setup:
+
+```bash
+ssh-keygen -t ed25519                # if you have no key
+ssh-copy-id remote@10.0.0.7          # asks for the password, this once
+ssh remote@10.0.0.7 true             # the gate: must succeed silently
+```
+
+That last command is exactly what the tool needs to work. If it prompts,
+standup will fail.
+
+- **Passphrase-protected key** — load it into the agent once
+  (`ssh-add ~/.ssh/id_ed25519`). The agent satisfies `BatchMode=yes`, since no
+  terminal prompt is involved.
+- **Non-default key** — `--set nok8s.sshIdentity=/Users/local/.ssh/id_node`.
+- **First connection to an unknown host** — the host key must already be in
+  `known_hosts` (`ssh-keyscan -H 10.0.0.7 >> ~/.ssh/known_hosts`), or
+  `BatchMode` fails on the confirmation prompt.
+
+> **`sshIdentity` does not reach the `docker` client.** It is applied to every
+> `ssh`/`scp` probe (`-i /path`) and to podman (`podman --url … --identity
+> /path`), but `docker -H ssh://…` takes no `-i` — docker shells out to your
+> system `ssh`, so it reads the key from the agent or `~/.ssh/config`. With
+> docker **and** a non-default key, put it in `~/.ssh/config` as `IdentityFile`;
+> `sshIdentity` alone gives you a passing preflight and failing container
+> commands.
+
+`nok8s.sshArgs` replaces the default args, so `BatchMode` *can* be switched off
+(`sshArgs: ["-o", "BatchMode=no", "-o", "ConnectTimeout=10"]`). This is not a
+supported way to use a password -- it affects only the `ssh`/`scp` probes, not
+the `docker -H` / `podman --url` calls, so you get repeated prompts and a
+standup that still stalls. Use keys.
+
 ### What the node needs
 
 Only what a bare-metal box already has:
@@ -328,13 +410,14 @@ Only what a bare-metal box already has:
 - **A container runtime** (`docker` or `podman`) running, and your SSH user able
   to use it (in the `docker` group, or rootless podman with its socket active —
   `systemctl --user enable --now podman.socket`).
-- **Key-based SSH that works non-interactively.** The connection is opened with
-  `BatchMode=yes`, so a passphrase or an unknown-host prompt fails fast instead
-  of hanging a standup. Verify with the exact command the preflight suggests:
+- **Key-based SSH that works non-interactively** — passwords are not supported.
+  Verify with the exact command the preflight suggests:
   ```bash
-  ssh bench@10.0.0.7 true      # must succeed with no prompt
+  ssh remote@10.0.0.7 true     # must succeed with no prompt
   ```
-  Pass a specific key with `nok8s.sshIdentity: /path/to/key`.
+  See [Authentication](#authentication-keys-not-passwords) for the setup, and
+  [Usernames](#usernames-when-yours-differs-from-the-nodes) when your local user
+  is not the node's.
 - **`curl`, `timeout`, and `ss` or `lsof`** — checked by step 00 on the node.
 
 No `llmdbenchmark`, no Python, and no cluster tooling is installed there, and
@@ -400,7 +483,12 @@ container without ever being written to the node's disk.
   (`ssh <dest> docker info`).
 - **A prompt appears and the standup fails immediately** — `BatchMode=yes` is
   doing its job. Add the host key (`ssh-keyscan -H <host> >> ~/.ssh/known_hosts`)
-  or load the key into your agent.
+  or load the key into your agent. Passwords are not supported at all — see
+  [Authentication](#authentication-keys-not-passwords).
+- **`Permission denied (publickey)` naming the wrong user** — the connection
+  carried no username, so `ssh` used yours. Give it one
+  (`--set nok8s.connection=remote@10.0.0.7`) or set `User` in `~/.ssh/config`;
+  see [Usernames](#usernames-when-yours-differs-from-the-nodes).
 - **`Failed to stage nok8s configs to …`** — fatal on purpose: docker silently
   turns a missing bind-mount source into an *empty directory*, so the EPP would
   come up with no endpoints file and route nothing. Check that

--- a/docs/nok8s.md
+++ b/docs/nok8s.md
@@ -22,6 +22,12 @@ equivalent of the upstream
 Use it for HPC/Slurm nodes, bare-metal boxes, or a single GPU workstation
 where standing up Kubernetes is not worth it.
 
+The host running the containers does not have to be the host running
+`llmdbenchmark`. Point `nok8s.connection` at a node and the whole lifecycle —
+standup, smoketest, run, teardown — drives that node over SSH, with nothing to
+install or configure there beyond a container runtime. See
+[Remote host](#remote-host).
+
 ## Prerequisites
 
 `llmdbenchmark standup` validates these automatically in step 00; a missing or
@@ -31,15 +37,23 @@ broken container runtime is fatal, the rest are warnings.
 |-------------|-------|
 | Linux host + NVIDIA GPU(s) | Images/flags are NVIDIA + vLLM specific |
 | NVIDIA driver | `nvidia-smi` must work |
-| Container runtime | **docker** or **podman** (`nok8s.runtime`) |
+| Container runtime | **docker** or **podman** (`nok8s.runtime`), on the host named by `nok8s.connection` |
 | NVIDIA Container Toolkit | docker: `nvidia-ctk runtime configure --runtime=docker`; podman: `nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml` |
 | Hugging Face token | `export HUGGING_FACE_HUB_TOKEN=hf_...` (only for gated models) |
 | Free host ports | 8000 (vLLM), 8081 (Envoy), 9002/9003/9090 (EPP), 19000 (Envoy admin) |
 | Outbound network | to pull images (docker.io, ghcr.io) and model weights (Hugging Face) |
 | `llmdbenchmark` CLI | `./install.sh` (Python 3.11+) |
 
+Every requirement above applies to the host that runs the containers. For a
+remote `nok8s.connection` the client additionally needs `ssh` and `scp`, and the
+node needs `curl`, `timeout` and a listening-socket tool (`ss` or `lsof`) —
+step 00 checks each one on the side that has to have it.
+
 **Not required:** Kubernetes, `kubectl`/`oc`, `helm`/`helmfile`, Gateway CRDs,
-PVCs, or any cluster access.
+PVCs, or any cluster access. For a remote node, also not required: a
+daemon listening on a TCP port, a manually opened SSH tunnel, an agent or
+anything else installed there, or a login session — `llmdbenchmark` never needs
+you to shell into the node.
 
 Verify GPU-in-container before you start:
 ```bash
@@ -63,7 +77,7 @@ llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . --dr
 
 | What | Without a GPU |
 |------|---------------|
-| `pytest tests/ -q -n2` | **Works** (739 passed, 31 skipped). `tests/test_nok8s_plan.py` covers template rendering, per-accelerator device flags, per-replica pinning, and the preflight |
+| `pytest tests/ -q -n2` | **Works** (1389 passed, 32 skipped). `tests/test_nok8s_plan.py` covers template rendering, per-accelerator device flags, per-replica pinning, and the preflight |
 | `plan` | **Works** -- renders all 36 artifacts, including `31/32/33/34_nok8s-*` |
 | `--dry-run standup --methods nok8s` | **Works** (12/12 steps) -- step 06 logs each `docker run` it *would* execute, and records `http://localhost:8081` |
 | `--dry-run run` | **Works** -- endpoint resolves locally with no cluster query, profiles render, the harness `docker run` is logged |
@@ -108,6 +122,21 @@ llmdbenchmark --spec config/specification/guides/nok8s.yaml.j2 --base-dir . tear
 `--methods nok8s` is optional when the scenario sets `nok8s.enabled: true`
 (the method is auto-detected), but harmless to pass explicitly.
 
+To run the same stack on a bare-metal node, add `--set nok8s.connection=<IP>`
+to **each** of those commands — `run` included, since it launches the harness
+on the node:
+
+```bash
+llmdbenchmark --spec guides/nok8s standup  --methods nok8s --set nok8s.connection=10.0.0.7
+llmdbenchmark --spec guides/nok8s smoketest                --set nok8s.connection=10.0.0.7
+llmdbenchmark --spec guides/nok8s run                      --set nok8s.connection=10.0.0.7
+llmdbenchmark --spec guides/nok8s teardown --methods nok8s --set nok8s.connection=10.0.0.7
+```
+
+Or `export LLMDBENCH_SET='nok8s.connection=10.0.0.7'` once and drop the flag
+everywhere — see [Remote host](#remote-host). Nothing else changes, and you
+never log into the node.
+
 Send your own requests to the Envoy front door:
 ```bash
 curl -s http://localhost:8081/v1/completions -H 'Content-Type: application/json' \
@@ -125,6 +154,9 @@ single-GPU example. Key fields (full defaults in
 | Key | Meaning |
 |-----|---------|
 | `nok8s.runtime` | `docker` or `podman` (GPU flag switches to CDI for podman) |
+| `nok8s.connection` | Host whose runtime runs the stack. `localhost` (default), or `ssh://[user@]host[:port][/socket]`. A bare `10.0.0.7` / `user@node` is read as `ssh://`. Settable per run with `--set nok8s.connection=…` instead of editing the scenario. See [Remote host](#remote-host) |
+| `nok8s.sshIdentity` | SSH private key for a remote connection (default: the agent / `~/.ssh` keys) |
+| `nok8s.sshArgs` | Extra `ssh`/`scp` options. **Replaces** the defaults (`BatchMode=yes`, `ConnectTimeout=10`), so restate them if you override |
 | `nok8s.hfTokenEnv` | Host env var passed to vLLM for HF auth |
 | `nok8s.workspaceHostDir` | Host dir where EPP/Envoy configs are staged + bind-mounted |
 | `nok8s.vllm.{image,tag,hostPort,tensorParallel,accelerator,gpus,deviceArgs,shmSize,replicas,extraArgs}` | vLLM worker(s); worker *i* is published on `hostPort + i` (see Accelerators for `accelerator`/`deviceArgs`) |
@@ -170,6 +202,236 @@ nok8s:
 Step 00 probes the accelerator when it can (`nvidia-smi`/`rocm-smi`/`xpu-smi`/
 `hl-smi`); `cpu`/`spyre`/custom are not probed (a note is logged) — ensure the
 device and image match yourself.
+
+## Remote host
+
+By default the containers run on the machine that runs `llmdbenchmark`. Set
+`nok8s.connection` and they run somewhere else instead:
+
+```yaml
+nok8s:
+  enabled: true
+  connection: 10.0.0.7          # or ssh://bench@10.0.0.7, or a hostname
+```
+
+That is the whole change. Everything else — `standup`, `smoketest`, `run`,
+`teardown` — works exactly as it does locally:
+
+```bash
+llmdbenchmark --spec my-scenario.yaml standup --methods nok8s
+llmdbenchmark --spec my-scenario.yaml smoketest
+llmdbenchmark --spec my-scenario.yaml run
+llmdbenchmark --spec my-scenario.yaml teardown --methods nok8s
+```
+
+### Without editing the scenario (`--set`)
+
+The node's address is usually a property of *this run*, not of the scenario, so
+it does not have to be committed to a file. `--set` takes any dotted path into
+the merged stack config, and every subcommand accepts it:
+
+```bash
+llmdbenchmark --spec my-scenario.yaml standup --methods nok8s --set nok8s.connection=10.0.0.7
+```
+
+`run`, `smoketest` and `teardown` take the same flag, and each phase needs it
+for a different reason:
+
+| Phase | What `nok8s.connection` decides |
+|-------|---------------------------------|
+| `standup` | Which host's runtime starts vLLM / EPP / Envoy, and where the configs are staged |
+| `smoketest` | Which address is probed — the node's (`http://10.0.0.7:8081`), from the client |
+| `run` | Which host's runtime runs the harness container, and where its inputs are staged and results pulled from |
+| `teardown` | Which host's containers are removed |
+
+Several keys fit in one flag (comma-separated), and the flag repeats:
+
+```bash
+--set 'nok8s.connection=ssh://bench@10.0.0.7:2222,nok8s.sshIdentity=/keys/id_ed25519'
+```
+
+The override is echoed at render time, which is worth reading back:
+
+```
+[nok8s-single] Scenario override: nok8s.connection: 'localhost' -> '10.0.0.7'
+```
+
+**`--set` applies to one invocation, so it has to be repeated on every phase.**
+A `run` without it starts the harness on *your own* machine against
+`localhost:8081`, where nothing is listening, while the stack sits idle on the
+node — no error, just the wrong machine. The tell is the launch command: a
+remote run reads `docker -H ssh://10.0.0.7/... run -d`, a local one is a bare
+`docker run -d`. Likewise a `teardown` without it leaves the node's containers
+running. To set it once for a whole session, use the env var instead:
+
+```bash
+export LLMDBENCH_SET='nok8s.connection=10.0.0.7'
+```
+
+Precedence is `scenario` < `--cluster-config` < `--set`, so this overrides a
+`connection` already in the scenario file.
+
+> **A typo in the last path segment still renders, and deploys wherever the
+> scenario said.** `--set nok8s.conection=10.0.0.7` (one `n`) gives
+> `Errors: 0` — `nok8s` exists, so the unknown-path check passes and the
+> misspelled key is merged in as a new, unused one while the real
+> `connection` keeps its value. Render warns when the misspelling is close
+> enough to a real sibling to name it:
+>
+> ```
+> ⚠️ [nok8s-single] override path 'nok8s.conection' does not exist, but
+>    'nok8s.connection' does -- did you mean that? As written,
+>    'nok8s.conection' is created as a new unused key and
+>    'nok8s.connection' keeps its current value.
+> ```
+>
+> It is a warning, not an error, because free-form blocks (e.g.
+> `kustomize.guideVariableOverrides`) gain new keys by design — so a key too
+> far from any sibling to be a plausible misspelling passes without comment.
+> The other tell is the echoed override line: a working one reads
+> `'localhost' -> '10.0.0.7'`, a typo'd one reads `<unset> -> '10.0.0.7'`. A
+> typo in a *parent* segment (`nok8ss.connection`) warns too. All of this is
+> how `--set` behaves tool-wide, not just here.
+
+Guardrails still apply through `--set`: `--set nok8s.connection=tcp://10.0.0.7:2375`
+fails at render with the reason, before anything is launched.
+
+### Accepted values
+
+| `nok8s.connection` | Meaning |
+|--------------------|---------|
+| `localhost` (default), `local`, `127.0.0.1`, a `unix://` or `/…` socket path | The local runtime — commands are byte-identical to a pre-`connection` release |
+| `10.0.0.7`, `node1`, `bench@node1` | Read as `ssh://` — the "just give it the IP" case |
+| `ssh://[user@]host[:port][/socket-path]` | Explicit. `port` is the **SSH** port; `socket-path` is the daemon socket on the node (rootless podman: `/run/user/<uid>/podman/podman.sock`) |
+| `tcp://…` | **Refused**, with an error at render time |
+
+### Why SSH, and why not `tcp://`
+
+Both runtimes have a native SSH transport, so nothing has to be reconfigured
+on the node and no tunnel has to be opened by hand:
+
+```bash
+docker -H ssh://bench@10.0.0.7 run ...
+podman --url ssh://bench@10.0.0.7/run/user/1000/podman/podman.sock run ...
+```
+
+`tcp://` is refused on purpose. A docker/podman socket bound to a TCP port with
+no TLS and no authentication grants root on that node to anyone who can reach
+the port — mounting `/` into a privileged container is a one-liner. Since the
+SSH transport needs no daemon changes at all, there is no case where opening
+that port is the better trade.
+
+### What the node needs
+
+Only what a bare-metal box already has:
+
+- **A container runtime** (`docker` or `podman`) running, and your SSH user able
+  to use it (in the `docker` group, or rootless podman with its socket active —
+  `systemctl --user enable --now podman.socket`).
+- **Key-based SSH that works non-interactively.** The connection is opened with
+  `BatchMode=yes`, so a passphrase or an unknown-host prompt fails fast instead
+  of hanging a standup. Verify with the exact command the preflight suggests:
+  ```bash
+  ssh bench@10.0.0.7 true      # must succeed with no prompt
+  ```
+  Pass a specific key with `nok8s.sshIdentity: /path/to/key`.
+- **`curl`, `timeout`, and `ss` or `lsof`** — checked by step 00 on the node.
+
+No `llmdbenchmark`, no Python, and no cluster tooling is installed there, and
+you never need an interactive login.
+
+### What runs where
+
+The distinction that matters is *client* versus *daemon host*, because a path or
+a `localhost` means different things on each side:
+
+| | Runs on | Why |
+|---|---------|-----|
+| `llmdbenchmark` itself | Client | It only drives the runtime client |
+| vLLM / EPP / Envoy | Node | That is the point |
+| **Benchmark harness** | **Node** | Driving load from the client would add the SSH round-trip to every request and report it as the stack's latency |
+| EPP/Envoy configs | Pushed to the node (`scp`) | Bind-mount sources are resolved by the daemon |
+| Readiness probes (`curl`) | Node | `curl localhost:8081` from the client would probe the client |
+| Container logs | Pulled to the client | A failed standup is diagnosable without SSHing in |
+| Results | Pulled to the client | You get the same `workspace/results/` tree as a local run |
+
+Because the harness runs on the node, the rendered
+`34_nok8s-containers.yaml` carries **two** endpoints, and they are identical
+for a local stack:
+
+| Field | Value | Used by |
+|-------|-------|---------|
+| `endpoint` | `http://localhost:<listenPort>` | The harness container (`--network host`, on the node) |
+| `clientEndpoint` | `http://<node>:<listenPort>` | The smoketest and your own `curl`, from the client |
+
+A `run` that follows a `standup` in the same command inherits `endpoint`
+directly. A standalone `llmdbenchmark run` has nothing in memory, so it starts
+from the client URL and step 07 swaps in `endpoint` from the rendered spec
+before launching the harness. An explicit `--endpoint-url` is never swapped --
+if you name a target, that is the target.
+
+So `curl` the node, not localhost:
+```bash
+curl -s http://10.0.0.7:8081/v1/completions -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen2.5-0.5B-Instruct","prompt":"Hello","max_tokens":32}'
+```
+
+Envoy's `listenPort` has to be reachable from the client for the smoketest (or
+tunnel it: `ssh -L 8081:localhost:8081 bench@10.0.0.7`). The vLLM and EPP ports
+never need to be — they are probed on the node.
+
+Where things land on the node:
+
+| Path | Contents |
+|------|----------|
+| `nok8s.workspaceHostDir` (default `~/.llmdbench/nok8s`) | Staged EPP/Envoy configs. `~` is expanded against the **node's** `$HOME`, not yours |
+| `nok8s.vllm.hfCacheDir` (default `~/.cache/huggingface`) | Model weights, so a re-run does not re-download |
+| `~/.llmdbench/nok8s-runs/<stack>/<workspace-name>/` | Per-run harness inputs and results. Kept after the pull, so a failed run stays inspectable |
+
+The Hugging Face token is passed as a valueless `-e HUGGING_FACE_HUB_TOKEN`,
+which both CLIs expand from your **client** environment. It reaches the vLLM
+container without ever being written to the node's disk.
+
+### Remote troubleshooting
+
+- **`Cannot reach the 'docker' daemon at ssh://…`** — step 00 already ran
+  `docker -H … info`, so the connection, not the config, is the problem. Work
+  through `ssh <dest> true`, then whether your user can use the runtime there
+  (`ssh <dest> docker info`).
+- **A prompt appears and the standup fails immediately** — `BatchMode=yes` is
+  doing its job. Add the host key (`ssh-keyscan -H <host> >> ~/.ssh/known_hosts`)
+  or load the key into your agent.
+- **`Failed to stage nok8s configs to …`** — fatal on purpose: docker silently
+  turns a missing bind-mount source into an *empty directory*, so the EPP would
+  come up with no endpoints file and route nothing. Check that
+  `nok8s.workspaceHostDir` is writable by the SSH user.
+- **Smoketest cannot reach the endpoint but standup passed** — standup probes
+  from the node, the smoketest from the client. The stack is up; Envoy's
+  `listenPort` is firewalled.
+- **Paths containing `~` did not resolve** — step 00 warns when it cannot read
+  `$HOME` on the node. Use absolute paths for `workspaceHostDir` and
+  `hfCacheDir`.
+- **It deployed locally and the node is untouched** — the connection never took
+  effect. Check the render log for
+  `Scenario override: nok8s.connection: 'localhost' -> '<IP>'`; `<unset> ->`
+  means the `--set` path was misspelled, and no line at all means `--set` was
+  missing from *this* command (it is per invocation — see
+  [Without editing the scenario](#without-editing-the-scenario---set)). A
+  targeted command logs `nok8s target: docker @ ssh://…` and every container
+  command carries `-H ssh://…`.
+- **The stack is on the node but the benchmark numbers look like localhost** —
+  `run` was invoked without the connection, so the harness ran on the client
+  against its own port 8081. Re-run `run` with the same `--set` you gave
+  `standup`.
+
+### Several nodes
+
+`nok8s.connection` is per stack, so a multi-stack scenario can spread stacks
+across nodes — and stacks on *different* nodes no longer contend for ports or
+devices. The clash checks are deliberately conservative and treat all stacks as
+sharing one host, so two stacks on different nodes still have to be given
+distinct ports and container names. Benchmark them one at a time with
+`--stack` (see [Several stacks on one host](#several-stacks-on-one-host)).
 
 ## Several stacks on one host
 
@@ -245,13 +507,13 @@ and filing the results under every stack's name.
 
 | Phase | nok8s behaviour |
 |-------|-----------------|
-| standup step 00 | Preflight: runtime / GPU / ports / token (replaces helm/kubectl checks) |
+| standup step 00 | Preflight: runtime / GPU / ports / token (replaces helm/kubectl checks). For a remote `connection`, `<runtime> info` doubles as the connection test, and the GPU/port/tool probes run on the node |
 | standup steps 02–05 | Skipped (no namespace, PVC, model-download Job) |
-| standup step 06 | `step_06_nok8s_deploy` launches the containers, waits for `/v1/models`, records `http://localhost:<listenPort>` |
-| smoketest steps 00–01 | Cluster-free probes: `GET /v1/models` and `POST /v1/completions` against the Envoy front door, read from the rendered `34_nok8s-containers.yaml` (no pods, Service or route) |
-| run step 03 | Endpoint resolves to the local Envoy URL (no cluster query) |
-| run step 07 | `step_07_deploy_harness_local` runs the harness image locally with `--network host`; results land in `workspace/results/` via a bind-mount |
-| teardown step 06 | `step_06_nok8s_teardown` removes the containers |
+| standup step 06 | `step_06_nok8s_deploy` launches the containers, waits for `/v1/models`, records `http://localhost:<listenPort>`. Remote: pushes the staged configs first, expands `~` against the node's `$HOME`, probes readiness on the node |
+| smoketest steps 00–01 | Cluster-free probes: `GET /v1/models` and `POST /v1/completions` against the Envoy front door, read from the rendered `34_nok8s-containers.yaml` (no pods, Service or route). Dials `clientEndpoint`, since it runs on the client |
+| run step 03 | Endpoint resolves to the Envoy URL without a cluster query: `localhost` for a local stack, the node for a remote one |
+| run step 07 | `step_07_deploy_harness_local` runs the harness image with `--network host`; results land in `workspace/results/` via a bind-mount. Remote: the container runs **on the node** (so the measured latency is the stack's), using the in-host `endpoint`, with inputs pushed and results pulled back |
+| teardown step 06 | `step_06_nok8s_teardown` removes the containers on the host the spec names; an unresolvable `connection` fails the step rather than falling back to the local runtime |
 
 ## Multiple GPUs
 
@@ -298,3 +560,5 @@ auto-pinning and puts you in control).
 - **podman + GPU** — ensure the CDI spec exists: `nvidia-ctk cdi list` should show
   `nvidia.com/gpu=all`.
 - **Ports busy** — a stale run; `teardown --methods nok8s`, or change the ports.
+- **Remote (`nok8s.connection`)** — see
+  [Remote troubleshooting](#remote-troubleshooting).

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-08-19 22:54:35` (UTC)
-- Generated against git ref: `d6c1e3a1a34294bc58ebfca0922f84868660694a`
+- Generated at: `2026-08-20 15:55:52` (UTC)
+- Generated against git ref: `e525662796b19a4a68f6d1b5f4c0344b636b088d`
 
 ## System Tool Dependencies
 
@@ -120,6 +120,7 @@ annotated with their `pyproject.toml` line.
 | **cryptography** | `50.0.0` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
 | **detect_secrets** | `38ba7e335083e0a4db8c53e9be414795b27891e9` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
 | **distlib** | `0.4.3` | version | (transitive in `.venv`) | [distlib (PyPI)](https://pypi.org/project/distlib/) |
+| **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
 | **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
 | **execnet** | `2.1.2` | version | (transitive in `.venv`) | [execnet (PyPI)](https://pypi.org/project/execnet/) |
 | **fastapi** | `0.141.1` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
@@ -161,7 +162,7 @@ annotated with their `pyproject.toml` line.
 | **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
 | **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
 | **ollama** | `0.6.2` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
-| **openai** | `3.3.1` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
+| **openai** | `3.2.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
 | **packaging** | `26.3` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
 | **pandas** | `3.0.3` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
 | **planner** | `9def3abea1720bce19823a4b5ae3ff2015ae77f1` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
@@ -194,7 +195,6 @@ annotated with their `pyproject.toml` line.
 | **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
 | **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
 | **rich** | `15.0.0` | version | (transitive in `.venv`) | [rich (PyPI)](https://pypi.org/project/rich/) |
-| **ruff** | `0.15.11` | version | (transitive in `.venv`) | [ruff (PyPI)](https://pypi.org/project/ruff/) |
 | **safetensors** | `0.8.0` | version | (transitive in `.venv`) | [safetensors (PyPI)](https://pypi.org/project/safetensors/) |
 | **scipy** | `1.17.1` | version | (transitive in `.venv`) | [scipy (PyPI)](https://pypi.org/project/scipy/) |
 | **shellingham** | `1.5.4` | version | (transitive in `.venv`) | [shellingham (PyPI)](https://pypi.org/project/shellingham/) |
@@ -205,7 +205,7 @@ annotated with their `pyproject.toml` line.
 | **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
 | **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
 | **tqdm** | `4.70.0` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
-| **transformers** | `5.15.1` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **transformers** | `5.15.0` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
 | **truststore** | `0.10.4` | version | (transitive in `.venv`) | [truststore (PyPI)](https://pypi.org/project/truststore/) |
 | **typer** | `0.27.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
 | **typing-inspection** | `0.4.4` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-08-20 15:55:52` (UTC)
-- Generated against git ref: `e525662796b19a4a68f6d1b5f4c0344b636b088d`
+- Generated at: `2026-08-21 19:47:14` (UTC)
+- Generated against git ref: `26c6bd2b0be7035e9bc9042963dc00939267079d`
 
 ## System Tool Dependencies
 
@@ -62,7 +62,7 @@ generation (and plan) time.
 | **benchmark** | `v0.8.0` | tag | `config/templates/values/defaults.yaml` line 380 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
 | **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 428 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
 | **routerEndpointPicker** | `v0.10.0` | tag | `config/templates/values/defaults.yaml` line 405 (`images.routerEndpointPicker`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) |
-| **routingSidecar** | `v0.9.0` | tag | `config/templates/values/defaults.yaml` line 411 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
+| **routingSidecar** | `v0.10.0` | tag | `config/templates/values/defaults.yaml` line 411 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
 | **udsTokenizer** | `v0.26.0` | tag | `config/templates/values/defaults.yaml` line 417 (`images.udsTokenizer`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
 | **vllm** | `v0.26.0` | tag | `config/templates/values/defaults.yaml` line 386 (`images.vllm`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |
 | **vllmOpenai** | `v0.26.0` | tag | `config/templates/values/defaults.yaml` line 397 (`images.vllmOpenai`) | [vllm-project/vllm](https://github.com/vllm-project/vllm) (`docker.io/vllm/vllm-openai`) |

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -594,12 +594,31 @@ def _report_pod_restarts(context, logger):
     )
 
 
+def _log_failure_artifacts(logger):
+    """Point at the workspace after a phase failed.
+
+    The workspace path is otherwise only printed by the per-phase success
+    summaries and by a startup line that a long render pushes off screen --
+    so the one run whose logs somebody needs is the one that never says
+    where they are. Read from the ``config`` singleton rather than a
+    context, because the failure can be the context construction itself.
+    """
+    workspace = config.workspace
+    if not workspace:
+        return
+    logger.log_error(f"Workspace: {workspace}")
+    logs_dir = Path(workspace) / "setup" / "logs"
+    if logs_dir.is_dir():
+        logger.log_error(f"Step logs and captured container logs: {logs_dir}")
+
+
 def _execute_standup(args, logger, render_plan_errors):
     """Build execution context and run standup steps."""
     try:
         context, result = _do_standup(args, logger, render_plan_errors)
     except PhaseError as e:
         logger.log_error(str(e))
+        _log_failure_artifacts(logger)
         sys.exit(1)
 
     _print_standup_summary(context, result, logger)
@@ -622,6 +641,7 @@ def _execute_standup(args, logger, render_plan_errors):
             _do_smoketest(args, logger, render_plan_errors)
         except PhaseError as e:
             logger.log_error(str(e))
+            _log_failure_artifacts(logger)
             sys.exit(1)
 
 
@@ -695,6 +715,7 @@ def _execute_smoketest(args, logger, render_plan_errors):
         _do_smoketest(args, logger, render_plan_errors)
     except PhaseError as e:
         logger.log_error(str(e))
+        _log_failure_artifacts(logger)
         sys.exit(1)
 
 
@@ -896,6 +917,7 @@ def _execute_teardown(args, logger, render_plan_errors):
         context, result = _do_teardown(args, logger, render_plan_errors)
     except PhaseError as e:
         logger.log_error(str(e))
+        _log_failure_artifacts(logger)
         sys.exit(1)
 
     ns = context.namespace or "unknown"
@@ -1191,6 +1213,7 @@ def _execute_run(args, logger, render_plan_errors):
         context, result = _do_run(args, logger, render_plan_errors)
     except PhaseError as e:
         logger.log_error(str(e))
+        _log_failure_artifacts(logger)
         sys.exit(1)
 
     # --list-endpoints short-circuits the run - no harness pods launched,

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -323,6 +323,12 @@ def _load_stack_info_from_config(config_file, stack_name=""):
                 "nok8s_runtime": (
                     plan_config.get("nok8s", {}).get("runtime", "docker")
                 ),
+                "nok8s_connection": (
+                    plan_config.get("nok8s", {}).get("connection", "localhost")
+                ),
+                "nok8s_client_host": (
+                    plan_config.get("nok8s", {}).get("clientHost", "localhost")
+                ),
                 "harness": plan_config.get("harness", {}),
             }
     except (OSError, _yaml.YAMLError):
@@ -347,13 +353,18 @@ def _load_all_stacks_info(rendered_paths):
 
 
 def _nok8s_endpoint_url(all_stacks_info, stack_filter=None):
-    """Default the nok8s run target to the local Envoy front door.
+    """Default the nok8s run target to that stack's Envoy front door.
 
     Each nok8s stack has its own Envoy, so there is no scenario-wide
     endpoint: picking one stack's port and benchmarking every stack through
     it files stack A's traffic under stack B's name. Refuse instead, unless
     --stack narrows the run to a single nok8s stack (then use that stack's
     port) or the caller passed --endpoint-url.
+
+    For a remote stack the URL names the node, not localhost: this value is
+    what a *client-side* caller would dial, and it is only a fallback -- the
+    harness itself runs on the node and uses the in-host endpoint that step 06
+    recorded in ``deployed_endpoints``.
     """
     stacks = [s for s in all_stacks_info if s.get("nok8s_enabled")]
     if stack_filter:
@@ -365,11 +376,13 @@ def _nok8s_endpoint_url(all_stacks_info, stack_filter=None):
             + " nok8s stacks, each with its own Envoy port, so there is no "
             "single endpoint to benchmark. Run them one at a time with "
             "'--stack <name>', or pass '--endpoint-url "
-            "http://localhost:<that stack's nok8s.envoy.listenPort>'. Stacks: "
+            "http://<node>:<that stack's nok8s.envoy.listenPort>'. Stacks: "
             + ", ".join(f"{s['stack_name']} ({s['nok8s_listen_port']})" for s in stacks)
         )
-    port = (stacks[0] if stacks else {}).get("nok8s_listen_port", 8081)
-    return f"http://localhost:{port}"
+    first = stacks[0] if stacks else {}
+    port = first.get("nok8s_listen_port", 8081)
+    host = first.get("nok8s_client_host") or "localhost"
+    return f"http://{host}:{port}"
 
 
 def _load_plan_info(rendered_paths):
@@ -515,6 +528,7 @@ def _do_standup(args, logger, render_plan_errors):
         logger=logger,
         container_only=container_only,
         container_runtime=plan_info.get("nok8s_runtime", "docker"),
+        container_connection=plan_info.get("nok8s_connection", "localhost"),
         nok8s_deploy_timeout=int(getattr(args, "nok8s_deploy_timeout", 900) or 900),
         standalone_deploy_timeout=int(
             getattr(args, "standalone_deploy_timeout", 900) or 900
@@ -622,6 +636,7 @@ def _do_smoketest(args, logger, render_plan_errors):
         logger=logger,
         container_only=container_only,
         container_runtime=plan_info.get("nok8s_runtime", "docker"),
+        container_connection=plan_info.get("nok8s_connection", "localhost"),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
@@ -821,6 +836,7 @@ def _do_teardown(args, logger, render_plan_errors):
         deployed_methods=deployed_methods,
         container_only=container_only,
         container_runtime=plan_info.get("nok8s_runtime", "docker"),
+        container_connection=plan_info.get("nok8s_connection", "localhost"),
         deep_clean=getattr(args, "deep", False),
         release=getattr(args, "release", "llmdbench"),
         namespace=namespace,
@@ -982,6 +998,7 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         run_config_file=run_config_file,
         container_only=container_only,
         container_runtime=plan_info.get("nok8s_runtime", "docker"),
+        container_connection=plan_info.get("nok8s_connection", "localhost"),
         generate_config_only=getattr(args, "generate_config", False),
         dataset_url=getattr(args, "dataset", None),
         harness_data_access_timeout=int(

--- a/llmdbenchmark/executor/command.py
+++ b/llmdbenchmark/executor/command.py
@@ -139,12 +139,18 @@ class CommandExecutor:
         delay: int = 10,
         check: bool = True,
         force: bool = False,
+        stdin: str = "",
     ) -> CommandResult:
         """Run a shell command with optional retry. Raises ExecutionError if fatal and failed.
 
         When *force* is True the command runs even in dry-run mode.
         Use this for local-only read operations (e.g. ``kubectl config view``)
         whose results are needed to build later commands correctly.
+
+        *stdin* is written to the process's standard input and, unlike the
+        command itself, is **never logged** -- it is the channel for values that
+        must not be persisted (a Hugging Face token forwarded to a remote
+        runtime). It is not replayed on retries other than as given.
         """
         cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
         timestamp = int(time.time() * 1e9)
@@ -155,7 +161,7 @@ class CommandExecutor:
         self._write_log(f"{timestamp}_command.log", f'---> will execute: "{cmd_str}"')
 
         exit_code, stdout, stderr = self._run_with_retries(
-            cmd_str, attempts, silent, delay
+            cmd_str, attempts, silent, delay, stdin
         )
 
         if exit_code != 0 and check:
@@ -177,7 +183,7 @@ class CommandExecutor:
         return CommandResult(command=cmd_str, exit_code=0, dry_run=True)
 
     def _run_with_retries(
-        self, cmd_str: str, attempts: int, silent: bool, delay: int
+        self, cmd_str: str, attempts: int, silent: bool, delay: int, stdin: str = ""
     ) -> tuple[int, str, str]:
         """Execute a command with retry logic, returning (exit_code, stdout, stderr)."""
         exit_code = 1
@@ -185,7 +191,7 @@ class CommandExecutor:
         stderr = ""
 
         for attempt in range(1, attempts + 1):
-            exit_code, stdout, stderr = self._run_once(cmd_str, silent)
+            exit_code, stdout, stderr = self._run_once(cmd_str, silent, stdin)
 
             if exit_code == 0:
                 break
@@ -199,7 +205,9 @@ class CommandExecutor:
 
         return exit_code, stdout, stderr
 
-    def _run_once(self, cmd_str: str, silent: bool) -> tuple[int, str, str]:
+    def _run_once(
+        self, cmd_str: str, silent: bool, stdin: str = ""
+    ) -> tuple[int, str, str]:
         """Run a single command attempt, returning (exit_code, stdout, stderr)."""
         timestamp = int(time.time() * 1e9)
         try:
@@ -210,6 +218,9 @@ class CommandExecutor:
                 text=True,
                 check=False,
                 executable="/bin/bash",
+                # None, not "": an empty string would close stdin on commands
+                # that inherit it today, changing behaviour for every caller.
+                input=stdin or None,
             )
             self._write_log(f"{timestamp}_stdout.log", result.stdout)
             self._write_log(f"{timestamp}_stderr.log", result.stderr)

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -149,6 +149,10 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # True, cluster resolution is skipped and steps talk to docker/podman.
     container_only: bool = False
     container_runtime: str = "docker"
+    # Where that runtime runs: "localhost" (default) or ssh://[user@]host[:port]
+    # [/socket] for a remote node. Steps read the per-stack value from the
+    # rendered launch spec; this is the scenario-wide fallback.
+    container_connection: str = "localhost"
 
     pvc_bind_timeout: int = 240
 

--- a/llmdbenchmark/parser/cli_overrides.py
+++ b/llmdbenchmark/parser/cli_overrides.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import re
 import datetime
+import difflib
 import fnmatch
 from typing import Any
 
@@ -428,6 +429,62 @@ def resolve_segments(values: dict, segments: tuple[str, ...] | list[str]) -> Any
 
 #: Sentinel returned by :func:`resolve_dotted` for an absent path.
 MISSING = _MISSING
+
+
+# How close a misspelling has to be to an existing sibling before we call it a
+# typo. 0.8 flags "conection"/"connection" and "replias"/"replicas" while
+# leaving genuinely new keys ("INFRA_PROVIDER" beside "FOO_BAR") alone; 0.85
+# already misses "connexion".
+_TYPO_CUTOFF = 0.8
+
+
+def find_typo_leaves(
+    overrides: dict,
+    base: dict,
+    prefix: str = "",
+) -> list[tuple[str, str]]:
+    """Find leaf keys that look like a misspelling of an existing sibling.
+
+    Returns ``(path, suggestion)`` pairs. A leaf whose parent map exists but
+    which is itself absent is *usually* legitimate -- free-form blocks such as
+    ``kustomize.guideVariableOverrides`` gain new keys by design, and so does
+    any brand-new top-level key -- so absence alone says nothing and is not
+    reported. What is suspicious is an absent leaf sitting next to a key that
+    is one or two characters away from it: ``nok8s.conection`` beside
+    ``nok8s.connection``. That override silently creates a dead key and leaves
+    the real one at its default, which for something like ``nok8s.connection``
+    means the deployment quietly lands on the wrong machine.
+
+    Matching is case-insensitive so ``sshidentity`` still suggests
+    ``sshIdentity``, and only the *closest* sibling is offered.
+    """
+    typos: list[tuple[str, str]] = []
+    if not isinstance(base, dict):
+        return typos
+
+    for key, value in overrides.items():
+        path = f"{prefix}.{key}" if prefix else key
+        child = base.get(key) if isinstance(base, dict) else None
+
+        if isinstance(value, dict) and value:
+            # An intermediate node: only recurse where the parent really is a
+            # map. A missing or non-map parent is find_broken_parent_paths's
+            # business (unknown / clobbered), not ours.
+            if isinstance(child, dict):
+                typos.extend(find_typo_leaves(value, child, path))
+            continue
+
+        if key in base:
+            continue
+        siblings = [k for k in base if isinstance(k, str)]
+        lowered = {k.lower(): k for k in siblings}
+        match = difflib.get_close_matches(
+            key.lower(), list(lowered), n=1, cutoff=_TYPO_CUTOFF
+        )
+        if match:
+            typos.append((path, lowered[match[0]]))
+
+    return typos
 
 
 def find_broken_parent_paths(

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -22,6 +22,7 @@ from llmdbenchmark.parser.cli_overrides import (
     MISSING,
     REDACTED,
     find_broken_parent_paths,
+    find_typo_leaves,
     is_secret_path,
     leaf_entries,
     resolve_segments,
@@ -30,6 +31,10 @@ from llmdbenchmark.parser.cli_overrides import (
 )
 from llmdbenchmark.parser.config_schema import validate_config
 from llmdbenchmark.parser.render_result import StackErrors, RenderResult
+from llmdbenchmark.utilities.container_host import (
+    ContainerHost,
+    ContainerHostError,
+)
 
 
 class RenderPlans:
@@ -1066,6 +1071,30 @@ class RenderPlans:
 
         return values
 
+    def _resolve_nok8s_connection(self, values: dict, stack_name: str) -> list[str]:
+        """Parse ``nok8s.connection`` and publish the host it resolves to.
+
+        The connection string is authored once but consumed by five steps, so
+        it is parsed here -- at render time, before anything is launched -- and
+        the resolved host is written back as ``nok8s.clientHost`` for the
+        templates. A malformed value (or ``tcp://``) is a render error rather
+        than a traceback in the middle of a standup.
+        """
+        nok8s = values.get("nok8s") or {}
+        if not nok8s.get("enabled"):
+            return []
+        try:
+            host = ContainerHost.parse(
+                nok8s.get("connection"),
+                runtime=str(nok8s.get("runtime") or "docker"),
+                identity=str(nok8s.get("sshIdentity") or ""),
+                ssh_args=nok8s.get("sshArgs") or None,
+            )
+        except ContainerHostError as exc:
+            return [f"[{stack_name}] {exc}"]
+        nok8s["clientHost"] = host.host
+        return []
+
     def _validate_nok8s_host_claims(self, values: dict, stack_name: str) -> list[str]:
         """Reject two nok8s stacks claiming the same container name or host port.
 
@@ -2005,7 +2034,8 @@ class RenderPlans:
         """Validate override paths against the pre-override config.
 
         Warns (non-fatally) when a parent key is absent -- usually a typo,
-        but legitimate for free-form blocks. Returns fatal errors for paths
+        but legitimate for free-form blocks -- and when a leaf key looks like
+        a misspelling of an existing sibling. Returns fatal errors for paths
         that descend into a list or scalar: dotted paths cannot index into a
         list here, so the merge would silently replace the whole value.
         """
@@ -2016,6 +2046,20 @@ class RenderPlans:
                 f"[{stack_name}] override path '{path}' does not exist in "
                 "defaults + scenario -- it will be created as a new block. "
                 "Check for a typo if you meant to change an existing value."
+            )
+
+        # A misspelled leaf passes the check above (its parent exists), so it
+        # merges into a dead key while the real one keeps its default -- silent
+        # unless we say something. Warn-only: new leaves are legitimate on
+        # free-form blocks, so only near-misses of an existing sibling qualify.
+        for path, suggestion in find_typo_leaves(overrides, base_values):
+            parent = path.rsplit(".", 1)[0] if "." in path else ""
+            intended = f"{parent}.{suggestion}" if parent else suggestion
+            self.logger.log_warning(
+                f"[{stack_name}] override path '{path}' does not exist, but "
+                f"'{intended}' does -- did you mean that? As written, "
+                f"'{path}' is created as a new unused key and "
+                f"'{intended}' keeps its current value."
             )
 
         errors: list[str] = []
@@ -2191,6 +2235,10 @@ class RenderPlans:
             stack_name=stack_name,
         )
         for msg in kustomize_errors:
+            self.logger.log_error(msg)
+            stack_errors.render_errors.append(msg)
+
+        for msg in self._resolve_nok8s_connection(merged_values, stack_name):
             self.logger.log_error(msg)
             stack_errors.render_errors.append(msg)
 

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1089,6 +1089,7 @@ class RenderPlans:
                 runtime=str(nok8s.get("runtime") or "docker"),
                 identity=str(nok8s.get("sshIdentity") or ""),
                 ssh_args=nok8s.get("sshArgs") or None,
+                transport=str(nok8s.get("transport") or ""),
             )
         except ContainerHostError as exc:
             return [f"[{stack_name}] {exc}"]

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1071,6 +1071,44 @@ class RenderPlans:
 
         return values
 
+    def _resolve_nok8s_envoy_base_id(self, values: dict) -> dict:
+        """Give each nok8s Envoy its own hot-restart base ID.
+
+        Envoy's hot-restart machinery claims a shared-memory region and an
+        abstract-namespace domain socket named after ``--base-id`` (default
+        0). nok8s runs Envoy with ``--network host``, so that claim is
+        host-wide rather than per-stack: a second Envoy anywhere on the node
+        -- a sibling stack, or a container still up from an earlier run --
+        exits immediately with ``unable to bind domain socket with
+        base_id=0, id=0, errno=98``. It never binds its listener, so the
+        only symptom the CLI sees is a readiness timeout on a port whose
+        vLLM behind it is perfectly healthy.
+
+        Applied to every stack, not just multi-stack scenarios (unlike
+        ``_resolve_nok8s_stack_scope``): the Envoy this one collides with
+        need not belong to the same scenario.
+
+        ``listenPort`` is the seed because ``_validate_nok8s_host_claims``
+        already proves it unique across the host's stacks, so the base IDs
+        inherit that uniqueness instead of becoming a second set of numbers
+        to keep in sync. A value that validator will reject is left alone:
+        it already has its own error, and deriving from it here would only
+        put a plausible number in front of the real complaint.
+        """
+        nok8s = values.get("nok8s") or {}
+        envoy = nok8s.get("envoy")
+        if not nok8s.get("enabled") or not isinstance(envoy, dict):
+            return values
+        if envoy.get("baseId"):
+            # Authored (or already resolved) -- 0 means "unset", as in Envoy.
+            return values
+        port = envoy.get("listenPort")
+        if isinstance(port, str) and port.strip().isdigit():
+            port = int(port.strip())
+        if isinstance(port, int) and not isinstance(port, bool) and 1 <= port <= 65535:
+            envoy["baseId"] = port
+        return values
+
     def _resolve_nok8s_connection(self, values: dict, stack_name: str) -> list[str]:
         """Parse ``nok8s.connection`` and publish the host it resolves to.
 
@@ -2238,6 +2276,10 @@ class RenderPlans:
         for msg in kustomize_errors:
             self.logger.log_error(msg)
             stack_errors.render_errors.append(msg)
+
+        # After _substitute_config_variables: the base ID is seeded from
+        # envoy.listenPort, which a scenario may write as a ${...} variable.
+        merged_values = self._resolve_nok8s_envoy_base_id(merged_values)
 
         for msg in self._resolve_nok8s_connection(merged_values, stack_name):
             self.logger.log_error(msg)

--- a/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
@@ -21,6 +21,7 @@ Reuses DeployHarnessStep's static command/name helpers so the in-container
 harness invocation matches the pod path exactly.
 """
 
+import os
 import time
 from pathlib import Path
 
@@ -70,6 +71,7 @@ class DeployHarnessLocalStep(Step):
                 runtime=runtime,
                 identity=nok8s_cfg.get("sshIdentity") or "",
                 ssh_args=nok8s_cfg.get("sshArgs") or None,
+                transport=nok8s_cfg.get("transport") or "",
             )
         except ContainerHostError as exc:
             return self._fail(stack_path, str(exc))
@@ -201,8 +203,15 @@ class DeployHarnessLocalStep(Step):
                             errors.append(err)
                             continue
 
-                run_cmd = (
-                    f"{host.runtime_cmd('run')} -d --name {name} --network host "
+                # Built as an argument tail and wrapped once at the end: under
+                # ssh transport the command is quoted as a unit, so appending to
+                # an already-wrapped prefix would strand these flags outside the
+                # quotes. The HF token is forwarded the same way as in standup.
+                token_prefix, token_stdin = host.env_forward_stdin(
+                    [hf_token_env], os.environ
+                )
+                run_tail = (
+                    f"run -d --name {name} --network host "
                     # Stage markers are logged in local time, then compared against
                     # `date -u` scrape timestamps when clipping per-stage series.
                     f"-e TZ=UTC "
@@ -228,8 +237,9 @@ class DeployHarnessLocalStep(Step):
                     # setup script runs -- mirrors the k8s pod's command:[sh,-c].
                     f"--entrypoint sh {image} /tmp/harness-entry.sh"
                 )
+                run_cmd = host.wrap_runtime(run_tail, token_prefix)
                 cmd.execute(host.runtime_cmd("rm", "-f", name), check=False)
-                result = cmd.execute(run_cmd, check=False)
+                result = cmd.execute(run_cmd, check=False, stdin=token_stdin)
                 if not result.success and not context.dry_run:
                     errors.append(f"Failed to start harness container {name}")
                 else:

--- a/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness_local.py
@@ -1,10 +1,21 @@
-"""Step 07 (nok8s) -- Run the benchmark harness as a LOCAL container.
+"""Step 07 (nok8s) -- Run the benchmark harness as a container, no cluster.
 
 The default DeployHarnessStep launches the load generator as a Kubernetes Pod.
 For the no-Kubernetes (nok8s) method there is no cluster, so this step runs the
-same harness image as a docker/podman container on the host, pointed at the
-local Envoy endpoint (http://localhost:<listenPort>).  Results are written
-straight to the host results dir via a bind-mount -- no PVC or data-access pod.
+same harness image as a docker/podman container, pointed at the Envoy front
+door.  Results are written straight to a host results dir via a bind-mount --
+no PVC or data-access pod.
+
+The container runs on whichever host ``nok8s.connection`` names, and for a
+remote node it runs **there**, not on the client, because the endpoint it
+measures is ``http://localhost:<listenPort>`` inside that host's network
+namespace (``--network host``).  Driving the load from the client instead would
+add the WAN round-trip to every request and report it as the stack's latency.
+
+Running on the node means the three bind-mounted directories -- profiles, the
+harness scripts, and the results dir -- have to exist there, so they are pushed
+before launch and the results are pulled back after, leaving the caller with
+the same local results tree the local path produces.
 
 Reuses DeployHarnessStep's static command/name helpers so the in-container
 harness invocation matches the pod path exactly.
@@ -13,9 +24,16 @@ harness invocation matches the pod path exactly.
 import time
 from pathlib import Path
 
+import yaml
+
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
+from llmdbenchmark.utilities.container_host import (
+    ContainerHost,
+    ContainerHostError,
+    expand_remote_path,
+)
 
 
 class DeployHarnessLocalStep(Step):
@@ -45,6 +63,16 @@ class DeployHarnessLocalStep(Step):
         cmd = context.require_cmd()
         plan_config = self._load_stack_config(stack_path)
         runtime = context.container_runtime or "docker"
+        nok8s_cfg = plan_config.get("nok8s") or {}
+        try:
+            host = ContainerHost.parse(
+                nok8s_cfg.get("connection") or context.container_connection,
+                runtime=runtime,
+                identity=nok8s_cfg.get("sshIdentity") or "",
+                ssh_args=nok8s_cfg.get("sshArgs") or None,
+            )
+        except ContainerHostError as exc:
+            return self._fail(stack_path, str(exc))
 
         harness_name = self._resolve(
             plan_config,
@@ -55,9 +83,7 @@ class DeployHarnessLocalStep(Step):
         model_name = self._resolve(
             plan_config, "model.name", context_value=context.model_name, default=""
         )
-        endpoint_url = (
-            context.deployed_endpoints.get(stack_name) or context.endpoint_url
-        )
+        endpoint_url = self._resolve_endpoint(context, stack_path, host, stack_name)
         if not endpoint_url:
             return self._fail(stack_path, "No endpoint URL resolved for nok8s run")
 
@@ -93,6 +119,29 @@ class DeployHarnessLocalStep(Step):
         results_dir = context.run_results_dir()
         timeout = context.harness_wait_timeout
 
+        # Bind-mount sources are resolved by the daemon, so for a remote host
+        # the profiles/harnesses/results trees are mirrored under a scratch dir
+        # there and the container mounts *those* paths. `mount_*` is what goes
+        # into the -v flags; the `*_dir` locals stay client-side, which is where
+        # the entry script is written and the results are finally read.
+        mount_harnesses, mount_profiles, mount_results = (
+            harnesses_dir,
+            profiles_dir,
+            results_dir,
+        )
+        remote_root = ""
+        if host.is_remote:
+            remote_root = self._remote_run_dir(cmd, host, context, stack_name)
+            mount_harnesses = Path(remote_root) / "harnesses"
+            mount_profiles = Path(remote_root) / "profiles"
+            mount_results = Path(remote_root) / "results"
+            if not context.dry_run:
+                push_err = self._push_inputs(
+                    cmd, host, harnesses_dir, profiles_dir, remote_root, context
+                )
+                if push_err:
+                    return self._fail(stack_path, push_err, [push_err])
+
         treatments = context.experiment_treatments or [None]
         parallelism = context.harness_parallelism
         errors: list[str] = []
@@ -124,6 +173,7 @@ class DeployHarnessLocalStep(Step):
                 # Write the in-container entry script to disk and mount it, to
                 # avoid shell-quoting issues with the harness command.
                 entry_host = results_dir / f".harness-entry-{name}.sh"
+                mount_entry = mount_results / entry_host.name
                 if not context.dry_run:
                     entry_host.write_text(
                         "#!/bin/sh\n"
@@ -134,9 +184,25 @@ class DeployHarnessLocalStep(Step):
                         f"{harness_command}\n",
                         encoding="utf-8",
                     )
+                    # The entry script is a bind-mount source too, so a remote
+                    # daemon needs its own copy. Pushed per container because
+                    # the command it carries is per container.
+                    if host.is_remote:
+                        push = cmd.execute(
+                            host.push_file(str(entry_host), str(mount_entry)),
+                            check=False,
+                        )
+                        if not push.success:
+                            err = (
+                                f"Failed to stage the harness entry script to "
+                                f"{host.destination}:{mount_entry}: "
+                                f"{(push.stderr or '').strip()[:200]}"
+                            )
+                            errors.append(err)
+                            continue
 
                 run_cmd = (
-                    f"{runtime} run -d --name {name} --network host "
+                    f"{host.runtime_cmd('run')} -d --name {name} --network host "
                     # Stage markers are logged in local time, then compared against
                     # `date -u` scrape timestamps when clipping per-stage series.
                     f"-e TZ=UTC "
@@ -154,15 +220,15 @@ class DeployHarnessLocalStep(Step):
                     # keep it in sync with the profiles bind-mount below.
                     f"-e LLMDBENCH_RUN_WORKSPACE_DIR=/workspace "
                     f"-e {hf_token_env} "
-                    f"-v {results_dir}:/requests "
-                    f"-v {profiles_dir}:/workspace/profiles "
-                    f"-v {harnesses_dir}:/workspace/harnesses:ro "
-                    f"-v {entry_host}:/tmp/harness-entry.sh:ro "
+                    f"-v {mount_results}:/requests "
+                    f"-v {mount_profiles}:/workspace/profiles "
+                    f"-v {mount_harnesses}:/workspace/harnesses:ro "
+                    f"-v {mount_entry}:/tmp/harness-entry.sh:ro "
                     # Override the image ENTRYPOINT (llm-d-benchmark.sh) so our
                     # setup script runs -- mirrors the k8s pod's command:[sh,-c].
                     f"--entrypoint sh {image} /tmp/harness-entry.sh"
                 )
-                cmd.execute(f"{runtime} rm -f {name}", check=False)
+                cmd.execute(host.runtime_cmd("rm", "-f", name), check=False)
                 result = cmd.execute(run_cmd, check=False)
                 if not result.success and not context.dry_run:
                     errors.append(f"Failed to start harness container {name}")
@@ -176,8 +242,10 @@ class DeployHarnessLocalStep(Step):
 
             if not context.dry_run and names:
                 # Block until all containers exit (or the wait times out).
+                # `timeout` bounds the client-side wait; the runtime client is
+                # what blocks, so this stays local even for a remote daemon.
                 cmd.execute(
-                    f"timeout {timeout} {runtime} wait {' '.join(names)}",
+                    f"timeout {timeout} {host.runtime_cmd('wait', *names)}",
                     check=False,
                     force=True,
                 )
@@ -185,10 +253,24 @@ class DeployHarnessLocalStep(Step):
                     # In debug mode the container runs 'sleep infinity', so the
                     # wait always times out -- there is no harness status to read.
                     if not context.harness_debug:
-                        error = self._exit_status_error(cmd, runtime, name, timeout)
+                        error = self._exit_status_error(cmd, host, name, timeout)
                         if error:
                             errors.append(error)
-                    self._capture_and_remove(cmd, runtime, name, results_dir)
+                    self._capture_and_remove(cmd, host, name, results_dir)
+
+                # Bring the results home so the collect/analyze steps and the
+                # caller see the same tree the local path produces.
+                if host.is_remote:
+                    pull = cmd.execute(
+                        host.pull_dir(str(mount_results), str(results_dir)),
+                        check=False,
+                    )
+                    if not pull.success:
+                        errors.append(
+                            f"Failed to fetch results from "
+                            f"{host.destination}:{mount_results}: "
+                            f"{(pull.stderr or '').strip()[:200]}"
+                        )
 
             context.experiment_ids.append(experiment_id)
 
@@ -221,7 +303,109 @@ class DeployHarnessLocalStep(Step):
             return f"{harness_name}-{tname}-{timestamp}-{rand}"
         return f"{harness_name}-{timestamp}-{rand}"
 
-    def _exit_status_error(self, cmd, runtime, name, timeout) -> str | None:
+    @classmethod
+    def _resolve_endpoint(cls, context, stack_path: Path, host, stack_name: str) -> str:
+        """The URL this harness container should benchmark.
+
+        The container runs *on* the daemon host, so for a remote node it must
+        use the in-host ``endpoint`` (``http://localhost:<port>``) rather than
+        the client-side ``clientEndpoint`` (``http://<node>:<port>``); dialling
+        the node's external address from the node itself adds a hop to every
+        request and reports it as the stack's latency.
+
+        Both other sources are client-side by construction: for a ``run`` with
+        no standup in the same process, the CLI defaults ``endpoint_url`` to the
+        client URL, and step 03 copies that straight into
+        ``deployed_endpoints``. So a resolved value equal to the spec's
+        ``clientEndpoint`` is that default and gets swapped for the in-host one.
+        Anything else came from an explicit ``--endpoint-url`` and is left
+        alone, as is every local stack (where the two are identical anyway).
+        """
+        resolved = context.deployed_endpoints.get(stack_name) or context.endpoint_url
+        if not host.is_remote:
+            return resolved
+        spec = cls._read_endpoints(stack_path)
+        in_host, client = spec.get("endpoint", ""), spec.get("clientEndpoint", "")
+        # Both sides normalised: the spec's endpoints and a --endpoint-url may
+        # differ only by a trailing slash, which is the same target.
+        if in_host and (not resolved or (resolved or "").rstrip("/") == client):
+            return in_host
+        return resolved
+
+    @staticmethod
+    def _read_endpoints(stack_path: Path) -> dict:
+        """``endpoint``/``clientEndpoint`` from the rendered launch spec.
+
+        Empty when there is no spec (a hand-rolled plan, or a ``--endpoint-url``
+        run against a stack this workspace never rendered), which leaves the
+        resolved endpoint untouched.
+        """
+        for spec_file in sorted(stack_path.glob("34_nok8s-containers*")):
+            try:
+                spec = yaml.safe_load(spec_file.read_text(encoding="utf-8")) or {}
+            except (OSError, yaml.YAMLError):
+                return {}
+            return {
+                "endpoint": str(spec.get("endpoint") or "").rstrip("/"),
+                "clientEndpoint": str(spec.get("clientEndpoint") or "").rstrip("/"),
+            }
+        return {}
+
+    @staticmethod
+    def _remote_run_dir(cmd, host, context, stack_name: str) -> str:
+        """Scratch dir on the daemon host holding this run's bind-mount trees.
+
+        Keyed by the workspace directory name, which is unique per invocation
+        (``<user>-<timestamp>``), so results are never mixed with an earlier
+        run's -- ``run_results_dir()`` is always literally ``results`` and would
+        have made every run share one remote directory. The tree is left in
+        place after the pull so a failed remote run stays inspectable on the
+        node.
+        """
+        run_id = context.workspace.name or "run"
+        home = ""
+        if not context.dry_run:
+            result = cmd.execute(host.shell("printenv HOME"), check=False, force=True)
+            home = (result.stdout or "").strip()
+        root = expand_remote_path("~/.llmdbench/nok8s-runs", home)
+        return f"{root}/{stack_name}/{run_id}"
+
+    @staticmethod
+    def _push_inputs(  # pylint: disable=too-many-arguments
+        cmd, host, harnesses_dir: Path, profiles_dir: Path, remote_root: str, context
+    ) -> str | None:
+        """Mirror the harness inputs to the daemon host. Error string or None.
+
+        Fatal rather than best-effort: docker turns a missing bind-mount source
+        into an empty directory, so a silent failure here would start a harness
+        with no profile and no scripts, and the run would fail deep inside the
+        container instead of here.
+        """
+        results_remote = f"{remote_root}/results"
+        for local, remote in (
+            (harnesses_dir, f"{remote_root}/harnesses"),
+            (profiles_dir, f"{remote_root}/profiles"),
+        ):
+            result = cmd.execute(host.push_dir(str(local), remote), check=False)
+            if not result.success:
+                return (
+                    f"Failed to stage {local.name} to {host.destination}:{remote}: "
+                    f"{(result.stderr or '').strip()[:300]}"
+                )
+        # The harness writes into /requests, so the mount source has to exist
+        # before the container starts.
+        mk = cmd.execute(host.shell(f"mkdir -p {results_remote}"), check=False)
+        if not mk.success:
+            return (
+                f"Failed to create {host.destination}:{results_remote}: "
+                f"{(mk.stderr or '').strip()[:300]}"
+            )
+        context.logger.log_info(
+            f"Staged harness inputs to {host.destination}:{remote_root}"
+        )
+        return None
+
+    def _exit_status_error(self, cmd, host, name, timeout) -> str | None:
         """Return an error string if harness container *name* did not exit 0.
 
         ``<runtime> wait`` prints the exit code(s) to stdout and exits 0 itself,
@@ -230,8 +414,9 @@ class DeployHarnessLocalStep(Step):
         _capture_and_remove(), which removes the container.
         """
         result = cmd.execute(
-            f"{runtime} inspect "
-            f"-f '{{{{.State.Status}}}} {{{{.State.ExitCode}}}}' {name}",
+            host.runtime_cmd(
+                "inspect", "-f", "'{{.State.Status}} {{.State.ExitCode}}'", name
+            ),
             check=False,
             force=True,
         )
@@ -253,15 +438,21 @@ class DeployHarnessLocalStep(Step):
             )
         return None
 
-    def _capture_and_remove(self, cmd, runtime, name, results_dir: Path) -> None:
-        result = cmd.execute(f"{runtime} logs {name}", check=False, force=True)
+    def _capture_and_remove(self, cmd, host, name, results_dir: Path) -> None:
+        """Save the container's log locally, then remove it.
+
+        The log is written to the *client's* results dir even for a remote run,
+        so a failed remote run is diagnosable without SSHing to the node. It has
+        to be read before the ``rm -f`` below, which destroys it.
+        """
+        result = cmd.execute(host.runtime_cmd("logs", name), check=False, force=True)
         try:
             (results_dir / f"{name}.log").write_text(
                 (result.stdout or "") + (result.stderr or ""), encoding="utf-8"
             )
         except OSError:
             pass
-        cmd.execute(f"{runtime} rm -f {name}", check=False)
+        cmd.execute(host.runtime_cmd("rm", "-f", name), check=False)
 
     def _fail(self, stack_path, message, errors=None) -> StepResult:
         return StepResult(

--- a/llmdbenchmark/smoketests/nok8s.py
+++ b/llmdbenchmark/smoketests/nok8s.py
@@ -46,10 +46,19 @@ def _session() -> requests.Session:
 
 
 def _read_spec(stack_path: Path) -> tuple[str, str, str]:
-    """Return (endpoint, model, error) from the rendered nok8s launch spec."""
+    """Return (endpoint, model, error) from the rendered nok8s launch spec.
+
+    The smoketest runs on the machine invoking llmdbenchmark, so it uses
+    ``clientEndpoint`` -- which names the node for a remote stack and is
+    identical to ``endpoint`` for a local one. ``endpoint`` is the in-host URL
+    and would resolve to the client's own ports here. Older rendered specs have
+    no ``clientEndpoint``, so it falls back to ``endpoint``.
+    """
     for spec_file in sorted(stack_path.glob(f"{_SPEC_PREFIX}*")):
         spec = yaml.safe_load(spec_file.read_text(encoding="utf-8")) or {}
-        endpoint = str(spec.get("endpoint") or "").rstrip("/")
+        endpoint = str(spec.get("clientEndpoint") or spec.get("endpoint") or "").rstrip(
+            "/"
+        )
         model = str(spec.get("model") or "")
         if not endpoint or not model:
             return "", "", f"{spec_file} is missing 'endpoint' and/or 'model'"

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -23,6 +23,93 @@ from llmdbenchmark.utilities.container_host import (
 # lsof covers macOS and hosts without iproute2.
 PORT_PROBES = ("ss -ltn", "lsof -nP -iTCP -sTCP:LISTEN")
 
+# Signatures of a runtime client being refused by the node's sshd. Worth
+# recognising because the generic "check your ssh" advice is actively wrong for
+# them: podman's Go SSH client does not read ~/.ssh/id_rsa the way OpenSSH does,
+# so `ssh <dest> true` can succeed while every container command fails.
+_SSH_AUTH_SIGNATURES = (
+    "unable to authenticate",
+    "handshake failed",
+    "no supported methods remain",
+    "permission denied",
+)
+
+
+# ssh exits 255 for its own failures (refused, timed out, auth rejected) and
+# passes the remote command's status through otherwise. A probe that comes back
+# 255 therefore says nothing about the node, so it must not be read as "the tool
+# is missing there".
+SSH_FAILURE_EXIT = 255
+
+
+def _client_flavor(cmd, runtime: str) -> str:
+    """Which implementation the *runtime* binary really is: podman, docker, "".
+
+    ``docker`` is often a podman shim (the ``podman-docker`` package, or an
+    alias), and podman accepts docker's ``-H`` as a synonym for ``--url`` -- so
+    a mismatched pair does not fail on the flag, it fails much later with
+    podman's error text under a docker-shaped socket path. The two clients also
+    authenticate differently, so a connection failure has to name the client
+    that actually produced it rather than the one that was configured.
+    """
+    result = cmd.execute(f"{runtime} --version", check=False, force=True, silent=True)
+    text = f"{result.stdout or ''} {result.stderr or ''}".lower()
+    if "podman" in text:
+        return "podman"
+    if "docker" in text:
+        return "docker"
+    return ""
+
+
+def _daemon_hints(runtime: str, flavor: str, identity: str, stderr: str) -> str:
+    """Guidance for a daemon that would not answer, tailored to the client.
+
+    The generic advice ("check that ssh works") is misleading in the two cases
+    this untangles: the client is not the one configured, and the client is
+    podman refusing to authenticate even though ssh itself is fine.
+    """
+    hints: list[str] = []
+    lowered = (stderr or "").lower()
+    if flavor and flavor != runtime:
+        hints.append(
+            f"the '{runtime}' on PATH is actually {flavor} (it accepts docker's "
+            f"-H, so the mismatch surfaces here rather than as a bad flag) -- "
+            f"set nok8s.runtime={flavor} to match the client and its socket path"
+        )
+    if any(sig in lowered for sig in _SSH_AUTH_SIGNATURES):
+        if "podman" in (flavor, runtime):
+            if identity:
+                # A key was supplied and still refused, so the fix is on the
+                # node, not in the configuration.
+                hints.append(
+                    "podman does its own SSH auth, so a working 'ssh' says "
+                    "nothing about it: the key in nok8s.sshIdentity was offered "
+                    "and refused -- check it is in the node's authorized_keys "
+                    "for that user"
+                )
+            else:
+                hints.append(
+                    "podman does its own SSH auth and, unlike ssh, never falls "
+                    "back to ~/.ssh/id_rsa -- with no key from "
+                    "nok8s.sshIdentity, CONTAINER_SSHKEY, ssh-agent, or 'podman "
+                    "system connection add' it offers none at all (hence "
+                    "'attempted methods [none]'), so a working 'ssh' proves "
+                    "nothing. Pass nok8s.sshIdentity=<path-to-private-key>"
+                )
+        else:
+            hints.append(
+                "docker shells out to your system ssh, so the key must be in the "
+                "agent ('ssh-add <key>') or IdentityFile in ~/.ssh/config -- "
+                "nok8s.sshIdentity does not reach the docker client"
+            )
+    if not hints:
+        hints.append(
+            f"check that '{runtime}' is running on the node and that the SSH user "
+            f"may use it (docker group, or rootless podman with "
+            f"'systemctl --user enable --now podman.socket')"
+        )
+    return "; ".join(hints) + "."
+
 
 def _as_port(value, default: int) -> int | None:
     """Coerce a configured nok8s port to an int, or None if it isn't one.
@@ -219,6 +306,10 @@ class EnsureInfraStep(Step):
         cmd = context.require_cmd()
         errors: list[str] = []
         warnings: list[str] = []
+        # Set when the runtime could not reach a remote daemon: every probe
+        # below travels the same SSH connection, so continuing would turn one
+        # connection failure into a list of bogus "not found on the node" errors.
+        remote_unreachable = False
 
         # 1. Container runtime present and usable (fatal). The *client* binary
         #    must exist locally even for a remote stack -- it is what carries the
@@ -236,13 +327,19 @@ class EnsureInfraStep(Step):
                 host.runtime_cmd("info"), check=False, force=True, silent=True
             )
             if not info.success and host.is_remote:
+                stderr = (info.stderr or "").strip()
+                flavor = _client_flavor(cmd, runtime)
                 errors.append(
                     f"Cannot reach the '{runtime}' daemon at {host.url}: "
-                    f"{(info.stderr or '').strip()[:300]}. Check that "
-                    f"'ssh {host.destination} true' succeeds without a prompt "
-                    f"(key-based auth, key in the agent or nok8s.sshIdentity, host "
-                    f"key already known) and that '{runtime}' is running there."
+                    f"{stderr[:300]}. Check that 'ssh {host.destination} true' "
+                    f"succeeds without a prompt (key-based auth, host key already "
+                    f"known); if it does, the client is at fault, not ssh: "
+                    + _daemon_hints(runtime, flavor, host.identity, stderr)
                 )
+                # The connection is what failed, so the per-tool probes below
+                # would each report the node's tools as missing. Skip them and
+                # let this one error stand.
+                remote_unreachable = True
             elif not info.success:
                 errors.append(
                     f"'{runtime}' is installed but not usable (daemon down or "
@@ -257,9 +354,24 @@ class EnsureInfraStep(Step):
         #     06 and `timeout` bounds the harness container, which also runs
         #     there. For a remote stack `ssh` is needed on the client instead.
         for tool in ("timeout", "curl"):
-            if not cmd.execute(
+            if remote_unreachable:
+                break
+            probe = cmd.execute(
                 host.shell(f"command -v {tool}"), check=False, force=True, silent=True
-            ).success:
+            )
+            if host.is_remote and probe.exit_code == SSH_FAILURE_EXIT:
+                # ssh could not run anything, so the node's PATH is unknown.
+                # Report the connection once instead of every tool.
+                errors.append(
+                    f"Cannot run commands on {host.destination}: "
+                    f"{(probe.stderr or '').strip()[:200] or 'ssh exited 255'}. "
+                    f"The node's tools, accelerator and ports were not checked. "
+                    f"Verify 'ssh {host.destination} true' succeeds without a "
+                    f"prompt."
+                )
+                remote_unreachable = True
+                break
+            if not probe.success:
                 where = f" on {host.destination}" if host.is_remote else ""
                 errors.append(
                     f"'{tool}' not found on PATH{where}; the nok8s path needs it "
@@ -283,7 +395,11 @@ class EnsureInfraStep(Step):
             "intel": "xpu-smi discovery",
             "gaudi": "hl-smi -L",
         }.get(accelerator)
-        if probe:
+        if probe and remote_unreachable:
+            context.logger.log_info(
+                "    skipping accelerator probe: the node was unreachable."
+            )
+        elif probe:
             if not cmd.execute(
                 host.shell(probe), check=False, force=True, silent=True
             ).success:
@@ -307,7 +423,7 @@ class EnsureInfraStep(Step):
             * _as_count(cfg.get("vllm", {}).get("tensorParallel", 1))
             for cfg in stacks
         )
-        if accelerator == "nvidia" and needed > 1:
+        if accelerator == "nvidia" and needed > 1 and not remote_unreachable:
             res_gpu = cmd.execute(
                 host.shell("nvidia-smi -L"), check=False, force=True, silent=True
             )
@@ -367,7 +483,9 @@ class EnsureInfraStep(Step):
             ),
             None,
         )
-        if probe_cmd is None:
+        if remote_unreachable:
+            pass  # Already reported; the ports on an unreachable node are moot.
+        elif probe_cmd is None:
             warnings.append(
                 f"Cannot verify host ports {ports}: none of "
                 f"{', '.join(p.split()[0] for p in PORT_PROBES)} found on PATH"

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -14,6 +14,10 @@ from llmdbenchmark.executor.deps import (
     MIN_HELMFILE_VERSION,
 )
 from llmdbenchmark.utilities.cluster import print_phase_banner
+from llmdbenchmark.utilities.container_host import (
+    ContainerHost,
+    ContainerHostError,
+)
 
 # Listening-socket probes, first one available wins. ss is iproute2 (Linux);
 # lsof covers macOS and hosts without iproute2.
@@ -167,6 +171,26 @@ class EnsureInfraStep(Step):
         nok8s = plan_config.get("nok8s", {})
         accelerator = str(nok8s.get("vllm", {}).get("accelerator", "nvidia")).lower()
         hf_env = nok8s.get("hfTokenEnv", "HUGGING_FACE_HUB_TOKEN")
+        # The accelerator, the ports and the host tools all have to be present on
+        # the machine that will run the containers, so every probe below is
+        # wrapped in host.shell(). For a local stack that wrapper is the
+        # identity function and the checks are exactly what they were.
+        try:
+            host = ContainerHost.parse(
+                nok8s.get("connection") or context.container_connection,
+                runtime=runtime,
+                identity=nok8s.get("sshIdentity") or "",
+                ssh_args=nok8s.get("sshArgs") or None,
+            )
+        except ContainerHostError as exc:
+            context.logger.log_error(f"    {exc}")
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="nok8s infrastructure checks failed",
+                errors=[str(exc)],
+            )
         # Every nok8s stack in the plan lands on this host, so the port and
         # GPU checks cover all of them, not just the first.
         stacks = [
@@ -182,7 +206,8 @@ class EnsureInfraStep(Step):
         if context.dry_run:
             context.logger.log_info(
                 f"[dry-run] nok8s preflight: would verify '{runtime}' runtime, "
-                f"'{accelerator}' accelerator, free ports {ports}, and ${hf_env}."
+                f"'{accelerator}' accelerator, free ports {ports}, and ${hf_env} "
+                f"on {host.destination}."
             )
             return StepResult(
                 step_number=self.number,
@@ -195,34 +220,60 @@ class EnsureInfraStep(Step):
         errors: list[str] = []
         warnings: list[str] = []
 
-        # 1. Container runtime present and usable (fatal).
+        # 1. Container runtime present and usable (fatal). The *client* binary
+        #    must exist locally even for a remote stack -- it is what carries the
+        #    SSH transport -- but `info` is answered by the daemon, so a single
+        #    call also proves the connection works end to end.
         if not cmd.execute(
             f"command -v {runtime}", check=False, force=True, silent=True
         ).success:
             errors.append(
-                f"Container runtime '{runtime}' not found on PATH. Install docker "
-                f"or podman (or set nok8s.runtime to the one you have)."
+                f"Container runtime client '{runtime}' not found on PATH. Install "
+                f"docker or podman (or set nok8s.runtime to the one you have)."
             )
-        elif not cmd.execute(
-            f"{runtime} info", check=False, force=True, silent=True
-        ).success:
-            errors.append(
-                f"'{runtime}' is installed but not usable (daemon down or "
-                f"permissions). Verify with '{runtime} info'."
+        else:
+            info = cmd.execute(
+                host.runtime_cmd("info"), check=False, force=True, silent=True
             )
+            if not info.success and host.is_remote:
+                errors.append(
+                    f"Cannot reach the '{runtime}' daemon at {host.url}: "
+                    f"{(info.stderr or '').strip()[:300]}. Check that "
+                    f"'ssh {host.destination} true' succeeds without a prompt "
+                    f"(key-based auth, key in the agent or nok8s.sshIdentity, host "
+                    f"key already known) and that '{runtime}' is running there."
+                )
+            elif not info.success:
+                errors.append(
+                    f"'{runtime}' is installed but not usable (daemon down or "
+                    f"permissions). Verify with '{runtime} info'."
+                )
 
         # 1b. Host tools the nok8s path shells out to (fatal). The k8s
         #     toolchain check does not run for nok8s, so these would otherwise
         #     go unchecked: 'timeout' bounds the harness wait in step 07 and
         #     'curl' probes endpoint readiness in step 06.
+        #     Both run on the daemon host: `curl` probes readiness there in step
+        #     06 and `timeout` bounds the harness container, which also runs
+        #     there. For a remote stack `ssh` is needed on the client instead.
         for tool in ("timeout", "curl"):
             if not cmd.execute(
-                f"command -v {tool}", check=False, force=True, silent=True
+                host.shell(f"command -v {tool}"), check=False, force=True, silent=True
             ).success:
+                where = f" on {host.destination}" if host.is_remote else ""
                 errors.append(
-                    f"'{tool}' not found on PATH; the nok8s path needs it "
+                    f"'{tool}' not found on PATH{where}; the nok8s path needs it "
                     f"(install GNU coreutils and curl)."
                 )
+        if host.is_remote:
+            for tool in ("ssh", "scp"):
+                if not cmd.execute(
+                    f"command -v {tool}", check=False, force=True, silent=True
+                ).success:
+                    errors.append(
+                        f"'{tool}' not found on PATH; a remote nok8s connection "
+                        f"needs it to stage configs and probe the node."
+                    )
 
         # 2. Accelerator visible on the host (warning). Probe depends on the
         #    configured accelerator; cpu/spyre/custom are not probed here.
@@ -233,12 +284,15 @@ class EnsureInfraStep(Step):
             "gaudi": "hl-smi -L",
         }.get(accelerator)
         if probe:
-            if not cmd.execute(probe, check=False, force=True, silent=True).success:
+            if not cmd.execute(
+                host.shell(probe), check=False, force=True, silent=True
+            ).success:
                 tool = probe.split()[0]
+                where = f" on {host.destination}" if host.is_remote else ""
                 warnings.append(
-                    f"'{tool}' found no {accelerator} accelerator; vLLM needs the "
-                    f"device + driver present, the matching vLLM image, and the "
-                    f"container toolkit configured for '{runtime}'."
+                    f"'{tool}' found no {accelerator} accelerator{where}; vLLM "
+                    f"needs the device + driver present, the matching vLLM image, "
+                    f"and the container toolkit configured for '{runtime}'."
                 )
         else:
             context.logger.log_info(
@@ -254,7 +308,9 @@ class EnsureInfraStep(Step):
             for cfg in stacks
         )
         if accelerator == "nvidia" and needed > 1:
-            res_gpu = cmd.execute("nvidia-smi -L", check=False, force=True, silent=True)
+            res_gpu = cmd.execute(
+                host.shell("nvidia-smi -L"), check=False, force=True, silent=True
+            )
             if res_gpu.success and res_gpu.stdout:
                 count = sum(
                     1 for ln in res_gpu.stdout.splitlines() if ln.startswith("GPU ")
@@ -303,7 +359,10 @@ class EnsureInfraStep(Step):
                 p
                 for p in PORT_PROBES
                 if cmd.execute(
-                    f"command -v {p.split()[0]}", check=False, force=True, silent=True
+                    host.shell(f"command -v {p.split()[0]}"),
+                    check=False,
+                    force=True,
+                    silent=True,
                 ).success
             ),
             None,
@@ -311,11 +370,14 @@ class EnsureInfraStep(Step):
         if probe_cmd is None:
             warnings.append(
                 f"Cannot verify host ports {ports}: none of "
-                f"{', '.join(p.split()[0] for p in PORT_PROBES)} found on PATH. "
-                f"Install iproute2 or lsof, or check the ports yourself."
+                f"{', '.join(p.split()[0] for p in PORT_PROBES)} found on PATH"
+                + (f" on {host.destination}" if host.is_remote else "")
+                + ". Install iproute2 or lsof, or check the ports yourself."
             )
         else:
-            res = cmd.execute(probe_cmd, check=False, force=True, silent=True)
+            res = cmd.execute(
+                host.shell(probe_cmd), check=False, force=True, silent=True
+            )
             busy = [p for p in ports if f":{p} " in (res.stdout or "")]
             if busy:
                 warnings.append(
@@ -336,12 +398,12 @@ class EnsureInfraStep(Step):
                 errors=errors,
             )
 
-        context.logger.log_info(f"nok8s preflight passed (runtime={runtime}).")
+        context.logger.log_info(f"nok8s preflight passed ({host.describe()}).")
         return StepResult(
             step_number=self.number,
             step_name=self.name,
             success=True,
-            message=f"nok8s infrastructure ready (runtime={runtime})",
+            message=f"nok8s infrastructure ready ({host.describe()})",
         )
 
     # Config path -> whether the value is the base of `vllm.replicas`

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -15,6 +15,8 @@ from llmdbenchmark.executor.deps import (
 )
 from llmdbenchmark.utilities.cluster import print_phase_banner
 from llmdbenchmark.utilities.container_host import (
+    NATIVE,
+    SSH,
     ContainerHost,
     ContainerHostError,
 )
@@ -34,6 +36,40 @@ _SSH_AUTH_SIGNATURES = (
     "permission denied",
 )
 
+# Which client wrote the failure. This is more reliable than asking the binary
+# its version, because `docker` is frequently a shim for podman (the
+# podman-docker package, an alias, a DOCKER_HOST pointing at podman's socket)
+# and podman accepts docker's -H as a synonym for --url, so the substitution is
+# invisible until something fails. The wording, though, is not transferable:
+# podman dials SSH in-process with Go's x/crypto/ssh and surfaces its handshake
+# text, while docker's CLI execs the system `ssh` binary and can only report
+# that process's exit status. So whichever family the text belongs to is the
+# client that really ran, whatever nok8s.runtime says.
+_GO_SSH_SIGNATURES = (
+    "handshake failed",
+    "attempted methods",
+    "no supported methods remain",
+    "unable to connect to podman socket",
+)
+_DOCKER_SHELLOUT_SIGNATURES = (
+    "has exited with exit status",
+    "docker system dial-stdio",
+    "error during connect",
+)
+
+# Why the text is attributable, quoted back at the user so the claim that their
+# 'docker' is really podman comes with its evidence rather than as an assertion.
+_WHO_SPEAKS = {
+    "podman": (
+        "podman dials SSH itself and reports Go's handshake wording, whereas "
+        "docker execs the ssh binary and could only report its exit status"
+    ),
+    "docker": (
+        "docker execs the ssh binary and reports its exit status, whereas "
+        "podman dials SSH itself and would report Go's handshake wording"
+    ),
+}
+
 
 # ssh exits 255 for its own failures (refused, timed out, auth rejected) and
 # passes the remote command's status through otherwise. A probe that comes back
@@ -42,15 +78,28 @@ _SSH_AUTH_SIGNATURES = (
 SSH_FAILURE_EXIT = 255
 
 
-def _client_flavor(cmd, runtime: str) -> str:
-    """Which implementation the *runtime* binary really is: podman, docker, "".
+def _speaker_of(stderr: str) -> str:
+    """Which client family wrote *stderr*: ``podman``, ``docker`` or ``""``.
 
-    ``docker`` is often a podman shim (the ``podman-docker`` package, or an
-    alias), and podman accepts docker's ``-H`` as a synonym for ``--url`` -- so
-    a mismatched pair does not fail on the flag, it fails much later with
-    podman's error text under a docker-shaped socket path. The two clients also
-    authenticate differently, so a connection failure has to name the client
-    that actually produced it rather than the one that was configured.
+    See ``_GO_SSH_SIGNATURES``: the two clients cannot produce each other's
+    SSH-failure wording, so their own text identifies them even when the binary
+    that was invoked claims otherwise.
+    """
+    lowered = (stderr or "").lower()
+    if any(sig in lowered for sig in _GO_SSH_SIGNATURES):
+        return "podman"
+    if any(sig in lowered for sig in _DOCKER_SHELLOUT_SIGNATURES):
+        return "docker"
+    return ""
+
+
+def _version_flavor(cmd, runtime: str) -> str:
+    """What the *runtime* binary says it is: ``podman``, ``docker`` or ``""``.
+
+    Empty when the probe cannot run or prints something unrecognised -- e.g. a
+    wrapper script, or a client whose version goes to a pager. That is why this
+    is only ever corroborating evidence for :func:`_speaker_of`, never the
+    deciding one.
     """
     result = cmd.execute(f"{runtime} --version", check=False, force=True, silent=True)
     text = f"{result.stdout or ''} {result.stderr or ''}".lower()
@@ -61,23 +110,59 @@ def _client_flavor(cmd, runtime: str) -> str:
     return ""
 
 
-def _daemon_hints(runtime: str, flavor: str, identity: str, stderr: str) -> str:
+def _client_flavor(cmd, runtime: str, stderr: str = "") -> tuple[str, str]:
+    """The client that actually ran, and how that was established.
+
+    Returns ``(flavor, evidence)``. *evidence* is ``"error"`` when the failure
+    text gave it away, ``"version"`` when only ``--version`` did, and ``""``
+    when neither could -- in which case *flavor* is empty and the caller must
+    not make a claim about which client is on the PATH.
+
+    The error text wins when the two disagree. It was written by the process
+    that failed; ``--version`` only describes whichever binary the shell
+    resolved, which is exactly what a podman shim installed as ``docker``
+    misrepresents.
+    """
+    spoke = _speaker_of(stderr)
+    reported = _version_flavor(cmd, runtime)
+    if spoke:
+        return spoke, "error"
+    if reported:
+        return reported, "version"
+    return "", ""
+
+
+def _daemon_hints(  # pylint: disable=too-many-arguments
+    runtime: str, flavor: str, evidence: str, identity: str, stderr: str
+) -> str:
     """Guidance for a daemon that would not answer, tailored to the client.
 
     The generic advice ("check that ssh works") is misleading in the two cases
     this untangles: the client is not the one configured, and the client is
     podman refusing to authenticate even though ssh itself is fine.
+
+    *flavor* is what actually ran and *evidence* how that was determined, both
+    from :func:`_client_flavor`. Advice is keyed on *flavor*, not on *runtime*,
+    because a podman shim installed as ``docker`` needs podman's advice -- the
+    earlier version keyed on ``runtime`` and so handed the user docker's advice
+    alongside podman's own error text.
     """
     hints: list[str] = []
     lowered = (stderr or "").lower()
     if flavor and flavor != runtime:
+        because = (
+            f" -- {_WHO_SPEAKS[flavor]}"
+            if evidence == "error" and flavor in _WHO_SPEAKS
+            else ""
+        )
         hints.append(
-            f"the '{runtime}' on PATH is actually {flavor} (it accepts docker's "
-            f"-H, so the mismatch surfaces here rather than as a bad flag) -- "
-            f"set nok8s.runtime={flavor} to match the client and its socket path"
+            f"the '{runtime}' on PATH is actually {flavor}{because}. It accepts "
+            f"docker's -H as a synonym for --url, so the mismatch surfaces here "
+            f"rather than as a bad flag -- set nok8s.runtime={flavor} to match "
+            f"the client and its socket path"
         )
     if any(sig in lowered for sig in _SSH_AUTH_SIGNATURES):
-        if "podman" in (flavor, runtime):
+        if flavor == "podman" or (not flavor and runtime == "podman"):
             if identity:
                 # A key was supplied and still refused, so the fix is on the
                 # node, not in the configuration.
@@ -96,11 +181,20 @@ def _daemon_hints(runtime: str, flavor: str, identity: str, stderr: str) -> str:
                     "'attempted methods [none]'), so a working 'ssh' proves "
                     "nothing. Pass nok8s.sshIdentity=<path-to-private-key>"
                 )
-        else:
+        elif flavor == "docker" or runtime == "docker":
             hints.append(
                 "docker shells out to your system ssh, so the key must be in the "
                 "agent ('ssh-add <key>') or IdentityFile in ~/.ssh/config -- "
                 "nok8s.sshIdentity does not reach the docker client"
+            )
+        else:
+            # Neither the error text nor --version identified the client, so
+            # naming one would be a guess; give the advice for both.
+            hints.append(
+                f"'{runtime}' could not be identified as docker or podman, and "
+                f"they authenticate differently: podman needs a key it can see "
+                f"(nok8s.sshIdentity=<path>), docker needs one your system ssh "
+                f"can see ('ssh-add <key>')"
             )
     if not hints:
         hints.append(
@@ -268,6 +362,7 @@ class EnsureInfraStep(Step):
                 runtime=runtime,
                 identity=nok8s.get("sshIdentity") or "",
                 ssh_args=nok8s.get("sshArgs") or None,
+                transport=nok8s.get("transport") or "",
             )
         except ContainerHostError as exc:
             context.logger.log_error(f"    {exc}")
@@ -311,30 +406,69 @@ class EnsureInfraStep(Step):
         # connection failure into a list of bogus "not found on the node" errors.
         remote_unreachable = False
 
-        # 1. Container runtime present and usable (fatal). The *client* binary
-        #    must exist locally even for a remote stack -- it is what carries the
-        #    SSH transport -- but `info` is answered by the daemon, so a single
-        #    call also proves the connection works end to end.
-        if not cmd.execute(
-            f"command -v {runtime}", check=False, force=True, silent=True
-        ).success:
+        # 1. Container runtime present and usable (fatal). Where the *client*
+        #    has to be depends on the transport: the native transport carries the
+        #    connection in a local client binary, while ssh transport invokes the
+        #    runtime on the node, so nothing is required here but `ssh`. Either
+        #    way `info` is answered by the daemon, so the call also proves the
+        #    connection works end to end.
+        if (
+            host.needs_local_runtime
+            and not cmd.execute(
+                f"command -v {runtime}", check=False, force=True, silent=True
+            ).success
+        ):
             errors.append(
                 f"Container runtime client '{runtime}' not found on PATH. Install "
                 f"docker or podman (or set nok8s.runtime to the one you have)."
+                + (
+                    f" This is only needed because nok8s.transport is "
+                    f"'{NATIVE}'; the default '{SSH}' transport runs "
+                    f"'{runtime}' on the node instead and needs no local client."
+                    if host.is_remote
+                    else ""
+                )
             )
         else:
             info = cmd.execute(
                 host.runtime_cmd("info"), check=False, force=True, silent=True
             )
-            if not info.success and host.is_remote:
+            if not info.success and host.uses_ssh:
+                # Under ssh transport there is no local client to misidentify:
+                # the command ran (or failed to run) on the node. ssh's own 255
+                # separates the two halves cleanly -- a connection that never
+                # opened, versus a runtime the SSH user cannot drive -- so the
+                # client-flavour diagnosis below does not apply here, and naming
+                # a socket path would be doubly misleading since none is used.
                 stderr = (info.stderr or "").strip()
-                flavor = _client_flavor(cmd, runtime)
+                if info.exit_code == SSH_FAILURE_EXIT:
+                    errors.append(
+                        f"Cannot reach {host.destination} over ssh: "
+                        f"{stderr[:300]}. Check that 'ssh {host.destination} true' "
+                        f"succeeds without a prompt -- key-based auth (passwords "
+                        f"are not supported), the host key already in "
+                        f"known_hosts, and a key ssh can see (ssh-agent, "
+                        f"~/.ssh/config, or nok8s.sshIdentity)."
+                    )
+                else:
+                    errors.append(
+                        f"Reached {host.destination}, but '{runtime}' there did "
+                        f"not answer: {stderr[:300]}. Verify with 'ssh "
+                        f"{host.destination} {runtime} info'. Usually the daemon "
+                        f"is down, or the SSH user cannot use it -- add them to "
+                        f"the 'docker' group, or for rootless podman run "
+                        f"'systemctl --user enable --now podman.socket'."
+                    )
+                remote_unreachable = True
+            elif not info.success and host.is_remote:
+                stderr = (info.stderr or "").strip()
+                flavor, evidence = _client_flavor(cmd, runtime, stderr)
                 errors.append(
                     f"Cannot reach the '{runtime}' daemon at {host.url}: "
                     f"{stderr[:300]}. Check that 'ssh {host.destination} true' "
                     f"succeeds without a prompt (key-based auth, host key already "
                     f"known); if it does, the client is at fault, not ssh: "
-                    + _daemon_hints(runtime, flavor, host.identity, stderr)
+                    + _daemon_hints(runtime, flavor, evidence, host.identity, stderr)
                 )
                 # The connection is what failed, so the per-tool probes below
                 # would each report the node's tools as missing. Skip them and
@@ -347,19 +481,24 @@ class EnsureInfraStep(Step):
                 )
 
         # 1b. Host tools the nok8s path shells out to (fatal). The k8s
-        #     toolchain check does not run for nok8s, so these would otherwise
-        #     go unchecked: 'timeout' bounds the harness wait in step 07 and
-        #     'curl' probes endpoint readiness in step 06.
-        #     Both run on the daemon host: `curl` probes readiness there in step
-        #     06 and `timeout` bounds the harness container, which also runs
-        #     there. For a remote stack `ssh` is needed on the client instead.
-        for tool in ("timeout", "curl"):
-            if remote_unreachable:
+        #     toolchain check does not run for nok8s, so these would otherwise go
+        #     unchecked -- but each has to be checked where it actually runs:
+        #
+        #     * `curl` probes endpoint readiness *on the node* (step 06), so it
+        #       is looked for there.
+        #     * `timeout` bounds the harness wait in step 07 by wrapping the
+        #       command the *client* runs -- `ssh ...` or the local client
+        #       binary -- so it is needed here, not on the node. Probing it
+        #       remotely (as this did) passed on a node that had it while the
+        #       client did not, and the wait then ran unbounded.
+        for tool, on_node in (("timeout", False), ("curl", True)):
+            if remote_unreachable and on_node:
                 break
-            probe = cmd.execute(
-                host.shell(f"command -v {tool}"), check=False, force=True, silent=True
+            probe_target = (
+                host.shell(f"command -v {tool}") if on_node else (f"command -v {tool}")
             )
-            if host.is_remote and probe.exit_code == SSH_FAILURE_EXIT:
+            probe = cmd.execute(probe_target, check=False, force=True, silent=True)
+            if on_node and host.is_remote and probe.exit_code == SSH_FAILURE_EXIT:
                 # ssh could not run anything, so the node's PATH is unknown.
                 # Report the connection once instead of every tool.
                 errors.append(
@@ -372,7 +511,7 @@ class EnsureInfraStep(Step):
                 remote_unreachable = True
                 break
             if not probe.success:
-                where = f" on {host.destination}" if host.is_remote else ""
+                where = f" on {host.destination}" if on_node and host.is_remote else ""
                 errors.append(
                     f"'{tool}' not found on PATH{where}; the nok8s path needs it "
                     f"(install GNU coreutils and curl)."

--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -345,10 +345,19 @@ class NoK8sDeployStep(Step):
             )
         if kind == "envoy":
             mount_path = c.get("configMountPath", "/etc/envoy/envoy.yaml")
+            # Envoy's hot-restart shared memory and domain socket are named
+            # after the base ID, and --network host makes that name host-wide:
+            # with the default 0, a second Envoy on the node exits with
+            # errno=98 before it ever binds its listener. The renderer seeds a
+            # per-stack ID from listenPort; a plan rendered before it did omits
+            # the key, and 0 there means "leave it to Envoy" as it always did.
+            base_id = c.get("baseId")
+            base = f"--base-id {base_id} " if base_id else ""
             return (
                 host.wrap_runtime(
                     f"{run} -d --name {c['name']} --network host "
                     f"-v {workspace / 'envoy.yaml'}:{mount_path}:ro {image} "
+                    f"{base}"
                     f"--service-node envoy-proxy --log-level warn --concurrency 8 "
                     f"--drain-strategy immediate --drain-time-s 60 -c {mount_path}"
                 ),

--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -133,10 +133,10 @@ class NoK8sDeployStep(Step):
             name = c["name"]
             # Idempotency: remove any prior container with this name.
             cmd.execute(host.runtime_cmd("rm", "-f", name), check=False)
-            run_cmd = self._build_run_command(
+            run_cmd, run_stdin = self._build_run_command(
                 c, runtime, workspace, epp_dir, hf_cache, hf_token_env, model, host
             )
-            result = cmd.execute(run_cmd, check=False)
+            result = cmd.execute(run_cmd, check=False, stdin=run_stdin)
             if not result.success and not context.dry_run:
                 # The stack is unusable without every container, so stop at the
                 # first failure instead of launching the rest, and remove what
@@ -186,6 +186,7 @@ class NoK8sDeployStep(Step):
             runtime=runtime,
             identity=spec.get("sshIdentity") or "",
             ssh_args=spec.get("sshArgs") or None,
+            transport=spec.get("transport") or "",
         )
 
     def _daemon_home(
@@ -284,29 +285,39 @@ class NoK8sDeployStep(Step):
         hf_token_env: str,
         model: str,
         host: ContainerHost,
-    ) -> str:
+        environ=None,
+    ) -> tuple[str, str]:
         """Build the docker/podman run command for one container from its spec.
 
+        Returns ``(command, stdin)``; *stdin* carries the Hugging Face token for
+        a remote runtime and is empty otherwise (see :meth:`_token_forward`).
+
         Every path in a ``-v`` flag and every port in a ``-p`` flag is resolved
-        by the daemon, so on a remote host they already refer to that node --
-        the only client-side addition is the connection flag from *host*.
+        by the daemon, so on a remote host they already refer to that node.
+
+        The argument tail is assembled first and handed to ``wrap_runtime`` at
+        the end: under ssh transport the command is quoted as one unit, so
+        appending to an already-wrapped prefix would leave these flags outside
+        the quotes, where the *client's* shell would eat them.
         """
         kind = c["kind"]
         image = c["image"]
-        run = host.runtime_cmd("run")
+        run = "run"
         if kind == "vllm":
             device = self._device_args(runtime, c)
             pin = self._pin_env(c)
             extra = " ".join(c.get("extraArgs") or [])
-            return (
+            # `-e VAR` with no value is expanded by whoever runs the CLI: the
+            # local client under the native transport, the node's shell under
+            # ssh. Either way the token is never written to the node's disk --
+            # for ssh it is piped in, see _token_forward.
+            prefix, stdin = self._token_forward(host, hf_token_env, environ)
+            tail = (
                 f"{run} -d --name {c['name']}"
                 + (f" {device}" if device else "")
                 + (f" {pin}" if pin else "")
                 + f" --shm-size={c.get('shmSize', '20g')} "
                 f"-p {c['hostPort']}:{c.get('containerPort', 8000)} "
-                # `-e VAR` with no value is expanded from the *client's*
-                # environment by both CLIs, so the token reaches a remote
-                # daemon without ever being written to the node's disk.
                 f"-e {hf_token_env} "
                 f"-v {hf_cache}:/root/.cache/huggingface "
                 f"--entrypoint vllm {image} "
@@ -315,28 +326,53 @@ class NoK8sDeployStep(Step):
                 f"--tensor-parallel-size={c.get('tensorParallel', 1)}"
                 + (f" {extra}" if extra else "")
             )
+            return host.wrap_runtime(tail, prefix), stdin
         if kind == "epp":
             mount_dir = c.get("configMountDir", "/etc/epp")
             return (
-                f"{run} -d --name {c['name']} --network host "
-                f"-v {epp_dir}:{mount_dir}:ro {image} "
-                f"--config-file={mount_dir}/config.yaml "
-                f"--pool-name={c.get('poolName', 'file-discovery')} "
-                f"--pool-namespace={c.get('poolNamespace', 'default')} "
-                f"--grpc-port={c['grpcPort']} "
-                f"--grpc-health-port={c['grpcHealthPort']} "
-                f"--metrics-port={c['metricsPort']} "
-                f"--secure-serving=false --v=2"
+                host.wrap_runtime(
+                    f"{run} -d --name {c['name']} --network host "
+                    f"-v {epp_dir}:{mount_dir}:ro {image} "
+                    f"--config-file={mount_dir}/config.yaml "
+                    f"--pool-name={c.get('poolName', 'file-discovery')} "
+                    f"--pool-namespace={c.get('poolNamespace', 'default')} "
+                    f"--grpc-port={c['grpcPort']} "
+                    f"--grpc-health-port={c['grpcHealthPort']} "
+                    f"--metrics-port={c['metricsPort']} "
+                    f"--secure-serving=false --v=2"
+                ),
+                "",
             )
         if kind == "envoy":
             mount_path = c.get("configMountPath", "/etc/envoy/envoy.yaml")
             return (
-                f"{run} -d --name {c['name']} --network host "
-                f"-v {workspace / 'envoy.yaml'}:{mount_path}:ro {image} "
-                f"--service-node envoy-proxy --log-level warn --concurrency 8 "
-                f"--drain-strategy immediate --drain-time-s 60 -c {mount_path}"
+                host.wrap_runtime(
+                    f"{run} -d --name {c['name']} --network host "
+                    f"-v {workspace / 'envoy.yaml'}:{mount_path}:ro {image} "
+                    f"--service-node envoy-proxy --log-level warn --concurrency 8 "
+                    f"--drain-strategy immediate --drain-time-s 60 -c {mount_path}"
+                ),
+                "",
             )
         raise ValueError(f"Unknown nok8s container kind: {kind}")
+
+    @staticmethod
+    def _token_forward(
+        host: ContainerHost, hf_token_env: str, environ=None
+    ) -> tuple[str, str]:
+        """``(env_prefix, stdin)`` carrying the HF token to a remote runtime.
+
+        Under the native transport the local CLI expands ``-e VAR`` from this
+        process's environment, so nothing is needed. Under ssh transport the
+        runtime runs on the node, where that variable is unset -- without this
+        a gated model would fail to download and the only symptom would be a
+        401 deep in the vLLM log.
+
+        The value goes over stdin rather than in the command, because commands
+        are written to the workspace command log and this one is a credential.
+        """
+        env = os.environ if environ is None else environ
+        return host.env_forward_stdin([hf_token_env], env)
 
     # Per-accelerator env var that pins a process to a subset of devices.
     _VISIBLE_DEVICE_ENV = {

--- a/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_nok8s_deploy.py
@@ -1,12 +1,32 @@
-"""Step 06 -- Deploy the llm-d stack as local containers (no Kubernetes).
+"""Step 06 -- Deploy the llm-d stack as containers (no Kubernetes).
 
-Launches vLLM worker(s) + EPP (router) + Envoy as docker/podman containers on
-the host, driven by the rendered ``34_nok8s-containers.yaml`` launch spec and
-the ``31/32/33_nok8s-*`` config files.  No cluster is involved; the EPP uses
-the file-discovery plugin (reads endpoints.yaml).
+Launches vLLM worker(s) + EPP (router) + Envoy as docker/podman containers,
+driven by the rendered ``34_nok8s-containers.yaml`` launch spec and the
+``31/32/33_nok8s-*`` config files.  No cluster is involved; the EPP uses the
+file-discovery plugin (reads endpoints.yaml).
+
+The containers run wherever ``nok8s.connection`` points -- the local host by
+default, or a remote node over the runtime's SSH transport.  Remote is not just
+"add ``-H ssh://``" to each ``run``: three things in this step resolve on the
+machine that holds the files, not the one holding the client, and each is
+handled explicitly below.
+
+* **Bind-mount sources.** ``_stage_configs`` writes the EPP/Envoy configs, then
+  every container mounts them by path. A path is resolved by the *daemon*, so
+  for a remote host the staged files are pushed there first (docker would
+  otherwise mount an empty directory and the EPP would come up with no
+  endpoints; podman fails outright).
+* **``~`` in paths.** ``workspaceHostDir`` and ``hfCacheDir`` are the remote
+  user's home, so the home directory is read off the daemon host instead of
+  expanding the client's ``$HOME``.
+* **Readiness.** ``curl http://localhost:<port>`` from the client would probe
+  the client. The probe is executed on the daemon host, so what it proves is
+  that the node is serving -- which is also why the vLLM ports need no
+  client-side reachability.
 """
 
 import os
+import shlex
 import time
 from pathlib import Path
 
@@ -15,6 +35,11 @@ import yaml
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.executor.command import CommandExecutor
+from llmdbenchmark.utilities.container_host import (
+    ContainerHost,
+    ContainerHostError,
+    expand_remote_path,
+)
 
 
 class NoK8sDeployStep(Step):
@@ -52,15 +77,36 @@ class NoK8sDeployStep(Step):
         spec = yaml.safe_load(spec_yaml.read_text(encoding="utf-8")) or {}
 
         runtime = spec.get("runtime", context.container_runtime or "docker")
-        workspace = Path(os.path.expanduser(spec["workspaceHostDir"]))
-        hf_cache = os.path.expanduser(spec.get("hfCacheDir", "~/.cache/huggingface"))
+        try:
+            host = self._container_host(spec, runtime, context)
+        except ContainerHostError as exc:
+            return self._fail(stack_path, str(exc))
+
         hf_token_env = spec.get("hfTokenEnv", "HUGGING_FACE_HUB_TOKEN")
         model = spec["model"]
         endpoint = spec["endpoint"]
         containers = spec.get("containers", [])
 
+        # ``~`` in these paths belongs to the user that owns the daemon, which
+        # for a remote host is not the user running llmdbenchmark. Resolve it
+        # against that host's home so the bind-mount source and the staged
+        # files agree on one absolute path.
+        home = self._daemon_home(cmd, host, context)
+        workspace = Path(expand_remote_path(spec["workspaceHostDir"], home))
+        hf_cache = expand_remote_path(
+            spec.get("hfCacheDir", "~/.cache/huggingface"), home
+        )
+
         # Record the endpoint up front so downstream (even dry-run) can use it.
+        # This is the in-host URL: the harness runs on the daemon host with
+        # --network host, so keeping it there measures the stack and not the
+        # SSH link. The client-side URL is `clientEndpoint`.
         context.deployed_endpoints[stack_path.name] = endpoint
+        if host.is_remote:
+            context.logger.log_info(
+                f"nok8s target: {host.describe()} "
+                f"(client endpoint {spec.get('clientEndpoint') or endpoint})"
+            )
 
         if hf_token_env not in os.environ and not context.dry_run:
             context.logger.log_warning(
@@ -68,22 +114,27 @@ class NoK8sDeployStep(Step):
                 f"models will fail to download in the vLLM container."
             )
 
-        # Stage the EPP/Envoy config files to the host workspace dir.
+        # Stage the EPP/Envoy config files where the daemon will mount them.
         epp_dir = workspace / "epp"
         if not context.dry_run:
-            self._stage_configs(stack_path, workspace, epp_dir)
+            stage_err = self._stage_configs(
+                stack_path, workspace, epp_dir, cmd, host, context
+            )
+            if stage_err:
+                return self._fail(stack_path, stage_err, [stage_err])
         else:
             context.logger.log_info(
                 f"[dry-run] would stage nok8s configs under {workspace}"
+                + (f" on {host.destination}" if host.is_remote else "")
             )
 
         launched: list[str] = []
         for c in containers:
             name = c["name"]
             # Idempotency: remove any prior container with this name.
-            cmd.execute(f"{runtime} rm -f {name}", check=False)
+            cmd.execute(host.runtime_cmd("rm", "-f", name), check=False)
             run_cmd = self._build_run_command(
-                c, runtime, workspace, epp_dir, hf_cache, hf_token_env, model
+                c, runtime, workspace, epp_dir, hf_cache, hf_token_env, model, host
             )
             result = cmd.execute(run_cmd, check=False)
             if not result.success and not context.dry_run:
@@ -92,21 +143,21 @@ class NoK8sDeployStep(Step):
                 # is already up so it does not hold host ports (epp/envoy use
                 # --network host) against the next standup.
                 err = f"Failed to start container {name}: {result.stderr}"
-                self._dump_logs(cmd, runtime, name, context)
-                self._rollback(cmd, runtime, launched, context)
+                self._dump_logs(cmd, host, name, context)
+                self._rollback(cmd, host, launched, context)
                 return self._fail(stack_path, err, [err])
             launched.append(name)
 
         # Readiness: each vLLM worker, then Envoy.
         if not context.dry_run:
-            ready_err = self._wait_ready(cmd, runtime, spec, context)
+            ready_err = self._wait_ready(cmd, host, spec, context)
             if ready_err:
                 envoy = next(
                     (c["name"] for c in containers if c.get("kind") == "envoy"), None
                 )
                 if envoy:
-                    self._dump_logs(cmd, runtime, envoy, context)
-                self._rollback(cmd, runtime, launched, context)
+                    self._dump_logs(cmd, host, envoy, context)
+                self._rollback(cmd, host, launched, context)
                 return self._fail(stack_path, ready_err, [ready_err])
 
         return StepResult(
@@ -120,18 +171,108 @@ class NoK8sDeployStep(Step):
     # ------------------------------------------------------------------ #
     # helpers
     # ------------------------------------------------------------------ #
-    def _stage_configs(self, stack_path: Path, workspace: Path, epp_dir: Path) -> None:
-        """Copy rendered EPP/Envoy config files to the host workspace dir."""
-        epp_dir.mkdir(parents=True, exist_ok=True)
+    @staticmethod
+    def _container_host(
+        spec: dict, runtime: str, context: ExecutionContext
+    ) -> ContainerHost:
+        """Resolve the connection target from the rendered spec.
+
+        The render already rejected a malformed value, but the spec is a file on
+        disk that can be hand-edited between plan and standup, so it is parsed
+        (and can still fail) here too.
+        """
+        return ContainerHost.parse(
+            spec.get("connection") or context.container_connection,
+            runtime=runtime,
+            identity=spec.get("sshIdentity") or "",
+            ssh_args=spec.get("sshArgs") or None,
+        )
+
+    def _daemon_home(
+        self, cmd: CommandExecutor, host: ContainerHost, context: ExecutionContext
+    ) -> str:
+        """``$HOME`` of the user owning the daemon, for expanding ``~`` paths.
+
+        Local hosts keep using the client's ``$HOME`` (unchanged behaviour).
+        For a remote host the value is read over SSH; if that fails the ``~`` is
+        left for the remote shell to expand, which still works for the staging
+        ``mkdir`` even though a bind-mount source cannot rely on it -- so the
+        failure is logged rather than swallowed.
+
+        Skipped under ``--dry-run``, which must not require the node to be
+        reachable: the paths are then logged with their ``~`` intact.
+        """
+        if not host.is_remote:
+            return os.path.expanduser("~")
+        if context.dry_run:
+            return ""
+        result = cmd.execute(host.shell("printenv HOME"), check=False, force=True)
+        home = (result.stdout or "").strip()
+        if not home:
+            context.logger.log_warning(
+                f"Could not read $HOME on {host.destination} "
+                f"({(result.stderr or '').strip()[:200]}); paths containing '~' "
+                f"may not resolve. Use absolute paths for "
+                f"nok8s.workspaceHostDir and nok8s.vllm.hfCacheDir."
+            )
+        return home
+
+    def _stage_configs(  # pylint: disable=too-many-arguments
+        self,
+        stack_path: Path,
+        workspace: Path,
+        epp_dir: Path,
+        cmd: CommandExecutor,
+        host: ContainerHost,
+        context: ExecutionContext,
+    ) -> str | None:
+        """Put the rendered EPP/Envoy configs where the daemon will mount them.
+
+        Returns an error string on failure, or None. A remote staging failure is
+        fatal rather than a warning: docker happily bind-mounts a path that does
+        not exist on the daemon host as an empty directory, so the EPP would
+        start, find no endpoints file, and route nothing -- a much harder failure
+        to read than stopping here.
+        """
         mapping = {
-            "31_nok8s-epp-config": epp_dir / "config.yaml",
-            "32_nok8s-epp-endpoints": epp_dir / "endpoints.yaml",
-            "33_nok8s-envoy": workspace / "envoy.yaml",
+            "31_nok8s-epp-config": ("epp", "config.yaml"),
+            "32_nok8s-epp-endpoints": ("epp", "endpoints.yaml"),
+            "33_nok8s-envoy": ("", "envoy.yaml"),
         }
-        for prefix, dest in mapping.items():
+
+        if not host.is_remote:
+            epp_dir.mkdir(parents=True, exist_ok=True)
+            for prefix, (sub, filename) in mapping.items():
+                src = self._find_yaml(stack_path, prefix)
+                if src and self._has_yaml_content(src):
+                    dest = (epp_dir if sub else workspace) / filename
+                    dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+            return None
+
+        # Remote: assemble the exact directory tree locally, then push it in one
+        # scp so the daemon host sees a complete workspace or none of it.
+        local_stage = context.setup_logs_dir() / f"nok8s-stage-{stack_path.name}"
+        (local_stage / "epp").mkdir(parents=True, exist_ok=True)
+        for prefix, (sub, filename) in mapping.items():
             src = self._find_yaml(stack_path, prefix)
             if src and self._has_yaml_content(src):
+                dest = local_stage / sub / filename if sub else local_stage / filename
                 dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+        result = cmd.execute(
+            host.push_dir(str(local_stage), str(workspace)), check=False
+        )
+        if not result.success:
+            return (
+                f"Failed to stage nok8s configs to {host.destination}:{workspace}: "
+                f"{(result.stderr or '').strip()[:300]}. Check that SSH to "
+                f"{host.destination} works non-interactively "
+                f"('ssh {host.destination} true') and that the path is writable."
+            )
+        context.logger.log_info(
+            f"Staged nok8s configs to {host.destination}:{workspace}"
+        )
+        return None
 
     def _build_run_command(  # pylint: disable=too-many-arguments
         self,
@@ -142,20 +283,30 @@ class NoK8sDeployStep(Step):
         hf_cache: str,
         hf_token_env: str,
         model: str,
+        host: ContainerHost,
     ) -> str:
-        """Build the docker/podman run command for one container from its spec."""
+        """Build the docker/podman run command for one container from its spec.
+
+        Every path in a ``-v`` flag and every port in a ``-p`` flag is resolved
+        by the daemon, so on a remote host they already refer to that node --
+        the only client-side addition is the connection flag from *host*.
+        """
         kind = c["kind"]
         image = c["image"]
+        run = host.runtime_cmd("run")
         if kind == "vllm":
             device = self._device_args(runtime, c)
             pin = self._pin_env(c)
             extra = " ".join(c.get("extraArgs") or [])
             return (
-                f"{runtime} run -d --name {c['name']}"
+                f"{run} -d --name {c['name']}"
                 + (f" {device}" if device else "")
                 + (f" {pin}" if pin else "")
                 + f" --shm-size={c.get('shmSize', '20g')} "
                 f"-p {c['hostPort']}:{c.get('containerPort', 8000)} "
+                # `-e VAR` with no value is expanded from the *client's*
+                # environment by both CLIs, so the token reaches a remote
+                # daemon without ever being written to the node's disk.
                 f"-e {hf_token_env} "
                 f"-v {hf_cache}:/root/.cache/huggingface "
                 f"--entrypoint vllm {image} "
@@ -167,7 +318,7 @@ class NoK8sDeployStep(Step):
         if kind == "epp":
             mount_dir = c.get("configMountDir", "/etc/epp")
             return (
-                f"{runtime} run -d --name {c['name']} --network host "
+                f"{run} -d --name {c['name']} --network host "
                 f"-v {epp_dir}:{mount_dir}:ro {image} "
                 f"--config-file={mount_dir}/config.yaml "
                 f"--pool-name={c.get('poolName', 'file-discovery')} "
@@ -180,7 +331,7 @@ class NoK8sDeployStep(Step):
         if kind == "envoy":
             mount_path = c.get("configMountPath", "/etc/envoy/envoy.yaml")
             return (
-                f"{runtime} run -d --name {c['name']} --network host "
+                f"{run} -d --name {c['name']} --network host "
                 f"-v {workspace / 'envoy.yaml'}:{mount_path}:ro {image} "
                 f"--service-node envoy-proxy --log-level warn --concurrency 8 "
                 f"--drain-strategy immediate --drain-time-s 60 -c {mount_path}"
@@ -251,9 +402,20 @@ class NoK8sDeployStep(Step):
         return f"--gpus {gpus}"
 
     def _wait_ready(
-        self, cmd: CommandExecutor, runtime: str, spec: dict, context: ExecutionContext
+        self,
+        cmd: CommandExecutor,
+        host: ContainerHost,
+        spec: dict,
+        context: ExecutionContext,
     ) -> str | None:
-        """Poll vLLM workers then Envoy for /v1/models. Returns error string or None."""
+        """Poll vLLM workers then Envoy for /v1/models. Returns error string or None.
+
+        The probe runs *on the daemon host*, so ``localhost`` is the machine
+        actually serving. Probing from the client instead would report the
+        client's ports and would additionally require every vLLM port to be
+        reachable across the network, which is not something a bare-metal node's
+        firewall owes us.
+        """
         readiness = spec.get("readiness", {})
         ports = list(readiness.get("vllmPorts", [])) + [readiness.get("envoyPort")]
         timeout = context.nok8s_deploy_timeout
@@ -261,23 +423,28 @@ class NoK8sDeployStep(Step):
             if port is None:
                 continue
             url = f"http://localhost:{port}/v1/models"
+            probe = host.shell(f"curl -fsS {shlex.quote(url)}")
             deadline = time.time() + timeout
             ok = False
             while time.time() < deadline:
-                result = cmd.execute(f"curl -fsS {url}", check=False, force=True)
+                result = cmd.execute(probe, check=False, force=True)
                 if result.success:
                     ok = True
                     break
                 time.sleep(10)
             if not ok:
-                return f"Timed out waiting for {url} after {timeout}s"
-            context.logger.log_info(f"nok8s endpoint ready: {url}")
+                where = f" on {host.destination}" if host.is_remote else ""
+                return f"Timed out waiting for {url}{where} after {timeout}s"
+            context.logger.log_info(
+                f"nok8s endpoint ready: {url}"
+                + (f" (on {host.destination})" if host.is_remote else "")
+            )
         return None
 
     def _rollback(
         self,
         cmd: CommandExecutor,
-        runtime: str,
+        host: ContainerHost,
         launched: list[str],
         context: ExecutionContext,
     ) -> None:
@@ -289,16 +456,25 @@ class NoK8sDeployStep(Step):
         must not mask the failure that triggered it.
         """
         for name in reversed(launched):
-            self._dump_logs(cmd, runtime, name, context)
-            cmd.execute(f"{runtime} rm -f {name}", check=False)
+            self._dump_logs(cmd, host, name, context)
+            cmd.execute(host.runtime_cmd("rm", "-f", name), check=False)
             context.logger.log_info(f"nok8s rollback: removed container {name}")
 
     def _dump_logs(
-        self, cmd: CommandExecutor, runtime: str, name: str, context: ExecutionContext
+        self,
+        cmd: CommandExecutor,
+        host: ContainerHost,
+        name: str,
+        context: ExecutionContext,
     ) -> None:
-        """Best-effort capture of a container's logs into the setup logs dir."""
+        """Best-effort capture of a container's logs into the setup logs dir.
+
+        ``logs`` goes over the same connection as ``run``, so a remote failure
+        is diagnosable from the client without anyone SSHing in -- which is the
+        whole point of driving the node remotely.
+        """
         result = cmd.execute(
-            f"{runtime} logs {name} --tail 100", check=False, force=True
+            host.runtime_cmd("logs", name, "--tail", "100"), check=False, force=True
         )
         try:
             log_path = context.setup_logs_dir() / f"nok8s-{name}.log"

--- a/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
+++ b/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
@@ -38,7 +38,7 @@ class NoK8sTeardownStep(Step):
         cmd = context.require_cmd()
         runtime = context.container_runtime or "docker"
         connection = context.container_connection
-        identity, ssh_args = "", None
+        identity, ssh_args, transport = "", None, ""
 
         names: list[str] = []
         spec_yaml = (
@@ -50,6 +50,7 @@ class NoK8sTeardownStep(Step):
             connection = spec.get("connection") or connection
             identity = spec.get("sshIdentity") or ""
             ssh_args = spec.get("sshArgs") or None
+            transport = spec.get("transport") or ""
             names = [c["name"] for c in spec.get("containers", [])]
 
         # A teardown that cannot resolve its target must not fall back to the
@@ -57,7 +58,11 @@ class NoK8sTeardownStep(Step):
         # would remove the wrong containers and leave the remote node serving.
         try:
             host = ContainerHost.parse(
-                connection, runtime=runtime, identity=identity, ssh_args=ssh_args
+                connection,
+                runtime=runtime,
+                identity=identity,
+                ssh_args=ssh_args,
+                transport=transport,
             )
         except ContainerHostError as exc:
             return StepResult(

--- a/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
+++ b/llmdbenchmark/teardown/steps/step_06_nok8s_teardown.py
@@ -2,7 +2,7 @@
 
 Removes the vLLM/EPP/Envoy containers launched by
 step_06_nok8s_deploy.py, driven by the rendered ``34_nok8s-containers.yaml``
-launch spec.
+launch spec, on whichever host ``nok8s.connection`` names.
 """
 
 from pathlib import Path
@@ -11,6 +11,10 @@ import yaml
 
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.utilities.container_host import (
+    ContainerHost,
+    ContainerHostError,
+)
 
 
 class NoK8sTeardownStep(Step):
@@ -33,6 +37,8 @@ class NoK8sTeardownStep(Step):
     ) -> StepResult:
         cmd = context.require_cmd()
         runtime = context.container_runtime or "docker"
+        connection = context.container_connection
+        identity, ssh_args = "", None
 
         names: list[str] = []
         spec_yaml = (
@@ -41,7 +47,27 @@ class NoK8sTeardownStep(Step):
         if spec_yaml and self._has_yaml_content(spec_yaml):
             spec = yaml.safe_load(spec_yaml.read_text(encoding="utf-8")) or {}
             runtime = spec.get("runtime", runtime)
+            connection = spec.get("connection") or connection
+            identity = spec.get("sshIdentity") or ""
+            ssh_args = spec.get("sshArgs") or None
             names = [c["name"] for c in spec.get("containers", [])]
+
+        # A teardown that cannot resolve its target must not fall back to the
+        # local runtime: on a workstation that also ran a local stack, that
+        # would remove the wrong containers and leave the remote node serving.
+        try:
+            host = ContainerHost.parse(
+                connection, runtime=runtime, identity=identity, ssh_args=ssh_args
+            )
+        except ContainerHostError as exc:
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message=str(exc),
+                errors=[str(exc)],
+                stack_name=stack_path.name if stack_path else None,
+            )
 
         # Fallback to the well-known names if the spec is unavailable, but
         # only for a single-stack plan. With siblings around, those names
@@ -64,12 +90,13 @@ class NoK8sTeardownStep(Step):
             )
 
         for name in names:
-            cmd.execute(f"{runtime} rm -f {name}", check=False)
+            cmd.execute(host.runtime_cmd("rm", "-f", name), check=False)
 
+        where = f" on {host.destination}" if host.is_remote else ""
         return StepResult(
             step_number=self.number,
             step_name=self.name,
             success=True,
-            message=f"Removed nok8s containers: {', '.join(names)}",
+            message=f"Removed nok8s containers{where}: {', '.join(names)}",
             stack_name=stack_path.name if stack_path else None,
         )

--- a/llmdbenchmark/utilities/container_host.py
+++ b/llmdbenchmark/utilities/container_host.py
@@ -1,0 +1,321 @@
+"""Container-runtime connection target for the no-Kubernetes (nok8s) method.
+
+``nok8s.connection`` names the host whose docker/podman runs the stack.  The
+default ``localhost`` keeps every command exactly as it was before this module
+existed; an ``ssh://`` value points the runtime client at a remote daemon over
+SSH, so ``llmdbenchmark standup`` can bring up vLLM + EPP + Envoy on a
+bare-metal node without anybody logging into it.
+
+Both runtimes speak SSH natively, so no hand-rolled ``ssh -L`` tunnel is
+needed for the control plane::
+
+    docker -H ssh://user@node run ...
+    podman --url ssh://user@node/run/user/1000/podman/podman.sock run ...
+
+What SSH does *not* solve is that a nok8s standup is more than ``run``: it
+stages EPP/Envoy config files and bind-mounts them, expands ``~``, and probes
+readiness over HTTP.  Every one of those resolves on the machine that holds
+the files or the socket, which is the *daemon* host, not the client.  So this
+class exposes three things a step needs, rather than only a connection flag:
+
+* :meth:`runtime_args` -- the client flag that reaches the daemon.
+* :meth:`shell` -- run a command *on* the daemon host (``mkdir``, ``curl``,
+  ``nvidia-smi``), so probes describe the host that will actually serve.
+* :meth:`push_dir` / :meth:`pull_dir` -- move bind-mount sources and results
+  between client and daemon host.
+
+``tcp://`` is deliberately unsupported: an unencrypted, unauthenticated docker
+socket is root on the node for anyone who can reach the port, and the SSH
+transport removes any reason to open one.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+LOCAL = "localhost"
+
+# Default rootful socket paths, used when an ssh:// URL names no path. docker
+# has one well-known socket; podman resolves its own (rootless sockets live
+# under /run/user/<uid>), so we leave podman's path empty and let the client
+# ask the service.
+_DEFAULT_SOCKETS = {"docker": "/var/run/docker.sock"}
+
+# Non-interactive by default: a standup that blocks on a passphrase prompt or a
+# host-key question looks like a hang. Callers who want strict host-key
+# checking can add it back through nok8s.sshArgs.
+_DEFAULT_SSH_ARGS = ("-o", "BatchMode=yes", "-o", "ConnectTimeout=10")
+
+
+class ContainerHostError(ValueError):
+    """A ``nok8s.connection`` value that cannot be used as written."""
+
+
+@dataclass(frozen=True)
+class ContainerHost:
+    """Where a nok8s stack's containers run.
+
+    Construct with :meth:`parse`; the fields are the parsed form of
+    ``nok8s.connection`` plus the SSH options that reach it.
+    """
+
+    runtime: str = "docker"
+    user: str = ""
+    host: str = LOCAL
+    port: int | None = None
+    socket: str = ""
+    identity: str = ""
+    ssh_args: tuple[str, ...] = field(default_factory=tuple)
+
+    # ------------------------------------------------------------------ #
+    # construction
+    # ------------------------------------------------------------------ #
+    @classmethod
+    def parse(
+        cls,
+        connection: str | None,
+        runtime: str = "docker",
+        identity: str = "",
+        ssh_args: list[str] | tuple[str, ...] | None = None,
+    ) -> "ContainerHost":
+        """Build a host from a ``nok8s.connection`` value.
+
+        Accepted forms:
+
+        * ``""`` / ``localhost`` / ``local`` / ``unix://...`` -- the local
+          runtime, i.e. exactly the pre-existing behaviour.
+        * ``ssh://[user@]host[:port][/socket-path]``
+        * ``[user@]host`` -- bare hostname or IP, treated as ``ssh://``, so a
+          scenario can say ``connection: 10.0.0.7`` and mean the obvious
+          thing. This is the form the "just give it the node's IP" case wants.
+
+        Raises:
+            ContainerHostError: for ``tcp://`` (unauthenticated), any other
+                scheme, or a value with no host part.
+        """
+        runtime = (runtime or "docker").strip() or "docker"
+        raw = (connection or "").strip()
+        args = tuple(ssh_args or ()) or _DEFAULT_SSH_ARGS
+
+        if raw.lower() in ("", LOCAL, "local", "127.0.0.1", "::1"):
+            return cls(runtime=runtime)
+        if raw.startswith("unix://") or raw.startswith("/"):
+            # A local socket path is still local; keep it as the plain local
+            # runtime rather than inventing a flag for the default socket.
+            return cls(runtime=runtime)
+
+        scheme, sep, rest = raw.partition("://")
+        if not sep:
+            # Bare "[user@]host[:port]" -- imply ssh. Keyed on the separator,
+            # not on `rest`: "ssh://" has a scheme and an empty host, and
+            # treating it as a bare hostname would resolve it to a node
+            # literally called "ssh" instead of reporting the empty host.
+            scheme, rest = "ssh", raw
+        scheme = scheme.lower()
+
+        if scheme == "tcp":
+            raise ContainerHostError(
+                "nok8s.connection 'tcp://...' is not supported: an unencrypted "
+                "docker/podman TCP socket grants root on that node to anyone "
+                "who can reach the port. Use ssh:// instead "
+                "(e.g. ssh://user@10.0.0.7), which needs no daemon "
+                "reconfiguration."
+            )
+        if scheme not in ("ssh",):
+            raise ContainerHostError(
+                f"nok8s.connection scheme '{scheme}://' is not supported. Use "
+                f"'{LOCAL}' for the local runtime or 'ssh://[user@]host[:port]"
+                f"[/socket]' for a remote one."
+            )
+
+        parsed = urlparse(f"ssh://{rest}")
+        if not parsed.hostname:
+            raise ContainerHostError(
+                f"nok8s.connection '{connection}' has no host part. Expected "
+                f"'ssh://[user@]host[:port][/socket]'."
+            )
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            # urlparse defers port validation to attribute access.
+            raise ContainerHostError(
+                f"nok8s.connection '{connection}' has an invalid port: {exc}"
+            ) from exc
+
+        return cls(
+            runtime=runtime,
+            user=parsed.username or "",
+            host=parsed.hostname,
+            port=port,
+            socket=(parsed.path or "").rstrip("/"),
+            identity=(identity or "").strip(),
+            ssh_args=args,
+        )
+
+    # ------------------------------------------------------------------ #
+    # properties
+    # ------------------------------------------------------------------ #
+    @property
+    def is_remote(self) -> bool:
+        """True when the containers run on another machine."""
+        return self.host != LOCAL
+
+    @property
+    def destination(self) -> str:
+        """``[user@]host`` for an ``ssh``/``scp`` command line."""
+        return f"{self.user}@{self.host}" if self.user else self.host
+
+    @property
+    def url(self) -> str:
+        """The ``ssh://`` URL handed to the runtime client."""
+        if not self.is_remote:
+            return ""
+        socket = self.socket or _DEFAULT_SOCKETS.get(self.runtime, "")
+        port = f":{self.port}" if self.port else ""
+        return f"ssh://{self.destination}{port}{socket}"
+
+    def describe(self) -> str:
+        """Short human-readable form for logs and step messages."""
+        return (
+            f"{self.runtime} @ {self.url}"
+            if self.is_remote
+            else f"{self.runtime} (local)"
+        )
+
+    # ------------------------------------------------------------------ #
+    # command construction
+    # ------------------------------------------------------------------ #
+    def runtime_args(self) -> str:
+        """Client flags that point the runtime at this host (``""`` if local).
+
+        docker takes ``-H``; podman takes ``--url`` and, for a non-default key,
+        ``--identity``. Both must come *before* the subcommand, which is why
+        callers build ``f"{runtime} {args} run ..."`` rather than appending.
+        """
+        if not self.is_remote:
+            return ""
+        parts: list[str] = []
+        if self.runtime == "podman":
+            parts += ["--url", shlex.quote(self.url)]
+            if self.identity:
+                parts += ["--identity", shlex.quote(self.identity)]
+        else:
+            parts += ["-H", shlex.quote(self.url)]
+        return " ".join(parts)
+
+    def runtime_cmd(self, *args: str) -> str:
+        """A full runtime command line with the connection flags injected."""
+        flags = self.runtime_args()
+        head = f"{self.runtime} {flags}" if flags else self.runtime
+        return " ".join([head, *args])
+
+    def runtime_env(self) -> str:
+        """``VAR=value`` prefix for tools that read the connection from env.
+
+        docker's ``-H`` does not reach a helper that shells out to the client
+        itself, and podman's ``--identity`` only applies to podman; exporting
+        ``DOCKER_HOST`` / ``CONTAINER_HOST`` covers those. Empty when local.
+        """
+        if not self.is_remote:
+            return ""
+        if self.runtime == "podman":
+            env = [f"CONTAINER_HOST={shlex.quote(self.url)}"]
+            if self.identity:
+                env.append(f"CONTAINER_SSHKEY={shlex.quote(self.identity)}")
+            return " ".join(env)
+        return f"DOCKER_HOST={shlex.quote(self.url)}"
+
+    def _ssh_prefix(self, binary: str = "ssh") -> list[str]:
+        """``ssh``/``scp`` invocation with identity, port and options applied."""
+        parts = [binary, *self.ssh_args]
+        if self.identity:
+            parts += ["-i", shlex.quote(self.identity)]
+        if self.port:
+            # scp spells the port -P; ssh spells it -p.
+            parts += ["-P" if binary == "scp" else "-p", str(self.port)]
+        return parts
+
+    def shell(self, command: str) -> str:
+        """Wrap *command* so it runs on the daemon host.
+
+        Returns *command* unchanged when local, so a caller can use this
+        unconditionally and the local path stays byte-identical to before.
+        """
+        if not self.is_remote:
+            return command
+        return " ".join([*self._ssh_prefix(), self.destination, shlex.quote(command)])
+
+    def push_dir(self, local_dir: str, remote_dir: str) -> str:
+        """Command that mirrors *local_dir*'s contents into *remote_dir*.
+
+        Bind-mount sources have to exist on the daemon host, so staged EPP and
+        Envoy configs are copied there before any container starts. ``scp -r``
+        rather than ``rsync`` because ``rsync`` is not reliably installed on a
+        minimal compute node, while ``scp`` ships with the SSH the connection
+        already depends on.
+
+        The trailing ``/.`` copies the directory *contents*, so a re-run
+        overwrites the staged files instead of nesting a second copy inside.
+        """
+        if not self.is_remote:
+            return f"cp -a {shlex.quote(local_dir)}/. {shlex.quote(remote_dir)}/"
+        scp = " ".join(self._ssh_prefix("scp"))
+        return (
+            f"{self.shell(f'mkdir -p {shlex.quote(remote_dir)}')} && "
+            f"{scp} -r {shlex.quote(local_dir)}/. "
+            f"{self.destination}:{shlex.quote(remote_dir)}/"
+        )
+
+    def push_file(self, local_file: str, remote_file: str) -> str:
+        """Command that copies one file to *remote_file* on the daemon host."""
+        if not self.is_remote:
+            return f"cp -a {shlex.quote(local_file)} {shlex.quote(remote_file)}"
+        scp = " ".join(self._ssh_prefix("scp"))
+        parent = remote_file.rsplit("/", 1)[0] or "/"
+        return (
+            f"{self.shell(f'mkdir -p {shlex.quote(parent)}')} && "
+            f"{scp} {shlex.quote(local_file)} "
+            f"{self.destination}:{shlex.quote(remote_file)}"
+        )
+
+    def pull_dir(self, remote_dir: str, local_dir: str) -> str:
+        """Command that copies *remote_dir*'s contents down to *local_dir*."""
+        if not self.is_remote:
+            return f"cp -a {shlex.quote(remote_dir)}/. {shlex.quote(local_dir)}/"
+        scp = " ".join(self._ssh_prefix("scp"))
+        return (
+            f"mkdir -p {shlex.quote(local_dir)} && {scp} -r "
+            f"{self.destination}:{shlex.quote(remote_dir)}/. "
+            f"{shlex.quote(local_dir)}/"
+        )
+
+    def endpoint(self, port: int, scheme: str = "http") -> str:
+        """URL a *client-side* caller uses to reach *port* on the daemon host.
+
+        The smoketest and any manual ``curl`` run on the client, so for a
+        remote stack they must address the node, not ``localhost``. Steps that
+        run *inside* the node (the harness container, with ``--network host``)
+        keep using ``localhost`` -- see ``clientEndpoint`` vs ``endpoint`` in
+        ``34_nok8s-containers.yaml``.
+        """
+        return f"{scheme}://{self.host}:{port}"
+
+
+def expand_remote_path(path: str, home: str = "") -> str:
+    """Expand a leading ``~`` against the *daemon host's* home directory.
+
+    ``os.path.expanduser`` resolves against the client's ``$HOME``, which is
+    the wrong user on a remote node (and wrong even locally under ``sudo``).
+    Paths are expanded from the home directory read off the daemon host; with
+    no *home* known the ``~`` is left in place for the remote shell to expand,
+    which is correct for ``shell()`` but not for a bind-mount source, so
+    callers pass the value they read from the host.
+    """
+    if not path.startswith("~"):
+        return path
+    if not home:
+        return path
+    return re.sub(r"^~(?=/|$)", home.rstrip("/"), path)

--- a/llmdbenchmark/utilities/container_host.py
+++ b/llmdbenchmark/utilities/container_host.py
@@ -6,11 +6,29 @@ existed; an ``ssh://`` value points the runtime client at a remote daemon over
 SSH, so ``llmdbenchmark standup`` can bring up vLLM + EPP + Envoy on a
 bare-metal node without anybody logging into it.
 
-Both runtimes speak SSH natively, so no hand-rolled ``ssh -L`` tunnel is
-needed for the control plane::
+There are two ways to drive a remote daemon, and this class supports both.
+
+``transport="ssh"`` (the default for a remote host) runs the runtime **on the
+node**, reached over plain ``ssh``::
+
+    ssh user@node 'docker run ...'
+
+``transport="native"`` uses the runtimes' own SSH transport, which requires a
+matching client binary on *this* machine::
 
     docker -H ssh://user@node run ...
     podman --url ssh://user@node/run/user/1000/podman/podman.sock run ...
+
+The native transport is the runtimes' own supported mechanism, but it charges
+for something the control plane never uses: a local client. Nothing is built or
+run locally -- every container command is a remote operation -- yet the client
+must be installed, must be the *same family* as the node's daemon (a podman
+client cannot drive dockerd: it asks for Libpod endpoints dockerd does not
+serve), and authenticates by its own rules (podman's Go SSH client does not read
+``~/.ssh/id_rsa``, so ``ssh node true`` can succeed while every container
+command fails). ``ssh`` transport has none of those coupling problems: it needs
+only the ``ssh`` already required for staging configs, and the runtime only has
+to exist where the containers actually run.
 
 What SSH does *not* solve is that a nok8s standup is more than ``run``: it
 stages EPP/Envoy config files and bind-mounts them, expands ``~``, and probes
@@ -37,6 +55,14 @@ from dataclasses import dataclass, field
 from urllib.parse import urlparse
 
 LOCAL = "localhost"
+
+# How a remote runtime is driven. SSH is the default: it needs no local client,
+# so the runtime only has to exist on the node where the containers run. NATIVE
+# is the runtimes' own transport (docker -H / podman --url), kept for anyone who
+# wants it -- see the module docstring for the trade-off.
+SSH = "ssh"
+NATIVE = "native"
+_TRANSPORTS = (SSH, NATIVE)
 
 # Default rootful socket paths, used when an ssh:// URL names no path. docker
 # has one well-known socket; podman resolves its own (rootless sockets live
@@ -69,6 +95,7 @@ class ContainerHost:
     socket: str = ""
     identity: str = ""
     ssh_args: tuple[str, ...] = field(default_factory=tuple)
+    transport: str = SSH
 
     # ------------------------------------------------------------------ #
     # construction
@@ -80,6 +107,7 @@ class ContainerHost:
         runtime: str = "docker",
         identity: str = "",
         ssh_args: list[str] | tuple[str, ...] | None = None,
+        transport: str = "",
     ) -> "ContainerHost":
         """Build a host from a ``nok8s.connection`` value.
 
@@ -92,20 +120,31 @@ class ContainerHost:
           scenario can say ``connection: 10.0.0.7`` and mean the obvious
           thing. This is the form the "just give it the node's IP" case wants.
 
+        *transport* selects how a remote runtime is driven -- ``"ssh"`` (default)
+        or ``"native"``; see the module docstring.
+
         Raises:
             ContainerHostError: for ``tcp://`` (unauthenticated), any other
-                scheme, or a value with no host part.
+                scheme, a value with no host part, or an unknown *transport*.
         """
         runtime = (runtime or "docker").strip() or "docker"
+        transport = (transport or "").strip().lower() or SSH
+        if transport not in _TRANSPORTS:
+            raise ContainerHostError(
+                f"nok8s.transport '{transport}' is not supported. Use "
+                f"'{SSH}' (run the runtime on the node over ssh; needs no local "
+                f"client) or '{NATIVE}' (docker -H / podman --url; needs a "
+                f"matching client here)."
+            )
         raw = (connection or "").strip()
         args = tuple(ssh_args or ()) or _DEFAULT_SSH_ARGS
 
         if raw.lower() in ("", LOCAL, "local", "127.0.0.1", "::1"):
-            return cls(runtime=runtime)
+            return cls(runtime=runtime, transport=transport)
         if raw.startswith("unix://") or raw.startswith("/"):
             # A local socket path is still local; keep it as the plain local
             # runtime rather than inventing a flag for the default socket.
-            return cls(runtime=runtime)
+            return cls(runtime=runtime, transport=transport)
 
         scheme, sep, rest = raw.partition("://")
         if not sep:
@@ -153,6 +192,7 @@ class ContainerHost:
             socket=(parsed.path or "").rstrip("/"),
             identity=(identity or "").strip(),
             ssh_args=args,
+            transport=transport,
         )
 
     # ------------------------------------------------------------------ #
@@ -188,14 +228,35 @@ class ContainerHost:
     # ------------------------------------------------------------------ #
     # command construction
     # ------------------------------------------------------------------ #
+    @property
+    def uses_ssh(self) -> bool:
+        """True when remote commands run *on* the node via ``ssh``.
+
+        False for a local host (nothing to transport) and for the native
+        transport (the local client carries the connection itself).
+        """
+        return self.is_remote and self.transport == SSH
+
+    @property
+    def needs_local_runtime(self) -> bool:
+        """Whether a runtime client must exist on *this* machine.
+
+        Only the native transport does: with ssh transport the runtime is
+        invoked on the node, so the client side needs nothing but ``ssh``.
+        """
+        return not self.is_remote or self.transport == NATIVE
+
     def runtime_args(self) -> str:
         """Client flags that point the runtime at this host (``""`` if local).
 
         docker takes ``-H``; podman takes ``--url`` and, for a non-default key,
         ``--identity``. Both must come *before* the subcommand, which is why
         callers build ``f"{runtime} {args} run ..."`` rather than appending.
+
+        Empty under ssh transport: there the runtime runs on the node and needs
+        no flag to find its own daemon.
         """
-        if not self.is_remote:
+        if not self.is_remote or self.transport == SSH:
             return ""
         parts: list[str] = []
         if self.runtime == "podman":
@@ -207,10 +268,90 @@ class ContainerHost:
         return " ".join(parts)
 
     def runtime_cmd(self, *args: str) -> str:
-        """A full runtime command line with the connection flags injected."""
+        """A complete runtime command line, ready to hand to the shell.
+
+        Under ssh transport the whole thing is wrapped in ``ssh`` so it executes
+        on the node; under the native transport the connection flags are
+        injected instead. Local is the bare command, unchanged.
+
+        Callers that append their own flags afterwards -- ``run`` lines are built
+        that way -- must **not** use this, or the appended text would land
+        outside the quoted remote command and be read by the local shell. Build
+        the tail first and pass it to :meth:`wrap_runtime`.
+        """
+        return self.wrap_runtime(" ".join(args))
+
+    def wrap_runtime(self, tail: str, env_prefix: str = "") -> str:
+        """Turn a runtime argument string into a command that reaches this host.
+
+        *tail* is everything after the runtime binary (``"run -d --name x ..."``)
+        and is quoted as one unit under ssh transport, so its own quoting
+        survives the extra shell.
+
+        *env_prefix* comes from :meth:`env_forward` or
+        :meth:`env_forward_stdin`. It is applied here rather than by the caller
+        because it has to end up **inside** the quoted remote command -- prefixed
+        onto the ``ssh`` invocation instead, it would run on the client and never
+        reach the node.
+        """
         flags = self.runtime_args()
         head = f"{self.runtime} {flags}" if flags else self.runtime
-        return " ".join([head, *args])
+        full = f"{env_prefix}{head} {tail}".strip()
+        return self.shell(full) if self.uses_ssh else full
+
+    def env_forward(self, names: list[str] | tuple[str, ...], environ) -> str:
+        """Prefix that makes client-side env vars visible to a remote runtime.
+
+        ``-e VAR`` with no value is expanded by whoever runs the CLI. Under the
+        native transport that is the *local* client, so the token in your shell
+        reaches the container. Under ssh transport the runtime runs on the node,
+        where the variable is unset -- a gated model would then fail to download
+        with no clue why. So the values are carried across explicitly.
+
+        They are passed as a ``VAR=value`` prefix to the remote command, which
+        keeps them out of ``argv`` on the node (a prefix is consumed by that
+        shell, not handed to ``docker``) -- but the command *string* is written
+        to the workspace command log, so a genuine secret must not travel this
+        way. See :meth:`env_forward_stdin` for those.
+
+        Empty unless ssh transport is in use, so the local and native paths keep
+        their previous behaviour byte for byte.
+        """
+        if not self.uses_ssh:
+            return ""
+        parts = [
+            f"{name}={shlex.quote(environ[name])}"
+            for name in names
+            if environ.get(name)
+        ]
+        return " ".join(parts)
+
+    def env_forward_stdin(
+        self, names: list[str] | tuple[str, ...], environ
+    ) -> tuple[str, str]:
+        """Same as :meth:`env_forward` for values that must not be logged.
+
+        Returns ``(prefix, stdin)``. The variables are read from *stdin* by the
+        remote shell, so their values never appear in the command line, the
+        process table on either side, or the command log::
+
+            eval "$(cat)" && docker run -e TOK ...     <-- what is logged
+            TOK='hf_...'                               <-- what is piped in
+
+        Both are empty when there is nothing to forward or the transport does
+        not need it, in which case the caller uses the plain command unchanged.
+        """
+        if not self.uses_ssh:
+            return "", ""
+        assignments = [
+            f"{name}={shlex.quote(environ[name])}"
+            for name in names
+            if environ.get(name)
+        ]
+        if not assignments:
+            return "", ""
+        # `export` so the runtime, a child of this shell, inherits them.
+        return 'eval "$(cat)" && ', "export " + " ".join(assignments) + "\n"
 
     def runtime_env(self) -> str:
         """``VAR=value`` prefix for tools that read the connection from env.

--- a/tests/test_cli_failure_artifacts.py
+++ b/tests/test_cli_failure_artifacts.py
@@ -1,0 +1,87 @@
+"""Tests for the workspace pointer printed when a phase fails.
+
+A failed phase exits through ``sys.exit(1)`` before its success summary
+runs, so without this the run that needs its logs is the only one that
+never says where they are.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from llmdbenchmark.cli import (
+    PhaseError,
+    _execute_standup,
+    _log_failure_artifacts,
+)
+from llmdbenchmark.config import config
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """Point the config singleton at a throwaway workspace."""
+    monkeypatch.setattr(config, "workspace", tmp_path)
+    return tmp_path
+
+
+def _messages(logger) -> str:
+    return "\n".join(str(c.args[0]) for c in logger.log_error.call_args_list)
+
+
+def test_the_workspace_is_named_when_a_phase_fails(workspace):
+    logger = MagicMock()
+
+    _log_failure_artifacts(logger)
+
+    assert str(workspace) in _messages(logger)
+
+
+def test_the_captured_container_logs_are_pointed_at_when_they_exist(workspace):
+    logs = workspace / "setup" / "logs"
+    logs.mkdir(parents=True)
+    (logs / "nok8s-envoy-chat.log").write_text("boom", encoding="utf-8")
+    logger = MagicMock()
+
+    _log_failure_artifacts(logger)
+
+    assert str(logs) in _messages(logger)
+
+
+def test_a_workspace_without_captured_logs_names_only_itself(workspace):
+    """A phase can fail before any step writes a log; don't cite a missing dir."""
+    logger = MagicMock()
+
+    _log_failure_artifacts(logger)
+
+    joined = _messages(logger)
+    assert str(workspace) in joined
+    assert "setup/logs" not in joined
+
+
+def test_nothing_is_claimed_before_the_workspace_is_configured(monkeypatch):
+    """Argument parsing can fail ahead of ``setup_workspace``."""
+    monkeypatch.setattr(config, "workspace", None)
+    logger = MagicMock()
+
+    _log_failure_artifacts(logger)
+
+    assert logger.log_error.call_args_list == []
+
+
+def test_a_failed_standup_reports_the_workspace(workspace, monkeypatch):
+    """The path users actually hit: standup raises, and must still point home."""
+    logs = workspace / "setup" / "logs"
+    logs.mkdir(parents=True)
+    monkeypatch.setattr(
+        "llmdbenchmark.cli._do_standup",
+        MagicMock(side_effect=PhaseError("Standup failed:\nEnvoy never answered")),
+    )
+    logger = MagicMock()
+
+    with pytest.raises(SystemExit) as exc:
+        _execute_standup(MagicMock(), logger, MagicMock())
+
+    assert exc.value.code == 1
+    joined = _messages(logger)
+    assert "Envoy never answered" in joined
+    assert str(logs) in joined

--- a/tests/test_cli_set_overrides.py
+++ b/tests/test_cli_set_overrides.py
@@ -25,6 +25,7 @@ from llmdbenchmark.parser.cli_overrides import (
     coerce_value,
     dotted_leaves,
     find_broken_parent_paths,
+    find_typo_leaves,
     is_glob,
     is_secret_path,
     leaf_entries,
@@ -506,6 +507,91 @@ class TestPathHelpers:
 
     def test_top_level_leaf_never_reported(self):
         assert find_broken_parent_paths({"newKey": 1}, {}) == ([], [])
+
+
+class TestFindTypoLeaves:
+    """A misspelled leaf merges into a dead key; only near-misses are flagged."""
+
+    def test_near_miss_leaf_suggests_the_real_sibling(self):
+        # The motivating case: the stack silently deploys to localhost because
+        # nok8s.connection kept its default.
+        assert find_typo_leaves(
+            {"nok8s": {"conection": "10.0.0.7"}},
+            {"nok8s": {"connection": "localhost", "runtime": "docker"}},
+        ) == [("nok8s.conection", "connection")]
+
+    def test_correct_leaf_is_silent(self):
+        assert (
+            find_typo_leaves(
+                {"nok8s": {"connection": "10.0.0.7"}},
+                {"nok8s": {"connection": "localhost"}},
+            )
+            == []
+        )
+
+    def test_case_only_difference_is_flagged(self):
+        assert find_typo_leaves(
+            {"nok8s": {"sshidentity": "/k"}},
+            {"nok8s": {"sshIdentity": "", "sshArgs": []}},
+        ) == [("nok8s.sshidentity", "sshIdentity")]
+
+    def test_genuinely_new_leaf_on_a_free_form_block_is_silent(self):
+        # Same shape the parent-path check deliberately allows: free-form
+        # blocks gain new keys by design, so absence alone must not warn.
+        assert (
+            find_typo_leaves(
+                {"kustomize": {"guideVariableOverrides": {"INFRA_PROVIDER": "base"}}},
+                {"kustomize": {"guideVariableOverrides": {"FOO_BAR": "x"}}},
+            )
+            == []
+        )
+
+    def test_new_leaf_on_an_empty_map_is_silent(self):
+        assert (
+            find_typo_leaves(
+                {"kustomize": {"guideVariableOverrides": {"INFRA_PROVIDER": "base"}}},
+                {"kustomize": {"guideVariableOverrides": {}}},
+            )
+            == []
+        )
+
+    def test_distinct_real_key_is_not_a_typo_of_its_neighbours(self):
+        # extraArgs vs deviceArgs/sshArgs share a suffix but are different keys.
+        assert (
+            find_typo_leaves(
+                {"vllm": {"extraArgs": ["--x"]}},
+                {"vllm": {"deviceArgs": [], "gpus": "all"}},
+            )
+            == []
+        )
+
+    def test_top_level_leaf_is_not_reported(self):
+        # Mirrors find_broken_parent_paths: a bare new top-level key is
+        # indistinguishable from a legitimate one.
+        assert find_typo_leaves({"newKey": 1}, {}) == []
+
+    def test_missing_parent_is_left_to_the_parent_check(self):
+        # nok8ss.* already warns via find_broken_parent_paths; don't double-report.
+        assert find_typo_leaves({"nok8ss": {"connection": "x"}}, {"nok8s": {}}) == []
+
+    def test_non_map_parent_is_not_traversed(self):
+        # Descending into a scalar is a clobber, reported elsewhere.
+        assert find_typo_leaves({"a": {"b": 1}}, {"a": "scalar"}) == []
+
+    def test_nested_leaf_path_is_fully_qualified(self):
+        assert find_typo_leaves(
+            {"nok8s": {"vllm": {"replias": 2}}},
+            {"nok8s": {"vllm": {"replicas": 1, "image": "x"}}},
+        ) == [("nok8s.vllm.replias", "replicas")]
+
+    def test_only_the_closest_sibling_is_suggested(self):
+        typos = find_typo_leaves(
+            {"nok8s": {"conection": "x"}},
+            {"nok8s": {"connection": "a", "connections": "b"}},
+        )
+        assert len(typos) == 1
+        assert typos[0][0] == "nok8s.conection"
+        assert typos[0][1] in ("connection", "connections")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_container_host.py
+++ b/tests/test_container_host.py
@@ -13,9 +13,13 @@ remote one, and five steps read it, so these tests pin two things:
 
 from __future__ import annotations
 
+import shlex
+
 import pytest
 
 from llmdbenchmark.utilities.container_host import (
+    NATIVE,
+    SSH,
     ContainerHost,
     ContainerHostError,
     expand_remote_path,
@@ -115,18 +119,149 @@ def test_local_commands_are_unchanged() -> None:
 
 def test_docker_uses_dash_h_before_the_subcommand() -> None:
     """`docker run -H ...` is not a thing: the flag has to precede the verb."""
-    cmd = ContainerHost.parse("node1").runtime_cmd("run", "-d", "--name", "epp")
+    cmd = ContainerHost.parse("node1", transport=NATIVE).runtime_cmd(
+        "run", "-d", "--name", "epp"
+    )
     assert cmd.startswith("docker -H ")
     assert cmd.index("-H ") < cmd.index(" run ")
     assert "ssh://node1/var/run/docker.sock" in cmd
 
 
 def test_podman_uses_url_and_identity() -> None:
-    host = ContainerHost.parse("node1", runtime="podman", identity="/keys/id_ed25519")
+    host = ContainerHost.parse(
+        "node1", runtime="podman", identity="/keys/id_ed25519", transport=NATIVE
+    )
     cmd = host.runtime_cmd("ps")
     assert cmd.startswith("podman --url ")
     assert "--identity /keys/id_ed25519" in cmd
     assert cmd.endswith(" ps")
+
+
+# ---------------------------------------------------------------------------
+# transport
+# ---------------------------------------------------------------------------
+
+
+def test_remote_defaults_to_running_the_runtime_on_the_node() -> None:
+    """The default remote transport is plain ssh, not the client's own.
+
+    The native transport charges for a local client that does nothing but relay
+    -- and one that must match the node's daemon family. Running the runtime on
+    the node removes both couplings, so it is what an unqualified remote
+    connection gets.
+    """
+    host = ContainerHost.parse("bench@node1")
+    assert host.transport == SSH
+    cmd = host.runtime_cmd("rm", "-f", "envoy")
+    assert cmd == (
+        "ssh -o BatchMode=yes -o ConnectTimeout=10 bench@node1 'docker rm -f envoy'"
+    )
+    assert " -H " not in cmd
+
+
+def test_ssh_transport_needs_no_client_here_but_native_does() -> None:
+    """The whole point of the default: nothing to install on this machine."""
+    assert not ContainerHost.parse("node1").needs_local_runtime
+    assert ContainerHost.parse("node1", transport=NATIVE).needs_local_runtime
+    # Local always needs one -- that is where the containers run.
+    assert ContainerHost.parse("localhost").needs_local_runtime
+    assert ContainerHost.parse("localhost", transport=NATIVE).needs_local_runtime
+
+
+def test_transport_does_not_change_the_local_path() -> None:
+    """`transport` is meaningless locally and must not leak an ssh wrapper."""
+    for transport in ("", SSH, NATIVE):
+        host = ContainerHost.parse("localhost", transport=transport)
+        assert host.runtime_cmd("ps") == "docker ps"
+        assert not host.uses_ssh
+
+
+def test_ssh_transport_carries_identity_port_and_options() -> None:
+    """sshIdentity works uniformly here -- no podman/docker asymmetry."""
+    host = ContainerHost.parse("ssh://bench@node1:2222", identity="/keys/id_ed25519")
+    cmd = host.runtime_cmd("ps")
+    assert "-i /keys/id_ed25519" in cmd
+    assert "-p 2222" in cmd
+    assert cmd.endswith("bench@node1 'docker ps'")
+
+
+def test_a_quoted_tail_survives_the_extra_shell() -> None:
+    """Go templates are the sharp case: `{{.State.Status}}` must arrive intact."""
+    host = ContainerHost.parse("node1")
+    tail = "inspect -f '{{.State.Status}} {{.State.ExitCode}}' vllm"
+    wrapped = host.wrap_runtime(tail)
+    inner = shlex.split(wrapped)[-1]
+    assert inner == f"docker {tail}"
+    # docker, inspect, -f, template -- the template survives as ONE argv word.
+    assert shlex.split(inner)[3] == "{{.State.Status}} {{.State.ExitCode}}"
+
+
+def test_an_unknown_transport_is_refused_with_both_choices() -> None:
+    with pytest.raises(ContainerHostError) as exc:
+        ContainerHost.parse("node1", transport="tcp")
+    assert SSH in str(exc.value) and NATIVE in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# env forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_values_are_carried_across_for_the_node_to_expand() -> None:
+    """`-e VAR` with no value is expanded by whoever runs the CLI.
+
+    Natively that is this process, so the token arrives. Over ssh it is the
+    *node's* shell, where the variable is unset -- and a gated model would then
+    401 with nothing in the logs to explain it.
+    """
+    host = ContainerHost.parse("node1")
+    assert host.env_forward(["TOK"], {"TOK": "v"}) == "TOK=v"
+    # Nothing set, or nothing to transport: no prefix at all.
+    assert host.env_forward(["TOK"], {}) == ""
+    assert ContainerHost.parse("localhost").env_forward(["TOK"], {"TOK": "v"}) == ""
+    assert (
+        ContainerHost.parse("node1", transport=NATIVE).env_forward(
+            ["TOK"], {"TOK": "v"}
+        )
+        == ""
+    )
+
+
+def test_a_secret_travels_on_stdin_and_not_in_the_command() -> None:
+    """Every command string is written to the workspace command log.
+
+    So a token passed as a `VAR=value` prefix would be logged in cleartext. It
+    goes in over stdin instead, which the log never records.
+    """
+    host = ContainerHost.parse("node1")
+    prefix, stdin = host.env_forward_stdin(["TOK"], {"TOK": "hf_secret"})
+    cmd = host.wrap_runtime("run -d -e TOK img", prefix)
+    assert "hf_secret" not in cmd
+    assert "hf_secret" in stdin
+    # The remote shell reads it before exec'ing the runtime, so `-e TOK` resolves.
+    assert 'eval "$(cat)" &&' in cmd
+    assert stdin.startswith("export TOK=")
+
+
+def test_the_forwarding_prefix_lands_inside_the_remote_command() -> None:
+    """Outside the ssh quotes it would run on the client and forward nothing."""
+    host = ContainerHost.parse("node1")
+    prefix, _ = host.env_forward_stdin(["TOK"], {"TOK": "v"})
+    cmd = host.wrap_runtime("run img", prefix)
+    assert prefix.strip() not in cmd.split("'")[0]
+    assert shlex.split(cmd)[-1].startswith('eval "$(cat)" && docker run')
+
+
+def test_nothing_is_forwarded_when_there_is_nothing_to_forward() -> None:
+    host = ContainerHost.parse("node1")
+    assert host.env_forward_stdin(["TOK"], {}) == ("", "")
+    assert host.env_forward_stdin([], {"TOK": "v"}) == ("", "")
+    # Native and local expand client-side already.
+    for other in (
+        ContainerHost.parse("localhost"),
+        ContainerHost.parse("node1", transport=NATIVE),
+    ):
+        assert other.env_forward_stdin(["TOK"], {"TOK": "v"}) == ("", "")
 
 
 def test_runtime_env_matches_the_runtime() -> None:

--- a/tests/test_container_host.py
+++ b/tests/test_container_host.py
@@ -1,0 +1,232 @@
+"""Tests for the nok8s container-runtime connection target (``ContainerHost``).
+
+``nok8s.connection`` is the one knob that turns a local nok8s standup into a
+remote one, and five steps read it, so these tests pin two things:
+
+1. The *local* default produces byte-identical commands to the pre-connection
+   code -- no flags, no ssh wrapper, no scp. A regression there breaks every
+   existing single-host user.
+2. A remote value produces commands that resolve on the **daemon** host, not the
+   client: the runtime flag goes before the subcommand, probes are wrapped in
+   ssh, and bind-mount sources are pushed with scp.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmdbenchmark.utilities.container_host import (
+    ContainerHost,
+    ContainerHostError,
+    expand_remote_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "connection",
+    ["", None, "localhost", "LOCALHOST", "local", "127.0.0.1", "::1"],
+)
+def test_local_forms_parse_as_local(connection) -> None:
+    host = ContainerHost.parse(connection)
+    assert host.is_remote is False
+    assert host.runtime_args() == ""
+    assert host.url == ""
+
+
+@pytest.mark.parametrize(
+    "connection", ["unix:///var/run/docker.sock", "/run/podman.sock"]
+)
+def test_socket_paths_stay_local(connection: str) -> None:
+    """A socket path is the local runtime, not a new transport to invent."""
+    assert ContainerHost.parse(connection).is_remote is False
+
+
+def test_bare_ip_is_read_as_ssh() -> None:
+    """The headline case: `connection: 10.0.0.7` and nothing else."""
+    host = ContainerHost.parse("10.0.0.7")
+    assert host.is_remote is True
+    assert host.host == "10.0.0.7"
+    assert host.user == ""
+    assert host.destination == "10.0.0.7"
+
+
+def test_user_host_port_and_socket_are_parsed() -> None:
+    host = ContainerHost.parse(
+        "ssh://bench@node1:2222/run/user/1000/podman/podman.sock", runtime="podman"
+    )
+    assert (host.user, host.host, host.port) == ("bench", "node1", 2222)
+    assert host.socket == "/run/user/1000/podman/podman.sock"
+    assert host.destination == "bench@node1"
+    assert host.url == "ssh://bench@node1:2222/run/user/1000/podman/podman.sock"
+
+
+def test_docker_url_gets_the_default_socket_path() -> None:
+    """docker needs an explicit socket in the URL; podman resolves its own."""
+    assert ContainerHost.parse("node1").url == "ssh://node1/var/run/docker.sock"
+    assert ContainerHost.parse("node1", runtime="podman").url == "ssh://node1"
+
+
+def test_tcp_is_refused_with_the_reason_and_the_alternative() -> None:
+    """An unauthenticated daemon socket is root on the node; say so."""
+    with pytest.raises(ContainerHostError) as exc:
+        ContainerHost.parse("tcp://10.0.0.7:2375")
+    message = str(exc.value)
+    assert "root" in message
+    assert "ssh://" in message
+
+
+@pytest.mark.parametrize("connection", ["http://node1", "https://node1", "vsock://x"])
+def test_other_schemes_are_refused(connection: str) -> None:
+    with pytest.raises(ContainerHostError):
+        ContainerHost.parse(connection)
+
+
+def test_invalid_port_is_a_container_host_error_not_a_valueerror() -> None:
+    """urlparse defers port validation to attribute access; catch it there."""
+    with pytest.raises(ContainerHostError) as exc:
+        ContainerHost.parse("ssh://node1:notaport")
+    assert "port" in str(exc.value)
+
+
+def test_scheme_with_no_host_is_refused() -> None:
+    with pytest.raises(ContainerHostError):
+        ContainerHost.parse("ssh://")
+
+
+# ---------------------------------------------------------------------------
+# command construction
+# ---------------------------------------------------------------------------
+
+
+def test_local_commands_are_unchanged() -> None:
+    """The local path must be exactly what it was before connections existed."""
+    host = ContainerHost.parse("localhost")
+    assert host.runtime_cmd("rm", "-f", "envoy") == "docker rm -f envoy"
+    assert host.shell("curl -fsS http://localhost:8081") == (
+        "curl -fsS http://localhost:8081"
+    )
+    assert host.runtime_env() == ""
+
+
+def test_docker_uses_dash_h_before_the_subcommand() -> None:
+    """`docker run -H ...` is not a thing: the flag has to precede the verb."""
+    cmd = ContainerHost.parse("node1").runtime_cmd("run", "-d", "--name", "epp")
+    assert cmd.startswith("docker -H ")
+    assert cmd.index("-H ") < cmd.index(" run ")
+    assert "ssh://node1/var/run/docker.sock" in cmd
+
+
+def test_podman_uses_url_and_identity() -> None:
+    host = ContainerHost.parse("node1", runtime="podman", identity="/keys/id_ed25519")
+    cmd = host.runtime_cmd("ps")
+    assert cmd.startswith("podman --url ")
+    assert "--identity /keys/id_ed25519" in cmd
+    assert cmd.endswith(" ps")
+
+
+def test_runtime_env_matches_the_runtime() -> None:
+    assert "DOCKER_HOST=" in ContainerHost.parse("node1").runtime_env()
+    podman = ContainerHost.parse("node1", runtime="podman", identity="/k/id")
+    assert "CONTAINER_HOST=" in podman.runtime_env()
+    assert "CONTAINER_SSHKEY=" in podman.runtime_env()
+
+
+def test_shell_runs_the_command_on_the_daemon_host() -> None:
+    """A readiness probe for `localhost` must mean the node, not the client."""
+    host = ContainerHost.parse("bench@node1")
+    wrapped = host.shell("curl -fsS http://localhost:8081/v1/models")
+    assert wrapped.startswith("ssh ")
+    assert " bench@node1 " in wrapped
+    # The whole remote command is one quoted argument, so the client shell does
+    # not try to interpret it.
+    assert wrapped.endswith("'curl -fsS http://localhost:8081/v1/models'")
+
+
+def test_shell_is_non_interactive_by_default() -> None:
+    """A standup blocked on a passphrase prompt looks like a hang."""
+    wrapped = ContainerHost.parse("node1").shell("true")
+    assert "BatchMode=yes" in wrapped
+    assert "ConnectTimeout=10" in wrapped
+
+
+def test_ssh_args_replace_the_defaults() -> None:
+    host = ContainerHost.parse("node1", ssh_args=["-o", "StrictHostKeyChecking=yes"])
+    wrapped = host.shell("true")
+    assert "StrictHostKeyChecking=yes" in wrapped
+    assert "BatchMode=yes" not in wrapped
+
+
+def test_port_flag_differs_between_ssh_and_scp() -> None:
+    """scp spells the port -P; ssh spells it -p. Mixing them silently fails."""
+    host = ContainerHost.parse("node1:2222")
+    assert " -p 2222 " in host.shell("true")
+    assert " -P 2222 " in host.push_dir("/local", "/remote")
+
+
+def test_push_dir_creates_the_target_and_copies_contents() -> None:
+    """Contents, not the directory: a re-run must overwrite, not nest."""
+    pushed = ContainerHost.parse("bench@node1").push_dir("/local/stage", "/remote/ws")
+    assert "mkdir -p /remote/ws" in pushed
+    assert "scp " in pushed and " -r " in pushed
+    assert "/local/stage/." in pushed
+    assert "bench@node1:/remote/ws/" in pushed
+
+
+def test_push_file_creates_the_parent_directory() -> None:
+    pushed = ContainerHost.parse("node1").push_file("/local/x.sh", "/remote/d/x.sh")
+    assert "mkdir -p /remote/d" in pushed
+    assert "node1:/remote/d/x.sh" in pushed
+
+
+def test_pull_dir_brings_results_back_to_the_client() -> None:
+    pulled = ContainerHost.parse("node1").pull_dir("/remote/results", "/local/results")
+    assert pulled.startswith("mkdir -p /local/results")
+    assert "node1:/remote/results/." in pulled
+
+
+def test_local_transfers_are_plain_copies() -> None:
+    host = ContainerHost.parse("localhost")
+    assert host.push_dir("/a", "/b") == "cp -a /a/. /b/"
+    assert host.pull_dir("/a", "/b") == "cp -a /a/. /b/"
+
+
+def test_endpoint_addresses_the_node_for_a_client_side_caller() -> None:
+    assert ContainerHost.parse("10.0.0.7").endpoint(8081) == "http://10.0.0.7:8081"
+    assert ContainerHost.parse("localhost").endpoint(8081) == "http://localhost:8081"
+
+
+def test_describe_names_the_target() -> None:
+    assert "local" in ContainerHost.parse("").describe()
+    assert "ssh://node1" in ContainerHost.parse("node1").describe()
+
+
+# ---------------------------------------------------------------------------
+# ~ expansion
+# ---------------------------------------------------------------------------
+
+
+def test_tilde_expands_against_the_daemon_hosts_home() -> None:
+    """The client's $HOME is the wrong user on a remote node."""
+    assert (
+        expand_remote_path("~/.llmdbench/nok8s", "/home/bench")
+        == "/home/bench/.llmdbench/nok8s"
+    )
+    assert expand_remote_path("~", "/home/bench") == "/home/bench"
+
+
+def test_absolute_paths_are_untouched() -> None:
+    assert expand_remote_path("/srv/ws", "/home/bench") == "/srv/ws"
+
+
+def test_unknown_home_leaves_the_tilde_for_the_remote_shell() -> None:
+    assert expand_remote_path("~/x", "") == "~/x"
+
+
+def test_a_username_after_the_tilde_is_not_rewritten() -> None:
+    """`~other/x` names a different user's home; only a bare `~` is ours."""
+    assert expand_remote_path("~other/x", "/home/bench") == "~other/x"

--- a/tests/test_nok8s_harness_status.py
+++ b/tests/test_nok8s_harness_status.py
@@ -237,11 +237,15 @@ def test_debug_mode_does_not_check_exit_status(tmp_path: Path) -> None:
 REMOTE = "ssh://bench@10.0.0.7"
 
 
-def _remote_context(tmp_path: Path, cmd: _Command, logger: _Logger):
+def _remote_context(
+    tmp_path: Path, cmd: _Command, logger: _Logger, transport: str = ""
+):
     """A context whose stack config points the runtime at a remote node."""
     context, stack_path = _context(tmp_path, cmd, logger)
     config = _plan_config()
     config["nok8s"]["connection"] = REMOTE
+    if transport:
+        config["nok8s"]["transport"] = transport
     (stack_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
     return context, stack_path
 
@@ -269,9 +273,32 @@ def test_remote_harness_runs_on_the_node(tmp_path: Path) -> None:
 
     assert result.success, result.errors
     run = next(c for c in cmd.commands if " run -d --name " in c)
-    assert run.startswith("docker -H ssh://bench@10.0.0.7/var/run/docker.sock run")
+    # Default transport is ssh: the runtime is invoked on the node, so no
+    # client binary is needed here and no -H/--url flag appears.
+    assert run.startswith("ssh ")
+    assert "bench@10.0.0.7 'docker run -d --name " in run
+    assert " -H ssh://" not in run
     # It measures the in-host endpoint, which the deploy step recorded.
     assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://localhost:8081" in run
+
+
+def test_native_transport_still_uses_the_client_connection_flag(
+    tmp_path: Path,
+) -> None:
+    """``transport: native`` keeps the runtimes' own SSH transport.
+
+    Anyone who already has a matching client and prefers ``docker -H`` should
+    get exactly the command they got before the ssh transport existed.
+    """
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger(), transport="native")
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert run.startswith("docker -H ssh://bench@10.0.0.7/var/run/docker.sock run")
+    assert not run.startswith("ssh ")
 
 
 def test_remote_harness_mounts_paths_staged_on_the_node(tmp_path: Path) -> None:

--- a/tests/test_nok8s_harness_status.py
+++ b/tests/test_nok8s_harness_status.py
@@ -228,3 +228,245 @@ def test_debug_mode_does_not_check_exit_status(tmp_path: Path) -> None:
 
     assert result.success
     assert _inspect_commands(cmd) == []
+
+
+# ---------------------------------------------------------------------------
+# Remote nok8s (nok8s.connection)
+# ---------------------------------------------------------------------------
+
+REMOTE = "ssh://bench@10.0.0.7"
+
+
+def _remote_context(tmp_path: Path, cmd: _Command, logger: _Logger):
+    """A context whose stack config points the runtime at a remote node."""
+    context, stack_path = _context(tmp_path, cmd, logger)
+    config = _plan_config()
+    config["nok8s"]["connection"] = REMOTE
+    (stack_path / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    return context, stack_path
+
+
+def _remote_cmd() -> _Command:
+    return _Command(
+        {
+            "printenv HOME": _Result(stdout="/home/bench\n"),
+            " inspect ": _Result(stdout="exited 0\n"),
+        }
+    )
+
+
+def test_remote_harness_runs_on_the_node(tmp_path: Path) -> None:
+    """The load generator belongs on the serving host.
+
+    Driving it from the client would add the SSH round-trip to every request
+    and report that as the stack's latency, so the container is launched
+    through the remote runtime, not locally.
+    """
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert run.startswith("docker -H ssh://bench@10.0.0.7/var/run/docker.sock run")
+    # It measures the in-host endpoint, which the deploy step recorded.
+    assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://localhost:8081" in run
+
+
+def test_remote_harness_mounts_paths_staged_on_the_node(tmp_path: Path) -> None:
+    """Bind-mount sources resolve on the daemon, so the -v paths are remote."""
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+
+    DeployHarnessLocalStep().execute(context, stack_path)
+
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    remote_root = f"/home/bench/.llmdbench/nok8s-runs/stack/{tmp_path.name}"
+    for mount in ("results:/requests", "profiles:/workspace/profiles"):
+        assert f"{remote_root}/{mount}" in run, run
+    assert f"{remote_root}/harnesses:/workspace/harnesses:ro" in run
+    # Nothing client-side leaks into a mount source.
+    assert str(context.run_results_dir()) not in run
+
+
+def test_remote_harness_pushes_inputs_before_launching(tmp_path: Path) -> None:
+    """Profiles and scripts have to be on the node before the container starts."""
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+
+    DeployHarnessLocalStep().execute(context, stack_path)
+
+    first_scp = next(i for i, c in enumerate(cmd.commands) if "scp " in c)
+    first_run = next(i for i, c in enumerate(cmd.commands) if " run -d --name " in c)
+    assert first_scp < first_run
+
+
+def test_remote_harness_pulls_results_back(tmp_path: Path) -> None:
+    """The caller must end up with the same results tree the local path makes."""
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+
+    DeployHarnessLocalStep().execute(context, stack_path)
+
+    pulls = [c for c in cmd.commands if "scp " in c and "bench@10.0.0.7:" in c]
+    assert pulls, cmd.commands
+    assert any(str(context.run_results_dir()) in c for c in pulls)
+
+
+def test_remote_input_push_failure_is_fatal(tmp_path: Path) -> None:
+    """docker mounts a missing source as an empty dir, so never launch blind."""
+    cmd = _Command(
+        {
+            "printenv HOME": _Result(stdout="/home/bench\n"),
+            "scp ": _Result(exit_code=1),
+        }
+    )
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert not result.success
+    assert any("stage" in error.lower() for error in result.errors)
+    assert not any(" run -d --name " in c for c in cmd.commands)
+
+
+def test_remote_scratch_dir_is_unique_per_invocation(tmp_path: Path) -> None:
+    """Two runs must not share a remote results dir, or the second reports the
+    first's numbers."""
+    seen = set()
+    for name in ("user-20260818-000001-000", "user-20260818-000002-000"):
+        workspace = tmp_path / name
+        workspace.mkdir()
+        cmd = _remote_cmd()
+        context, stack_path = _remote_context(workspace, cmd, _Logger())
+        DeployHarnessLocalStep().execute(context, stack_path)
+        run = next(c for c in cmd.commands if " run -d --name " in c)
+        seen.add(run.split(":/requests")[0].rsplit(" ", 1)[-1])
+    assert len(seen) == 2, seen
+
+
+def _rendered_spec(stack_path: Path) -> None:
+    """The launch spec standup leaves behind, carrying both endpoints."""
+    (stack_path / "34_nok8s-containers.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "endpoint": "http://localhost:8081",
+                "clientEndpoint": "http://10.0.0.7:8081",
+                "model": "test-model",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_standalone_run_measures_the_in_host_endpoint(tmp_path: Path) -> None:
+    """A fresh ``run`` reads the endpoint off the rendered spec, not the CLI.
+
+    ``deployed_endpoints`` is only populated when standup ran in the same
+    process. Without it the step used to fall back to ``context.endpoint_url``,
+    which is the client-side URL -- so a container running *on the node* would
+    have sent every request out to the node's external address and back.
+    """
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+    context.deployed_endpoints.clear()
+    context.endpoint_url = "http://10.0.0.7:8081"
+    _rendered_spec(stack_path)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://localhost:8081" in run
+    assert "10.0.0.7:8081" not in run
+
+
+def test_standalone_run_without_a_spec_still_falls_back(tmp_path: Path) -> None:
+    """No rendered spec (e.g. a hand-rolled plan) must not break the run."""
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+    context.deployed_endpoints.clear()
+    context.endpoint_url = "http://10.0.0.7:8081"
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://10.0.0.7:8081" in run
+
+
+def test_local_run_ignores_the_spec_endpoint(tmp_path: Path) -> None:
+    """A local stack keeps its previous fallback exactly.
+
+    Both endpoints are identical for a local stack, so reading the spec would
+    change nothing -- and an explicit --endpoint-url must still win over a
+    stale spec left over from an earlier standup.
+    """
+    cmd = _Command({" inspect ": _Result(stdout="exited 0\n")})
+    context, stack_path = _context(tmp_path, cmd, _Logger())
+    context.deployed_endpoints.clear()
+    context.endpoint_url = "http://127.0.0.1:9999"
+    _rendered_spec(stack_path)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://127.0.0.1:9999" in run
+
+
+def test_client_endpoint_from_step_03_is_swapped_for_the_in_host_one(
+    tmp_path: Path,
+) -> None:
+    """Step 03 copies the CLI's client-side default into deployed_endpoints.
+
+    So the swap cannot only cover an *empty* deployed_endpoints -- by the time
+    this step runs in a standalone ``run``, the client URL is already recorded
+    under the stack's name.
+    """
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+    context.deployed_endpoints["stack"] = "http://10.0.0.7:8081"
+    context.endpoint_url = "http://10.0.0.7:8081"
+    _rendered_spec(stack_path)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://localhost:8081" in run
+
+
+def test_an_explicit_endpoint_url_is_not_overridden(tmp_path: Path) -> None:
+    """--endpoint-url names a target the caller chose; the spec must not win.
+
+    Only the CLI's derived default (which equals clientEndpoint) is replaced.
+    Anything else -- a proxy, a second front door, another node -- is a
+    deliberate choice and is passed through untouched.
+    """
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+    context.deployed_endpoints["stack"] = "http://proxy.internal:9000"
+    context.endpoint_url = "http://proxy.internal:9000"
+    _rendered_spec(stack_path)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://proxy.internal:9000" in run
+
+
+def test_a_trailing_slash_still_counts_as_the_client_default(tmp_path: Path) -> None:
+    """The comparison is on the URL, not on its punctuation."""
+    cmd = _remote_cmd()
+    context, stack_path = _remote_context(tmp_path, cmd, _Logger())
+    context.deployed_endpoints["stack"] = "http://10.0.0.7:8081/"
+    _rendered_spec(stack_path)
+
+    result = DeployHarnessLocalStep().execute(context, stack_path)
+
+    assert result.success, result.errors
+    run = next(c for c in cmd.commands if " run -d --name " in c)
+    assert "LLMDBENCH_HARNESS_STACK_ENDPOINT_URL=http://localhost:8081" in run

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -738,6 +738,99 @@ def test_shared_nok8s_name_suffix_is_a_render_error(tmp_path: Path) -> None:
     assert any("envoy-shared" in e and "nok8s-single" in e for e in errors), errors
 
 
+# ---------------------------------------------------------------------- #
+# Envoy hot-restart base ID
+# ---------------------------------------------------------------------- #
+def _envoy_of(stack_dir: Path) -> dict:
+    return next(c for c in _spec_of(stack_dir)["containers"] if c["kind"] == "envoy")
+
+
+def test_two_stacks_get_distinct_envoy_base_ids(tmp_path: Path) -> None:
+    """Envoy's base ID is a host-wide claim under --network host.
+
+    Two Envoys sharing one would leave the second dead with errno=98 before it
+    bound its listener, which the CLI could only report as a readiness timeout.
+    """
+    result = _render_scenario(tmp_path, _two_stack_scenario(tmp_path, True))
+    assert not result.has_errors, result.to_dict()
+    first, second = (Path(p) for p in result.rendered_paths)
+
+    base_a, base_b = _envoy_of(first)["baseId"], _envoy_of(second)["baseId"]
+    assert base_a != base_b
+    # Seeded from listenPort, which the host-claim validator already proves
+    # unique -- so the IDs are not a second set of numbers to hand-sync.
+    assert (base_a, base_b) == (8081, 8181)
+
+
+def test_single_stack_envoy_also_gets_a_base_id(tmp_path: Path) -> None:
+    """One stack needs it too: the Envoy it collides with can be last run's."""
+    assert _envoy_of(_stack_dir(_render(tmp_path)))["baseId"] == 8081
+
+
+def test_authored_envoy_base_id_is_preserved(tmp_path: Path) -> None:
+    """An explicit baseId wins over the listenPort-derived default."""
+    scenario = _two_stack_scenario(tmp_path, True, both_nok8s={"envoy": {"baseId": 42}})
+    result = _render_scenario(tmp_path, scenario)
+    first = Path(result.rendered_paths[0])
+    assert _envoy_of(first)["baseId"] == 42
+
+
+@pytest.mark.parametrize("port", ["auto", None, 0, 99999])
+def test_unusable_listen_port_leaves_the_base_id_alone(port) -> None:
+    """A port the host-claim validator rejects must not seed a base ID.
+
+    Reporting a plausible-looking ID in front of the real complaint would only
+    make the port error harder to read.
+    """
+    values = {"nok8s": {"enabled": True, "envoy": {"listenPort": port}}}
+    out = _validator()._resolve_nok8s_envoy_base_id(values)
+    assert "baseId" not in out["nok8s"]["envoy"]
+
+
+def test_quoted_listen_port_still_seeds_the_base_id() -> None:
+    """`listenPort: '8081'` is a string; the derived ID is still an int."""
+    values = {"nok8s": {"enabled": True, "envoy": {"listenPort": "8081"}}}
+    out = _validator()._resolve_nok8s_envoy_base_id(values)
+    assert out["nok8s"]["envoy"]["baseId"] == 8081
+
+
+def test_base_id_resolver_skips_a_disabled_nok8s() -> None:
+    values = {"nok8s": {"enabled": False, "envoy": {"listenPort": 8081}}}
+    out = _validator()._resolve_nok8s_envoy_base_id(values)
+    assert "baseId" not in out["nok8s"]["envoy"]
+
+
+def test_envoy_is_launched_with_its_base_id(tmp_path: Path) -> None:
+    """The resolved ID reaches the docker command as --base-id."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _nok8s_stack(tmp_path)
+    spec = yaml.safe_load(
+        (stack / "34_nok8s-containers.yaml").read_text(encoding="utf-8")
+    )
+    for container in spec["containers"]:
+        if container["kind"] == "envoy":
+            container["baseId"] = 8081
+    (stack / "34_nok8s-containers.yaml").write_text(yaml.safe_dump(spec), "utf-8")
+
+    cmd = _RecordingCmd(fail_substrings=("--name envoy",))
+    NoK8sDeployStep().execute(_nok8s_ctx(tmp_path, cmd), stack)
+
+    envoy_run = next(c for c in cmd.commands if " run -d --name envoy" in c)
+    assert "--base-id 8081" in envoy_run
+
+
+def test_a_plan_without_a_base_id_launches_envoy_unchanged(tmp_path: Path) -> None:
+    """Back-compat: a plan rendered before baseId existed gets no flag."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    cmd = _RecordingCmd(fail_substrings=("--name envoy",))
+    NoK8sDeployStep().execute(_nok8s_ctx(tmp_path, cmd), _nok8s_stack(tmp_path))
+
+    envoy_run = next(c for c in cmd.commands if " run -d --name envoy" in c)
+    assert "--base-id" not in envoy_run
+
+
 def _validator() -> RenderPlans:
     return RenderPlans(
         template_dir=TEMPLATE_DIR,

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -124,8 +124,10 @@ class _FakeCmd:
     def __init__(self, fail_substrings=(), stdout_for=None) -> None:
         self.fail_substrings = fail_substrings
         self.stdout_for = stdout_for or {}
+        self.seen: list[str] = []
 
     def execute(self, cmd, *_, **__):
+        self.seen.append(cmd)
         ok = not any(s in cmd for s in self.fail_substrings)
         out = ""
         for key, val in self.stdout_for.items():
@@ -188,6 +190,70 @@ def test_nok8s_preflight_passes_when_runtime_and_gpu_present(tmp_path: Path) -> 
     finally:
         os.environ.pop("HUGGING_FACE_HUB_TOKEN", None)
     assert result.success is True
+
+
+def test_remote_preflight_does_not_require_a_client_here(tmp_path: Path) -> None:
+    """Under the default ssh transport nothing runs a container locally.
+
+    So a missing local docker/podman must not block a remote standup -- that
+    requirement is what forced people to install a client that only relays, and
+    a client of the *same family* as the node's daemon at that.
+    """
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _FakeCmd(
+            fail_substrings=("command -v docker",),
+            stdout_for={"ss -ltn": "State  Recv-Q\n"},
+        ),
+        nok8s={"enabled": True, "connection": "bench@10.0.0.7"},
+    )
+    result = EnsureInfraStep().execute(ctx)
+    assert not any("not found on PATH" in e and "docker" in e for e in result.errors), (
+        result.errors
+    )
+
+
+def test_native_transport_still_requires_a_client_here(tmp_path: Path) -> None:
+    """`docker -H` cannot run without docker, and the error should say why."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _FakeCmd(fail_substrings=("command -v docker",)),
+        nok8s={
+            "enabled": True,
+            "connection": "bench@10.0.0.7",
+            "transport": "native",
+        },
+    )
+    result = EnsureInfraStep().execute(ctx)
+    assert not result.success
+    missing = next(e for e in result.errors if "not found on PATH" in e)
+    # It points at the way out rather than only at the missing binary.
+    assert "transport" in missing and "ssh" in missing
+
+
+def test_timeout_is_probed_on_the_client_not_the_node(tmp_path: Path) -> None:
+    """`timeout` wraps the *client* command (ssh, or the local client binary).
+
+    Probing it on the node passed on a node that had it while the client did
+    not, and the harness wait then ran unbounded. `curl` is the opposite case:
+    it probes readiness from the node, so it is checked there.
+    """
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _FakeCmd(stdout_for={"ss -ltn": "State  Recv-Q\n"}),
+        nok8s={"enabled": True, "connection": "bench@10.0.0.7"},
+    )
+    EnsureInfraStep().execute(ctx)
+    probes = [c for c in ctx.cmd.seen if "command -v timeout" in c]
+    assert probes and not any(c.startswith("ssh ") for c in probes), probes
+    node_probes = [c for c in ctx.cmd.seen if "command -v curl" in c]
+    assert node_probes and all(c.startswith("ssh ") for c in node_probes), node_probes
 
 
 def _busy_warning(ctx) -> str:
@@ -427,13 +493,22 @@ class _RecordingCmd(_FakeCmd):
     def __init__(self, fail_substrings=(), stdout_for=None) -> None:
         super().__init__(fail_substrings, stdout_for)
         self.commands: list[str] = []
+        # Commands passed force=True, which is what actually runs under
+        # --dry-run: everything else the executor only prints.
+        self.forced: list[str] = []
+        self.stdins: list[str] = []
 
     def execute(self, cmd, *args, **kwargs):
         self.commands.append(cmd)
+        self.stdins.append(kwargs.get("stdin", ""))
+        if kwargs.get("force"):
+            self.forced.append(cmd)
         return super().execute(cmd, *args, **kwargs)
 
     def removed(self) -> set[str]:
-        return {c.split()[-1] for c in self.commands if " rm -f " in c}
+        # Under ssh transport the command is quoted as a unit, so the last
+        # token carries the closing quote; the container name is the same.
+        return {c.split()[-1].rstrip("'") for c in self.commands if " rm -f " in c}
 
     def launched(self) -> set[str]:
         return {
@@ -970,12 +1045,16 @@ def test_unsupported_connection_scheme_is_a_render_error(tmp_path: Path) -> None
     assert result.stacks["nok8s-single"].render_errors
 
 
-def _remote_stack(tmp_path: Path, connection: str = REMOTE) -> Path:
+def _remote_stack(
+    tmp_path: Path, connection: str = REMOTE, transport: str = ""
+) -> Path:
     """A rendered-spec stack dir whose containers live on a remote node."""
     stack = _nok8s_stack(tmp_path)
     spec_file = stack / "34_nok8s-containers.yaml"
     spec = yaml.safe_load(spec_file.read_text(encoding="utf-8"))
     spec["connection"] = connection
+    if transport:
+        spec["transport"] = transport
     spec["clientEndpoint"] = "http://10.0.0.7:8081"
     spec["workspaceHostDir"] = "~/.llmdbench/nok8s"
     spec["readiness"] = {"vllmPorts": [8000], "envoyPort": 8081}
@@ -987,10 +1066,13 @@ def _remote_stack(tmp_path: Path, connection: str = REMOTE) -> Path:
     return stack
 
 
-def test_remote_deploy_puts_the_connection_flag_before_the_subcommand(
-    tmp_path: Path,
-) -> None:
-    """`docker run -H ssh://...` is not valid; the flag has to precede `run`."""
+def test_remote_deploy_runs_the_runtime_on_the_node(tmp_path: Path) -> None:
+    """The default transport needs no container client on this machine.
+
+    Every one of the three launches is a remote operation, so the runtime is
+    invoked on the node over ssh rather than through a local client that would
+    only relay -- and would have to match the node's daemon family to do it.
+    """
     from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
 
     stack = _remote_stack(tmp_path)
@@ -1003,7 +1085,63 @@ def test_remote_deploy_puts_the_connection_flag_before_the_subcommand(
     runs = [c for c in cmd.commands if " run -d --name " in c]
     assert len(runs) == 3, cmd.commands
     for run in runs:
+        assert run.startswith("ssh ")
+        assert "bench@10.0.0.7 'docker run -d --name " in run
+        assert " -H ssh://" not in run
+
+
+def test_native_transport_puts_the_connection_flag_before_the_subcommand(
+    tmp_path: Path,
+) -> None:
+    """`docker run -H ssh://...` is not valid; the flag has to precede `run`."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path, transport="native")
+    cmd = _RecordingCmd(stdout_for={"printenv HOME": "/home/bench\n"})
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sDeployStep().execute(ctx, stack)
+    assert result.success is True, result.message
+
+    runs = [c for c in cmd.commands if " run -d --name " in c]
+    assert len(runs) == 3, cmd.commands
+    for run in runs:
         assert run.startswith("docker -H ssh://bench@10.0.0.7/var/run/docker.sock run")
+
+
+def test_the_hf_token_reaches_the_node_without_being_logged(tmp_path: Path) -> None:
+    """`-e VAR` with no value is expanded by whoever runs the CLI.
+
+    Natively that is this process, so the token in the operator's shell reaches
+    the container. Over ssh the runtime runs on the *node*, where the variable is
+    unset -- a gated model would 401 with nothing in the logs to explain it. So
+    the value is carried across explicitly, but over stdin: every command string
+    is written to the workspace command log, so a `VAR=value` prefix would leave
+    the token there in cleartext.
+    """
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd(stdout_for={"printenv HOME": "/home/bench\n"})
+    ctx = _nok8s_ctx(tmp_path, cmd)
+    import os
+
+    os.environ["HUGGING_FACE_HUB_TOKEN"] = "hf_supersecret"
+    try:
+        result = NoK8sDeployStep().execute(ctx, stack)
+    finally:
+        os.environ.pop("HUGGING_FACE_HUB_TOKEN", None)
+    assert result.success is True, result.message
+
+    vllm = next(c for c in cmd.commands if "--name vllm-0" in c)
+    assert "hf_supersecret" not in vllm
+    # It is still requested, and the remote shell has it by then.
+    assert "-e HUGGING_FACE_HUB_TOKEN" in vllm
+    assert 'eval "$(cat)" &&' in vllm
+    token_stdin = next(s for s in cmd.stdins if s)
+    assert "hf_supersecret" in token_stdin
+    # Nothing anywhere in the log carries the value.
+    assert not any("hf_supersecret" in c for c in cmd.commands)
 
 
 def test_remote_deploy_stages_configs_on_the_node_before_launching(
@@ -1105,6 +1243,28 @@ def test_remote_teardown_removes_containers_on_the_node(tmp_path: Path) -> None:
     assert "10.0.0.7" in result.message
     assert cmd.removed() == {"vllm-0", "epp", "envoy"}
     for c in cmd.commands:
+        assert c.startswith("ssh ")
+        assert "bench@10.0.0.7 'docker rm -f " in c
+
+
+def test_native_transport_teardown_reaches_the_same_daemon(tmp_path: Path) -> None:
+    """Teardown reads the transport off the spec standup left behind.
+
+    Defaulting it here instead would leave a native-transport stack running:
+    the removals would go out over a different mechanism than the launches, and
+    on a host with no local client they would not go out at all.
+    """
+    from llmdbenchmark.teardown.steps.step_06_nok8s_teardown import NoK8sTeardownStep
+
+    stack = _remote_stack(tmp_path, transport="native")
+    cmd = _RecordingCmd()
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sTeardownStep().execute(ctx, stack)
+
+    assert result.success is True
+    assert cmd.removed() == {"vllm-0", "epp", "envoy"}
+    for c in cmd.commands:
         assert c.startswith("docker -H ssh://bench@10.0.0.7/var/run/docker.sock rm")
 
 
@@ -1147,14 +1307,57 @@ def test_remote_preflight_tests_the_connection_and_probes_the_node(
 
     assert result.success is True, result.errors
     commands = ctx.cmd.commands
-    assert any(c.startswith("docker -H ") and c.endswith(" info") for c in commands)
-    # The client binary is checked locally; the host tools on the node.
-    assert "command -v docker" in commands
+    assert any(c.startswith("ssh ") and c.endswith("'docker info'") for c in commands)
+    # No local client is consulted -- there is nothing for one to do.
+    assert "command -v docker" not in commands
     assert any(c.startswith("ssh ") and "nvidia-smi -L" in c for c in commands)
     assert any(c.startswith("ssh ") and "ss -ltn" in c for c in commands)
 
 
-def test_remote_preflight_reports_an_unreachable_daemon_with_the_fix(
+def test_a_dead_connection_and_a_dead_daemon_are_reported_differently(
+    tmp_path: Path,
+) -> None:
+    """Under ssh transport the two failures are distinguishable, so distinguish.
+
+    ssh exits 255 for its own failures and passes the remote command's status
+    through otherwise, which separates "never reached the node" from "reached it
+    and the runtime would not answer". Collapsing them sent people to debug SSH
+    keys when their user simply was not in the `docker` group.
+    """
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    # (a) ssh itself failed.
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _ScriptedCmd(scripted=(("docker info", 255, "Permission denied (publickey)"),)),
+        nok8s={"enabled": True, "connection": REMOTE},
+    )
+    result = EnsureInfraStep().execute(ctx)
+    assert result.success is False
+    joined = " ".join(result.errors)
+    assert "ssh bench@10.0.0.7 true" in joined
+    assert "over ssh" in joined
+    # No local client is implicated -- there is none.
+    assert "nok8s.runtime=" not in joined
+
+    # (b) the node answered; its runtime did not.
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _ScriptedCmd(
+            scripted=(("docker info", 1, "permission denied while trying to connect"),)
+        ),
+        nok8s={"enabled": True, "connection": REMOTE},
+    )
+    result = EnsureInfraStep().execute(ctx)
+    assert result.success is False
+    joined = " ".join(result.errors)
+    assert "ssh bench@10.0.0.7 docker info" in joined
+    assert "'docker' group" in joined, joined
+    # It does not blame the SSH setup, which demonstrably worked.
+    assert "ssh bench@10.0.0.7 true" not in joined
+
+
+def test_native_preflight_reports_an_unreachable_daemon_with_the_fix(
     tmp_path: Path,
 ) -> None:
     from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
@@ -1162,7 +1365,7 @@ def test_remote_preflight_reports_an_unreachable_daemon_with_the_fix(
     ctx = _nok8s_ctx(
         tmp_path,
         _RecordingCmd(fail_substrings=("docker -H ",)),
-        nok8s={"enabled": True, "connection": REMOTE},
+        nok8s={"enabled": True, "connection": REMOTE, "transport": "native"},
     )
     result = EnsureInfraStep().execute(ctx)
 
@@ -1201,7 +1404,13 @@ def test_remote_dry_run_never_touches_the_node(tmp_path: Path) -> None:
     result = NoK8sDeployStep().execute(ctx, stack)
 
     assert result.success is True
-    assert not any(c.startswith("ssh ") for c in cmd.commands)
+    # The launch commands are *built* -- printing them is the point of a dry
+    # run -- and the executor prints rather than runs them. What must not
+    # happen is a `force=True` call, which runs even under --dry-run because
+    # the step needs its output: reading the node's $HOME, staging configs,
+    # probing readiness.
+    assert cmd.forced == [], cmd.forced
+    assert not any("printenv HOME" in c for c in cmd.commands)
     assert not any("scp " in c for c in cmd.commands)
     assert not any("curl" in c for c in cmd.commands)
 
@@ -1240,10 +1449,17 @@ class _ScriptedCmd(_RecordingCmd):
         return _FakeResult(True, out)
 
 
-def _remote_ctx(tmp_path: Path, cmd, connection: str, runtime: str = "docker"):
-    ctx = _nok8s_ctx(
-        tmp_path, cmd, nok8s={"enabled": True, "connection": connection, "vllm": {}}
-    )
+def _remote_ctx(
+    tmp_path: Path,
+    cmd,
+    connection: str,
+    runtime: str = "docker",
+    transport: str = "",
+):
+    nok8s = {"enabled": True, "connection": connection, "vllm": {}}
+    if transport:
+        nok8s["transport"] = transport
+    ctx = _nok8s_ctx(tmp_path, cmd, nok8s=nok8s)
     ctx.container_runtime = runtime
     return ctx
 
@@ -1254,14 +1470,43 @@ PODMAN_AUTH_STDERR = (
     "no supported methods remain"
 )
 
+# docker's equivalent, which reads nothing like podman's: the CLI has no SSH
+# client of its own, so it execs `ssh` and can only report that process's exit
+# status. ssh's own "Permission denied" arrives on the same stream.
+DOCKER_AUTH_STDERR = (
+    "root@10.0.0.7: Permission denied (publickey).\n"
+    "error during connect: Get "
+    '"http://docker.example.com/v1.47/info": command '
+    "[ssh -l root -- 10.0.0.7 docker system dial-stdio] has exited with exit "
+    "status 255"
+)
 
-def _errors_of(tmp_path: Path, cmd, connection: str, runtime: str = "docker"):
+
+def _errors_of(
+    tmp_path: Path,
+    cmd,
+    connection: str,
+    runtime: str = "docker",
+    transport: str = "",
+):
     from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
 
-    ctx = _remote_ctx(tmp_path, cmd, connection, runtime)
+    ctx = _remote_ctx(tmp_path, cmd, connection, runtime, transport)
     result = EnsureInfraStep().execute(ctx)
     assert result.success is False
     return result.errors
+
+
+def _native_errors_of(tmp_path: Path, cmd, connection: str, runtime: str = "docker"):
+    """Errors from a `transport: native` preflight.
+
+    Everything below this point is about *which local client* failed and how it
+    authenticates -- a question that only exists for the native transport, where
+    a client on this machine opens the connection itself. Under the default ssh
+    transport there is no local client to misidentify, so those diagnoses are
+    deliberately not reached; see the ssh-transport tests further down.
+    """
+    return _errors_of(tmp_path, cmd, connection, runtime, transport="native")
 
 
 def test_unreachable_node_is_reported_once_not_as_missing_tools(
@@ -1289,13 +1534,13 @@ def test_unreachable_node_is_reported_once_not_as_missing_tools(
 def test_a_remote_command_that_really_fails_is_still_reported(tmp_path: Path) -> None:
     """The 255 special-case must not swallow a genuinely missing tool.
 
-    A reachable node that lacks `timeout` returns 127 from `command -v`, which
-    is a real answer about that node and has to stay fatal.
+    A reachable node that lacks `curl` returns 127 from `command -v`, which is a
+    real answer about that node and has to stay fatal.
     """
-    cmd = _ScriptedCmd(scripted=(("command -v timeout", 127, ""),))
+    cmd = _ScriptedCmd(scripted=(("command -v curl", 127, ""),))
     errors = _errors_of(tmp_path, cmd, "10.0.0.7")
 
-    assert any("'timeout' not found on PATH on 10.0.0.7" in e for e in errors), errors
+    assert any("'curl' not found on PATH on 10.0.0.7" in e for e in errors), errors
 
 
 def test_podman_masquerading_as_docker_is_named(tmp_path: Path) -> None:
@@ -1309,11 +1554,98 @@ def test_podman_masquerading_as_docker_is_named(tmp_path: Path) -> None:
         scripted=((" info", 125, PODMAN_AUTH_STDERR),),
         stdout_for={"docker --version": "podman version 5.8.3"},
     )
-    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7")
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7")
 
     daemon = next(e for e in errors if "Cannot reach" in e)
     assert "is actually podman" in daemon, daemon
     assert "nok8s.runtime=podman" in daemon, daemon
+
+
+def test_podmans_error_text_outweighs_a_docker_version_string(
+    tmp_path: Path,
+) -> None:
+    """The failure text names the client, even when --version disagrees.
+
+    Reported from a real node: `nok8s.runtime` defaulted to docker, the local
+    `docker` answered "Docker version ...", and yet the connection failed with
+    podman's Go-SSH handshake wording. Keying the advice on the configured
+    runtime handed the user docker's advice ("put the key in your ssh-agent")
+    directly underneath podman's own error -- advice that cannot work, since
+    podman never consults the agent's OpenSSH-side defaults the same way.
+
+    Only one of the two clients can produce this text, so it decides.
+    """
+    cmd = _ScriptedCmd(
+        scripted=((" info", 125, PODMAN_AUTH_STDERR),),
+        stdout_for={"docker --version": "Docker version 27.1.1, build 6312585"},
+    )
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "nok8s.sshIdentity=<path-to-private-key>" in daemon, daemon
+    # And it must not also carry docker's contradictory advice.
+    assert "does not reach the docker client" not in daemon, daemon
+
+
+def test_podman_symlinked_as_docker_reports_docker_in_its_version(
+    tmp_path: Path,
+) -> None:
+    """The shim case is invisible to --version, which is why it cannot decide.
+
+    podman prints "<argv[0]> version <n>", so the *same binary* reached through
+    a symlink named `docker` says "docker version 4.4.1" -- a string with no
+    trace of podman in it, and one that also looks like an old Docker to a
+    reader (Docker prints "Docker version 27.1.1, build <sha>" and never had a
+    4.4.1). Reported from a real client: `--version` corroborated docker, the
+    connection failed with podman's handshake wording, and the advice has to
+    follow the latter.
+    """
+    cmd = _ScriptedCmd(
+        scripted=((" info", 125, PODMAN_AUTH_STDERR),),
+        stdout_for={"docker --version": "docker version 4.4.1"},
+    )
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "is actually podman" in daemon, daemon
+    assert "nok8s.runtime=podman" in daemon, daemon
+    assert "nok8s.sshIdentity=<path-to-private-key>" in daemon, daemon
+    assert "does not reach the docker client" not in daemon, daemon
+
+
+def test_an_attributed_mismatch_shows_its_evidence(tmp_path: Path) -> None:
+    """ "Your docker is really podman" is a surprising claim; justify it."""
+    cmd = _ScriptedCmd(
+        scripted=((" info", 125, PODMAN_AUTH_STDERR),),
+        stdout_for={"docker --version": "podman version 5.8.3"},
+    )
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "is actually podman" in daemon, daemon
+    assert "podman dials SSH itself" in daemon, daemon
+
+
+def test_an_unidentifiable_client_gets_both_recipes(tmp_path: Path) -> None:
+    """A wrapper script may reveal nothing; guessing one client misdirects.
+
+    `--version` can fail or print something unrecognised (a shim, a wrapper,
+    an unusual build). With no evidence either way the message must not assert
+    a client -- it covers both, so whichever it is the user has the right step.
+    """
+    cmd = _ScriptedCmd(
+        scripted=(
+            (" info", 1, "ssh: unable to authenticate"),
+            ("--version", 127, ""),
+        ),
+    )
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7", runtime="ctr-wrapper")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "could not be identified" in daemon, daemon
+    assert "nok8s.sshIdentity=<path>" in daemon, daemon
+    assert "ssh-add <key>" in daemon, daemon
+    assert "is actually" not in daemon, daemon
 
 
 def test_podman_auth_failure_points_at_sshidentity(tmp_path: Path) -> None:
@@ -1327,7 +1659,7 @@ def test_podman_auth_failure_points_at_sshidentity(tmp_path: Path) -> None:
         scripted=((" info", 125, PODMAN_AUTH_STDERR),),
         stdout_for={"podman --version": "podman version 5.8.3"},
     )
-    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7", runtime="podman")
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7", runtime="podman")
 
     daemon = next(e for e in errors if "Cannot reach" in e)
     assert "nok8s.sshIdentity" in daemon, daemon
@@ -1349,6 +1681,7 @@ def test_podman_refusing_a_supplied_key_blames_the_node(tmp_path: Path) -> None:
         nok8s={
             "enabled": True,
             "connection": "root@10.0.0.7",
+            "transport": "native",
             "sshIdentity": "/home/me/.ssh/id_rsa",
             "vllm": {},
         },
@@ -1364,14 +1697,16 @@ def test_podman_refusing_a_supplied_key_blames_the_node(tmp_path: Path) -> None:
 def test_docker_auth_failure_does_not_suggest_sshidentity(tmp_path: Path) -> None:
     """sshIdentity never reaches `docker -H`, so suggesting it would misdirect."""
     cmd = _ScriptedCmd(
-        scripted=((" info", 1, "ssh: handshake failed: unable to authenticate"),),
+        scripted=((" info", 1, DOCKER_AUTH_STDERR),),
         stdout_for={"docker --version": "Docker version 27.1.1, build 6312585"},
     )
-    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7")
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7")
 
     daemon = next(e for e in errors if "Cannot reach" in e)
     assert "ssh-add" in daemon, daemon
     assert "nok8s.sshIdentity does not reach" in daemon, daemon
+    # docker really is docker here, so there is no mismatch to report.
+    assert "is actually" not in daemon, daemon
 
 
 def test_daemon_down_keeps_the_generic_runtime_advice(tmp_path: Path) -> None:
@@ -1381,7 +1716,7 @@ def test_daemon_down_keeps_the_generic_runtime_advice(tmp_path: Path) -> None:
         scripted=((" info", 1, "Cannot connect to the Docker daemon at unix:///..."),),
         stdout_for={"docker --version": "Docker version 27.1.1"},
     )
-    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7")
+    errors = _native_errors_of(tmp_path, cmd, "root@10.0.0.7")
 
     daemon = next(e for e in errors if "Cannot reach" in e)
     assert "is running on the node" in daemon, daemon

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -1204,3 +1204,211 @@ def test_remote_dry_run_never_touches_the_node(tmp_path: Path) -> None:
     assert not any(c.startswith("ssh ") for c in cmd.commands)
     assert not any("scp " in c for c in cmd.commands)
     assert not any("curl" in c for c in cmd.commands)
+
+
+# ---------------------------------------------------------------------------
+# Preflight diagnosis: a broken connection must not read as a broken node
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedCmd(_RecordingCmd):
+    """_RecordingCmd with per-command exit codes and stderr.
+
+    _FakeCmd only models success/failure with exit_code 1, but the two bugs
+    covered here are specifically about *which* failure happened: ssh's own 255
+    versus a remote command's non-zero status, and the runtime client's stderr
+    text.
+    """
+
+    def __init__(self, scripted=(), stdout_for=None) -> None:
+        super().__init__((), stdout_for)
+        # (substring, exit_code, stderr), first match wins.
+        self.scripted = scripted
+
+    def execute(self, cmd, *args, **kwargs):
+        self.commands.append(cmd)
+        for needle, code, stderr in self.scripted:
+            if needle in cmd:
+                result = _FakeResult(code == 0)
+                result.exit_code = code
+                result.stderr = stderr
+                return result
+        out = ""
+        for key, val in self.stdout_for.items():
+            if key in cmd:
+                out = val
+        return _FakeResult(True, out)
+
+
+def _remote_ctx(tmp_path: Path, cmd, connection: str, runtime: str = "docker"):
+    ctx = _nok8s_ctx(
+        tmp_path, cmd, nok8s={"enabled": True, "connection": connection, "vllm": {}}
+    )
+    ctx.container_runtime = runtime
+    return ctx
+
+
+PODMAN_AUTH_STDERR = (
+    "Error: unable to connect to Podman socket: failed to connect: ssh: "
+    "handshake failed: ssh: unable to authenticate, attempted methods [none], "
+    "no supported methods remain"
+)
+
+
+def _errors_of(tmp_path: Path, cmd, connection: str, runtime: str = "docker"):
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _remote_ctx(tmp_path, cmd, connection, runtime)
+    result = EnsureInfraStep().execute(ctx)
+    assert result.success is False
+    return result.errors
+
+
+def test_unreachable_node_is_reported_once_not_as_missing_tools(
+    tmp_path: Path,
+) -> None:
+    """One dead connection used to surface as four unrelated failures.
+
+    `ssh -p 2222` to a host whose sshd is on 22 exits 255, and every probe --
+    timeout, curl, nvidia-smi, the port check -- travels that same connection.
+    Reading their non-zero status as a verdict about the node told the user to
+    install coreutils on a machine the tool had never reached.
+    """
+    cmd = _ScriptedCmd(
+        scripted=(
+            (" info", 1, "connect: connection refused"),
+            ("ssh ", 255, "ssh: connect to host 10.0.0.7 port 2222: refused"),
+        )
+    )
+    errors = _errors_of(tmp_path, cmd, "ssh://10.0.0.7:2222")
+
+    assert not any("not found on PATH on" in e for e in errors), errors
+    assert not any("coreutils" in e for e in errors), errors
+
+
+def test_a_remote_command_that_really_fails_is_still_reported(tmp_path: Path) -> None:
+    """The 255 special-case must not swallow a genuinely missing tool.
+
+    A reachable node that lacks `timeout` returns 127 from `command -v`, which
+    is a real answer about that node and has to stay fatal.
+    """
+    cmd = _ScriptedCmd(scripted=(("command -v timeout", 127, ""),))
+    errors = _errors_of(tmp_path, cmd, "10.0.0.7")
+
+    assert any("'timeout' not found on PATH on 10.0.0.7" in e for e in errors), errors
+
+
+def test_podman_masquerading_as_docker_is_named(tmp_path: Path) -> None:
+    """`nok8s.runtime: docker` with a podman binary fails with podman's error.
+
+    podman accepts docker's -H as a synonym for --url, so the mismatch is not
+    caught by the flag -- it surfaces as a podman authentication error under a
+    /var/run/docker.sock URL, and the advice for docker is then wrong.
+    """
+    cmd = _ScriptedCmd(
+        scripted=((" info", 125, PODMAN_AUTH_STDERR),),
+        stdout_for={"docker --version": "podman version 5.8.3"},
+    )
+    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "is actually podman" in daemon, daemon
+    assert "nok8s.runtime=podman" in daemon, daemon
+
+
+def test_podman_auth_failure_points_at_sshidentity(tmp_path: Path) -> None:
+    """'attempted methods [none]' means podman offered no key at all.
+
+    podman's Go SSH client does not fall back to ~/.ssh/id_rsa the way OpenSSH
+    does, so `ssh <dest> true` succeeding proves nothing -- which is exactly
+    what the old generic advice told the user to check.
+    """
+    cmd = _ScriptedCmd(
+        scripted=((" info", 125, PODMAN_AUTH_STDERR),),
+        stdout_for={"podman --version": "podman version 5.8.3"},
+    )
+    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7", runtime="podman")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "nok8s.sshIdentity" in daemon, daemon
+    assert "never falls back" in daemon, daemon
+    assert "a working 'ssh' proves nothing" in daemon, daemon
+
+
+def test_podman_refusing_a_supplied_key_blames_the_node(tmp_path: Path) -> None:
+    """With sshIdentity already set, re-suggesting it would be a dead end."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    cmd = _ScriptedCmd(
+        scripted=((" info", 125, PODMAN_AUTH_STDERR),),
+        stdout_for={"podman --version": "podman version 5.8.3"},
+    )
+    ctx = _nok8s_ctx(
+        tmp_path,
+        cmd,
+        nok8s={
+            "enabled": True,
+            "connection": "root@10.0.0.7",
+            "sshIdentity": "/home/me/.ssh/id_rsa",
+            "vllm": {},
+        },
+    )
+    ctx.container_runtime = "podman"
+    result = EnsureInfraStep().execute(ctx)
+
+    daemon = next(e for e in result.errors if "Cannot reach" in e)
+    assert "authorized_keys" in daemon, daemon
+    assert "Pass nok8s.sshIdentity" not in daemon, daemon
+
+
+def test_docker_auth_failure_does_not_suggest_sshidentity(tmp_path: Path) -> None:
+    """sshIdentity never reaches `docker -H`, so suggesting it would misdirect."""
+    cmd = _ScriptedCmd(
+        scripted=((" info", 1, "ssh: handshake failed: unable to authenticate"),),
+        stdout_for={"docker --version": "Docker version 27.1.1, build 6312585"},
+    )
+    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "ssh-add" in daemon, daemon
+    assert "nok8s.sshIdentity does not reach" in daemon, daemon
+
+
+def test_daemon_down_keeps_the_generic_runtime_advice(tmp_path: Path) -> None:
+    """A reachable node whose daemon is simply not running is neither of the
+    special cases, and must not be told about keys it already has."""
+    cmd = _ScriptedCmd(
+        scripted=((" info", 1, "Cannot connect to the Docker daemon at unix:///..."),),
+        stdout_for={"docker --version": "Docker version 27.1.1"},
+    )
+    errors = _errors_of(tmp_path, cmd, "root@10.0.0.7")
+
+    daemon = next(e for e in errors if "Cannot reach" in e)
+    assert "is running on the node" in daemon, daemon
+    assert "sshIdentity" not in daemon, daemon
+
+
+def test_unreachable_daemon_skips_the_node_probes_entirely(tmp_path: Path) -> None:
+    """No point asking an unreachable node about GPUs or ports."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    cmd = _ScriptedCmd(
+        scripted=(
+            (" info", 1, "ssh: handshake failed: unable to authenticate"),
+            ("ssh ", 255, "Permission denied (publickey)."),
+        ),
+        stdout_for={"docker --version": "Docker version 27.1.1"},
+    )
+    ctx = _remote_ctx(tmp_path, cmd, "root@10.0.0.7")
+    EnsureInfraStep().execute(ctx)
+
+    assert not any("nvidia-smi" in c for c in cmd.commands), cmd.commands
+    assert not any("ss -ltn" in c for c in cmd.commands), cmd.commands
+
+
+def test_local_preflight_is_unaffected_by_the_ssh_special_case(tmp_path: Path) -> None:
+    """A local stack has no ssh in the path at all; 127 stays fatal as before."""
+    cmd = _ScriptedCmd(scripted=(("command -v curl", 127, ""),))
+    errors = _errors_of(tmp_path, cmd, "localhost")
+
+    assert any("'curl' not found on PATH;" in e for e in errors), errors

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -893,3 +893,314 @@ def test_kubernetes_scenario_still_resolves_versions(tmp_path: Path) -> None:
     assert not any(resolver.calls), (
         f"expected skip_kubernetes=False off the nok8s path, got {resolver.calls}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Remote connection (nok8s.connection)
+# ---------------------------------------------------------------------------
+
+REMOTE = "ssh://bench@10.0.0.7"
+
+
+def _remote_scenario(tmp_path: Path, connection: str = REMOTE, **nok8s) -> Path:
+    """The shipped single-stack scenario, pointed at a remote node."""
+    doc = yaml.safe_load(NOK8S_SCENARIO.read_text(encoding="utf-8"))
+    doc["scenario"][0]["nok8s"].update({"connection": connection, **nok8s})
+    path = tmp_path / "remote.yaml"
+    path.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    return path
+
+
+def test_local_render_keeps_both_endpoints_on_localhost(tmp_path: Path) -> None:
+    """Back-compat: the default connection changes nothing a consumer reads."""
+    spec = _spec_of(_stack_dir(_render(tmp_path)))
+    assert spec["connection"] == "localhost"
+    assert spec["endpoint"] == "http://localhost:8081"
+    assert spec["clientEndpoint"] == "http://localhost:8081"
+
+
+def test_remote_render_splits_in_host_and_client_endpoints(tmp_path: Path) -> None:
+    """The harness runs on the node; the smoketest dials it from the client.
+
+    Collapsing these two would either point the smoketest at the client's own
+    port 8081 or make every harness request traverse the SSH link and report
+    that latency as the stack's.
+    """
+    result = _render_scenario(tmp_path, _remote_scenario(tmp_path))
+    assert not result.has_errors, result.to_dict()
+    spec = _spec_of(Path(result.rendered_paths[0]))
+
+    assert spec["connection"] == REMOTE
+    assert spec["endpoint"] == "http://localhost:8081"
+    assert spec["clientEndpoint"] == "http://10.0.0.7:8081"
+
+
+def test_remote_render_carries_ssh_identity_and_args(tmp_path: Path) -> None:
+    """The steps re-parse the spec, so the SSH options have to survive render."""
+    scenario = _remote_scenario(
+        tmp_path,
+        sshIdentity="/keys/id_ed25519",
+        sshArgs=["-o", "StrictHostKeyChecking=yes"],
+    )
+    spec = _spec_of(Path(_render_scenario(tmp_path, scenario).rendered_paths[0]))
+    assert spec["sshIdentity"] == "/keys/id_ed25519"
+    assert spec["sshArgs"] == ["-o", "StrictHostKeyChecking=yes"]
+
+
+def test_bare_ip_connection_resolves_the_client_host(tmp_path: Path) -> None:
+    """`connection: 10.0.0.7` is the whole ask -- no scheme, no tunnel."""
+    result = _render_scenario(tmp_path, _remote_scenario(tmp_path, "10.0.0.7"))
+    assert not result.has_errors, result.to_dict()
+    spec = _spec_of(Path(result.rendered_paths[0]))
+    assert spec["clientEndpoint"] == "http://10.0.0.7:8081"
+
+
+def test_tcp_connection_is_a_render_error(tmp_path: Path) -> None:
+    """Fail at render, before any container is launched, and say why."""
+    result = _render_scenario(
+        tmp_path, _remote_scenario(tmp_path, "tcp://10.0.0.7:2375")
+    )
+    assert result.has_errors
+    errors = result.stacks["nok8s-single"].render_errors
+    assert any("tcp://" in e and "ssh://" in e for e in errors), errors
+
+
+def test_unsupported_connection_scheme_is_a_render_error(tmp_path: Path) -> None:
+    result = _render_scenario(tmp_path, _remote_scenario(tmp_path, "http://10.0.0.7"))
+    assert result.stacks["nok8s-single"].render_errors
+
+
+def _remote_stack(tmp_path: Path, connection: str = REMOTE) -> Path:
+    """A rendered-spec stack dir whose containers live on a remote node."""
+    stack = _nok8s_stack(tmp_path)
+    spec_file = stack / "34_nok8s-containers.yaml"
+    spec = yaml.safe_load(spec_file.read_text(encoding="utf-8"))
+    spec["connection"] = connection
+    spec["clientEndpoint"] = "http://10.0.0.7:8081"
+    spec["workspaceHostDir"] = "~/.llmdbench/nok8s"
+    spec["readiness"] = {"vllmPorts": [8000], "envoyPort": 8081}
+    # Give the stack the config files the step stages, so the staging path is
+    # exercised rather than skipped.
+    for prefix in ("31_nok8s-epp-config", "32_nok8s-epp-endpoints", "33_nok8s-envoy"):
+        (stack / f"{prefix}.yaml").write_text("k: v\n", encoding="utf-8")
+    spec_file.write_text(yaml.safe_dump(spec), encoding="utf-8")
+    return stack
+
+
+def test_remote_deploy_puts_the_connection_flag_before_the_subcommand(
+    tmp_path: Path,
+) -> None:
+    """`docker run -H ssh://...` is not valid; the flag has to precede `run`."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd(stdout_for={"printenv HOME": "/home/bench\n"})
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sDeployStep().execute(ctx, stack)
+    assert result.success is True, result.message
+
+    runs = [c for c in cmd.commands if " run -d --name " in c]
+    assert len(runs) == 3, cmd.commands
+    for run in runs:
+        assert run.startswith("docker -H ssh://bench@10.0.0.7/var/run/docker.sock run")
+
+
+def test_remote_deploy_stages_configs_on_the_node_before_launching(
+    tmp_path: Path,
+) -> None:
+    """Bind-mount sources resolve on the daemon, so they must exist there first.
+
+    docker turns a missing source into an empty directory, so without the push
+    the EPP would start with no endpoints file and route nothing.
+    """
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd(stdout_for={"printenv HOME": "/home/bench\n"})
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    NoK8sDeployStep().execute(ctx, stack)
+
+    scp = next((i for i, c in enumerate(cmd.commands) if "scp " in c), None)
+    first_run = next(i for i, c in enumerate(cmd.commands) if " run -d --name " in c)
+    assert scp is not None, cmd.commands
+    assert scp < first_run, "configs staged after the containers were launched"
+    assert "bench@10.0.0.7:" in cmd.commands[scp]
+
+
+def test_remote_deploy_expands_tilde_against_the_nodes_home(tmp_path: Path) -> None:
+    """`~` in workspaceHostDir belongs to the remote user, not the caller."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd(stdout_for={"printenv HOME": "/home/bench\n"})
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    NoK8sDeployStep().execute(ctx, stack)
+
+    envoy_run = next(c for c in cmd.commands if " run -d --name envoy" in c)
+    assert "/home/bench/.llmdbench/nok8s/envoy.yaml" in envoy_run
+    assert "~" not in envoy_run
+
+
+def test_remote_deploy_probes_readiness_on_the_node(tmp_path: Path) -> None:
+    """A curl for `localhost` from the client would probe the client."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd(stdout_for={"printenv HOME": "/home/bench\n"})
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    NoK8sDeployStep().execute(ctx, stack)
+
+    probes = [c for c in cmd.commands if "curl -fsS" in c]
+    assert probes, cmd.commands
+    for probe in probes:
+        assert probe.startswith("ssh ")
+        assert "bench@10.0.0.7" in probe
+
+
+def test_remote_deploy_records_the_in_host_endpoint(tmp_path: Path) -> None:
+    """The harness runs on the node, so it benchmarks localhost there."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd(stdout_for={"printenv HOME": "/home/bench\n"})
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    NoK8sDeployStep().execute(ctx, stack)
+    assert ctx.deployed_endpoints["stack"] == "http://localhost:8081"
+
+
+def test_remote_staging_failure_stops_before_any_container_starts(
+    tmp_path: Path,
+) -> None:
+    """Fatal, not best-effort: an empty mount is a much worse failure to read."""
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd(
+        fail_substrings=("scp ",), stdout_for={"printenv HOME": "/home/bench\n"}
+    )
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sDeployStep().execute(ctx, stack)
+
+    assert result.success is False
+    assert "stage" in result.message.lower()
+    assert not any(" run -d --name " in c for c in cmd.commands)
+
+
+def test_remote_teardown_removes_containers_on_the_node(tmp_path: Path) -> None:
+    from llmdbenchmark.teardown.steps.step_06_nok8s_teardown import NoK8sTeardownStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd()
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sTeardownStep().execute(ctx, stack)
+
+    assert result.success is True
+    assert "10.0.0.7" in result.message
+    assert cmd.removed() == {"vllm-0", "epp", "envoy"}
+    for c in cmd.commands:
+        assert c.startswith("docker -H ssh://bench@10.0.0.7/var/run/docker.sock rm")
+
+
+def test_teardown_refuses_an_unusable_connection_instead_of_going_local(
+    tmp_path: Path,
+) -> None:
+    """Falling back to the local runtime would remove another stack's containers
+    and leave the remote node serving."""
+    from llmdbenchmark.teardown.steps.step_06_nok8s_teardown import NoK8sTeardownStep
+
+    stack = _remote_stack(tmp_path, connection="tcp://10.0.0.7:2375")
+    cmd = _RecordingCmd()
+    ctx = _nok8s_ctx(tmp_path, cmd)
+
+    result = NoK8sTeardownStep().execute(ctx, stack)
+
+    assert result.success is False
+    assert cmd.commands == []
+
+
+def test_remote_preflight_tests_the_connection_and_probes_the_node(
+    tmp_path: Path,
+) -> None:
+    """`info` is answered by the daemon, so one call proves the SSH path works;
+    the accelerator and the ports have to be checked on the serving host."""
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _RecordingCmd(stdout_for={"ss -ltn": "State  Recv-Q\n"}),
+        nok8s={"enabled": True, "connection": REMOTE},
+    )
+    import os
+
+    os.environ["HUGGING_FACE_HUB_TOKEN"] = "hf_test"
+    try:
+        result = EnsureInfraStep().execute(ctx)
+    finally:
+        os.environ.pop("HUGGING_FACE_HUB_TOKEN", None)
+
+    assert result.success is True, result.errors
+    commands = ctx.cmd.commands
+    assert any(c.startswith("docker -H ") and c.endswith(" info") for c in commands)
+    # The client binary is checked locally; the host tools on the node.
+    assert "command -v docker" in commands
+    assert any(c.startswith("ssh ") and "nvidia-smi -L" in c for c in commands)
+    assert any(c.startswith("ssh ") and "ss -ltn" in c for c in commands)
+
+
+def test_remote_preflight_reports_an_unreachable_daemon_with_the_fix(
+    tmp_path: Path,
+) -> None:
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _RecordingCmd(fail_substrings=("docker -H ",)),
+        nok8s={"enabled": True, "connection": REMOTE},
+    )
+    result = EnsureInfraStep().execute(ctx)
+
+    assert result.success is False
+    joined = " ".join(result.errors)
+    assert "ssh bench@10.0.0.7 true" in joined
+
+
+def test_preflight_refuses_a_tcp_connection(tmp_path: Path) -> None:
+    from llmdbenchmark.standup.steps.step_00_ensure_infra import EnsureInfraStep
+
+    ctx = _nok8s_ctx(
+        tmp_path,
+        _RecordingCmd(),
+        nok8s={"enabled": True, "connection": "tcp://10.0.0.7:2375"},
+    )
+    result = EnsureInfraStep().execute(ctx)
+    assert result.success is False
+    assert any("tcp://" in e for e in result.errors)
+
+
+def test_remote_dry_run_never_touches_the_node(tmp_path: Path) -> None:
+    """--dry-run must work with the node unreachable (or nonexistent).
+
+    It proves the plan and the command strings, so reaching out to read $HOME
+    would make a dry-run wait on an SSH timeout for a host that may not be up
+    yet.
+    """
+    from llmdbenchmark.standup.steps.step_06_nok8s_deploy import NoK8sDeployStep
+
+    stack = _remote_stack(tmp_path)
+    cmd = _RecordingCmd()
+    ctx = _nok8s_ctx(tmp_path, cmd)
+    ctx.dry_run = True
+
+    result = NoK8sDeployStep().execute(ctx, stack)
+
+    assert result.success is True
+    assert not any(c.startswith("ssh ") for c in cmd.commands)
+    assert not any("scp " in c for c in cmd.commands)
+    assert not any("curl" in c for c in cmd.commands)

--- a/tests/test_nok8s_smoketest.py
+++ b/tests/test_nok8s_smoketest.py
@@ -332,3 +332,46 @@ def test_do_smoketest_sets_container_only(monkeypatch, tmp_path):
         lambda ctx: pytest.fail("smoketest must not resolve a cluster for nok8s"),
     )
     captured["context"].resolve_cluster()
+
+
+# ---------------------------------------------------------------------------
+# Remote stacks: the probes run on the client, so they use clientEndpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteEndpointSelection:
+    """A remote stack's `endpoint` is in-host; the smoketest is not."""
+
+    def test_client_endpoint_wins_over_the_in_host_endpoint(self, server, tmp_path):
+        # `endpoint` points at a closed port, so a pass proves clientEndpoint
+        # was the one dialed.
+        _responses, port = server
+        stack = tmp_path / "nok8s-remote"
+        stack.mkdir()
+        (stack / "34_nok8s-containers.yaml").write_text(
+            f"runtime: docker\nmodel: {MODEL}\n"
+            f'endpoint: "http://127.0.0.1:{_closed_port()}"\n'
+            f'clientEndpoint: "http://127.0.0.1:{port}"\n',
+            encoding="utf-8",
+        )
+        report = nok8s.health_check(_context(), stack)
+        assert report.passed, report.errors()
+
+    def test_spec_without_client_endpoint_falls_back(self, server, tmp_path):
+        """A spec rendered before clientEndpoint existed must still work."""
+        _responses, port = server
+        report = nok8s.health_check(_context(), _stack_dir(tmp_path, port))
+        assert report.passed, report.errors()
+
+    def test_inference_uses_the_client_endpoint_too(self, server, tmp_path):
+        _responses, port = server
+        stack = tmp_path / "nok8s-remote"
+        stack.mkdir()
+        (stack / "34_nok8s-containers.yaml").write_text(
+            f"runtime: docker\nmodel: {MODEL}\n"
+            f'endpoint: "http://127.0.0.1:{_closed_port()}"\n'
+            f'clientEndpoint: "http://127.0.0.1:{port}"\n',
+            encoding="utf-8",
+        )
+        report = nok8s.inference_test(_context(), stack)
+        assert report.passed, report.errors()


### PR DESCRIPTION
This PR includes: 
- Add support of remote `standup` and `run` for no-k8s llm-d stack
- Fix bugs when multi-stack llm-d exists within the same node
- Add default `workspace` for no-k8s deployment just like other deployments 

✅ Have tested on a GPU bare-metal node by deploying and benchmarking multi-stack and single-stack no-k8s llm-d with different number of GPUs. 