### PR TITLE
feat: anchor actuation timing on container start (additive)

### DIFF
--- a/llmdbenchmark/analysis/benchmark_report/native_to_br0_1.py
+++ b/llmdbenchmark/analysis/benchmark_report/native_to_br0_1.py
@@ -2433,6 +2433,10 @@ def import_nop(results_file: str) -> BenchmarkReportV01:
                 "units": Units.S,
                 "value": vllm_metrics["pod_start"],
             },
+            "container_start": {
+                "units": Units.S,
+                "value": vllm_metrics.get("container_start", 0.0),
+            },
             "vllm_start_timestamp": {
                 "units": Units.S,
                 "value": vllm_metrics["vllm_start_timestamp"],

--- a/llmdbenchmark/analysis/scripts/nop-analyze_results.py
+++ b/llmdbenchmark/analysis/scripts/nop-analyze_results.py
@@ -176,6 +176,7 @@ def write_vllm_metrics(  # pylint: disable=too-many-locals,too-many-statements
     for metrics_metadata in metadatas:
         name = metrics_metadata["name"]
         pod_start = metrics_metadata["pod_start"]["value"]
+        container_start = metrics_metadata.get("container_start", {}).get("value", 0.0)
         vllm_start = (
             metrics_metadata["vllm_ready_timestamp"]["value"]
             - metrics_metadata["vllm_start_timestamp"]["value"]
@@ -197,6 +198,7 @@ def write_vllm_metrics(  # pylint: disable=too-many-locals,too-many-statements
 
         file.write(f"\n  Name                              : {name}\n")
         file.write(f"    Pod  Start(secs)                : {pod_start:7.3f}\n")
+        file.write(f"    Container Start(secs)           : {container_start:7.3f}\n")
         file.write(f"    vLLM Start(secs)                : {vllm_start:7.3f}\n")
         file.write("    Model Load\n")
         file.write(f"      Elapsed(secs)                 : {elapsed:7.3f}\n")

--- a/llmdbenchmark/analysis/scripts/nop-analyze_results.py
+++ b/llmdbenchmark/analysis/scripts/nop-analyze_results.py
@@ -302,6 +302,10 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
     file.write("  T_warm: existing launcher creates new vLLM instance\n")
     file.write("  T_hot: waking sleeping vLLM instance\n\n")
     file.write("T_actuation: Time for the Requester Pod to be ready\n")
+    file.write(
+        "T_actuation_cstart: Same, measured from the Requester container start "
+        "(-- if unavailable)\n"
+    )
     file.write("T_hot: Hot-start timing\n")
     file.write("T_warm: Warm-start timing\n")
     file.write("T_cold_launcher: Cold-start-with-launcher timing\n")
@@ -324,6 +328,17 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
             ct = float(launcher_info["requester_info"]["creation_timestamp"]["value"])
             rt = float(launcher_info["requester_info"]["ready_timestamp"]["value"])
             ttrr = rt - ct if rt > 0.0 else 0.0
+            # Container-start anchor: elapsed from the requester container's
+            # start to Ready, reported alongside the pod-create anchor above.
+            # Guarded so older artifacts that lack container_start_timestamp
+            # still parse; None renders as "--" (no data), distinct from a real
+            # zero, matching the per-path timing columns below.
+            cst = float(
+                launcher_info["requester_info"]
+                .get("container_start_timestamp", {})
+                .get("value", 0.0)
+            )
+            ttrr_cstart = rt - cst if rt > 0.0 and cst > 0.0 else None
             ttft = float(launcher_info["ttft"]["value"])
             actuation_condition = launcher_info["actuation_condition"]
             if actuation_condition == "T_hot":
@@ -379,6 +394,7 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
                     "GPU UUID": launcher_info["requester_info"].get("gpu_uuids", ""),
                     "Actuation Condition": actuation_condition,
                     "T_actuation(s)": ttrr,
+                    "T_actuation_cstart(s)": ttrr_cstart,
                     "T_hot(s)": t_hot_val,
                     "T_warm(s)": t_warm_val,
                     "T_cold(s)": t_cold_val,
@@ -398,6 +414,7 @@ def write_fma_metrics(  # pylint: disable=too-many-locals,too-many-statements
     # Float formatting
     float_columns = [
         "T_actuation(s)",
+        "T_actuation_cstart(s)",
         "T_hot(s)",
         "T_warm(s)",
         "T_cold(s)",

--- a/tests/test_native_to_br01_container_start.py
+++ b/tests/test_native_to_br01_container_start.py
@@ -1,0 +1,73 @@
+"""Tests that container_start survives the native -> benchmark-report v0.1 import.
+
+The native results dict carries a bare container_start float on each vLLM
+metric (elapsed seconds from the main container's start to Pod-Ready), next to
+the pod_start anchor. import_nop hand-maps each vLLM metric into the
+{units, value} schema, so it must map container_start too or the anchor is
+silently dropped from the emitted report. The mapping must also degrade
+gracefully on older native artifacts that predate the field.
+"""
+
+import yaml
+
+from llmdbenchmark.analysis.benchmark_report.native_to_br0_1 import import_nop
+
+
+def _nop_results(include_container_start=True):
+    """Minimal nop results dict carrying one vLLM metric."""
+    vllm_metric = {
+        "name": "vllm-standalone-x",
+        "pod_start": 125.0,
+        "vllm_start_timestamp": 1000.0,
+        "vllm_ready_timestamp": 1079.0,
+        "load": {"time": 1.0, "size": 1.0, "transfer_rate": 1.0},
+        "dynamo_bytecode_transform": 0.0,
+        "torch_compile": 0.0,
+        "memory_profiling": {"initial_free": 0.0, "after_free": 0.0, "time": 0.0},
+        "sleep_wake": [],
+    }
+    if include_container_start:
+        vllm_metric["container_start"] = 119.0
+    return {
+        "scenario": {
+            "model": {"name": "m"},
+            "deploy_methods": "standalone",
+            "load_format": "auto",
+            "sleep_mode": "0",
+            "gpus": 1,
+            "platform": {
+                "engines": [
+                    {"name": "vllm", "version": "0.1", "args": {}, "image": "img:tag"}
+                ]
+            },
+        },
+        "time": {"duration": 1.0, "start": 0.0, "stop": 1.0},
+        "vllm_metrics": [vllm_metric],
+        "extra_metrics": [],
+    }
+
+
+def _vllm_metadata(tmp_path, results):
+    path = tmp_path / "results.yaml"
+    path.write_text(yaml.safe_dump(results))
+    br = import_nop(str(path))
+    bd = br.model_dump()
+    md = next(m for m in bd["metrics"]["metadata"] if m["name"] == "vllm_metrics")
+    return md["value"][0]
+
+
+def test_container_start_survives(tmp_path):
+    m = _vllm_metadata(tmp_path, _nop_results(include_container_start=True))
+    assert m["container_start"]["value"] == 119.0
+    assert m["container_start"]["units"] == "s"
+
+
+def test_pod_start_still_survives(tmp_path):
+    m = _vllm_metadata(tmp_path, _nop_results(include_container_start=True))
+    assert m["pod_start"]["value"] == 125.0
+
+
+def test_absent_container_start_defaults_to_zero(tmp_path):
+    # Older native artifact: no container_start on the vLLM metric.
+    m = _vllm_metadata(tmp_path, _nop_results(include_container_start=False))
+    assert m["container_start"]["value"] == 0.0

--- a/tests/test_nop_analyze_container_start.py
+++ b/tests/test_nop_analyze_container_start.py
@@ -1,0 +1,63 @@
+"""Tests for the Container Start line in write_vllm_metrics.
+
+write_vllm_metrics prints the per-instance vLLM timing block. It must emit a
+Container Start(secs) line from the container_start metric alongside the
+existing Pod Start(secs) line, so the container-start anchor is visible in the
+analysis output next to the pod-start anchor.
+"""
+
+import importlib.util
+import io
+import os
+import sys
+
+_ANALYSIS = os.path.join("llmdbenchmark", "analysis")
+_SCRIPTS = os.path.join(_ANALYSIS, "scripts")
+for _p in (_ANALYSIS, _SCRIPTS):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SPEC = importlib.util.spec_from_file_location(
+    "nop_analyze_results",
+    os.path.join(_SCRIPTS, "nop-analyze_results.py"),
+)
+nar = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(nar)
+
+
+def _scalar(value):
+    return {"value": value}
+
+
+def _metrics_metadata(pod_start, container_start):
+    return {
+        "name": "vllm-standalone-qwen-qwen3-4b",
+        "pod_start": _scalar(pod_start),
+        "container_start": _scalar(container_start),
+        "vllm_start_timestamp": _scalar(0.0),
+        "vllm_ready_timestamp": _scalar(0.0),
+        "load": {"time": _scalar(0.0), "transfer_rate": _scalar(0.0)},
+        "dynamo_bytecode_transform": _scalar(0.0),
+        "torch_compile": _scalar(0.0),
+        "memory_profiling": {
+            "initial_free": _scalar(0.0),
+            "after_free": _scalar(0.0),
+            "time": _scalar(0.0),
+        },
+    }
+
+
+def test_writes_container_start_line():
+    out = io.StringIO()
+    nar.write_vllm_metrics(out, [_metrics_metadata(30.0, 12.5)], 0)
+    text = out.getvalue()
+    assert "Container Start(secs)" in text
+    assert "12.500" in text
+
+
+def test_still_writes_pod_start_line():
+    out = io.StringIO()
+    nar.write_vllm_metrics(out, [_metrics_metadata(30.0, 12.5)], 0)
+    text = out.getvalue()
+    assert "Pod  Start(secs)" in text
+    assert "30.000" in text

--- a/tests/test_nop_analyze_fma_cstart.py
+++ b/tests/test_nop_analyze_fma_cstart.py
@@ -1,0 +1,89 @@
+"""Tests for the T_actuation_cstart column in write_fma_metrics.
+
+write_fma_metrics emits the per-iteration actuation table. Alongside the
+existing T_actuation column (ready - creation_timestamp, the pod-create
+anchor), it must emit a T_actuation_cstart column measured from the
+requester container's start (ready - container_start_timestamp), so the
+container-start anchor is visible next to the pod-create anchor. The column
+must degrade gracefully on older artifacts that lack container_start_timestamp.
+"""
+
+import importlib.util
+import io
+import os
+import sys
+
+_ANALYSIS = os.path.join("llmdbenchmark", "analysis")
+_SCRIPTS = os.path.join(_ANALYSIS, "scripts")
+for _p in (_ANALYSIS, _SCRIPTS):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+_SPEC = importlib.util.spec_from_file_location(
+    "nop_analyze_results",
+    os.path.join(_SCRIPTS, "nop-analyze_results.py"),
+)
+nar = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(nar)
+
+
+def _scalar(value):
+    return {"value": value}
+
+
+def _iteration(creation, ready, container_start=None):
+    requester_info = {
+        "creation_timestamp": _scalar(creation),
+        "ready_timestamp": _scalar(ready),
+        "gpu_uuids": "",
+    }
+    if container_start is not None:
+        requester_info["container_start_timestamp"] = _scalar(container_start)
+    return {
+        "iteration": _scalar(1),
+        "launcher_infos": [
+            {
+                "name": "vllm-qwen3-4b",
+                "launcher_node": "node-a",
+                "requester_info": requester_info,
+                "ttft": _scalar(0.5),
+                "actuation_condition": "T_hot",
+                "timing_source": "dpc",
+            }
+        ],
+    }
+
+
+def test_writes_t_actuation_cstart_column_header():
+    out = io.StringIO()
+    # ready=130, creation=100 -> T_actuation 30; container_start=112 -> cstart 18
+    nar.write_fma_metrics(out, [_iteration(100.0, 130.0, 112.0)], 0)
+    text = out.getvalue()
+    assert "T_actuation_cstart(s)" in text
+
+
+def test_computes_cstart_from_container_start_timestamp():
+    out = io.StringIO()
+    nar.write_fma_metrics(out, [_iteration(100.0, 130.0, 112.0)], 0)
+    text = out.getvalue()
+    # container-start anchored actuation = 130 - 112 = 18.0
+    assert "18.0000" in text
+
+
+def test_still_writes_t_actuation_column():
+    out = io.StringIO()
+    nar.write_fma_metrics(out, [_iteration(100.0, 130.0, 112.0)], 0)
+    text = out.getvalue()
+    assert "T_actuation(s)" in text
+    # pod-create anchored actuation = 130 - 100 = 30.0
+    assert "30.0000" in text
+
+
+def test_cstart_absent_container_start_falls_back_gracefully():
+    out = io.StringIO()
+    # Old artifact: no container_start_timestamp field at all.
+    nar.write_fma_metrics(out, [_iteration(100.0, 130.0, None)], 0)
+    text = out.getvalue()
+    # Column still present; the pod-create anchor is unaffected.
+    assert "T_actuation_cstart(s)" in text
+    assert "30.0000" in text

--- a/tests/test_nop_container_start.py
+++ b/tests/test_nop_container_start.py
@@ -1,0 +1,65 @@
+"""Tests for VllmInfo.get_container_start (standalone container-start anchor).
+
+Mirrors the FMA container-start baseline (get_container_start_timestamp in
+fma_functions.py) but returns ELAPSED seconds (Ready - container start),
+matching the shape of the existing get_pod_start().
+"""
+
+import importlib
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+nf = importlib.import_module("workload.harnesses.nop_functions")
+
+
+def _ready_cond(ts):
+    return SimpleNamespace(type="Ready", status="True", last_transition_time=ts)
+
+
+def _pod(
+    container_started_at, ready_at, container_name="vllm-standalone-qwen-qwen3-4b"
+):
+    running = SimpleNamespace(started_at=container_started_at)
+    state = SimpleNamespace(running=running)
+    cs = SimpleNamespace(name=container_name, state=state)
+    status = SimpleNamespace(
+        container_statuses=[cs],
+        conditions=[_ready_cond(ready_at)],
+    )
+    return SimpleNamespace(status=status)
+
+
+def _make_info(pod):
+    v1 = MagicMock()
+    v1.read_namespaced_pod.return_value = pod
+    return nf.VllmStandaloneInfo(
+        v1=v1,
+        namespace="ns",
+        pod_name="p",
+        container_name="vllm-standalone-qwen-qwen3-4b",
+        timeout=5.0,
+    )
+
+
+def test_returns_elapsed_ready_minus_container_start():
+    started = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ready = datetime(2026, 1, 1, 0, 0, 42, tzinfo=timezone.utc)
+    info = _make_info(_pod(started, ready))
+    assert info.get_container_start() == 42.0
+
+
+def test_zero_when_no_running_container():
+    ready = datetime(2026, 1, 1, 0, 0, 42, tzinfo=timezone.utc)
+    running = SimpleNamespace(running=None)
+    cs = SimpleNamespace(name="vllm-standalone-qwen-qwen3-4b", state=running)
+    status = SimpleNamespace(container_statuses=[cs], conditions=[_ready_cond(ready)])
+    info = _make_info(SimpleNamespace(status=status))
+    assert info.get_container_start() == 0.0
+
+
+def test_falls_back_to_sole_container_when_name_mismatch():
+    started = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ready = datetime(2026, 1, 1, 0, 0, 10, tzinfo=timezone.utc)
+    info = _make_info(_pod(started, ready, container_name="something-else"))
+    assert info.get_container_start() == 10.0

--- a/tests/test_nop_container_start_metrics.py
+++ b/tests/test_nop_container_start_metrics.py
@@ -1,0 +1,31 @@
+"""Tests for the container_start field on BenchmarkVllmMetrics.
+
+container_start is the elapsed-seconds anchor from the main container's start
+to Pod-Ready, persisted alongside the existing pod_start anchor and surfaced by
+dump() so it lands in the result artifact.
+"""
+
+import importlib
+
+nf = importlib.import_module("workload.harnesses.nop_functions")
+
+
+def test_container_start_defaults_to_zero():
+    metrics = nf.BenchmarkVllmMetrics()
+    assert metrics.container_start == 0.0
+
+
+def test_dump_includes_container_start():
+    metrics = nf.BenchmarkVllmMetrics()
+    metrics.container_start = 12.5
+    dumped = metrics.dump()
+    assert dumped["container_start"] == 12.5
+
+
+def test_dump_keeps_pod_start_alongside_container_start():
+    metrics = nf.BenchmarkVllmMetrics()
+    metrics.pod_start = 30.0
+    metrics.container_start = 12.5
+    dumped = metrics.dump()
+    assert dumped["pod_start"] == 30.0
+    assert dumped["container_start"] == 12.5

--- a/workload/harnesses/nop_functions.py
+++ b/workload/harnesses/nop_functions.py
@@ -763,6 +763,7 @@ class BenchmarkVllmMetrics:
     # pylint: disable=too-many-instance-attributes
     name: str = ""
     pod_start: float = 0.0
+    container_start: float = 0.0
     vllm_start_timestamp: float = 0.0
     vllm_ready_timestamp: float = 0.0
     load: MetricsLoad = field(default_factory=MetricsLoad)
@@ -1819,9 +1820,11 @@ def populate_benchmark(  # pylint: disable=too-many-arguments,too-many-positiona
         parse_gpu_logs(benchmark_result.scenario, log_list)
 
     pod_start = vllm_info.get_pod_start()
+    container_start = vllm_info.get_container_start()
     metrics = BenchmarkVllmMetrics()
     metrics.name = engine.name
     metrics.pod_start = pod_start
+    metrics.container_start = container_start
     parse_logs(
         benchmark_result.scenario,
         engine,
@@ -1843,6 +1846,7 @@ def populate_benchmark(  # pylint: disable=too-many-arguments,too-many-positiona
         metrics = BenchmarkVllmMetrics()
         metrics.name = engine.name
         metrics.pod_start = pod_start
+        metrics.container_start = container_start
         parse_logs(
             benchmark_result.scenario,
             engine,

--- a/workload/harnesses/nop_functions.py
+++ b/workload/harnesses/nop_functions.py
@@ -118,6 +118,57 @@ class VllmInfo(ABC):
             logger.exception("error on pod '%s:%s'", self.namespace, self.pod_name)
             return 0.0
 
+    def get_container_start(self) -> float:
+        """get elapsed seconds from the main container's start to Pod-Ready.
+
+        Returns Ready.lastTransitionTime - container.state.running.started_at,
+        the same elapsed-seconds shape as get_pod_start() (which anchors on
+        the Pod's status.startTime instead). Matches the container by
+        self.container_name, falling back to the sole container status when
+        there is exactly one. Returns 0.0 on any failure.
+        """
+        try:
+            start = time.time()
+            elapsed = 0.0
+            while elapsed < self.timeout:
+                pod = self.v1.read_namespaced_pod(
+                    name=self.pod_name, namespace=self.namespace
+                )
+                statuses = pod.status.container_statuses or []
+                cs = None
+                for candidate in statuses:
+                    if candidate.name == self.container_name:
+                        cs = candidate
+                        break
+                if cs is None and len(statuses) == 1:
+                    cs = statuses[0]
+
+                started_at = None
+                if cs is not None:
+                    state = getattr(cs, "state", None)
+                    running = getattr(state, "running", None) if state else None
+                    started_at = (
+                        getattr(running, "started_at", None) if running else None
+                    )
+
+                if started_at is not None:
+                    for cond in pod.status.conditions or []:
+                        if cond.type == "Ready" and cond.status == "True":
+                            return (
+                                cond.last_transition_time - started_at
+                            ).total_seconds()
+
+                time.sleep(2)
+                elapsed = time.time() - start
+            return 0.0
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception(
+                "error reading container start '%s:%s'",
+                self.namespace,
+                self.pod_name,
+            )
+            return 0.0
+
     def get_pod_logs(self) -> bytes:
         """get pod logs"""
         data = bytes()


### PR DESCRIPTION
## Summary

Adds a **container-start** timing anchor alongside the existing pod-create anchor, on both the
standalone (no-FMA) path and the FMA analysis output. Everything here is **additive** — no existing
column, field, or number changes — so nothing that currently consumes the pod-create anchor breaks.

Closes #1836.

## Why

The standalone (no-FMA) baseline is measured from Pod creation (includes scheduling + container
startup), while FMA `T_actuation` is measured from the requester container's start (excludes that
front-matter). Comparing the two paths across a differing start instant is unsound. This surfaces a
consistent **container-start** number on both paths so a fair, same-anchor comparison is possible —
while keeping the pod-create numbers in place, since we don't know who else consumes them.

See #1836 for the full rationale; this also addresses the [review comment](https://github.com/llm-d/llm-d-benchmark/pull/1583#discussion_r3510315941).

## Changes

- **`workload/harnesses/nop_functions.py`** — `get_container_start()` (elapsed Ready − container
  `state.running.startedAt`, matches the container by name with a sole-container fallback); a
  `container_start` field on `BenchmarkVllmMetrics`, captured and assigned next to `pod_start`.
- **`llmdbenchmark/analysis/scripts/nop-analyze_results.py`** — prints a `Container Start(secs)` line
  in the vLLM metrics; adds a `T_actuation_cstart(s)` column (`ready − container_start_timestamp`) to
  the FMA metrics table (missing anchor renders as `--`, distinct from a real `0.0`).
- **`llmdbenchmark/analysis/benchmark_report/native_to_br0_1.py`** — maps `container_start` through
  the native->benchmark-report import (the hand-mapped converter otherwise dropped it).
- Tests for each (15 new tests), including back-compat: older artifacts without `container_start`
  default gracefully to `0.0` rather than erroring.

## Testing

```
pytest tests/test_nop_container_start.py tests/test_nop_container_start_metrics.py \
  tests/test_nop_analyze_container_start.py tests/test_nop_analyze_fma_cstart.py \
  tests/test_native_to_br01_container_start.py -q
# 15 passed
```

Validated end-to-end on live standalone Qwen3-4B runs (container_start ~119s) and on existing FMA
4B result artifacts (container_start_timestamp present on every iteration).

Assisted-By: Claude Code