### PR TITLE
fix: add fma-controllers to teardown's managed-chart safety net

### DIFF
--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -37,11 +37,14 @@ class UninstallHelmStep(Step):
         }
     )
 
-    # Chart name prefixes used exclusively by modelservice deployments this
-    # tool creates (llm-d-modelservice, llm-d-router-gateway/-standalone).
+    # Chart name prefixes used exclusively by deployments this tool creates
+    # (llm-d-modelservice, llm-d-router-gateway/-standalone, fma-controllers).
     # Used as a fallback match on full-scenario teardowns -- see
-    # _release_matches.
-    _MANAGED_CHART_PREFIXES = ("llm-d-modelservice", "llm-d-router-")
+    # _release_matches. fma-controllers is model-agnostic (its release name
+    # is only model-keyed, e.g. "<model_id_label>-fma-dp"), so without this
+    # entry a mismatched/omitted model label at teardown leaves the release
+    # deployed while teardown still reports success (#1820).
+    _MANAGED_CHART_PREFIXES = ("llm-d-modelservice", "llm-d-router-", "fma-controllers")
 
     def __init__(self):
         super().__init__(

--- a/tests/test_teardown_gaie_epp_cleanup.py
+++ b/tests/test_teardown_gaie_epp_cleanup.py
@@ -67,6 +67,20 @@ class TestReleaseMatchesChartFallback:
             full_teardown=True,
         )
 
+    def test_full_teardown_matches_fma_controllers_chart_too(self):
+        """The bug: the FMA controllers release is model-keyed
+        (``<model_id_label>-fma-dp``) but the chart itself is model-agnostic,
+        so it had no chart-identity safety net -- a mismatched/omitted model
+        label at teardown left it deployed while teardown still reported
+        success (#1820)."""
+        assert UninstallHelmStep._release_matches(
+            "qwen-qwe-04b6bb85-fma-dp",
+            "llmdbench",
+            ["some-other-model-label"],
+            "fma-controllers-0.6.4",
+            full_teardown=True,
+        )
+
     def test_partial_stack_teardown_does_not_use_chart_fallback(self):
         """A --stack-filtered teardown must not sweep up sibling stacks'
         releases just because they share a chart -- only a real name/label


### PR DESCRIPTION
The FMA controllers Helm release is model-agnostic but named with the model label (<model_id_label>-fma-dp). Teardown's release matcher relies on that label (re-derived from --models/LLMDBENCH_MODELS at teardown time) or, on a full-scenario teardown, chart identity as a fallback -- but fma-controllers was missing from the managed-chart list that backs that fallback, unlike llm-d-modelservice/llm-d-router-*. Under asymmetric flags (standup given model flags, teardown not), the release matched neither the label nor a known chart, so it was left deployed while teardown reported success -- the next same-model standup then no-ops on it and the controller never redeploys.

Add "fma-controllers" to _MANAGED_CHART_PREFIXES so a full-scenario teardown removes it regardless of model-label mismatches, mirroring the existing modelservice/router behavior. Stack-filtered (partial) teardowns are unaffected, since the chart-identity fallback only applies to full-scenario teardowns.

Fixes #1820