### PR TITLE
Feat/compress out

### DIFF
--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -344,9 +344,18 @@ jobs:
             latest=$(find "$base" -type d -name "runner-*" 2>/dev/null | sort | tail -1)
             exp=""
             if [ -n "$latest" ]; then
-              exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d -exec test -f '{}/hpa.txt' \; -print 2>/dev/null | head -1)
+              # Prefer a result dir the dump helper can actually read hpa.txt from.
+              # A plain `test -f` can never succeed now that logs are archived, so it
+              # fell through to the bare listing below -- which, without a sort, picked
+              # an arbitrary dir and could label one arm's diagnostics as another's.
+              for _candidate in $(find "$latest/results" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort); do
+                _probe=$("$GITHUB_WORKSPACE/util/dump_result_file.sh" "$_candidate" "hpa.txt")
+                case "$_probe" in "no hpa.txt"*) continue ;; esac
+                exp="$_candidate"
+                break
+              done
               if [ -z "$exp" ]; then
-                exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)
+                exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | head -1)
               fi
             fi
             echo "${label}_exp=${exp}" >> "$GITHUB_OUTPUT"
@@ -359,123 +368,103 @@ jobs:
       - name: Dump HPA — Baseline (EPP+KEDA, no FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/hpa.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "hpa.txt"
 
       - name: Dump HPA describe — Baseline (EPP+KEDA, no FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/hpa-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "hpa-describe.txt"
 
       - name: Dump ScaledObject — Baseline (EPP+KEDA, no FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "scaledobject.txt"
 
       - name: Dump ScaledObject describe — Baseline (EPP+KEDA, no FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "scaledobject-describe.txt"
 
       - name: Dump events — Baseline (EPP+KEDA, no FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/events.log"
-          [ -f "$f" ] && cat "$f" || echo "no events.log for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "events.log"
 
       - name: Dump pods — Baseline (EPP+KEDA, no FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/pods.txt"
-          [ -f "$f" ] && cat "$f" || echo "no pods.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "pods.txt"
 
       # ---------------- EPP+KEDA with FMA (Warm-Start) dumps --------------------
 
       - name: Dump HPA — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/hpa.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" "hpa.txt"
 
       - name: Dump HPA describe — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/hpa-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" "hpa-describe.txt"
 
       - name: Dump ScaledObject — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/scaledobject.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" "scaledobject.txt"
 
       - name: Dump ScaledObject describe — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/scaledobject-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" "scaledobject-describe.txt"
 
       - name: Dump FMA launcher-populator log tail — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f=$(find "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
-          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" --glob --tail 200 "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" '*launcher-populator*.log'
 
       - name: Dump events — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/events.log"
-          [ -f "$f" ] && cat "$f" || echo "no events.log for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" "events.log"
 
       - name: Dump pods — EPP+KEDA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_warmstart_exp }}/pods.txt"
-          [ -f "$f" ] && cat "$f" || echo "no pods.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_warmstart_exp }}" "pods.txt"
 
       # ---------------- EPP+KEDA with FMA (Hot-Start) dumps ---------------------
 
       - name: Dump HPA — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/hpa.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" "hpa.txt"
 
       - name: Dump HPA describe — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/hpa-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" "hpa-describe.txt"
 
       - name: Dump ScaledObject — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/scaledobject.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" "scaledobject.txt"
 
       - name: Dump ScaledObject describe — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/scaledobject-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" "scaledobject-describe.txt"
 
       - name: Dump FMA launcher-populator log tail — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f=$(find "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
-          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" --glob --tail 200 "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" '*launcher-populator*.log'
 
       - name: Dump events — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/events.log"
-          [ -f "$f" ] && cat "$f" || echo "no events.log for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" "events.log"
 
       - name: Dump pods — EPP+KEDA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_keda_hotstart_exp }}/pods.txt"
-          [ -f "$f" ] && cat "$f" || echo "no pods.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_keda_hotstart_exp }}" "pods.txt"

--- a/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
@@ -347,9 +347,18 @@ jobs:
             latest=$(find "$base" -type d -name "runner-*" 2>/dev/null | sort | tail -1)
             exp=""
             if [ -n "$latest" ]; then
-              exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d -exec test -f '{}/hpa.txt' \; -print 2>/dev/null | head -1)
+              # Prefer a result dir the dump helper can actually read hpa.txt from.
+              # A plain `test -f` can never succeed now that logs are archived, so it
+              # fell through to the bare listing below -- which, without a sort, picked
+              # an arbitrary dir and could label one arm's diagnostics as another's.
+              for _candidate in $(find "$latest/results" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort); do
+                _probe=$("$GITHUB_WORKSPACE/util/dump_result_file.sh" "$_candidate" "hpa.txt")
+                case "$_probe" in "no hpa.txt"*) continue ;; esac
+                exp="$_candidate"
+                break
+              done
               if [ -z "$exp" ]; then
-                exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | head -1)
+                exp=$(find "$latest/results" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | head -1)
               fi
             fi
             echo "${label}_exp=${exp}" >> "$GITHUB_OUTPUT"
@@ -362,141 +371,118 @@ jobs:
       - name: Dump HPA — Baseline (WVA without FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/hpa.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "hpa.txt"
 
       - name: Dump HPA describe — Baseline (WVA without FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/hpa-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "hpa-describe.txt"
 
       - name: Dump ScaledObject — Baseline (WVA without FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "scaledobject.txt"
 
       - name: Dump ScaledObject describe — Baseline (WVA without FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/scaledobject-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "scaledobject-describe.txt"
 
       - name: Dump WVA controller log tail — Baseline (WVA without FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/wva-controller.log"
-          [ -f "$f" ] && tail -200 "$f" || echo "no wva-controller.log for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" --tail 200 "${{ steps.cs.outputs.baseline_exp }}" "wva-controller.log"
 
       - name: Dump events — Baseline (WVA without FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/events.log"
-          [ -f "$f" ] && cat "$f" || echo "no events.log for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "events.log"
 
       - name: Dump pods — Baseline (WVA without FMA)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.baseline_exp }}/pods.txt"
-          [ -f "$f" ] && cat "$f" || echo "no pods.txt for baseline"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.baseline_exp }}" "pods.txt"
 
       # ---------------- WVA with FMA (Warm-Start) dumps --------------------
 
       - name: Dump HPA — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" "hpa.txt"
 
       - name: Dump HPA describe — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/hpa-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" "hpa-describe.txt"
 
       - name: Dump ScaledObject — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" "scaledobject.txt"
 
       - name: Dump ScaledObject describe — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/scaledobject-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" "scaledobject-describe.txt"
 
       - name: Dump WVA controller log tail — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/wva-controller.log"
-          [ -f "$f" ] && tail -200 "$f" || echo "no wva-controller.log for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" --tail 200 "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" "wva-controller.log"
 
       - name: Dump FMA launcher-populator log tail — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f=$(find "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
-          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" --glob --tail 200 "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" '*launcher-populator*.log'
 
       - name: Dump events — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/events.log"
-          [ -f "$f" ] && cat "$f" || echo "no events.log for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" "events.log"
 
       - name: Dump pods — WVA with FMA (Warm-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_warmstart_exp }}/pods.txt"
-          [ -f "$f" ] && cat "$f" || echo "no pods.txt for warm-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_warmstart_exp }}" "pods.txt"
 
       # ---------------- WVA with FMA (Hot-Start) dumps ---------------------
 
       - name: Dump HPA — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" "hpa.txt"
 
       - name: Dump HPA describe — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/hpa-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no hpa-describe.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" "hpa-describe.txt"
 
       - name: Dump ScaledObject — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" "scaledobject.txt"
 
       - name: Dump ScaledObject describe — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/scaledobject-describe.txt"
-          [ -f "$f" ] && cat "$f" || echo "no scaledobject-describe.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" "scaledobject-describe.txt"
 
       - name: Dump WVA controller log tail — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/wva-controller.log"
-          [ -f "$f" ] && tail -200 "$f" || echo "no wva-controller.log for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" --tail 200 "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" "wva-controller.log"
 
       - name: Dump FMA launcher-populator log tail — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f=$(find "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" -maxdepth 1 -name "*launcher-populator*.log" 2>/dev/null | head -1)
-          [ -n "$f" ] && tail -200 "$f" || echo "no launcher-populator log for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" --glob --tail 200 "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" '*launcher-populator*.log'
 
       - name: Dump events — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/events.log"
-          [ -f "$f" ] && cat "$f" || echo "no events.log for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" "events.log"
 
       - name: Dump pods — WVA with FMA (Hot-Start)
         if: always()
         run: |
-          f="${{ steps.cs.outputs.fma_wva_hotstart_exp }}/pods.txt"
-          [ -f "$f" ] && cat "$f" || echo "no pods.txt for hot-start"
+          "$GITHUB_WORKSPACE/util/dump_result_file.sh" "${{ steps.cs.outputs.fma_wva_hotstart_exp }}" "pods.txt"

--- a/.github/workflows/ci-nightly-benchmark-ocp-fma.yaml
+++ b/.github/workflows/ci-nightly-benchmark-ocp-fma.yaml
@@ -96,6 +96,9 @@ jobs:
       GCP_PROJECT_ID: ${{ inputs.bucket_project || 'llm-d-scale' }}
       LLMDBENCH_CICD_TARGET: ${{ inputs.cluster_provider || 'ocp' }}
     steps:
+      - name: Checkout llm-d-benchmark (for the result-dump script)
+        uses: actions/checkout@v7.0.0
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
@@ -123,13 +126,14 @@ jobs:
           found=0
           if [ -n "$latest_standalone" ]; then
             echo "_Latest run: $(basename "$latest_standalone")_" >> "$GITHUB_STEP_SUMMARY"
-            for f in $(find "$latest_standalone" -path "*/analysis/*" -name "result.txt" 2>/dev/null | sort); do
+            for d in $(find "$latest_standalone" -type d -name results 2>/dev/null -exec find {} -mindepth 1 -maxdepth 1 -type d \; | sort); do
+              text=$("$GITHUB_WORKSPACE/util/dump_result_file.sh" "$d" "analysis/result.txt") || text=""
+              case "$text" in ""|"no analysis/result.txt"*) continue ;; esac
               found=1
-              experiment_id=$(basename "$(dirname "$f")")
               {
-                echo "### $experiment_id"
+                echo "### $(basename "$d")"
                 echo '```'
-                cat "$f"
+                printf '%s\n' "$text"
                 echo '```'
               } >> "$GITHUB_STEP_SUMMARY"
             done
@@ -143,13 +147,14 @@ jobs:
           found=0
           if [ -n "$latest_fma" ]; then
             echo "_Latest run: $(basename "$latest_fma")_" >> "$GITHUB_STEP_SUMMARY"
-            for f in $(find "$latest_fma" -path "*/analysis/*" -name "result.txt" 2>/dev/null | sort); do
+            for d in $(find "$latest_fma" -type d -name results 2>/dev/null -exec find {} -mindepth 1 -maxdepth 1 -type d \; | sort); do
+              text=$("$GITHUB_WORKSPACE/util/dump_result_file.sh" "$d" "analysis/result.txt") || text=""
+              case "$text" in ""|"no analysis/result.txt"*) continue ;; esac
               found=1
-              experiment_id=$(basename "$(dirname "$f")")
               {
-                echo "### $experiment_id"
+                echo "### $(basename "$d")"
                 echo '```'
-                cat "$f"
+                printf '%s\n' "$text"
                 echo '```'
               } >> "$GITHUB_STEP_SUMMARY"
             done

--- a/.github/workflows/ci-pr-benchmark.yaml
+++ b/.github/workflows/ci-pr-benchmark.yaml
@@ -21,9 +21,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      # zstd explicitly: install.sh only installs it best-effort, and without it the
+      # compression tests skip themselves and the suite passes vacuously. The analysis
+      # requirements are image-only, so the plot tests need them installed.
       - name: Install llmdbenchmark
         run: |
+          sudo apt-get update && sudo apt-get install -y zstd
           ./install.sh -y 2>&1
+          pip install -r build/requirements-analysis.txt
           pip install pytest pytest-xdist
 
       - name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Please refer to the official [llm-d prerequisites](https://github.com/llm-d/llm-
   which has kustomize built in; the standalone binary is only a convenience
 - **skopeo**, **crane** (optional) -- Used to resolve `:auto` image tags; any one
   of `skopeo`, `crane` or `podman` is enough
+- **zstd** (optional) -- Reads a compressed result set back out of its archive.
+  Without it a run collects uncompressed instead of failing
 - **oc** (optional) -- Required for OpenShift clusters (either `kubectl` or `oc` must be present)
 
 ### Administrative Requirements
@@ -377,7 +379,7 @@ The install script:
 
 1. Creates a Python virtual environment at `.venv/` (via [uv](https://docs.astral.sh/uv/) or `python3 -m venv` - see [Install](#install))
 2. Validates Python 3.11+ and pip
-3. Checks for required system tools (curl, git, kubectl or oc, helm, helmfile, jq, yq) and best-effort installs the optional ones (kustomize, skopeo, crane)
+3. Checks for required system tools (curl, git, kubectl or oc, helm, helmfile, jq, yq) and best-effort installs the optional ones (kustomize, skopeo, crane, zstd)
 4. Installs the `helm-diff` plugin (required by helmfile)
 5. Installs `llmdbenchmark` and `planner` (from [llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner))
 6. Verifies all Python packages are importable
@@ -413,6 +415,8 @@ llmdbenchmark --version
 | `--quiet-plan` / `--no-quiet-plan` | `LLMDBENCH_QUIET_PLAN` | Suppress the per-file plan-rendering narration on the console -- the `Rendered: <file>` lines, image overrides and per-stack banners -- replacing it with a one-line summary of what was rendered and where. **On by default** for `standup`, `smoketest`, `teardown`, `run` and `experiment`, where the render is an implicit prelude; **off by default** for `plan`, whose output it is. The detail is never lost: it is written to `<workspace>/logs/` at `DEBUG` either way. `--verbose` overrides this and always shows the full narration. See [Quieting the plan-rendering output](#quieting-the-plan-rendering-output). |
 | `--run-description TEXT` | `LLMDBENCH_DESCRIPTION_TEXT` | Human-readable label for the run, recorded as `run.description` in the benchmark report. Defaults to `<model> [<experiment id>]`. Also settable as `description.text` under a scenario's `common:` (or top-level `shared:`) block, or per treatment in an experiment. |
 | `--run-keywords LIST` | `LLMDBENCH_DESCRIPTION_KEYWORDS` | Comma-separated tags recorded as `run.keywords`. Never auto-populated; omitted entirely when unset. Also settable as `description.keywords` in the same places. |
+| `--compress` / `--no-compress` | `LLMDBENCH_COMPRESS` | Compress output (default: on). Each result set is compressed on the PVC before collection, so the archive rather than the raw tree crosses the tunnel; nothing is compressed on the driver. benchmark reports, `run_metadata.yaml`, `experiment-summary.yaml` and plots stay plain at the paths an uncompressed run writes them to; everything else lives in `workspace.tar.zst`. `--no-compress` keeps a fully plain tree. See [Compressed output](#compressed-output). |
+| `--compress-level N` | `LLMDBENCH_COMPRESS_LEVEL` | zstd level (default: 10, the speed/size knee). Raise for archival runs: level 16 costs roughly an order of magnitude more wall clock, for a size gain that measured between 6% and 12% on real result data. |
 | `--cluster-config FILE` / `--cc` | | YAML of cluster-specific overrides (storage class, service account, ...), deep-merged on top of the scenario. Not committed -- each user keeps their own. See [openshift-setup.md](docs/openshift-setup.md). |
 | `--set KEY=VALUE` | `LLMDBENCH_SET` | Scenario override(s) as `[stack:]dotted.key=value`, comma-separated and repeatable. Deep-merged on top of the scenario, so a variant differing in a few fields needs no separate YAML file. Prefix with a stack name or glob to scope it in a multi-stack scenario. Available on every subcommand that renders templates. **Distinct from `run`/`experiment`'s `-o`, which overrides the workload profile — the two can be combined.** See [standup.md](docs/standup.md#overriding-scenario-values-from-the-cli---set). |
 | `--version` | | Show version |
@@ -601,6 +605,74 @@ llmdbenchmark -v standup --spec gpu
 
 Precedence: `--quiet-plan` / `--no-quiet-plan` > `LLMDBENCH_QUIET_PLAN` >
 per-command default, with `--verbose` overriding all three.
+
+### Compressed output
+
+Output is compressed by default (`--no-compress` opts out). A result set is dominated by
+native harness JSON -- `per_request_lifecycle_metrics.json` alone reaches ~1.5 GB per run --
+and the pipeline is **generate, compress, copy**:
+
+* the harness pod produces every per-result-set artifact (reports, summaries, plots,
+  stage-clipped metrics) *before* anything is compressed;
+* each result set is then compressed in place **on the PVC**, so the archive rather than the
+  raw tree crosses the apiserver exec tunnel. This is a transfer speedup as much as a storage
+  one, and it composes with `--fast-collect`;
+* the archive is copied down as-is. Nothing is compressed, expanded, or re-analysed on the
+  driver.
+
+A small keep-plain set is left as real files so the collected tree stays usable without
+touching the archive:
+
+```
+<workspace>/
+├── latest -> <user>-<timestamp>/
+└── <user>-<timestamp>/
+    ├── plan/<scenario>/                       # teardown reads it live
+    ├── analysis/<experiment_id>/
+    │   └── distributions/*.png                # plain
+    └── results/<experiment_id>/
+        ├── benchmark_report_v0.2,_*.yaml      # plain
+        ├── run_metadata.yaml                  # plain
+        └── workspace.tar.zst                  # everything else
+```
+
+Four keep-plain entries, each earning it: the benchmark reports and `run_metadata.yaml` are
+what `results_store` globs off the live filesystem to resolve a run's uid/model/hardware,
+`experiment-summary.yaml` is a DoE run's only index, and the plots are the artifact people
+open (already-compressed bytes, so archiving them buys nothing).
+
+Everything else -- the per-request JSON, logs including the raw Prometheus snapshots, metric
+summaries, CSV, HTML, traces -- lives in `workspace.tar.zst`, and every component that reads
+one of those goes through the archive rather than requiring a plain copy: the cross-treatment
+overlays, summary extraction, the `eval-containers` roll-up and per-task reports, the failure
+validator, and the FMA comparison table. CI's log-dump steps read through
+`util/dump_result_file.sh`.
+
+Inspect an archive without expanding it:
+
+```bash
+tar -I zstd -tf workspace.tar.zst                        # list contents
+tar -I zstd -xOf workspace.tar.zst ./logs/stdout.log     # one member to stdout
+tar -I zstd -xf workspace.tar.zst                        # expand in place
+```
+
+Grep one member through `-xOf` as above. Piping the whole archive does not work: the tar
+padding reads as binary, so plain `grep` prints nothing and `grep -a` prints the
+surrounding tar block rather than the matching line. Level 10 is the default because it
+is the speed/size knee; `--compress-level` raises it for archival runs.
+
+`zstd` must be present in the benchmark image. Images predating it are detected by a probe
+and fall back to plain collection with a warning, never a failure. Compression is also
+skipped when the harness did not finish (a wait timeout, or `--wait-timeout 0`), since
+deleting files the harness may still be writing is not recoverable.
+
+`zstd` is needed on the driver too, to read a collected archive back. `install.sh`
+installs it best-effort; without it the run collects uncompressed and says so, so a
+host that cannot supply the package still works.
+
+`llmdbenchmark results add <path>` and UID lookups behave identically on a compressed and an
+uncompressed workspace: the plain files stay at `results/<experiment_id>/`, and `plan/`, which
+the store reads the scenario name from, is never touched.
 
 ## Architecture
 

--- a/benchmark-report/llmd_benchmark_report/native_to_br0_2.py
+++ b/benchmark-report/llmd_benchmark_report/native_to_br0_2.py
@@ -1620,10 +1620,39 @@ def import_eval_containers(results_file: str) -> BenchmarkReportV02:
     res = Path(results_file)
     root = res.parent.parent if res.parent.name == "task" else res.parent
 
-    def _read(rel: str) -> dict:
+    def _read_text(rel: str) -> str | None:
+        """Text of *rel* under the task dir, plain or from the task's archive.
+
+        Archived by default on a collected run, and every caller here treats a read
+        failure as "no data" -- so a plain-only read yields a report with the reward
+        and every perf field empty, which is indistinguishable from a task that
+        produced nothing.
+        """
+        plain = root / rel
+        if plain.is_file():
+            try:
+                return plain.read_text(encoding="utf-8")
+            except OSError:
+                return None
         try:
-            return json.loads((root / rel).read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            from llmdbenchmark.utilities.archive import read_member
+        except ImportError:  # in-pod: shipped flat, no llmdbenchmark package
+            return None
+        payload = read_member(root, rel)
+        if payload is None:
+            return None
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+
+    def _read(rel: str) -> dict:
+        text = _read_text(rel)
+        if text is None:
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
             return {}
 
     reward = _read("task/result.json")
@@ -1635,9 +1664,9 @@ def import_eval_containers(results_file: str) -> BenchmarkReportV02:
     n_calls = 0
     in_tok = out_tok = 0
     t_first = t_last = None
-    traces = root / "traces.jsonl"
-    if traces.exists():
-        for line in traces.read_text(encoding="utf-8").splitlines():
+    traces_text = _read_text("traces.jsonl")
+    if traces_text is not None:
+        for line in traces_text.splitlines():
             line = line.strip()
             if not line:
                 continue

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -133,6 +133,13 @@ ADD llmdbenchmark/analysis/scripts/ /tmp/analysis/
 ADD llmdbenchmark/standup/preprocess/ /tmp/preprocess/
 COPY llmdbenchmark/analysis/visualize_metrics.py /usr/local/bin/visualize_metrics.py
 
+# Plot modules the analyzers import flat: shipped alongside them, not as a package.
+COPY llmdbenchmark/analysis/per_request_plots.py /usr/local/bin/per_request_plots.py
+COPY llmdbenchmark/analysis/session_plots.py /usr/local/bin/session_plots.py
+COPY llmdbenchmark/analysis/session_metrics.py /usr/local/bin/session_metrics.py
+COPY llmdbenchmark/analysis/summary.py /usr/local/bin/summary.py
+COPY llmdbenchmark/analysis/metrics_embed.py /usr/local/bin/metrics_embed.py
+
 RUN rsync -az --exclude "__pycache__" /tmp/analysis/ /usr/local/bin/; rsync -az --exclude "__pycache__" /tmp/preprocess/ /usr/local/bin/
 
 ADD benchmark-report/ /tmp/benchmark-report/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update; \
     unzip \
     libpq-dev \
     vim-tiny \
+    zstd \
     && apt-get clean && rm -rf /var/cache/apt && rm -rf /var/lib/apt/lists/*
 
 # Install OpenShift CLI (oc)

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -412,8 +412,18 @@ COPY llmdbenchmark/analysis/scripts/vllm-benchmark-analyze_results.sh /usr/local
 COPY llmdbenchmark/analysis/scripts/guidellm-analyze_results.sh /usr/local/bin/guidellm-analyze_results.sh
 COPY llmdbenchmark/analysis/scripts/inferencemax-analyze_results.sh /usr/local/bin/inferencemax-analyze_results.sh
 COPY llmdbenchmark/analysis/scripts/lm-eval-analyze_results.sh /usr/local/bin/lm-eval-analyze_results.sh
+COPY llmdbenchmark/analysis/scripts/eval-containers-analyze_results.sh /usr/local/bin/eval-containers-analyze_results.sh
+COPY llmdbenchmark/analysis/scripts/aiperf-analyze_results.sh /usr/local/bin/aiperf-analyze_results.sh
 COPY llmdbenchmark/analysis/visualize_metrics.py /usr/local/bin/visualize_metrics.py
 COPY benchmark-report/ /opt/benchmark-report/
+COPY llmdbenchmark/analysis/scripts/generate_plots.py /usr/local/bin/generate_plots.py
+COPY llmdbenchmark/analysis/per_request_plots.py /usr/local/bin/per_request_plots.py
+COPY llmdbenchmark/analysis/session_plots.py /usr/local/bin/session_plots.py
+COPY llmdbenchmark/analysis/session_metrics.py /usr/local/bin/session_metrics.py
+COPY llmdbenchmark/analysis/summary.py /usr/local/bin/summary.py
+COPY llmdbenchmark/analysis/metrics_embed.py /usr/local/bin/metrics_embed.py
+COPY llmdbenchmark/analysis/scripts/embed_metrics.py /usr/local/bin/embed_metrics.py
+COPY llmdbenchmark/analysis/scripts/extract_summary.py /usr/local/bin/extract_summary.py
 
 # Install requirements for analysis scripts
 COPY build/requirements-analysis.txt .

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -9,7 +9,7 @@ WORKDIR /workspace
 # -----------------------------
 RUN microdnf clean all && microdnf makecache && \
     microdnf install -y \
-    git jq rsync wget tar \
+    git jq rsync wget tar zstd \
     which findutils \
     bc procps-ng \
     gcc gcc-c++ gcc-gfortran make cmake ninja-build \

--- a/config/templates/jinja/06_pod_access_to_harness_data.yaml.j2
+++ b/config/templates/jinja/06_pod_access_to_harness_data.yaml.j2
@@ -21,6 +21,15 @@ spec:
     # Keep-alive so the framework can `kubectl cp` results off the PVC (tar-based,
     # not rsync). Slim benchmark images may not ship rsync, so fall back to idling.
     command: ["sh", "-c", "command -v rsync >/dev/null 2>&1 && exec rsync --daemon --no-detach --port={{ dataAccess.rsyncPort }} --log-file=/dev/stdout || exec sleep infinity"]
+{% if dataAccess.resources is defined and dataAccess.resources %}
+    resources:
+      limits:
+        cpu: "{{ dataAccess.resources.limitsCpu }}"
+        memory: {{ dataAccess.resources.limitsMemory }}
+      requests:
+        cpu: "{{ dataAccess.resources.requestsCpu }}"
+        memory: {{ dataAccess.resources.requestsMemory }}
+{% endif %}
     volumeMounts:
     - name: requests
       mountPath: /requests

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1659,6 +1659,16 @@ downloadJob:
 dataAccess:
   rsyncPort: *rsync_port
   runAsUser: ~
+  # Compression runs here, not in the harness pod. `zstd -T0` reads the *host* core
+  # count, ignoring any cgroup quota, and its worker buffers scale with it -- GBs of
+  # RSS on a large benchmark node. The cpu *limit* sets the quota the script reads to
+  # pick a thread count; requests stay small so the pod still schedules on a
+  # single-node Kind cluster that is also running a model server.
+  resources:
+    limitsCpu: 4
+    limitsMemory: 8Gi
+    requestsCpu: 100m
+    requestsMemory: 128Mi
   nodeSelector: {}
   tolerations: []
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,7 +55,7 @@ You need these installed before starting:
 
 > **Resource note:** The `cicd/kind` scenario deploys ~7 pods on a single Kind node. With the default 2 CPUs that Docker Desktop, Colima, and Podman ship with, the harness pod (and sometimes the gateway) cannot schedule due to `Insufficient cpu`. Bump your container runtime to **4 CPUs** before creating the Kind cluster. See [Troubleshooting](#pods-stuck-in-pending-during-standup-or-run) if you hit this.
 
-Everything else - `kubectl`, `helm`, `helmfile`, `kind`, `skopeo`, `crane`, `helm-diff`, `jq`, `yq`, `kustomize` - will be installed for you by `./install.sh` in [step 3](#3-install-llmdbenchmark), with one exception: `kind` itself, which we install first below because we want the cluster up before the installer runs. `skopeo`, `crane` and `kustomize` are installed best-effort: they are optional, so a failure there is reported and the install continues.
+Everything else - `kubectl`, `helm`, `helmfile`, `kind`, `skopeo`, `crane`, `helm-diff`, `jq`, `yq`, `kustomize`, `zstd` - will be installed for you by `./install.sh` in [step 3](#3-install-llmdbenchmark), with one exception: `kind` itself, which we install first below because we want the cluster up before the installer runs. `skopeo`, `crane`, `kustomize` and `zstd` are installed best-effort: they are optional, so a failure there is reported and the install continues.
 
 ## 1. Install Kind locally
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -138,6 +138,8 @@ The following table displays a comprehensive list of environment variables (and 
 | LLMDBENCH_HARNESS_LOAD_PARALLELISM             | Controls the number harness pods which will be created to generate load (all pods execute the same workload profile) | Default=`1`, can be overriden with ` -j/--parallelism` |
 | LLMDBENCH_HARNESS_ENVVARS_TO_YAML              | List all environment variables to be added to all harness pods | Default=`LLMDBENCH_RUN_EXPERIMENT`, can be overriden with `-g/--envvarspod` |
 | LLMDBENCH_HARNESS_DEBUG                        | Execute harness in "debug-mode" (i.e., `sleep infinity`) | Default=`0`.  Can be overriden with CLI parameter `-d/--debug`|
+| LLMDBENCH_COMPRESS                             | Compress each result set on the `pvc` before collecting it, so the archive rather than the raw tree crosses the tunnel (benchmark reports, `run_metadata.yaml`, `experiment-summary.yaml` and plots stay plain) | Default=`1`. Can be overriden with CLI parameter `--compress/--no-compress` |
+| LLMDBENCH_COMPRESS_LEVEL                       | zstd compression level | Default=`10`. Can be overriden with CLI parameter `--compress-level` |
 
 > [!TIP]
 > In case the full path is ommited for the (workload) profile (either by setting `LLMDBENCH_HARNESS_EXPERIMENT_PROFILE` or CLI parameter `-w/--workload`), it is assumed that the file exists inside the `workload/profiles/<harness name>` folder

--- a/install.sh
+++ b/install.sh
@@ -456,7 +456,12 @@ else
     printf "  %-14s %-20s %s\n" "$kube_tool" "$($kube_tool version --client --short 2>/dev/null || $kube_tool version --client 2>/dev/null | head -1)" ""
 fi
 
-optional_tools="oc kustomize skopeo crane"
+# zstd: the driver reads collected result sets out of their archive with it, but
+# only for a compressed one -- read_member returns from the plain file first, and
+# `--no-compress` never writes an archive at all. Optional so a host whose package
+# manager cannot supply it can still run `plan`, and because the pod side already
+# warns-and-degrades on the same dependency rather than failing.
+optional_tools="oc kustomize skopeo crane zstd"
 
 # Demoted from `tools=` above, so install.sh has to keep provisioning them,
 # only without the power to abort the install. `oc` stays report-only, as on
@@ -464,7 +469,7 @@ optional_tools="oc kustomize skopeo crane"
 # and moves ITS kubectl into /usr/local/bin, which would replace a kubectl the
 # user already has. CI installs oc itself where it needs it (see the "Install
 # oc" step in .github/workflows/reusable-ci-nightly-benchmark.yaml).
-autoinstall_optional="kustomize skopeo crane"
+autoinstall_optional="kustomize skopeo crane zstd"
 
 # ---------------------------------------------------------------------------
 # Version helper
@@ -485,6 +490,10 @@ tool_version() {
         yq)         yq --version 2>&1 | awk '{print $NF}' ;;
         skopeo)     skopeo --version 2>&1 | awk '{print $NF}' ;;
         crane)      crane version 2>&1 | tr -d '\n' ;;
+        # Not $NF: the banner is '*** Zstandard CLI (64-bit) v1.5.7, by ... ***',
+        # so the last field is '***'. Matching the number also keeps version_gte
+        # off its "(unknown)" branch, which returns 1 even against an empty pin.
+        zstd)       zstd --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 ;;
         *)          echo "(unknown)" ;;
     esac
 }
@@ -733,6 +742,8 @@ install_crane_mac()    { brew install crane; }
 install_skopeo_mac()   { brew install skopeo; }
 install_curl_mac()     { brew install curl; }
 install_jq_mac()       { brew install jq; }
+install_zstd_mac()     { brew install zstd; }
+install_zstd_linux()   { ${PKG_MGR} zstd || true; }
 
 # ---------------------------------------------------------------------------
 # Check required tools (fail if missing, upgrade if outdated)

--- a/llmdbenchmark/analysis/__init__.py
+++ b/llmdbenchmark/analysis/__init__.py
@@ -24,6 +24,7 @@ from llmdbenchmark.analysis.metrics_embed import (  # noqa: F401
     REPORT_STAGE_RE as _REPORT_STAGE_RE,
     stage_windows as _stage_windows,
 )
+from llmdbenchmark.utilities.archive import read_member
 
 if TYPE_CHECKING:
     from llmdbenchmark.executor.context import ExecutionContext
@@ -76,7 +77,11 @@ def pod_analysis_present(harness_name: str, results_dir: Path) -> bool:
     if harness_name not in _IN_POD_ANALYZERS:
         return False
     if harness_name == "nop":
-        return (results_dir / "analysis" / "result.txt").is_file()
+        # Archived by default, and sync_analysis_dir moves analysis/ off the tree
+        # during collection either way -- so a plain check reads as "the pod did
+        # nothing" and hands the work to a driver path whose own input is archived
+        # too, failing the run.
+        return read_member(results_dir, "analysis/result.txt") is not None
     return any(results_dir.glob("benchmark_report_v0.2,_*.yaml"))
 
 
@@ -162,6 +167,13 @@ def run_analysis(
     # --- 1. Convert result files to benchmark report format ---
     pattern = _RESULT_PATTERNS.get(harness_name, "*.json")
     result_files = sorted(glob.glob(str(results_dir / pattern)))
+
+    # A fixed-path input may be archived rather than absent. The converters take a
+    # path and resolve the result root from it, reading through read_member, so the
+    # path only has to name the member -- it does not have to exist on disk.
+    if not result_files and not glob.has_magic(pattern):
+        if read_member(results_dir, pattern) is not None:
+            result_files = [str(results_dir / pattern)]
 
     if not result_files:
         _log(context, f"No result files matching '{pattern}' in {results_dir.name}")
@@ -333,7 +345,13 @@ def _convert_via_api(
         br.export_yaml(str(output_file))
         return None
 
-    except Exception as exc:
+    # SystemExit too: the converters share a CLI entry point whose input check calls
+    # sys.exit, and an input that only exists inside the archive trips it. Escaping
+    # here would kill the analysis phase instead of degrading to a warning.
+    except (Exception, SystemExit) as exc:
+        # str(SystemExit(2)) is just "2", which says nothing in a log.
+        if isinstance(exc, SystemExit):
+            return f"converter exited {exc.code}"
         return str(exc)
 
 

--- a/llmdbenchmark/analysis/__init__.py
+++ b/llmdbenchmark/analysis/__init__.py
@@ -12,13 +12,18 @@ from __future__ import annotations
 import glob
 import logging
 import os
-import re
 import shutil
 import subprocess
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from llmdbenchmark.analysis.summary import SUMMARY_MARKERS, extract_summary
+
+from llmdbenchmark.analysis.metrics_embed import (  # noqa: F401
+    REPORT_STAGE_RE as _REPORT_STAGE_RE,
+    stage_windows as _stage_windows,
+)
 
 if TYPE_CHECKING:
     from llmdbenchmark.executor.context import ExecutionContext
@@ -40,12 +45,40 @@ _RESULT_PATTERNS: dict[str, str] = {
 }
 
 # Summary marker per harness -- the line in stdout.log where the
-# interesting output starts.
-_SUMMARY_MARKERS: dict[str, str] = {
-    "guidellm": "Setup complete, starting benchmarks",
-    "vllm-benchmark": "Result ==",
-    "inferencemax": "Result ==",
-}
+# interesting output starts. Shared with the in-pod extractor.
+_SUMMARY_MARKERS = SUMMARY_MARKERS
+
+# Every harness analyses in the pod at exit. Re-running on the driver only rewrites
+# identical artifacts and forces a collected set to be read back out of its archive.
+# The driver pass stays the fallback for a set the pod did not analyse.
+_IN_POD_ANALYZERS = frozenset(
+    {
+        "inference-perf",
+        "guidellm",
+        "vllm-benchmark",
+        "inferencemax",
+        "aiperf",
+        "nop",
+        "lm-eval",
+        "eval-containers",
+    }
+)
+
+
+def pod_analysis_present(harness_name: str, results_dir: Path) -> bool:
+    """True when *results_dir* already holds the pod's own analysis output.
+
+    Presence is decided on the artifacts, not on the harness name alone: an
+    older image, a failed analyzer, or a hand-assembled directory leaves the
+    reports missing, and re-running on the driver is the fallback for exactly
+    those cases.
+    """
+    if harness_name not in _IN_POD_ANALYZERS:
+        return False
+    if harness_name == "nop":
+        return (results_dir / "analysis" / "result.txt").is_file()
+    return any(results_dir.glob("benchmark_report_v0.2,_*.yaml"))
+
 
 # Harness name to benchmark_report writer name
 _WRITER_NAMES: dict[str, str] = {
@@ -113,6 +146,12 @@ def run_analysis(
     Returns:
         ``None`` on success, or an error string.
     """
+    # Returns None (success) so the caller still counts this result set: the
+    # cross-treatment comparison is gated on that count and is driver-only work.
+    if pod_analysis_present(harness_name, results_dir):
+        _log(context, f"{results_dir.name}: using in-pod analysis")
+        return None
+
     if harness_name == "nop":
         return _run_nop_analysis(results_dir, context)
 
@@ -339,38 +378,18 @@ def _convert_via_cli(
 
 def _extract_summary(
     results_dir: Path,
-    marker: str,
+    marker: str | None,
     context: ExecutionContext | None,
 ) -> None:
     """Extract the tail of stdout.log from *marker* into analysis/summary.txt."""
-    stdout_log = results_dir / "stdout.log"
-    if not stdout_log.exists():
-        return
-
-    analysis_dir = results_dir / "analysis"
-    analysis_dir.mkdir(parents=True, exist_ok=True)
-
     try:
-        lines = stdout_log.read_text(
-            encoding="utf-8",
-            errors="replace",
-        ).splitlines()
-        # Find the last occurrence of the marker
-        # (matches bash ``grep | tail -1``)
-        start_idx = None
-        for idx, line in enumerate(lines):
-            if marker in line:
-                start_idx = idx
-        if start_idx is not None:
-            summary_lines = lines[start_idx:]
-            summary_path = analysis_dir / "summary.txt"
-            summary_path.write_text(
-                "\n".join(summary_lines) + "\n",
-                encoding="utf-8",
-            )
-            _log(context, f"Summary extracted to {summary_path.name}")
+        summary_path = extract_summary(results_dir, marker)
     except Exception as exc:
         _log(context, f"Could not extract summary: {exc}", warning=True)
+        return
+
+    if summary_path is not None:
+        _log(context, f"Summary extracted to {summary_path.name}")
 
 
 # ---------------------------------------------------------------------------
@@ -429,130 +448,25 @@ def _run_inference_perf_analyze(
 # ---------------------------------------------------------------------------
 
 
-# A failed stage still generated load and still gets a report, so it needs a window.
-_STAGE_MARKER_RE = re.compile(
-    r"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d),\d+ "
-    r".*Stage (\d+) - (?:session-based )?run (started|completed|failed)",
-    re.MULTILINE,
-)
-# Greedy, to take the last occurrence like native_to_br0_2 does on the same filename.
-_REPORT_STAGE_RE = re.compile(r".*stage_(\d+)", re.DOTALL)
-
-
-def _stage_windows(results_dir: Path) -> dict[int, tuple[datetime, datetime]]:
-    """Map stage index to its (start, end) as logged by the load generator.
-
-    The markers are ``%(asctime)s`` local time, stamped UTC here because the pod
-    pins ``TZ=UTC`` (20_harness_pod.yaml.j2). Returns {} when the log is missing
-    or holds no complete marker pair, leaving the caller on the whole-run series.
-    """
-    log = results_dir / "stdout.log"
-    try:
-        text = log.read_text(errors="replace")
-    except OSError:
-        return {}
-
-    bounds: dict[int, dict[str, datetime]] = {}
-    for stamp, stage, event in _STAGE_MARKER_RE.findall(text):
-        try:
-            when = datetime.strptime(stamp, "%Y-%m-%d %H:%M:%S").replace(
-                tzinfo=timezone.utc
-            )
-        except ValueError:
-            continue
-        key = "started" if event == "started" else "ended"
-        bounds.setdefault(int(stage), {})[key] = when
-
-    # A retried or restarted stage can log its markers out of order, which would
-    # clip every sample away; fall back to the whole run instead.
-    return {
-        stage: (pair["started"], pair["ended"])
-        for stage, pair in bounds.items()
-        if "started" in pair and "ended" in pair and pair["started"] < pair["ended"]
-    }
-
-
 def _embed_metrics_in_reports(
     metrics_dir: Path,
     results_dir: Path,
     context: ExecutionContext | None,
 ) -> None:
-    """Merge scraped metrics into the v0.2 reports written by step 1.
+    """Merge scraped metrics into the v0.2 reports, clipped per stage.
 
-    The in-pod ``*-analyze_results.sh`` scripts also do this, but they run when
-    the harness pod exits -- before the driver has written
-    ``metrics/processed/metrics_summary.json`` -- so their guard is always false
-    and the reports ship without time series. Here the metrics exist.
+    The in-pod analyzers run the same pass, via the same module, before the results
+    are collected -- so on a normal run this is a no-op re-do. It stays for the
+    result sets the pod did not analyse: an older image, or a harness with no in-pod
+    analyzer.
     """
-    import yaml
+    from llmdbenchmark.analysis.metrics_embed import embed_metrics
 
-    from llmdbenchmark.analysis.benchmark_report.metrics_processor import (
-        add_metrics_to_benchmark_report,
+    embed_metrics(
+        metrics_dir,
+        results_dir,
+        log=lambda message, warning=False: _log(context, message, warning=warning),
     )
-
-    if not (metrics_dir / "processed" / "metrics_summary.json").exists():
-        _log(context, "No metrics summary -- skipping report metrics embedding")
-        return
-
-    reports = sorted(results_dir.glob("benchmark_report_v0.2,_*.yaml"))
-    if not reports:
-        return
-
-    # One scrape covers the whole run, so each stage report needs its own window.
-    windows = _stage_windows(results_dir)
-
-    staged = [r for r in reports if _REPORT_STAGE_RE.search(r.name)]
-    # Staged reports with no window at all means the markers stopped parsing,
-    # which silently restores the whole-run series this clipping replaced.
-    if staged and not windows:
-        _log(
-            context,
-            f"No stage windows parsed from stdout.log for {len(staged)} stage "
-            f"report(s) -- embedding the whole run in each",
-            warning=True,
-        )
-
-    for report in reports:
-        try:
-            stage = _REPORT_STAGE_RE.search(report.name)
-            window = windows.get(int(stage.group(1))) if stage else None
-            # Warns only for a stage missing from an otherwise-parsed set; the
-            # none-parsed case is reported once above.
-            if stage and window is None and windows:
-                _log(
-                    context,
-                    f"No stage window for {report.name} -- embedding the whole run",
-                    warning=True,
-                )
-            with open(report) as fh:
-                br_dict = yaml.safe_load(fh) or {}
-            br_dict = add_metrics_to_benchmark_report(
-                br_dict, str(metrics_dir), time_series_window=window
-            )
-            interval = br_dict.get("results", {}).get("observability", {})
-            interval = interval.get("time_series_interval", {})
-            if (
-                window
-                and not interval.get("datapoints")
-                and interval.get("datapoints_available")
-            ):
-                _log(
-                    context,
-                    f"Stage window {interval.get('start')}..{interval.get('end')} "
-                    f"kept none of {interval.get('datapoints_available')} datapoints "
-                    f"scraped over {interval.get('scraped_from')}.."
-                    f"{interval.get('scraped_to')} in {report.name} -- series empty",
-                    warning=True,
-                )
-            with open(report, "w") as fh:
-                yaml.dump(br_dict, fh, default_flow_style=False, allow_unicode=True)
-            _log(context, f"Embedded metrics into {report.name}")
-        except Exception as exc:
-            _log(
-                context,
-                f"Metrics embedding failed for {report.name}: {exc}",
-                warning=True,
-            )
 
 
 def _run_metric_visualizations(
@@ -603,12 +517,8 @@ def _run_per_request_plots(
     Reads ``per_request_lifecycle_metrics.json`` and writes plots to
     ``analysis/distributions/``.  Requires ``matplotlib``.
     """
-    pr_file = results_dir / "per_request_lifecycle_metrics.json"
-    if not pr_file.exists():
-        pr_file = results_dir / "analysis" / "per_request_lifecycle_metrics.json"
-    if not pr_file.exists():
-        return
-
+    # Plain files only, and the in-pod pass runs before compression: on the driver
+    # this is a fallback that no-ops on an already-compressed result set.
     try:
         from llmdbenchmark.analysis.per_request_plots import (
             generate_per_request_plots,
@@ -639,126 +549,16 @@ def _run_session_plots(
     results_dir: Path,
     context: ExecutionContext | None,
 ) -> None:
-    """Generate bar charts for session lifecycle metrics from benchmark report v0.2 files.
-
-    Reads all ``benchmark_report_v0.2,_*_session_lifecycle_metrics.json.yaml``
-    files in results_dir and produces bar charts in ``analysis/session/``.
-    """
-    try:
-        import yaml as _yaml
-    except ImportError:
-        _log(context, "PyYAML not available -- skipping session plots")
-        return
+    """Generate bar charts for session lifecycle metrics from benchmark report v0.2 files."""
+    from llmdbenchmark.analysis.session_plots import generate_session_plots
 
     try:
-        import matplotlib
-
-        matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
-        import numpy as np
-    except ImportError:
-        _log(context, "matplotlib not available -- skipping session plots")
-        return
-
-    session_br_files = sorted(
-        results_dir.glob("benchmark_report_v0.2,_*_session_lifecycle_metrics.json.yaml")
-    )
-    if not session_br_files:
-        return
-
-    from llmdbenchmark.analysis.cross_treatment import (
-        SESSION_METRICS_OF_INTEREST,
-        deep_get,
-    )
-
-    # Load all stages into rows
-    rows: list[dict] = []
-    for br_file in session_br_files:
-        try:
-            with open(br_file, encoding="utf-8") as f:
-                report = _yaml.safe_load(f)
-            if not report:
-                continue
-        except Exception:
-            continue
-
-        row: dict = {"stage_file": br_file.name}
-        for dotted_path, col_name in SESSION_METRICS_OF_INTEREST:
-            row[col_name] = deep_get(report, dotted_path)
-        rows.append(row)
-
-    if not rows:
-        return
-
-    out_dir = results_dir / "analysis" / "session"
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    # (column_name, title, unit)
-    plot_specs = [
-        ("session_rate_qps", "Session Rate", "sessions/s"),
-        ("session_duration_mean_s", "Session Duration (Mean)", "seconds"),
-        ("session_duration_p99_s", "Session Duration P99", "seconds"),
-        ("events_per_session_mean", "Events per Session (Mean)", "count"),
-        (
-            "events_cancelled_per_session_mean",
-            "Cancelled Events per Session (Mean)",
-            "count",
-        ),
-        (
-            "output_tokens_per_session_mean",
-            "Output Tokens per Session (Mean)",
-            "tokens",
-        ),
-        ("failed_sessions", "Failed Sessions", "count"),
-    ]
-
-    bar_color = "#3498db"
-    generated = 0
-
-    stage_labels = [
-        r["stage_file"]
-        .replace("benchmark_report_v0.2,_", "")
-        .replace("_session_lifecycle_metrics.json.yaml", "")
-        for r in rows
-    ]
-
-    for col_name, title, unit in plot_specs:
-        values = [r.get(col_name) for r in rows]
-        if all(v is None for v in values):
-            continue
-        values_plot = [float(v) if v is not None else float("nan") for v in values]
-
-        fig, ax = plt.subplots(figsize=(max(6, len(rows) * 1.5), 5))
-        x_pos = range(len(rows))
-        bars = ax.bar(x_pos, values_plot, color=bar_color, alpha=0.85)
-
-        for bar, val in zip(bars, values_plot):
-            if np.isnan(val):
-                continue
-            text = f"{val:.4f}" if val < 10 else f"{val:.1f}"
-            ax.text(
-                bar.get_x() + bar.get_width() / 2,
-                bar.get_height(),
-                text,
-                ha="center",
-                va="bottom",
-                fontsize=8,
-                fontweight="bold",
-            )
-
-        ax.set_xticks(x_pos)
-        ax.set_xticklabels(stage_labels, rotation=30, ha="right", fontsize=9)
-        ax.set_ylabel(unit)
-        ax.set_title(title)
-        ax.grid(axis="y", alpha=0.3)
-
-        plt.tight_layout()
-        plt.savefig(str(out_dir / f"session_{col_name}.png"), dpi=150)
-        plt.close()
-        generated += 1
-
-    if generated:
-        _log(context, f"Generated {generated} session plot(s) in {out_dir}")
+        out_dir = results_dir / "analysis" / "session"
+        count = generate_session_plots(results_dir, output_dir=out_dir)
+        if count:
+            _log(context, f"Generated {count} session plot(s) in {out_dir}")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _log(context, f"Session plot generation failed: {exc}", warning=True)
 
 
 # ---------------------------------------------------------------------------

--- a/llmdbenchmark/analysis/aggregate_eval_containers.py
+++ b/llmdbenchmark/analysis/aggregate_eval_containers.py
@@ -28,6 +28,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from llmdbenchmark.utilities.archive import read_member
+
 import yaml
 
 from llmdbenchmark.analysis.benchmark_report.base import Units
@@ -88,17 +90,49 @@ def _polyglot_language(task_id: int | None) -> str:
     return ""
 
 
-def _read_json(path: Path) -> dict:
+def _read_text(task_dir: Path, relative: str) -> str | None:
+    """Text of ``relative`` under ``task_dir``, plain or from the task's archive.
+
+    Every scoring input here is archived by default, and each caller treats a read
+    failure as "no data" -- so without this the whole report comes out blank while
+    still reporting success.
+    """
+    plain = task_dir / relative
+    if plain.is_file():
+        # UnicodeDecodeError too, so both branches agree: catching it only on the
+        # archive side made a non-UTF8 trace raise on a plain tree and be swallowed
+        # on a compressed one.
+        try:
+            return plain.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    payload = read_member(task_dir, relative)
+    if payload is None:
+        return None
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        return payload.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _read_json(task_dir: Path, relative: str) -> dict:
+    text = _read_text(task_dir, relative)
+    if text is None:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
         return {}
 
 
-def _read_yaml(path: Path) -> dict:
+def _read_yaml(task_dir: Path, relative: str) -> dict:
+    text = _read_text(task_dir, relative)
+    if text is None:
+        return {}
     try:
-        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
+        loaded = yaml.safe_load(text)
+    except yaml.YAMLError:
         return {}
     return loaded if isinstance(loaded, dict) else {}
 
@@ -113,13 +147,11 @@ def _read_exit_code(task_dir: Path) -> int | None:
     trailing newline, so it must be read per-file -- concatenating several
     yields one run-together string.
     """
-    path = task_dir / "agent" / ".exit-code"
-    try:
-        text = path.read_text(encoding="utf-8").strip()
-    except OSError:
+    text = _read_text(task_dir, "agent/.exit-code")
+    if text is None:
         return None
     try:
-        return int(text)
+        return int(text.strip())
     except ValueError:
         return None
 
@@ -131,12 +163,12 @@ def _read_reward(task_dir: Path) -> tuple[float | None, bool | None, str, int | 
     ``logs/verifier/reward.txt`` (the grader writes it before the result file, so
     it survives a task that died between the two).
     """
-    result = _read_json(task_dir / "task" / "result.json")
+    result = _read_json(task_dir, "task/result.json")
     benchmark = str(result.get("benchmark") or "")
 
     task_id = result.get("task_id")
     if task_id is None:
-        task_id = _read_yaml(task_dir / "run_metadata.yaml").get("task_id")
+        task_id = _read_yaml(task_dir, "run_metadata.yaml").get("task_id")
     try:
         task_id_int = int(task_id)
     except (TypeError, ValueError):
@@ -153,22 +185,22 @@ def _read_reward(task_dir: Path) -> tuple[float | None, bool | None, str, int | 
             passed = reward_f >= 1.0
         return reward_f, passed, benchmark, task_id_int
 
+    text = _read_text(task_dir, "logs/verifier/reward.txt")
+    if text is None:
+        return None, None, benchmark, task_id_int
     try:
-        text = (task_dir / "logs" / "verifier" / "reward.txt").read_text(
-            encoding="utf-8"
-        )
         reward_f = float(text.strip())
-    except (OSError, ValueError):
+    except ValueError:
         return None, None, benchmark, task_id_int
     return reward_f, reward_f >= 1.0, benchmark, task_id_int
 
 
-def _iter_call_spans(traces: Path):
+def _iter_call_spans(task_dir: Path, relative: str = "traces.jsonl"):
     """Yield ``(name, attributes, start_ns, end_ns)`` for every span in a file."""
-    try:
-        lines = traces.read_text(encoding="utf-8").splitlines()
-    except OSError:
+    text = _read_text(task_dir, relative)
+    if text is None:
         return
+    lines = text.splitlines()
     for line in lines:
         line = line.strip()
         if not line:
@@ -211,7 +243,7 @@ class _TaskMetrics:
         self.task_id = task_id
         self.exit_code = _read_exit_code(task_dir)
 
-        metadata = _read_yaml(task_dir / "run_metadata.yaml")
+        metadata = _read_yaml(task_dir, "run_metadata.yaml")
         self.harness_rc = metadata.get("harness_rc")
         self.model = str(metadata.get("model") or "")
         self.task_latency_s = _duration_seconds(metadata.get("harness_delta"))
@@ -227,9 +259,7 @@ class _TaskMetrics:
 
         first_start: int | None = None
         last_end: int | None = None
-        for name, attrs, start_ns, end_ns in _iter_call_spans(
-            task_dir / "traces.jsonl"
-        ):
+        for name, attrs, start_ns, end_ns in _iter_call_spans(task_dir):
             # Usage rides on the provider span, not the HTTP span.
             if "gen_ai.usage.input_tokens" in attrs:
                 self.input_tokens += _int_attr(attrs, "gen_ai.usage.input_tokens")

--- a/llmdbenchmark/analysis/cross_treatment.py
+++ b/llmdbenchmark/analysis/cross_treatment.py
@@ -13,10 +13,15 @@ per-treatment analysis completes).
 from __future__ import annotations
 
 import csv
-import glob
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from llmdbenchmark.analysis.session_metrics import (
+    SESSION_METRICS_OF_INTEREST,
+    deep_get,
+)
+from llmdbenchmark.utilities.archive import read_member, read_members
 
 try:
     import yaml
@@ -77,53 +82,6 @@ METRICS_OF_INTEREST = [
     ("results.request_performance.aggregate.requests.total", "total_requests"),
     ("results.request_performance.aggregate.requests.failures", "failures"),
 ]
-
-SESSION_METRICS_OF_INTEREST = [
-    ("results.session_performance.sessions.session_rate.mean", "session_rate_qps"),
-    (
-        "results.session_performance.sessions.session_duration.mean",
-        "session_duration_mean_s",
-    ),
-    (
-        "results.session_performance.sessions.session_duration.p50",
-        "session_duration_p50_s",
-    ),
-    (
-        "results.session_performance.sessions.session_duration.p99",
-        "session_duration_p99_s",
-    ),
-    (
-        "results.session_performance.sessions.events_per_session.mean",
-        "events_per_session_mean",
-    ),
-    (
-        "results.session_performance.sessions.events_cancelled_per_session.mean",
-        "events_cancelled_per_session_mean",
-    ),
-    (
-        "results.session_performance.sessions.input_tokens_per_session.mean",
-        "input_tokens_per_session_mean",
-    ),
-    (
-        "results.session_performance.sessions.output_tokens_per_session.mean",
-        "output_tokens_per_session_mean",
-    ),
-    ("results.session_performance.sessions.total", "total_sessions"),
-    ("results.session_performance.sessions.failed", "failed_sessions"),
-]
-
-
-def deep_get(d: dict, dotted_key: str, default=None):
-    """Traverse nested dict by dotted key path."""
-    keys = dotted_key.split(".")
-    for k in keys:
-        if not isinstance(d, dict):
-            return default
-        d = d.get(k, default)
-        if d is default:
-            return default
-    return d
-
 
 # Only used when the caller has no harness name to hand: a results directory
 # name alone cannot be split into harness and treatment, since both may contain
@@ -889,15 +847,17 @@ def _generate_scatter_plots(
     return generated
 
 
-def _extract_per_request_metrics(pr_file: Path) -> dict[str, list[float]]:
-    """Extract per-request TTFT, TPOT, ITL, E2E from a per_request JSON file.
+def _extract_per_request_metrics(payload: bytes) -> dict[str, list[float]]:
+    """Extract per-request TTFT, TPOT, ITL, E2E from per_request JSON bytes.
+
+    Takes bytes rather than a path so a treatment whose results were archived is
+    read straight out of the archive, without expanding the ~1.5 GB file to disk.
 
     Returns dict with keys 'ttft', 'tpot', 'itl', 'e2e', each a list of floats.
     """
     import json
 
-    with open(pr_file, encoding="utf-8") as f:
-        raw = json.load(f)
+    raw = json.loads(payload)
 
     metrics: dict[str, list[float]] = {"ttft": [], "tpot": [], "itl": [], "e2e": []}
 
@@ -942,27 +902,23 @@ def _cache_epoch_from_name(path: Path) -> float | None:
     return float(m.group(1)) if m else None
 
 
-def _cache_parse_snapshot(path: Path) -> dict[str, float]:
+def _cache_parse_snapshot(text: str) -> dict[str, float]:
     """Parse one raw snapshot: {KV: mean, QUERIES: sum, HITS: sum} if present."""
     buckets: dict[str, list[float]] = {
         _CACHE_KV: [],
         _CACHE_QUERIES: [],
         _CACHE_HITS: [],
     }
-    try:
-        with open(path, encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                m = _CACHE_METRIC_RE.match(line)
-                if not m:
-                    continue
-                name = m.group(1)
-                if name in buckets:
-                    buckets[name].append(float(m.group(2)))
-    except OSError:
-        return {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _CACHE_METRIC_RE.match(line)
+        if not m:
+            continue
+        name = m.group(1)
+        if name in buckets:
+            buckets[name].append(float(m.group(2)))
     out: dict[str, float] = {}
     if buckets[_CACHE_KV]:
         out[_CACHE_KV] = sum(buckets[_CACHE_KV]) / len(buckets[_CACHE_KV])
@@ -1006,14 +962,15 @@ def _cache_trim_to_active(
 
 def _cache_load_series(results_dir: Path) -> list[tuple[float, dict[str, float]]]:
     """Return [(elapsed_sec, {metric: value}), ...] for one treatment, trimmed to its active window and re-based to t=0."""
-    files = sorted(glob.glob(str(results_dir / _CACHE_RAW_GLOB)))
     samples: list[tuple[float, dict[str, float]]] = []
-    for f in files:
-        p = Path(f)
-        epoch = _cache_epoch_from_name(p)
+    for relative, payload in sorted(read_members(results_dir, _CACHE_RAW_GLOB).items()):
+        epoch = _cache_epoch_from_name(Path(relative))
         if epoch is None:
             continue
-        values = _cache_parse_snapshot(p)
+        try:
+            values = _cache_parse_snapshot(payload.decode("utf-8"))
+        except UnicodeDecodeError:
+            continue
         if values:
             samples.append((epoch, values))
     if not samples:
@@ -1218,14 +1175,14 @@ def _generate_overlaid_cdf_plots(
         if not subdir.is_dir():
             continue
         # Check both root and analysis/ subdirectory (inference-perf --analyze
-        # moves the file into analysis/)
-        pr_file = subdir / "per_request_lifecycle_metrics.json"
-        if not pr_file.exists():
-            pr_file = subdir / "analysis" / "per_request_lifecycle_metrics.json"
-        if not pr_file.exists():
+        # moves the file into analysis/), plain or inside an archive.
+        payload = read_member(subdir, "per_request_lifecycle_metrics.json")
+        if payload is None:
+            payload = read_member(subdir, "analysis/per_request_lifecycle_metrics.json")
+        if payload is None:
             continue
         try:
-            metrics = _extract_per_request_metrics(pr_file)
+            metrics = _extract_per_request_metrics(payload)
             if any(len(v) > 0 for v in metrics.values()):
                 treatment_data[subdir.name] = metrics
         except Exception:

--- a/llmdbenchmark/analysis/metrics_embed.py
+++ b/llmdbenchmark/analysis/metrics_embed.py
@@ -1,0 +1,145 @@
+"""Embed scraped metrics into the v0.2 reports, clipped to each stage's window.
+
+Shared by the driver and the in-pod analyzers. One scrape covers a whole run, so
+without a per-stage window every stage report carries the whole-run series -- which
+is what the in-pod scripts used to produce, since they called
+``add_metrics_to_benchmark_report`` with no window at all.
+
+Runs in-pod, before the results are compressed, so every input here is a plain
+file: ``stdout.log`` for the markers, ``metrics/processed/`` for the scrape, and
+the reports themselves.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+STAGE_MARKER_RE = re.compile(
+    r"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d),\d+ "
+    r".*Stage (\d+) - (?:session-based )?run (started|completed|failed)",
+    re.MULTILINE,
+)
+# Greedy, to take the last occurrence like native_to_br0_2 does on the same filename.
+REPORT_STAGE_RE = re.compile(r".*stage_(\d+)", re.DOTALL)
+
+
+def stage_windows(results_dir: Path) -> dict[int, tuple[datetime, datetime]]:
+    """Map stage index to its (start, end) as logged by the load generator.
+
+    The markers are ``%(asctime)s`` local time, stamped UTC here because the pod
+    pins ``TZ=UTC`` (20_harness_pod.yaml.j2). Returns {} when the log is missing
+    or holds no complete marker pair, leaving the caller on the whole-run series.
+    """
+    try:
+        text = (results_dir / "stdout.log").read_text(errors="replace")
+    except OSError:
+        return {}
+
+    bounds: dict[int, dict[str, datetime]] = {}
+    for stamp, stage, event in STAGE_MARKER_RE.findall(text):
+        try:
+            when = datetime.strptime(stamp, "%Y-%m-%d %H:%M:%S").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            continue
+        key = "started" if event == "started" else "ended"
+        bounds.setdefault(int(stage), {})[key] = when
+
+    # A retried or restarted stage can log its markers out of order, which would
+    # clip every sample away; fall back to the whole run instead.
+    return {
+        stage: (pair["started"], pair["ended"])
+        for stage, pair in bounds.items()
+        if "started" in pair and "ended" in pair and pair["started"] < pair["ended"]
+    }
+
+
+def embed_metrics(
+    metrics_dir: Path,
+    results_dir: Path,
+    log=None,
+) -> int:
+    """Merge metrics into every v0.2 report under *results_dir*, stage-clipped.
+
+    Returns the number of reports written. *log* takes ``(message, warning)``.
+    """
+
+    def _say(message: str, warning: bool = False) -> None:
+        if log is not None:
+            log(message, warning)
+
+    import yaml
+
+    try:
+        from llmdbenchmark.analysis.benchmark_report.metrics_processor import (
+            add_metrics_to_benchmark_report,
+        )
+    except ImportError:  # in-pod: the library is installed, the package is not
+        from benchmark_report.metrics_processor import (  # type: ignore[no-redef]
+            add_metrics_to_benchmark_report,
+        )
+
+    if not (metrics_dir / "processed" / "metrics_summary.json").is_file():
+        _say("No metrics summary -- skipping report metrics embedding")
+        return 0
+
+    reports = sorted(results_dir.glob("benchmark_report_v0.2,_*.yaml"))
+    if not reports:
+        return 0
+
+    windows = stage_windows(results_dir)
+
+    staged = [r for r in reports if REPORT_STAGE_RE.search(r.name)]
+    # Staged reports with no window at all means the markers stopped parsing,
+    # which silently restores the whole-run series this clipping replaced.
+    if staged and not windows:
+        _say(
+            f"No stage windows parsed from stdout.log for {len(staged)} stage "
+            f"report(s) -- embedding the whole run in each",
+            True,
+        )
+
+    written = 0
+    for report in reports:
+        try:
+            stage = REPORT_STAGE_RE.search(report.name)
+            window = windows.get(int(stage.group(1))) if stage else None
+            # Warns only for a stage missing from an otherwise-parsed set; the
+            # none-parsed case is reported once above.
+            if stage and window is None and windows:
+                _say(
+                    f"No stage window for {report.name} -- embedding the whole run",
+                    True,
+                )
+
+            br_dict = yaml.safe_load(report.read_text()) or {}
+            br_dict = add_metrics_to_benchmark_report(
+                br_dict, str(metrics_dir), time_series_window=window
+            )
+
+            interval = br_dict.get("results", {}).get("observability", {})
+            interval = interval.get("time_series_interval", {})
+            if (
+                window
+                and not interval.get("datapoints")
+                and interval.get("datapoints_available")
+            ):
+                _say(
+                    f"Stage window {interval.get('start')}..{interval.get('end')} "
+                    f"kept none of {interval.get('datapoints_available')} datapoints "
+                    f"scraped over {interval.get('scraped_from')}.."
+                    f"{interval.get('scraped_to')} in {report.name} -- series empty",
+                    True,
+                )
+
+            with open(report, "w", encoding="utf-8") as fh:
+                yaml.dump(br_dict, fh, default_flow_style=False, allow_unicode=True)
+            _say(f"Embedded metrics into {report.name}")
+            written += 1
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            _say(f"Metrics embedding failed for {report.name}: {exc}", True)
+
+    return written

--- a/llmdbenchmark/analysis/per_request_plots.py
+++ b/llmdbenchmark/analysis/per_request_plots.py
@@ -43,16 +43,22 @@ def generate_per_request_plots(
         _log(context, "matplotlib not available -- skipping per-request plots")
         return 0
 
-    pr_file = results_dir / "per_request_lifecycle_metrics.json"
-    if not pr_file.exists():
-        pr_file = results_dir / "analysis" / "per_request_lifecycle_metrics.json"
-    if not pr_file.exists():
+    results_dir = Path(results_dir)
+    # Runs in-pod, before the results are compressed, so the metrics are plain
+    # files here. inference-perf --analyze may have moved them under analysis/.
+    for name in (
+        "per_request_lifecycle_metrics.json",
+        "analysis/per_request_lifecycle_metrics.json",
+    ):
+        metrics_file = results_dir / name
+        if metrics_file.is_file():
+            break
+    else:
         return 0
 
     try:
-        with open(pr_file, encoding="utf-8") as f:
-            raw_requests = json.load(f)
-    except (json.JSONDecodeError, Exception):
+        raw_requests = json.loads(metrics_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return 0
 
     if not isinstance(raw_requests, list) or len(raw_requests) < 2:

--- a/llmdbenchmark/analysis/scripts/aiperf-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/aiperf-analyze_results.sh
@@ -32,8 +32,10 @@ fi
 echo "Results data conversion completed successfully."
 
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis"
-if [[ -f "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log" ]]; then
-  cp "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log" \
-     "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/summary.txt"
-fi
+python3 /usr/local/bin/extract_summary.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR"
+# Outside the metrics guard: these read the harness result files, not the
+# Prometheus snapshots, so they apply whether or not metrics were collected.
+echo "Generating per-request and session plots..."
+python3 /usr/local/bin/generate_plots.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
+
 exit $?

--- a/llmdbenchmark/analysis/scripts/embed_metrics.py
+++ b/llmdbenchmark/analysis/scripts/embed_metrics.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""In-pod entry point for stage-clipped metrics embedding.
+
+The analyzers used to inline this as a python -c one-liner that called
+``add_metrics_to_benchmark_report`` with no ``time_series_window``, so every stage
+report carried the whole run's series. Clipping lived only on the driver, which no
+longer re-analyses a result set the pod already handled.
+
+Usage: embed_metrics.py <results_dir>
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    from llmdbenchmark.analysis.metrics_embed import embed_metrics
+except ImportError:  # in-pod: shipped flat, no llmdbenchmark package
+    from metrics_embed import embed_metrics
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <results_dir>", file=sys.stderr)
+        return 2
+
+    results_dir = Path(sys.argv[1])
+    if not results_dir.is_dir():
+        print(f"not a directory: {results_dir}", file=sys.stderr)
+        return 1
+
+    def log(message: str, warning: bool = False) -> None:
+        print(
+            f"{'WARNING: ' if warning else ''}{message}",
+            file=sys.stderr if warning else sys.stdout,
+        )
+
+    count = embed_metrics(results_dir / "metrics", results_dir, log=log)
+    print(f"Metrics embedded into {count} report(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/llmdbenchmark/analysis/scripts/eval-containers-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/eval-containers-analyze_results.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Analyze results for the eval-containers agentic harness.
+#
+# This harness had no analyzer, so its v0.2 report was the one report built only on
+# the driver -- which meant it had to read the collected result set, and broke once
+# that set was compressed. Building it here puts it with every other harness: the
+# pod produces the report, collection just moves it.
+#
+# Contract: consumes LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR, exits 0 on success.
+
+set -uo pipefail
+
+RESULTS_DIR="${LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR:-}"
+if [[ -z "${RESULTS_DIR}" || ! -d "${RESULTS_DIR}" ]]; then
+  echo "ERROR: LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR not set or missing: '${RESULTS_DIR}'" >&2
+  exit 1
+fi
+
+# One task per pod, so one result file. v0.2 only: the agentic schema has no v0.1
+# equivalent, and the converter is reached through the Python API rather than the
+# generic `benchmark-report -w` writer path.
+RESULT="${RESULTS_DIR}/task/result.json"
+if [[ ! -f "${RESULT}" ]]; then
+  echo "WARNING: no task/result.json under ${RESULTS_DIR}; nothing to convert." >&2
+  exit 0
+fi
+
+echo "Converting task/result.json to Benchmark Report v0.2"
+python3 - "${RESULT}" "${RESULTS_DIR}/benchmark_report_v0.2,_result.json.yaml" <<'PYEOF'
+import sys
+
+try:
+    from benchmark_report.native_to_br0_2 import import_eval_containers
+except ImportError:
+    from llmdbenchmark.analysis.benchmark_report.native_to_br0_2 import (
+        import_eval_containers,
+    )
+
+result_file, output_file = sys.argv[1], sys.argv[2]
+import_eval_containers(result_file).export_yaml(output_file)
+print(f"Wrote {output_file}")
+PYEOF
+rc=$?
+if [[ $rc -ne 0 ]]; then
+  echo "benchmark report conversion returned with error $rc" >&2
+  exit $rc
+fi
+
+mkdir -p "${RESULTS_DIR}/analysis"
+python3 /usr/local/bin/extract_summary.py "${RESULTS_DIR}"
+
+echo "eval-containers analysis complete."
+exit 0

--- a/llmdbenchmark/analysis/scripts/extract_summary.py
+++ b/llmdbenchmark/analysis/scripts/extract_summary.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""In-pod entry point for analysis/summary.txt.
+
+Usage: extract_summary.py <results_dir> [marker]
+"""
+
+import sys
+from pathlib import Path
+
+try:
+    from llmdbenchmark.analysis.summary import extract_summary
+except ImportError:  # in-pod: shipped flat, no llmdbenchmark package
+    from summary import extract_summary
+
+
+def main() -> int:
+    if not 2 <= len(sys.argv) <= 3:
+        print(f"usage: {sys.argv[0]} <results_dir> [marker]", file=sys.stderr)
+        return 2
+
+    results_dir = Path(sys.argv[1])
+    if not results_dir.is_dir():
+        print(f"not a directory: {results_dir}", file=sys.stderr)
+        return 1
+
+    marker = sys.argv[2] if len(sys.argv) == 3 else None
+    written = extract_summary(results_dir, marker)
+    if written is None:
+        print("No summary extracted (no stdout.log, or marker not found)")
+    else:
+        print(f"Summary extracted to {written}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/llmdbenchmark/analysis/scripts/fma_comparison_table.py
+++ b/llmdbenchmark/analysis/scripts/fma_comparison_table.py
@@ -18,9 +18,13 @@ Per-pass artifacts consumed:
 
 import argparse
 import glob
+import io
 import json
 import os
+import shutil
+import subprocess
 import sys
+import tarfile
 
 # Reuse the dual-pods-controller log parser (workload/harnesses) so hit-rate
 # classification matches the authoritative FMA actuation logic. The script runs
@@ -59,13 +63,80 @@ def _find_one(run_root, filename):
     return matches[-1] if matches else ""
 
 
-def load_json(p):
-    if not p or not os.path.isfile(p):
+def _archives(run_root):
+    """Every result archive under ``run_root``, newest-sorting last."""
+    if not run_root:
+        return []
+    found = glob.glob(os.path.join(run_root, "**/*.tar.zst"), recursive=True)
+    return sorted(f for f in found if os.path.isfile(f))
+
+
+def _read_from_archives(run_root, filename):
+    """Return ``filename``'s bytes from any archive under ``run_root``, or None.
+
+    A compressed run keeps the small artifacts plain, so this is the fallback for
+    a run whose keep-plain list predates them -- or for anything that legitimately
+    travels inside the archive. Matched on basename at any depth, mirroring
+    ``_find_one``. Self-contained on purpose: this script runs in CI from a
+    GCS download, with no llmdbenchmark package importable.
+    """
+    want = os.path.basename(filename)
+    for archive in reversed(_archives(run_root)):
+        try:
+            zstd = shutil.which("zstd")
+            if not zstd:
+                continue
+            proc = subprocess.Popen([zstd, "-dc", archive], stdout=subprocess.PIPE)
+            try:
+                with tarfile.open(fileobj=proc.stdout, mode="r|") as tar:
+                    for member in tar:
+                        if member.isfile() and os.path.basename(member.name) == want:
+                            handle = tar.extractfile(member)
+                            if handle is not None:
+                                return handle.read()
+            finally:
+                if proc.stdout is not None:
+                    proc.stdout.close()
+                proc.wait()
+        except (tarfile.TarError, OSError, subprocess.SubprocessError):
+            continue
+    return None
+
+
+def load_text(p, run_root="", filename=""):
+    """Text of ``p``, falling back to an archive under ``run_root``. None if absent."""
+    if p and os.path.isfile(p):
+        try:
+            with open(p, encoding="utf-8", errors="replace") as f:
+                return f.read()
+        except OSError:
+            return None
+
+    if not (run_root and filename):
+        return None
+    payload = _read_from_archives(run_root, filename)
+    if payload is None:
+        return None
+    return payload.decode("utf-8", errors="replace")
+
+
+def load_json(p, run_root="", filename=""):
+    """Load JSON from ``p``, falling back to an archive under ``run_root``."""
+    if p and os.path.isfile(p):
+        try:
+            with open(p, encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    if not (run_root and filename):
+        return None
+    payload = _read_from_archives(run_root, filename)
+    if payload is None:
         return None
     try:
-        with open(p, encoding="utf-8") as f:
-            return json.load(f)
-    except (json.JSONDecodeError, OSError):
+        return json.loads(payload.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return None
 
 
@@ -102,7 +173,9 @@ RUNNING_REQUESTS_METRIC = "llm_d_epp_request_running"
 def replica_stats(rdir):
     """(avg, max) ready replicas, read from process_metrics' pre-aggregated
     ``replica_status.json`` (``aggregate_ready_replicas``)."""
-    data = load_json(_find_one(rdir, "replica_status.json"))
+    data = load_json(
+        _find_one(rdir, "replica_status.json"), rdir, "replica_status.json"
+    )
     agg = (data or {}).get("aggregate_ready_replicas") or {}
     return (agg.get("mean"), agg.get("max"))
 
@@ -110,7 +183,9 @@ def replica_stats(rdir):
 def epp_gauge_mean(rdir, metric):
     """Mean of an EPP pool gauge, read from process_metrics' pre-aggregated
     ``metrics_summary.json`` (``_aggregated.metrics.<metric>.mean``)."""
-    data = load_json(_find_one(rdir, "metrics_summary.json"))
+    data = load_json(
+        _find_one(rdir, "metrics_summary.json"), rdir, "metrics_summary.json"
+    )
     metrics = (((data or {}).get("_aggregated") or {}).get("metrics")) or {}
     return (metrics.get(metric) or {}).get("mean")
 
@@ -118,7 +193,12 @@ def epp_gauge_mean(rdir, metric):
 def pod_startup_mean(rdir):
     """Avg pod startup = pod creation → Ready, read from process_metrics'
     pre-aggregated ``pod_startup_times.json``"""
-    data = load_json(_find_one(rdir, "pod_startup_times.json")) or {}
+    data = (
+        load_json(
+            _find_one(rdir, "pod_startup_times.json"), rdir, "pod_startup_times.json"
+        )
+        or {}
+    )
     agg = data.get("requester_runtime_aggregate") or data.get("aggregate") or {}
     return agg.get("mean")
 
@@ -139,19 +219,23 @@ def fma_hit_rates(rdir):
     process_metrics.py."""
     if parse_dpc_log is None:
         return (None, None, None)
-    log_path = _find_one(rdir, "dual-pods-controller.log")
-    if not log_path:
+    text = load_text(
+        _find_one(rdir, "dual-pods-controller.log"),
+        rdir,
+        "dual-pods-controller.log",
+    )
+    if text is None:
         return (None, None, None)
-    try:
-        with open(log_path, encoding="utf-8", errors="replace") as f:
-            records = parse_dpc_log(f)
-    except OSError:
-        return (None, None, None)
+    records = parse_dpc_log(io.StringIO(text))
 
     # Run start = first replica-status snapshot timestamp, as an epoch float to
     # compare against the DPC anchor times (also epoch). None => no filtering.
     run_start = None
-    ts_data = load_json(_find_one(rdir, "replica_status_timeseries.json"))
+    ts_data = load_json(
+        _find_one(rdir, "replica_status_timeseries.json"),
+        rdir,
+        "replica_status_timeseries.json",
+    )
     snaps = (ts_data or {}).get("snapshots", [])
     if snaps and _parse_rfc3339_nano is not None:
         run_start = _parse_rfc3339_nano(snaps[0].get("timestamp"))
@@ -245,16 +329,19 @@ _PER_WORKER_ROWS = {
 
 
 def _num_workers(rdir, workload):
-    prof = _find_one(rdir, os.path.basename(workload)) if workload else ""
-    if prof:
-        try:
-            with open(prof, encoding="utf-8") as f:
-                for line in f:
-                    s = line.strip()
-                    if s.startswith("num_workers:"):
-                        return int(s.split(":", 1)[1].strip())
-        except (OSError, ValueError):
-            pass
+    if not workload:
+        return 1
+    name = os.path.basename(workload)
+    text = load_text(_find_one(rdir, name), rdir, name)
+    if text is None:
+        return 1
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("num_workers:"):
+            try:
+                return int(s.split(":", 1)[1].strip())
+            except ValueError:
+                return 1
     return 1
 
 
@@ -308,9 +395,10 @@ def main():
 
     dirs = (args.baseline_dir, args.warmstart_dir, args.hotstart_dir)
     rdirs = [newest_run_dir(d) for d in dirs]
-    sums = [_find_one(r, "summary_lifecycle_metrics.json") for r in rdirs]
+    _sum_name = "summary_lifecycle_metrics.json"
+    sums = [_find_one(r, _sum_name) for r in rdirs]
 
-    bl, fw_ws, fw_hs = (load_json(p) for p in sums)
+    bl, fw_ws, fw_hs = (load_json(p, r, _sum_name) for p, r in zip(sums, rdirs))
     summaries = [bl, fw_ws, fw_hs]
 
     workers = [_num_workers(r, args.workload) for r in rdirs]

--- a/llmdbenchmark/analysis/scripts/generate_plots.py
+++ b/llmdbenchmark/analysis/scripts/generate_plots.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""In-pod entry point for the per-request and session-lifecycle plots.
+
+These two plot sets were the only analysis stages left running solely on the
+driver, which forced the collected results to be expanded locally just to be
+plotted. Producing them here keeps the pod the single producer of every
+artifact, so collection stays a pure transfer.
+
+Usage: generate_plots.py <results_dir>
+"""
+
+import sys
+from pathlib import Path
+
+from per_request_plots import generate_per_request_plots
+from session_plots import generate_session_plots
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <results_dir>", file=sys.stderr)
+        return 2
+
+    results_dir = Path(sys.argv[1])
+    if not results_dir.is_dir():
+        print(f"not a directory: {results_dir}", file=sys.stderr)
+        return 1
+
+    for label, generate in (
+        ("per-request distribution", generate_per_request_plots),
+        ("session lifecycle", generate_session_plots),
+    ):
+        # One failing set must not cost the other: the harness has already run,
+        # and a missing plot is not worth failing a completed benchmark over.
+        try:
+            count = generate(results_dir)
+            print(f"Generated {count} {label} plot(s)")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            print(f"WARNING: {label} plots failed: {exc}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/llmdbenchmark/analysis/scripts/guidellm-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/guidellm-analyze_results.sh
@@ -26,31 +26,29 @@ fi
 echo "Results data conversion completed successfully."
 
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis"
-#result_start=$(grep -nr "Benchmarks Stats:" $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | cut -d ':' -f 1)
-result_start=$(grep -nr "Setup complete, starting benchmarks" $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | cut -d ':' -f 1)
-total_file_lenght=$(cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | wc -l)
-cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | sed "$result_start,$total_file_lenght!d" > $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/summary.txt
+python3 /usr/local/bin/extract_summary.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" "Setup complete, starting benchmarks"
 _summary_rc=$?
 
 # Integrate vLLM metrics into benchmark report(s) v0.2 and generate plots
 _metrics_dir="$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics"
 if [[ -f "$_metrics_dir/processed/metrics_summary.json" ]]; then
+  # Via the shared module, not an inline one-liner: it clips each stage report to
+  # that stage's own window, which the one-liner could not do.
   echo "Integrating metrics summary into benchmark report(s) v0.2..."
-  for _report in $(find "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" -maxdepth 1 -name 'benchmark_report_v0.2,_*.yaml'); do
-    python3 -c "
-import yaml, sys
-from benchmark_report.metrics_processor import add_metrics_to_benchmark_report
-report_file, metrics_dir = sys.argv[1], sys.argv[2]
-with open(report_file) as f:
-    br_dict = yaml.safe_load(f)
-br_dict = add_metrics_to_benchmark_report(br_dict, metrics_dir)
-with open(report_file, 'w') as f:
-    yaml.dump(br_dict, f, default_flow_style=False, allow_unicode=True)
-print('Metrics integrated into: ' + report_file)
-" "$_report" "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
-  done
+  python3 /usr/local/bin/embed_metrics.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
   echo "Generating metric plots..."
+  # Both paths: the report's graph_path field cites metrics/graphs/ (the
+  # default), while the driver pass this replaces wrote analysis/graphs/ and
+  # sync_analysis_dir lifts that one into the workspace. Writing only one
+  # would change the tree an uncompressed run used to produce.
   python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
+  python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" \
+    -o "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/graphs" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 fi
+
+# Outside the metrics guard: these read the harness result files, not the
+# Prometheus snapshots, so they apply whether or not metrics were collected.
+echo "Generating per-request and session plots..."
+python3 /usr/local/bin/generate_plots.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 
 exit $_summary_rc

--- a/llmdbenchmark/analysis/scripts/inference-perf-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/inference-perf-analyze_results.sh
@@ -45,22 +45,23 @@ find $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR -type f -newermt "${tm}" -exec mv -t 
 # Integrate vLLM metrics into benchmark report(s) v0.2 and generate plots
 _metrics_dir="$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics"
 if [[ -f "$_metrics_dir/processed/metrics_summary.json" ]]; then
+  # Via the shared module, not an inline one-liner: it clips each stage report to
+  # that stage's own window, which the one-liner could not do.
   echo "Integrating metrics summary into benchmark report(s) v0.2..."
-  for _report in $(find "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" -maxdepth 1 -name 'benchmark_report_v0.2,_*.yaml'); do
-    python3 -c "
-import yaml, sys
-from benchmark_report.metrics_processor import add_metrics_to_benchmark_report
-report_file, metrics_dir = sys.argv[1], sys.argv[2]
-with open(report_file) as f:
-    br_dict = yaml.safe_load(f)
-br_dict = add_metrics_to_benchmark_report(br_dict, metrics_dir)
-with open(report_file, 'w') as f:
-    yaml.dump(br_dict, f, default_flow_style=False, allow_unicode=True)
-print('Metrics integrated into: ' + report_file)
-" "$_report" "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
-  done
+  python3 /usr/local/bin/embed_metrics.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
   echo "Generating metric plots..."
+  # Both paths: the report's graph_path field cites metrics/graphs/ (the
+  # default), while the driver pass this replaces wrote analysis/graphs/ and
+  # sync_analysis_dir lifts that one into the workspace. Writing only one
+  # would change the tree an uncompressed run used to produce.
   python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
+  python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" \
+    -o "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/graphs" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 fi
+
+# Outside the metrics guard: these read the harness result files, not the
+# Prometheus snapshots, so they apply whether or not metrics were collected.
+echo "Generating per-request and session plots..."
+python3 /usr/local/bin/generate_plots.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 
 exit $ec

--- a/llmdbenchmark/analysis/scripts/inferencemax-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/inferencemax-analyze_results.sh
@@ -31,30 +31,29 @@ fi
 echo "Results data conversion completed successfully."
 
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis"
-result_start=$(grep -nr "Result ==" $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | tail -1 | cut -d ':' -f 1)
-total_file_lenght=$(cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | wc -l)
-cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | sed "$result_start,$total_file_lenght!d" > $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/summary.txt
+python3 /usr/local/bin/extract_summary.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" "Result =="
 _summary_rc=$?
 
 # Integrate vLLM metrics into benchmark report(s) v0.2 and generate plots
 _metrics_dir="$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics"
 if [[ -f "$_metrics_dir/processed/metrics_summary.json" ]]; then
+  # Via the shared module, not an inline one-liner: it clips each stage report to
+  # that stage's own window, which the one-liner could not do.
   echo "Integrating metrics summary into benchmark report(s) v0.2..."
-  for _report in $(find "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" -maxdepth 1 -name 'benchmark_report_v0.2,_*.yaml'); do
-    python3 -c "
-import yaml, sys
-from benchmark_report.metrics_processor import add_metrics_to_benchmark_report
-report_file, metrics_dir = sys.argv[1], sys.argv[2]
-with open(report_file) as f:
-    br_dict = yaml.safe_load(f)
-br_dict = add_metrics_to_benchmark_report(br_dict, metrics_dir)
-with open(report_file, 'w') as f:
-    yaml.dump(br_dict, f, default_flow_style=False, allow_unicode=True)
-print('Metrics integrated into: ' + report_file)
-" "$_report" "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
-  done
+  python3 /usr/local/bin/embed_metrics.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
   echo "Generating metric plots..."
+  # Both paths: the report's graph_path field cites metrics/graphs/ (the
+  # default), while the driver pass this replaces wrote analysis/graphs/ and
+  # sync_analysis_dir lifts that one into the workspace. Writing only one
+  # would change the tree an uncompressed run used to produce.
   python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
+  python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" \
+    -o "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/graphs" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 fi
+
+# Outside the metrics guard: these read the harness result files, not the
+# Prometheus snapshots, so they apply whether or not metrics were collected.
+echo "Generating per-request and session plots..."
+python3 /usr/local/bin/generate_plots.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 
 exit $_summary_rc

--- a/llmdbenchmark/analysis/scripts/vllm-benchmark-analyze_results.sh
+++ b/llmdbenchmark/analysis/scripts/vllm-benchmark-analyze_results.sh
@@ -34,30 +34,29 @@ fi
 echo "Results data conversion completed successfully."
 
 mkdir -p "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis"
-result_start=$(grep -nr "Result ==" $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | tail -1 | cut -d ':' -f 1)
-total_file_lenght=$(cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | wc -l)
-cat $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stdout.log | sed "$result_start,$total_file_lenght!d" > $LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/summary.txt
+python3 /usr/local/bin/extract_summary.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" "Result =="
 _summary_rc=$?
 
 # Integrate vLLM metrics into benchmark report(s) v0.2 and generate plots
 _metrics_dir="$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/metrics"
 if [[ -f "$_metrics_dir/processed/metrics_summary.json" ]]; then
+  # Via the shared module, not an inline one-liner: it clips each stage report to
+  # that stage's own window, which the one-liner could not do.
   echo "Integrating metrics summary into benchmark report(s) v0.2..."
-  for _report in $(find "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" -maxdepth 1 -name 'benchmark_report_v0.2,_*.yaml'); do
-    python3 -c "
-import yaml, sys
-from benchmark_report.metrics_processor import add_metrics_to_benchmark_report
-report_file, metrics_dir = sys.argv[1], sys.argv[2]
-with open(report_file) as f:
-    br_dict = yaml.safe_load(f)
-br_dict = add_metrics_to_benchmark_report(br_dict, metrics_dir)
-with open(report_file, 'w') as f:
-    yaml.dump(br_dict, f, default_flow_style=False, allow_unicode=True)
-print('Metrics integrated into: ' + report_file)
-" "$_report" "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
-  done
+  python3 /usr/local/bin/embed_metrics.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
   echo "Generating metric plots..."
+  # Both paths: the report's graph_path field cites metrics/graphs/ (the
+  # default), while the driver pass this replaces wrote analysis/graphs/ and
+  # sync_analysis_dir lifts that one into the workspace. Writing only one
+  # would change the tree an uncompressed run used to produce.
   python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
+  python3 /usr/local/bin/visualize_metrics.py "$_metrics_dir" \
+    -o "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/analysis/graphs" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 fi
+
+# Outside the metrics guard: these read the harness result files, not the
+# Prometheus snapshots, so they apply whether or not metrics were collected.
+echo "Generating per-request and session plots..."
+python3 /usr/local/bin/generate_plots.py "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR" 2>&1 | tee -a "$LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR/stderr.log" || true
 
 exit $_summary_rc

--- a/llmdbenchmark/analysis/session_metrics.py
+++ b/llmdbenchmark/analysis/session_metrics.py
@@ -1,0 +1,54 @@
+"""Session-lifecycle metric paths and dict traversal, shared by driver and pod.
+
+Split out of ``cross_treatment`` so the in-pod plot scripts can import the same
+table: that module pulls in the driver-only archive reader, which the image does
+not ship.
+"""
+
+from __future__ import annotations
+
+SESSION_METRICS_OF_INTEREST = [
+    ("results.session_performance.sessions.session_rate.mean", "session_rate_qps"),
+    (
+        "results.session_performance.sessions.session_duration.mean",
+        "session_duration_mean_s",
+    ),
+    (
+        "results.session_performance.sessions.session_duration.p50",
+        "session_duration_p50_s",
+    ),
+    (
+        "results.session_performance.sessions.session_duration.p99",
+        "session_duration_p99_s",
+    ),
+    (
+        "results.session_performance.sessions.events_per_session.mean",
+        "events_per_session_mean",
+    ),
+    (
+        "results.session_performance.sessions.events_cancelled_per_session.mean",
+        "events_cancelled_per_session_mean",
+    ),
+    (
+        "results.session_performance.sessions.input_tokens_per_session.mean",
+        "input_tokens_per_session_mean",
+    ),
+    (
+        "results.session_performance.sessions.output_tokens_per_session.mean",
+        "output_tokens_per_session_mean",
+    ),
+    ("results.session_performance.sessions.total", "total_sessions"),
+    ("results.session_performance.sessions.failed", "failed_sessions"),
+]
+
+
+def deep_get(d: dict, dotted_key: str, default=None):
+    """Traverse nested dict by dotted key path."""
+    keys = dotted_key.split(".")
+    for k in keys:
+        if not isinstance(d, dict):
+            return default
+        d = d.get(k, default)
+        if d is default:
+            return default
+    return d

--- a/llmdbenchmark/analysis/session_plots.py
+++ b/llmdbenchmark/analysis/session_plots.py
@@ -1,0 +1,126 @@
+"""Session-lifecycle bar charts from benchmark report v0.2 files.
+
+Reads all ``benchmark_report_v0.2,_*_session_lifecycle_metrics.json.yaml`` files
+in a results directory and produces bar charts in ``analysis/session/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    from llmdbenchmark.analysis.session_metrics import (
+        SESSION_METRICS_OF_INTEREST,
+        deep_get,
+    )
+except ImportError:  # in-pod: shipped flat, no llmdbenchmark package
+    from session_metrics import SESSION_METRICS_OF_INTEREST, deep_get
+
+# (column_name, title, unit)
+PLOT_SPECS = [
+    ("session_rate_qps", "Session Rate", "sessions/s"),
+    ("session_duration_mean_s", "Session Duration (Mean)", "seconds"),
+    ("session_duration_p99_s", "Session Duration P99", "seconds"),
+    ("events_per_session_mean", "Events per Session (Mean)", "count"),
+    (
+        "events_cancelled_per_session_mean",
+        "Cancelled Events per Session (Mean)",
+        "count",
+    ),
+    ("output_tokens_per_session_mean", "Output Tokens per Session (Mean)", "tokens"),
+    ("failed_sessions", "Failed Sessions", "count"),
+]
+
+BAR_COLOR = "#3498db"
+
+
+def generate_session_plots(results_dir: Path, output_dir: Path | None = None) -> int:
+    """Generate session lifecycle bar charts. Returns the number written."""
+    try:
+        import yaml
+    except ImportError:
+        return 0
+
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        return 0
+
+    results_dir = Path(results_dir)
+    session_br_files = sorted(
+        results_dir.glob("benchmark_report_v0.2,_*_session_lifecycle_metrics.json.yaml")
+    )
+    if not session_br_files:
+        return 0
+
+    rows: list[dict] = []
+    for br_file in session_br_files:
+        try:
+            with open(br_file, encoding="utf-8") as handle:
+                report = yaml.safe_load(handle)
+            if not report:
+                continue
+        except Exception:  # pylint: disable=broad-exception-caught
+            continue
+
+        row: dict = {"stage_file": br_file.name}
+        for dotted_path, col_name in SESSION_METRICS_OF_INTEREST:
+            row[col_name] = deep_get(report, dotted_path)
+        rows.append(row)
+
+    if not rows:
+        return 0
+
+    if output_dir is None:
+        output_dir = results_dir / "analysis" / "session"
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    stage_labels = [
+        r["stage_file"]
+        .replace("benchmark_report_v0.2,_", "")
+        .replace("_session_lifecycle_metrics.json.yaml", "")
+        for r in rows
+    ]
+
+    generated = 0
+    for col_name, title, unit in PLOT_SPECS:
+        values = [r.get(col_name) for r in rows]
+        if all(v is None for v in values):
+            continue
+        values_plot = [float(v) if v is not None else float("nan") for v in values]
+
+        fig, ax = plt.subplots(figsize=(max(6, len(rows) * 1.5), 5))
+        x_pos = range(len(rows))
+        bars = ax.bar(x_pos, values_plot, color=BAR_COLOR, alpha=0.85)
+
+        for bar, val in zip(bars, values_plot):
+            if np.isnan(val):
+                continue
+            text = f"{val:.4f}" if val < 10 else f"{val:.1f}"
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height(),
+                text,
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                fontweight="bold",
+            )
+
+        ax.set_xticks(x_pos)
+        ax.set_xticklabels(stage_labels, rotation=30, ha="right", fontsize=9)
+        ax.set_ylabel(unit)
+        ax.set_title(title)
+        ax.grid(axis="y", alpha=0.3)
+
+        plt.tight_layout()
+        plt.savefig(str(output_dir / f"session_{col_name}.png"), dpi=150)
+        plt.close()
+        generated += 1
+
+    return generated

--- a/llmdbenchmark/analysis/summary.py
+++ b/llmdbenchmark/analysis/summary.py
@@ -25,13 +25,22 @@ def extract_summary(results_dir: Path, marker: str | None) -> Path | None:
     Returns the path written, or None when there was nothing to write.
     """
     stdout_log = results_dir / "stdout.log"
-    if not stdout_log.is_file():
-        return None
-
-    try:
-        text = stdout_log.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return None
+    if stdout_log.is_file():
+        try:
+            text = stdout_log.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+    else:
+        # Logs are archived, so a driver-side call on a collected tree has to read
+        # it back out. In-pod there is no archive yet and no package to import.
+        try:
+            from llmdbenchmark.utilities.archive import read_member
+        except ImportError:
+            return None
+        payload = read_member(results_dir, "stdout.log")
+        if payload is None:
+            return None
+        text = payload.decode("utf-8", errors="replace")
 
     lines = text.splitlines()
     if marker:

--- a/llmdbenchmark/analysis/summary.py
+++ b/llmdbenchmark/analysis/summary.py
@@ -1,0 +1,55 @@
+"""Extract the harness stdout tail into analysis/summary.txt.
+
+Shared by driver and pod. The bash form this replaces used ``grep -nr`` on a
+single named file, which prefixes the filename, so ``cut -d: -f1`` yielded
+``stdout.log`` instead of a line number and the following ``sed`` aborted --
+summary.txt came out empty for every marker-based harness.
+
+A harness with no marker (aiperf) keeps the whole log.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SUMMARY_MARKERS: dict[str, str] = {
+    "guidellm": "Setup complete, starting benchmarks",
+    "vllm-benchmark": "Result ==",
+    "inferencemax": "Result ==",
+}
+
+
+def extract_summary(results_dir: Path, marker: str | None) -> Path | None:
+    """Write ``analysis/summary.txt`` from stdout.log, starting at *marker*.
+
+    Returns the path written, or None when there was nothing to write.
+    """
+    stdout_log = results_dir / "stdout.log"
+    if not stdout_log.is_file():
+        return None
+
+    try:
+        text = stdout_log.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    lines = text.splitlines()
+    if marker:
+        # Last occurrence: a retried or multi-stage run logs the marker more
+        # than once and only the final block is the result.
+        start = None
+        for idx, line in enumerate(lines):
+            if marker in line:
+                start = idx
+        if start is None:
+            return None
+        lines = lines[start:]
+
+    if not lines:
+        return None
+
+    analysis_dir = results_dir / "analysis"
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = analysis_dir / "summary.txt"
+    summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return summary_path

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import yaml as _yaml
 
 from llmdbenchmark import __version__, __package_name__, __package_home__
-from llmdbenchmark.interface.env import env, env_bool, env_bool_optional
+from llmdbenchmark.interface.env import env, env_bool, env_bool_optional, env_int
 from llmdbenchmark.config import config
 from llmdbenchmark.logging.logger import get_logger
 from llmdbenchmark.logging.quiet import plan_logger
@@ -57,12 +57,39 @@ from llmdbenchmark.teardown.steps import get_teardown_steps
 
 from llmdbenchmark.run.steps import get_run_steps
 from llmdbenchmark.executor.command import CommandExecutor
+from llmdbenchmark.utilities.archive import DEFAULT_LEVEL as DEFAULT_COMPRESS_LEVEL
 
 
 class PhaseError(Exception):
     """Raised when a lifecycle phase (standup/run/teardown) fails."""
 
     pass
+
+
+def _compress_enabled(args: argparse.Namespace) -> bool:
+    """Whether output compression is on. Defaults to True (opt out with --no-compress)."""
+    value = getattr(args, "compress", None)
+    return True if value is None else bool(value)
+
+
+def _compress_level_arg(value: str) -> int:
+    """Reject levels zstd would refuse, before a whole run relies on them.
+
+    A negative level renders as ``-{level}``, i.e. a zstd *flag*, which fails per
+    directory and leaves the run uncompressed with only a warning.
+    """
+    try:
+        level = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from None
+    if not 1 <= level <= 19:
+        raise argparse.ArgumentTypeError(f"{level} is outside the zstd range 1-19")
+    return level
+
+
+def _compress_level(args: argparse.Namespace) -> int:
+    """Requested zstd level, falling back to the measured speed/size knee."""
+    return getattr(args, "compress_level", None) or DEFAULT_COMPRESS_LEVEL
 
 
 def setup_workspace(
@@ -564,6 +591,8 @@ def _do_standup(args, logger, render_plan_errors):
         dry_run=config.dry_run,
         verbose=config.verbose,
         non_admin=getattr(args, "non_admin", False),
+        compress_output=_compress_enabled(args),
+        compress_level=_compress_level(args),
         current_phase=Phase.STANDUP,
         kubeconfig=getattr(args, "kubeconfig", None),
         deployed_methods=deployed_methods,
@@ -719,6 +748,8 @@ def _do_smoketest(args, logger, render_plan_errors):
         dry_run=config.dry_run,
         verbose=config.verbose,
         non_admin=getattr(args, "non_admin", False),
+        compress_output=_compress_enabled(args),
+        compress_level=_compress_level(args),
         current_phase=Phase.SMOKETEST,
         kubeconfig=getattr(args, "kubeconfig", None),
         deployed_methods=deployed_methods,
@@ -924,6 +955,8 @@ def _do_teardown(args, logger, render_plan_errors):
         dry_run=config.dry_run,
         verbose=config.verbose,
         non_admin=getattr(args, "non_admin", False),
+        compress_output=_compress_enabled(args),
+        compress_level=_compress_level(args),
         current_phase=Phase.TEARDOWN,
         kubeconfig=getattr(args, "kubeconfig", None),
         deployed_methods=deployed_methods,
@@ -1050,6 +1083,8 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         dry_run=config.dry_run,
         verbose=config.verbose,
         non_admin=getattr(args, "non_admin", False),
+        compress_output=_compress_enabled(args),
+        compress_level=_compress_level(args),
         current_phase=Phase.RUN,
         kubeconfig=getattr(args, "kubeconfig", None),
         deployed_methods=deployed_methods,
@@ -1794,6 +1829,8 @@ def _log_env_overrides(logger, args):
         "LLMDBENCH_SKIP": ("skip", "--skip"),
         "LLMDBENCH_DEBUG": ("debug", "--debug"),
         "LLMDBENCH_FAST_COLLECT": ("fast_collect", "--fast-collect"),
+        "LLMDBENCH_COMPRESS": ("compress", "--compress"),
+        "LLMDBENCH_COMPRESS_LEVEL": ("compress_level", "--compress-level"),
         "LLMDBENCH_AFFINITY": ("affinity", "--affinity"),
         "LLMDBENCH_ANNOTATIONS": ("annotations", "--annotations"),
         "LLMDBENCH_WVA": ("wva", "--wva"),
@@ -1907,6 +1944,8 @@ def _all_flag_forms(flag: str) -> list[str]:
         "--skip": ["--skip", "-z"],
         "--debug": ["--debug", "-d"],
         "--fast-collect": ["--fast-collect"],
+        "--compress": ["--compress", "--no-compress"],
+        "--compress-level": ["--compress-level"],
         "--affinity": ["--affinity"],
         "--annotations": ["--annotations"],
         "--wva": ["--wva"],
@@ -2040,6 +2079,24 @@ def cli() -> None:
         help="Supply a workspace directory for placing generated items and logs.",
     )
     parser.add_argument(
+        "--compress",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Compress output: each result set is compressed on the PVC before "
+        "collection, so the archive rather than the raw tree is copied down. "
+        "Benchmark reports, run metadata and plots stay plain "
+        "(env: LLMDBENCH_COMPRESS). Default: on; use --no-compress to keep "
+        "plain text.",
+    )
+    parser.add_argument(
+        "--compress-level",
+        type=_compress_level_arg,
+        default=env_int("LLMDBENCH_COMPRESS_LEVEL"),
+        help=f"zstd compression level 1-19 (env: LLMDBENCH_COMPRESS_LEVEL). "
+        f"Default: {DEFAULT_COMPRESS_LEVEL}, the speed/size knee. Higher levels "
+        f"cost disproportionately more time for little extra saving.",
+    )
+    parser.add_argument(
         "--base-dir",
         "--bd",
         default=env("LLMDBENCH_BASE_DIR", "."),
@@ -2133,6 +2190,25 @@ def cli() -> None:
     )
 
     benchmark_parser.add_argument(
+        "--compress",
+        action=argparse.BooleanOptionalAction,
+        default=argparse.SUPPRESS,
+        help="Compress output: each result set is compressed on the PVC before "
+        "collection, so the archive rather than the raw tree is copied down. "
+        "Benchmark reports, run metadata and plots stay plain "
+        "(env: LLMDBENCH_COMPRESS). Default: on; use --no-compress to keep "
+        "plain text.",
+    )
+
+    benchmark_parser.add_argument(
+        "--compress-level",
+        type=_compress_level_arg,
+        default=argparse.SUPPRESS,
+        help=f"zstd compression level 1-19 (env: LLMDBENCH_COMPRESS_LEVEL). "
+        f"Default: {DEFAULT_COMPRESS_LEVEL}, the speed/size knee.",
+    )
+
+    benchmark_parser.add_argument(
         "--telemetry-enabled",
         action="store_true",
         help="Enable telemetry reporting.",
@@ -2218,6 +2294,15 @@ def cli() -> None:
         args.non_admin = env_bool("LLMDBENCH_NON_ADMIN")
     if hasattr(args, "monitoring") and args.monitoring is None:
         args.monitoring = env_bool("LLMDBENCH_MONITORING") or None
+    if getattr(args, "compress", None) is None:
+        args.compress = env_bool("LLMDBENCH_COMPRESS", default=True)
+    if not getattr(args, "compress_level", None):
+        # env_int bypasses the parser's own range check, so clamp rather than let an
+        # out-of-range level silently leave the whole run uncompressed.
+        args.compress_level = min(
+            19,
+            max(1, env_int("LLMDBENCH_COMPRESS_LEVEL", default=DEFAULT_COMPRESS_LEVEL)),
+        )
     if hasattr(args, "deep") and not args.deep:
         args.deep = env_bool("LLMDBENCH_DEEP_CLEAN")
     if hasattr(args, "skip") and not args.skip:

--- a/llmdbenchmark/executor/command.py
+++ b/llmdbenchmark/executor/command.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import shlex
 import subprocess
 import sys
 import time
@@ -277,6 +278,55 @@ class CommandExecutor:
             parts.extend(["--namespace", namespace])
         parts.extend(args)
         return self.execute(" ".join(parts), check=check, force=force)
+
+    def kube_exec(
+        self,
+        pod: str,
+        *remote_argv: str,
+        namespace: str | None = None,
+        check: bool = True,
+        timeout: int | None = None,
+    ) -> CommandResult:
+        """Run ``remote_argv`` inside ``pod`` without a local shell.
+
+        ``kube()`` space-joins its arguments and :meth:`_run_once` feeds the
+        result to ``bash -c``, so a payload meant for the pod's ``sh -c`` is
+        re-parsed by the *local* shell first -- quotes collapse, and anything
+        destructive in it runs against the driver's own filesystem. Passing argv
+        straight to ``subprocess.run`` keeps each element intact, so use this for
+        every ``sh -c`` payload.
+        """
+        argv = [self._kube_bin, *self._kubeconfig_args()]
+        if namespace:
+            argv.extend(["--namespace", namespace])
+        argv.extend(["exec", pod, "--", *remote_argv])
+
+        cmd_str = shlex.join(argv)
+        timestamp = int(time.time() * 1e9)
+        if self.dry_run:
+            return self._handle_dry_run(cmd_str, timestamp)
+
+        self._write_log(f"{timestamp}_command.log", f'---> will execute: "{cmd_str}"')
+        try:
+            proc = subprocess.run(
+                argv, capture_output=True, text=True, check=False, timeout=timeout
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self.logger.log_error(f"Exception executing command: {exc}")
+            return CommandResult(command=cmd_str, exit_code=1, stderr=str(exc))
+
+        self._write_log(f"{timestamp}_stdout.log", proc.stdout)
+        self._write_log(f"{timestamp}_stderr.log", proc.stderr)
+        if proc.returncode != 0 and check:
+            self._handle_failure(
+                cmd_str, proc.returncode, proc.stdout, proc.stderr, fatal=False
+            )
+        return CommandResult(
+            command=cmd_str,
+            exit_code=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+        )
 
     def helm(self, *args: str, check: bool = True) -> CommandResult:
         """Execute a helm command with auto-injected kubeconfig flags."""

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from llmdbenchmark.executor.protocols import LoggerProtocol
+from llmdbenchmark.utilities.archive import DEFAULT_LEVEL as DEFAULT_COMPRESS_LEVEL
 
 if TYPE_CHECKING:
     from llmdbenchmark.executor.command import CommandExecutor
@@ -105,6 +106,11 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # differs -- but is much faster for large result trees. Relies on the
     # fragile apiserver exec stream (retried). Off by default. See step_07.
     harness_fast_collect: bool = False
+    # Compress each result set on the PVC before collecting, so the archive crosses
+    # the tunnel. Nothing is compressed on the driver; reports, metadata and plots
+    # stay plain so results_store can still index the collected tree.
+    compress_output: bool = True
+    compress_level: int = DEFAULT_COMPRESS_LEVEL
     # When True, reset the vLLM prefix, multimodal, and encoder caches
     # (POST /reset_prefix_cache, /reset_mm_cache, /reset_encoder_cache) on
     # every serving pod before each treatment's run, so every treatment

--- a/llmdbenchmark/executor/deps.py
+++ b/llmdbenchmark/executor/deps.py
@@ -15,7 +15,14 @@ MIN_HELMFILE_VERSION = (1, 5, 0)
 
 
 REQUIRED_TOOLS = ["kubectl", "helm", "helmfile", "jq", "yq"]
-OPTIONAL_TOOLS = ["oc", "kustomize", "skopeo", "crane", "rsync", "make"]
+# zstd reads a compressed result set back; without it the run phase collects
+# uncompressed instead of failing, so it is reported, not enforced.
+OPTIONAL_TOOLS = ["oc", "kustomize", "skopeo", "crane", "rsync", "make", "zstd"]
+
+# What the absence actually costs, so "optional tool not found" is actionable.
+OPTIONAL_TOOL_CONSEQUENCE = {
+    "zstd": "results will be collected uncompressed (--no-compress behaviour)",
+}
 
 
 @dataclass

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -150,7 +150,8 @@ Steps are registered in `steps/__init__.py` via `get_run_steps()`:
 | 11 | `RunCleanupPostStep` | Delete harness pods and ConfigMaps |
 
 Note: Step 12 (analyze) runs before step 10 (upload) so analysis artifacts are included in the
-upload.
+upload. Compression happens inside step 07, on the PVC, before the results are collected --
+nothing is compressed on the driver.
 
 Step 12 defers per-result-set analysis to the harness pod: where a harness ships an
 analyzer, the pod builds its reports, summary and plots before the results are collected,
@@ -159,7 +160,8 @@ the pod did not analyse -- an older image, a harness with no analyzer, or one th
 
 It still runs the work no single pod can: the cross-treatment comparison (which spans
 result directories) and the `eval-containers` run-level roll-up (which spans task
-directories).
+directories). Both read their inputs out of the archive rather than requiring a plain
+copy.
 
 ## Common Patterns
 

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -149,7 +149,17 @@ Steps are registered in `steps/__init__.py` via `get_run_steps()`:
 | 10 | `UploadResultsStep` | Upload results to cloud storage (GCS/S3) |
 | 11 | `RunCleanupPostStep` | Delete harness pods and ConfigMaps |
 
-Note: Step 12 (analyze) runs before step 10 (upload) so analysis artifacts are included in the upload.
+Note: Step 12 (analyze) runs before step 10 (upload) so analysis artifacts are included in the
+upload.
+
+Step 12 defers per-result-set analysis to the harness pod: where a harness ships an
+analyzer, the pod builds its reports, summary and plots before the results are collected,
+so collection is a pure transfer. The driver pass remains the fallback for a result set
+the pod did not analyse -- an older image, a harness with no analyzer, or one that failed.
+
+It still runs the work no single pod can: the cross-treatment comparison (which spans
+result directories) and the `eval-containers` run-level roll-up (which spans task
+directories).
 
 ## Common Patterns
 

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -34,6 +34,7 @@ from llmdbenchmark.utilities.kube_helpers import (
     capture_pod_logs,
     capture_infrastructure_logs,
 )
+from llmdbenchmark.utilities.archive import read_member, remote_compress_script
 from llmdbenchmark.utilities.cloud_upload import upload_results_dir
 from llmdbenchmark.utilities.endpoint import reset_caches_pods
 
@@ -455,6 +456,7 @@ class DeployHarnessStep(Step):
                         harness_ns,
                         results_dir_prefix,
                         context,
+                        harness_settled=not treatment_errors,
                     )
                     if collect_errors:
                         treatment_errors.extend(collect_errors)
@@ -622,28 +624,28 @@ class DeployHarnessStep(Step):
         base = context.run_results_dir()
         for i in range(1, parallelism + 1):
             pod_dir = base / f"{experiment_id}_{i}"
-            summary = pod_dir / "summary_lifecycle_metrics.json"
-            if not summary.exists():
-                summary = pod_dir / "analysis" / "summary_lifecycle_metrics.json"
-            if not summary.exists():
-                errs.append(
-                    f"validate_failures: missing summary_lifecycle_metrics.json "
-                    f"under {pod_dir}"
-                )
+            # Runs after collection, so the file may already be archived; without
+            # read_member every treatment reads as "missing" and the retry loop
+            # discards a run that succeeded.
+            name = "summary_lifecycle_metrics.json"
+            payload = read_member(pod_dir, name)
+            if payload is None:
+                payload = read_member(pod_dir, f"analysis/{name}")
+            if payload is None:
+                errs.append(f"validate_failures: missing {name} under {pod_dir}")
                 continue
             try:
-                with open(summary, encoding="utf-8") as f:
-                    count = json.load(f)["failures"]["count"]
-                count = int(count)
-            except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+                count = int(json.loads(payload)["failures"]["count"])
+            except (ValueError, TypeError, KeyError, json.JSONDecodeError):
                 errs.append(
-                    f"validate_failures: cannot parse failures.count from {summary}"
+                    f"validate_failures: cannot parse failures.count from "
+                    f"{name} under {pod_dir}"
                 )
                 continue
             if count > 0:
                 errs.append(
                     f"validate_failures: {count} failed session(s) reported in "
-                    f"{summary}"
+                    f"{name} under {pod_dir}"
                 )
         return errs
 
@@ -682,6 +684,7 @@ class DeployHarnessStep(Step):
         namespace: str,
         results_dir_prefix: str,
         context: ExecutionContext,
+        harness_settled: bool = True,
     ) -> list[str]:
         """Collect results by discovering directories on the PVC.
 
@@ -761,12 +764,30 @@ class DeployHarnessStep(Step):
         # ``oc exec | tar`` stream, which crosses the tunnel far faster.
         FAST_COLLECT = context.harness_fast_collect
 
+        # Only compress a PVC nothing is still writing to: compression deletes the
+        # originals, and a file written after the tar snapshot is in no archive while
+        # its parent directory is removed regardless.
+        compress_on_pvc = DeployHarnessStep._should_compress_on_pvc(
+            cmd, context, data_pod, namespace, harness_settled
+        )
+
         for dir_name in matching_dirs:
             local_path = local_results_dir / dir_name
             local_path.mkdir(parents=True, exist_ok=True)
 
+            # Per dir, not once: a failure here must not make the collector below
+            # expect an archive this dir does not have.
+            dir_compressed = compress_on_pvc and DeployHarnessStep._compress_on_pvc(
+                cmd,
+                data_pod,
+                namespace,
+                f"{results_dir_prefix}/{dir_name}",
+                context,
+            )
+
             if FAST_COLLECT:
                 remote_dir = f"{results_dir_prefix}/{dir_name}"
+                tar_flags = "cf" if dir_compressed else "cz"
                 # Auto-detected binary + kubeconfig/context/namespace flags.
                 kube_argv = [
                     cmd._kube_bin,
@@ -777,7 +798,7 @@ class DeployHarnessStep(Step):
                     data_pod,
                     "--",
                     "tar",
-                    "cz",
+                    tar_flags,
                     "-C",
                     remote_dir,
                     ".",
@@ -789,7 +810,9 @@ class DeployHarnessStep(Step):
                 cp_result = CommandResult(command=" ".join(kube_argv), exit_code=1)
                 for cp_attempt in range(1, max_attempts + 1):
                     cp_result = DeployHarnessStep._fast_collect_stream(
-                        kube_argv, local_path
+                        kube_argv,
+                        local_path,
+                        mode="r|" if dir_compressed else "r|gz",
                     )
                     if cp_result.success:
                         break
@@ -924,28 +947,141 @@ class DeployHarnessStep(Step):
         return errors
 
     @staticmethod
-    def _fast_collect_stream(kube_argv: list[str], local_path: Path) -> CommandResult:
-        """Stream ``<kube> exec ... -- tar cz`` stdout into local ``tarfile``.
+    def _should_compress_on_pvc(
+        cmd,
+        context: ExecutionContext,
+        data_pod: str,
+        namespace: str,
+        harness_settled: bool,
+    ) -> bool:
+        """True when it is safe to compress this result set in place on the PVC.
+
+        Extracted so the gate on an irreversible delete is testable without a live
+        `kubectl exec`. Every reason to decline warns exactly once; the pod probe is
+        last so a driver that could not read the archive back never pays for it.
+        """
+        if not context.compress_output:
+            return False
+
+        # Only compress a PVC nothing is still writing to: compression deletes the
+        # originals, and a file written after the tar snapshot is in no archive while
+        # its parent directory is removed regardless.
+        if not DeployHarnessStep._pvc_settled(context, harness_settled):
+            context.logger.log_warning(
+                "Harness did not complete -- collecting results uncompressed so "
+                "nothing still being written is deleted"
+            )
+            return False
+
+        # Both ends need zstd: the pod to write the archive, the driver to read it
+        # back. Compressing without it here would leave a result set only the pod
+        # could open.
+        if shutil.which("zstd") is None:
+            context.logger.log_warning(
+                "zstd not found on this machine -- collecting results uncompressed, "
+                "since nothing here could read the archive back"
+            )
+            return False
+
+        if not DeployHarnessStep._pvc_has_zstd(cmd, data_pod, namespace):
+            context.logger.log_warning(
+                "zstd not found in the data-access pod -- collecting results "
+                "uncompressed. Rebuild the benchmark image to enable "
+                "PVC-side compression."
+            )
+            return False
+
+        return True
+
+    @staticmethod
+    def _pvc_settled(context: ExecutionContext, harness_settled: bool) -> bool:
+        """True when nothing can still be writing to the PVC.
+
+        Compression deletes the originals, so both halves matter: on a wait timeout
+        the harness pod is still Running, and wait_timeout 0 skips the wait entirely
+        so nothing ever observed the harness finish.
+        """
+        return harness_settled and context.harness_wait_timeout != 0
+
+    @staticmethod
+    def _pvc_has_zstd(cmd, data_pod: str, namespace: str) -> bool:
+        """True when the data-access pod ships a ``zstd`` binary.
+
+        Probed, not assumed: older images predate zstd being baked in, and a
+        restricted SCC rules out installing it at runtime.
+
+        ``zstd --version`` rather than ``command -v zstd``: the latter needs a
+        shell, and one argv element per word is what ``sh -c`` expects as its
+        script -- ``sh -c command -v zstd`` instead runs the bare ``command``
+        builtin with ``-v`` as ``$0``, which exits 0 with no output whether or not
+        zstd exists.
+        """
+        probe = cmd.kube_exec(
+            data_pod,
+            "zstd",
+            "--version",
+            namespace=namespace,
+            check=False,
+        )
+        return probe.success
+
+    @staticmethod
+    def _compress_on_pvc(
+        cmd,
+        data_pod: str,
+        namespace: str,
+        remote_dir: str,
+        context: ExecutionContext,
+    ) -> bool:
+        """Compress one PVC results dir in place. False leaves it untouched."""
+        # bash, not sh: the benchmark image is debian-slim, where /bin/sh is dash
+        # and `set -o pipefail` is an "Illegal option" that kills the script on its
+        # first statement -- so every run would degrade to uncompressed collection.
+        # The script needs pipefail to keep a broken `zstd -dc` from being read as
+        # an empty member list.
+        result = cmd.kube_exec(
+            data_pod,
+            "bash",
+            "-c",
+            remote_compress_script(remote_dir, level=context.compress_level),
+            namespace=namespace,
+            check=False,
+        )
+        if not result.success:
+            context.logger.log_warning(
+                f"PVC-side compression failed for {remote_dir} "
+                f"(exit={result.exit_code}), collecting uncompressed: "
+                f"{(result.stderr or result.stdout)[:300]}"
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _fast_collect_stream(
+        kube_argv: list[str], local_path: Path, mode: str = "r|gz"
+    ) -> CommandResult:
+        """Stream ``<kube> exec ... -- tar c*`` stdout into local ``tarfile``.
 
         Pure-Python replacement for a ``kube exec ... | tar xz -C`` shell pipe:
         no shell, no local ``tar`` binary, no quoting. Returns a CommandResult
-        so the caller keeps its uniform success/stderr handling.
+        so the caller keeps its uniform success/stderr handling. ``mode`` must
+        match the remote tar's compression (``r|`` for a plain ``tar cf``).
         """
         cmd_str = " ".join(kube_argv)
         try:
             with subprocess.Popen(
                 kube_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             ) as proc:
-                # ``r|gz`` = streaming read; tarfile consumes bytes as they land
+                # ``r|*`` = streaming read; tarfile consumes bytes as they land
                 # on stdout without seeking, so it works on a live pipe.
                 try:
-                    with tarfile.open(fileobj=proc.stdout, mode="r|gz") as tar:
+                    with tarfile.open(fileobj=proc.stdout, mode=mode) as tar:
                         # ``filter="data"`` rejects absolute paths, ``..`` and
                         # device entries (default in Py 3.14+, safe elsewhere).
                         tar.extractall(path=local_path, filter="data")
                     stderr = proc.stderr.read().decode("utf-8", errors="replace")
                     exit_code = proc.wait()
-                except Exception as exc:  # pylint: disable=broad-exception-caught
+                except Exception as exc:  # noqa: BLE001 -- must not leak the child
                     proc.kill()
                     stderr = proc.stderr.read().decode("utf-8", errors="replace")
                     proc.wait()

--- a/llmdbenchmark/standup/steps/step_00_ensure_infra.py
+++ b/llmdbenchmark/standup/steps/step_00_ensure_infra.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.executor.deps import (
+    OPTIONAL_TOOL_CONSEQUENCE,
     check_system_dependencies,
     check_python_version,
     check_helm_version,
@@ -275,7 +276,11 @@ class EnsureInfraStep(Step):
         if dep_result.missing_optional:
             if context.logger:
                 for tool in dep_result.missing_optional:
-                    context.logger.log_warning(f"Optional tool not found: {tool}")
+                    cost = OPTIONAL_TOOL_CONSEQUENCE.get(tool)
+                    context.logger.log_warning(
+                        f"Optional tool not found: {tool}"
+                        + (f" -- {cost}" if cost else "")
+                    )
 
         # Helm 4 toolchain guard. Standup deploys via helmfile; a Helm-3 host
         # or a pre-1.5 helmfile makes `helmfile template` panic with an

--- a/llmdbenchmark/utilities/archive.py
+++ b/llmdbenchmark/utilities/archive.py
@@ -1,0 +1,353 @@
+"""Compress a benchmark result set on the PVC, and read it back without expanding.
+
+Generate -> compress -> copy: the pod produces every artifact, the set is compressed
+in place, and the archive is what crosses the exec tunnel. Nothing is compressed or
+expanded on the driver. Level 10 is the speed/size knee (see --compress-level in
+README.md for the measured tradeoff).
+"""
+
+import posixpath
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+DEFAULT_LEVEL = 10
+
+# Left plain at any depth: results_store globs the reports and run_metadata.yaml off
+# the live filesystem, and plots are already-compressed bytes. experiment-summary.yaml
+# is a DoE run's index; it lives above any directory this runs in, so the entry only
+# guards against that changing. Patterns must mean the same to ``find -name`` and to
+# fnmatch/rglob, which disagree on character classes and '**' -- keep to plain '*'.
+KEEP_PLAIN = (
+    "benchmark_report*.yaml",
+    "run_metadata.yaml",
+    "experiment-summary.yaml",
+    "*.png",
+)
+
+REMOTE_ARCHIVE_NAME = "workspace.tar.zst"
+
+# THE INVARIANT every guard below serves: the set tar is told to pack must equal the
+# set the delete loop removes. find writes the skip list, tar reads it and emits
+# member names, the shell reads those back -- three quoting dialects, and every bug
+# found here has been a mismatch between them, never a compression failure. Reason
+# from that rule rather than the individual guards.
+#
+# A template, not concatenated f-strings: this deletes the only copy of a result set,
+# so it has to read as shell to stay safely editable.
+_REMOTE_SCRIPT = r"""
+set -e
+set -o pipefail
+cd {quoted_dir}
+
+# A crashed attempt can leave a corrupt archive; trust it only if it verifies.
+if [ -f {archive} ] && zstd -t {archive} 2>/dev/null; then
+    exit 0
+fi
+rm -f {archive}
+
+# Ahead of mktemp, whose temp files would otherwise read as content.
+if [ -z "$(find . -mindepth 1 -type f \( {keep_tests} \) -prune -o -print -quit)" ]; then
+    exit 0
+fi
+
+# A newline splits one skip-list entry into two bogus patterns, so the keeper is
+# archived instead of left plain. --null is not the fix: under it GNU tar honours
+# only the list's first pattern, leaking every keeper after it.
+#
+# A backslash is refused for a subtler reason. `tar tf` escapes 161 of 255 byte
+# values (measured), and an escaped name matches no file, so the loop skips it
+# harmlessly -- unless a second real file's literal name equals that rendering, which
+# the loop would then delete with its bytes in no archive. Every escape tar emits
+# contains a backslash, so refusing backslashes makes that collision unreachable.
+# Do not relax this without re-deriving that.
+if find . -mindepth 1 \( -name '*
+*' -o -name '*\\*' \) -print -quit | grep -q .; then
+    echo 'refusing to compress: a file name contains a newline or backslash' >&2
+    exit 3
+fi
+
+# -T0 reads the *host* core count, ignoring the pod's cgroup quota, and zstd's worker
+# buffers scale with it. Ask the cgroup instead -- in-pod, so it cannot drift from the
+# pod actually running. 0 means unlimited, where -T0 is right.
+threads=$(
+    q=; p=
+    if [ -r /sys/fs/cgroup/cpu.max ]; then
+        read -r q p < /sys/fs/cgroup/cpu.max
+    elif [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then
+        q=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+        p=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+    fi
+    # Both numeric and a positive period, or fall back to 0 (= all cores). An
+    # unexpected cgroup format must not divide by zero: that aborts the whole
+    # script here, leaving the set uncompressed with a clean exit.
+    case "$q$p" in
+        *[!0-9]* | '') echo 0 ;;
+        *) if [ "$q" -gt 0 ] && [ "$p" -gt 0 ]; then
+               echo $(( (q + p - 1) / p ))
+           else
+               echo 0
+           fi ;;
+    esac
+)
+
+# In the results dir, not /tmp: the pod's /tmp is small, the tar is multi-GB.
+pack=$(mktemp ./.pack.XXXXXX.tar)
+list=$(mktemp ./.list.XXXXXX)
+skip=$(mktemp ./.list.XXXXXX)
+trap 'rm -f -- "$pack" "$list" "$skip"' EXIT
+
+# --no-wildcards, or --exclude-from reads a keeper holding '[' as a glob and
+# archives it instead. Not --null: under it GNU tar honours only the list's *first*
+# pattern, silently leaking every keeper after it.
+find . -mindepth 1 -maxdepth 1 -type f \( {keep_tests} \
+    -o -name '.pack.*' -o -name '.list.*' \) -printf './%f\n' > "$skip"
+find . -mindepth 1 -type f \( {nested_finds} \) -print >> "$skip"
+
+# --exclude={archive} as well as the skip list: the list is a snapshot taken above,
+# so a concurrent run creating the archive between then and now would make it a member
+# of its own pack -- and the delete loop, trusting the verified member list, would then
+# remove the archive holding everything. The temp files need no live exclude; they exist
+# before the snapshot.
+tar cf "$pack" --anchored --no-wildcards --exclude='./{archive}' \
+    --exclude-from="$skip" .
+zstd -{level} -T"$threads" -q -f -o {archive} "$pack"
+zstd -t {archive}
+
+# The delete list, so a failure reading it must abort rather than delete nothing.
+zstd -dc {archive} | tar tf - > "$list"
+[ -s "$list" ]
+
+# Individually, not `rm -rf` on the parent, which would take the excluded plots.
+# IFS= : the default strips trailing space, resolving 'latency.png ' to the keeper
+# 'latency.png' and deleting bytes held nowhere else.
+while IFS= read -r member; do
+    if [ -f "$member" ]; then
+        rm -f -- "$member"
+    fi
+done < "$list"
+
+find . -mindepth 1 -depth -type d -empty -delete
+
+sed -e 's#^\./##' -e 's#/.*##' "$list" | sort -u | while IFS= read -r top; do
+    # '..' as well as '.': a member named ../x would resolve $top to the parent,
+    # which on a PVC holds every other result set. tar rooted at '.' cannot emit one,
+    # so this only closes the gap if that ever stops being true.
+    if [ -n "$top" ] && [ "$top" != '.' ] && [ "$top" != '..' ]; then
+        # Exit status, not just output: a failing find prints nothing, and reading
+        # that as "no keepers" deletes what was deliberately left out of the archive.
+        # 2>/dev/null: the empty-dir sweep above already removed fully-archived
+        # dirs, and one benign "No such file" per entry crowds the truncated warning
+        # the caller logs. The exit status still gates the rm -rf.
+        if keepers=$(find "./$top" \( {nested_finds} \) -print -quit 2>/dev/null); then
+            if [ -z "$keepers" ]; then
+                rm -rf -- "./$top"
+            fi
+        fi
+    fi
+done
+"""
+
+
+def remote_compress_script(remote_dir: str, level: int = DEFAULT_LEVEL) -> str:
+    """Shell for compressing a PVC results dir in place, run via ``kube_exec``.
+
+    Deletion is gated on ``zstd -t`` *and* a readable member list: the PVC holds the
+    only copy. Must go to ``kube_exec`` (argv), never ``kube``, which joins arguments
+    into a string ``bash -c`` re-parses locally -- pointing the deletes at the
+    driver's own filesystem. ``bash`` not ``sh``: dash rejects ``pipefail``.
+    """
+    # Built by find, not --exclude globs: a glob also matches directories, so a dir
+    # named 'logs.txt' would leave the archive while the delete loop still removed it.
+    keep_tests = " -o ".join(
+        f"-name '{pattern}'" for pattern in (*KEEP_PLAIN, REMOTE_ARCHIVE_NAME)
+    )
+    # nested_finds omits the archive itself: it only ever exists at depth 1.
+    nested_finds = " -o ".join(f"-name '{pattern}'" for pattern in KEEP_PLAIN)
+    return _REMOTE_SCRIPT.format(
+        quoted_dir=shlex.quote(remote_dir),
+        archive=REMOTE_ARCHIVE_NAME,
+        keep_tests=keep_tests,
+        nested_finds=nested_finds,
+        level=level,
+    )
+
+
+def _read_archive(archive: Path, consume, partial: bool = False) -> None:
+    """Open ``archive`` for reading and hand the tar to ``consume``.
+
+    Set ``partial`` when ``consume`` may return before the last member.
+    """
+    proc = subprocess.Popen(
+        ["zstd", "-dc", str(archive)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        with tarfile.open(fileobj=proc.stdout, mode="r|") as tar:
+            consume(tar)
+    finally:
+        # Close first, or zstd blocks writing into a pipe nobody drains and
+        # wait() deadlocks. An early-stopping consumer makes that the norm.
+        proc.stdout.close()
+        stderr = proc.stderr.read().decode("utf-8", errors="replace")
+        code = proc.wait()
+        # Only SIGPIPE is forgiven -- and it cannot be told apart from a truncation
+        # the consumer stopped before reaching. Deletion is gated on `zstd -t`, so a
+        # bad archive reaching here is already rare.
+        if code != 0 and not (partial and code == -signal.SIGPIPE):
+            raise RuntimeError(f"zstd -dc exited {code}: {stderr}")
+
+
+def read_member(root: Path, name: str) -> bytes | None:
+    """Return ``name``'s bytes from under ``root``, plain or from an archive.
+
+    Reads either tree shape, so a compressed result set need not be expanded to
+    disk to be read once. ``None`` when the file is in neither place.
+    """
+    root = Path(root)
+    plain = root / name
+    if plain.is_file():
+        return plain.read_bytes()
+
+    for archive, prefix in _archives_covering(root):
+        payload = _read_one(archive, f"{prefix}{name}")
+        if payload is not None:
+            return payload
+    return None
+
+
+def read_members(root: Path, pattern: str) -> dict[str, bytes]:
+    """Return ``{relative path: bytes}`` for every match of ``pattern`` under ``root``.
+
+    The globbing counterpart to :func:`read_member`. Plain files win, and an archive
+    is consulted only when the tree holds none, so a partially-expanded tree is
+    never merged with its own archive.
+    """
+    root = Path(root)
+    plain = {
+        str(p.relative_to(root)): p.read_bytes()
+        for p in sorted(root.glob(pattern))
+        if p.is_file()
+    }
+    if plain:
+        return plain
+
+    for archive, prefix in _archives_covering(root):
+        found: dict[str, bytes] = {}
+
+        def _consume(tar: tarfile.TarFile, found=found, prefix=prefix) -> None:
+            for member in tar:
+                if not member.isfile():
+                    continue
+                name = _strip_dot_slash(member.name)
+                if not name.startswith(prefix):
+                    continue
+                relative = name[len(prefix) :]
+                if not _glob_match(relative, pattern):
+                    continue
+                handle = tar.extractfile(member)
+                if handle is not None:
+                    found[relative] = handle.read()
+
+        try:
+            # Not partial: every member has to be examined, so the reader is
+            # drained rather than stopped at the first hit.
+            _read_archive(archive, _consume)
+        except _UNREADABLE as exc:
+            _warn_unreadable(archive, exc)
+            continue
+        if found:
+            return found
+    return {}
+
+
+def _glob_match(relative: str, pattern: str) -> bool:
+    """Match ``pattern`` the way ``Path.glob`` does, not the way ``fnmatch`` does.
+
+    fnmatch's ``*`` crosses ``/``, so it would fold a nested file into a match the
+    plain-filesystem side excludes -- the same glob answering differently depending
+    on whether the tree happens to be compressed. (``PurePath.full_match`` is 3.13+;
+    the floor here is 3.11.)
+    """
+    segments = pattern.split("**/")
+    expr = "(?:[^/]+/)*".join(
+        "[^/]*".join(re.escape(part) for part in segment.split("*"))
+        for segment in segments
+    )
+    return re.fullmatch(expr, relative) is not None
+
+
+def _strip_dot_slash(name: str) -> str:
+    """Drop a leading ``./`` -- as a prefix, not as ``lstrip('./')``, which is a
+    character set and would eat the leading dot of a real name."""
+    return name[2:] if name.startswith("./") else name
+
+
+def _archives_covering(root: Path) -> list[tuple[Path, str]]:
+    """Archives that may hold ``root``'s contents, with each one's member prefix.
+
+    Only inside ``root``: searching wider would read a sibling tree's archive as this
+    one's.
+    """
+    archive = root / REMOTE_ARCHIVE_NAME
+    return [(archive, "")] if archive.is_file() else []
+
+
+_UNREADABLE = (RuntimeError, tarfile.TarError, OSError)
+
+
+def _warn_unreadable(archive: Path, exc: BaseException) -> None:
+    """Report an unreadable archive rather than letting it read as "member absent".
+
+    The originals are gone once it verifies, so silence looks like an empty run.
+    """
+    print(
+        f"WARNING: cannot read {archive} ({type(exc).__name__}: {exc}) -- "
+        f"treating its contents as absent",
+        file=sys.stderr,
+    )
+
+
+def _read_one(archive: Path, wanted: str, _depth: int = 0) -> bytes | None:
+    """First member of ``archive`` named exactly ``wanted``, or None.
+
+    A link member carries no data (tar stores the payload once), so it is resolved
+    by re-reading its target -- else one name of a linked pair reads as absent.
+    """
+    found: list[bytes] = []
+    link_to: list[str] = []
+
+    def _consume(tar: tarfile.TarFile) -> None:
+        for member in tar:
+            if _strip_dot_slash(member.name) != wanted:
+                continue
+            if member.isfile():
+                handle = tar.extractfile(member)
+                if handle is not None:
+                    found.append(handle.read())
+            elif member.islnk() or member.issym():
+                target = _strip_dot_slash(member.linkname)
+                if member.issym() and not target.startswith("/"):
+                    target = posixpath.normpath(
+                        posixpath.join(posixpath.dirname(wanted), target)
+                    )
+                link_to.append(target)
+            return
+
+    try:
+        _read_archive(archive, _consume, partial=True)
+    except _UNREADABLE as exc:
+        _warn_unreadable(archive, exc)
+        return None
+    if found:
+        return found[0]
+    # Depth cap, not a visited set: a tar can hold a link cycle, and one hop is
+    # all a real archive needs.
+    if link_to and _depth < 4:
+        return _read_one(archive, link_to[0], _depth + 1)
+    return None

--- a/tests/test_compressed_consumers.py
+++ b/tests/test_compressed_consumers.py
@@ -1,0 +1,583 @@
+"""Every post-collection consumer has to work on a compressed result set.
+
+Compression deletes the originals, so a consumer that only reads plain paths does
+not raise -- it silently reports nothing, which reads as "the benchmark found no
+data" rather than "the reader is broken". These pin the readers that were converted
+for that reason; each one failed before conversion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from llmdbenchmark.utilities.archive import remote_compress_script
+
+# Skipping locally is fine; skipping in CI would mean this whole file -- every guard
+# on the only copy of a result set -- passes vacuously, which is how it went unnoticed
+# that CI had no zstd at all.
+if shutil.which("zstd") is None and os.environ.get("CI"):
+    raise RuntimeError("zstd missing in CI: these tests would skip silently")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("zstd") is None, reason="needs the zstd CLI"
+)
+
+
+def _compress(directory: Path, expect_ok: bool = True, env: dict | None = None):
+    """Run the real PVC script locally. ``expect_ok=False`` for the guard tests,
+    which assert it refuses rather than deletes."""
+    result = subprocess.run(
+        ["bash", "-c", remote_compress_script(str(directory), level=1)],
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    if expect_ok:
+        assert result.returncode == 0, result.stderr
+    return result
+
+
+def test_metrics_embedding_clips_each_stage_in_pod(tmp_path):
+    """One scrape covers the whole run, so each stage report needs its own window.
+
+    The in-pod analyzers used to inline a one-liner that passed no window, leaving
+    every stage carrying the whole run -- clipping existed only on the driver, which
+    no longer re-analyses a set the pod already handled.
+    """
+    import yaml
+
+    from llmdbenchmark.analysis.metrics_embed import embed_metrics, stage_windows
+
+    results = tmp_path / "results"
+    (results / "metrics" / "processed").mkdir(parents=True)
+    (results / "stdout.log").write_text(
+        "2026-08-18 10:00:00,1 INFO Stage 0 - run started\n"
+        "2026-08-18 10:01:00,1 INFO Stage 0 - run completed\n"
+        "2026-08-18 10:02:00,1 INFO Stage 1 - run started\n"
+        "2026-08-18 10:03:00,1 INFO Stage 1 - run completed\n",
+        encoding="utf-8",
+    )
+    for stage in (0, 1):
+        (results / f"benchmark_report_v0.2,_stage_{stage}.json.yaml").write_text(
+            "run:\n  uid: x\nresults: {}\n", encoding="utf-8"
+        )
+    (results / "metrics" / "processed" / "metrics_summary.json").write_text(
+        '{"_aggregated": {"metrics": {}}}', encoding="utf-8"
+    )
+
+    assert sorted(stage_windows(results)) == [0, 1]
+    assert embed_metrics(results / "metrics", results, log=None) == 2
+
+    windows = {}
+    for stage in (0, 1):
+        report = results / f"benchmark_report_v0.2,_stage_{stage}.json.yaml"
+        obs = yaml.safe_load(report.read_text())["results"]["observability"]
+        interval = obs["time_series_interval"]
+        windows[stage] = (interval["start"], interval["end"])
+
+    # Distinct windows: identical ones mean the whole run was embedded in both.
+    assert windows[0] != windows[1]
+    assert windows[0][0].startswith("2026-08-18T10:00:00")
+    assert windows[1][0].startswith("2026-08-18T10:02:00")
+
+
+def test_every_harness_builds_its_report_in_the_pod():
+    """The report is the pod's output, so collection is a pure transfer.
+
+    eval-containers was the last harness without an analyzer, which made its report
+    the one the driver had to build -- from a result set that by then is compressed.
+    """
+    from llmdbenchmark.analysis import _IN_POD_ANALYZERS, _WRITER_NAMES
+
+    scripts = (
+        Path(__file__).resolve().parents[1] / "llmdbenchmark" / "analysis" / "scripts"
+    )
+    for harness in sorted(_IN_POD_ANALYZERS):
+        shell = scripts / f"{harness}-analyze_results.sh"
+        python = scripts / f"{harness}-analyze_results.py"
+        assert shell.is_file() or python.is_file(), f"{harness} ships no analyzer"
+
+    # Anything the driver can write a report for must have an in-pod analyzer too,
+    # or that report only ever exists after collection.
+    assert set(_WRITER_NAMES) <= _IN_POD_ANALYZERS
+
+
+def test_nop_gate_sees_in_pod_output_in_the_archive(tmp_path):
+    """A plain check reads as "the pod did nothing" and hands the work to a driver
+    path whose own input is archived too, failing the run."""
+    from llmdbenchmark.analysis import pod_analysis_present, run_analysis
+
+    results = tmp_path / "exp_1"
+    (results / "analysis").mkdir(parents=True)
+    (results / "benchmark_report").mkdir()
+    (results / "analysis" / "result.txt").write_text("nop output\n", encoding="utf-8")
+    (results / "benchmark_report" / "result.yaml").write_text(
+        "x: 1\n", encoding="utf-8"
+    )
+    _compress(results)
+
+    assert pod_analysis_present("nop", results)
+    assert run_analysis("nop", results, None) is None
+
+
+def test_eval_containers_report_is_gated_once_the_pod_built_it(tmp_path):
+    """With the analyzer in place the driver must defer -- and must still fall back
+    for a result set an older image left unanalysed."""
+    from llmdbenchmark.analysis import pod_analysis_present, run_analysis
+
+    built = tmp_path / "built"
+    (built / "task").mkdir(parents=True)
+    (built / "task" / "result.json").write_text(
+        json.dumps({"benchmark": "polyglot", "reward": 1.0, "passed": True}),
+        encoding="utf-8",
+    )
+    (built / "benchmark_report_v0.2,_result.json.yaml").write_text(
+        "run: {}\n", encoding="utf-8"
+    )
+    assert pod_analysis_present("eval-containers", built)
+    assert run_analysis("eval-containers", built, None) is None
+
+    unanalysed = tmp_path / "unanalysed"
+    (unanalysed / "task").mkdir(parents=True)
+    (unanalysed / "task" / "result.json").write_text(
+        json.dumps({"benchmark": "polyglot", "reward": 1.0, "passed": True}),
+        encoding="utf-8",
+    )
+    assert not pod_analysis_present("eval-containers", unanalysed)
+    assert run_analysis("eval-containers", unanalysed, None) is None
+    assert list(unanalysed.glob("benchmark_report_v0.2,_*.yaml"))
+
+
+def test_no_compress_leaves_the_same_artifacts_as_compress(tmp_path):
+    """--no-compress must leave the same artifacts at the same paths: the only
+    difference is whether the bulk sits in the archive or beside it."""
+    from llmdbenchmark.utilities.archive import read_member
+
+    def build(results: Path) -> None:
+        (results / "analysis" / "distributions").mkdir(parents=True)
+        (results / "metrics" / "graphs").mkdir(parents=True)
+        (results / "benchmark_report_v0.2,_stage_0.json.yaml").write_text(
+            "run: {}\n", encoding="utf-8"
+        )
+        (results / "run_metadata.yaml").write_text("model: m\n", encoding="utf-8")
+        (results / "analysis" / "distributions" / "dist_ttft.png").write_bytes(b"PNG\n")
+        (results / "metrics" / "graphs" / "kv.png").write_bytes(b"PNG\n")
+        (results / "analysis" / "summary.txt").write_text("sum\n", encoding="utf-8")
+        (results / "stdout.log").write_text("log\n", encoding="utf-8")
+        (results / "per_request_lifecycle_metrics.json").write_text(
+            '[{"id": 1}]\n' * 50, encoding="utf-8"
+        )
+
+    plain = tmp_path / "plain" / "exp_1"
+    compressed = tmp_path / "compressed" / "exp_1"
+    build(plain)
+    build(compressed)
+    _compress(compressed)
+
+    # Hardcoded, not derived from KEEP_PLAIN: deriving it would make the test agree
+    # with whatever that constant says, including a change that moves a plot or a
+    # report into the archive. Globbed with '*' rather than the patterns, so the
+    # shell's idea of what stays plain is checked against nothing but this literal.
+    expected = {
+        "benchmark_report_v0.2,_stage_0.json.yaml",
+        "run_metadata.yaml",
+        "analysis/distributions/dist_ttft.png",
+        "metrics/graphs/kv.png",
+    }
+    assert expected == {
+        str(f.relative_to(compressed))
+        for f in compressed.rglob("*")
+        if f.is_file() and ".tar." not in f.name
+    }
+
+    # Nothing lost: every archived file is still readable, without expanding.
+    for archived in (
+        "stdout.log",
+        "analysis/summary.txt",
+        "per_request_lifecycle_metrics.json",
+    ):
+        assert read_member(compressed, archived) == (plain / archived).read_bytes()
+
+
+def test_member_names_keep_a_leading_dot():
+    """``lstrip('./')`` is a character set, so it eats the dot of a real name:
+    ``./.exit-code`` becomes ``exit-code`` and the eval-containers exit code reads
+    as absent, which that roll-up cannot tell from a task that produced nothing."""
+    from llmdbenchmark.utilities.archive import _strip_dot_slash
+
+    assert _strip_dot_slash("./.exit-code") == ".exit-code"
+    assert _strip_dot_slash("./agent/.exit-code") == "agent/.exit-code"
+
+
+def test_plain_files_win_over_an_archive(tmp_path):
+    """A partially-expanded tree must not be merged with its own archive, or a
+    reader sees two generations of the same file."""
+    from llmdbenchmark.utilities.archive import read_members
+
+    results = tmp_path / "exp_1"
+    (results / "metrics" / "raw").mkdir(parents=True)
+    (results / "metrics" / "raw" / "a_metrics.log").write_text("OLD", encoding="utf-8")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+    _compress(results)
+
+    (results / "metrics" / "raw").mkdir(parents=True, exist_ok=True)
+    (results / "metrics" / "raw" / "a_metrics.log").write_text("NEW", encoding="utf-8")
+
+    got = read_members(results, "metrics/raw/*_metrics.log")
+    assert got == {"metrics/raw/a_metrics.log": b"NEW"}
+
+    # And the archive branch, which is the only reason this function exists: with no
+    # plain copy it must still find the snapshot, not silently return nothing.
+    (results / "metrics" / "raw" / "a_metrics.log").unlink()
+    assert read_members(results, "metrics/raw/*_metrics.log") == {
+        "metrics/raw/a_metrics.log": b"OLD"
+    }
+
+
+def test_a_corrupt_leftover_archive_is_rebuilt(tmp_path):
+    """A crashed attempt leaves a truncated archive. Trusting it and then deleting
+    against its member list is how the only copy of a result set disappears."""
+    results = tmp_path / "exp_1"
+    (results / "logs").mkdir(parents=True)
+    (results / "logs" / "stdout.log").write_text("BULK", encoding="utf-8")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+    (results / "workspace.tar.zst").write_bytes(b"\x00truncated garbage")
+
+    _compress(results)
+
+    # The archive has to be the rebuilt one, not the garbage: reading the log would
+    # pass either way, because the early-exit path leaves the plain file in place.
+    assert (
+        subprocess.run(
+            ["zstd", "-t", str(results / "workspace.tar.zst")], check=False
+        ).returncode
+        == 0
+    )
+    assert not (results / "logs" / "stdout.log").exists()
+
+    from llmdbenchmark.utilities.archive import read_member
+
+    assert read_member(results, "logs/stdout.log") == b"BULK"
+    assert (results / "run_metadata.yaml").is_file()
+
+    # None, not b"": pod_analysis_present treats "not None" as "the pod analysed
+    # this", so an empty-bytes answer on a corrupt archive skips the driver fallback.
+    archive = results / "workspace.tar.zst"
+    archive.write_bytes(b"\x00not an archive")
+    assert read_member(results, "logs/stdout.log") is None
+
+
+def test_a_failing_keeper_probe_spares_the_directory(tmp_path):
+    """The probe authorises the only ``rm -rf`` here. A find that fails prints
+    nothing, and treating that as "no keepers" deletes files deliberately left out
+    of the archive -- the one direction with no recovery."""
+    results = tmp_path / "exp_1"
+    (results / "plots").mkdir(parents=True)
+    (results / "plots" / "latency.png").write_bytes(b"KEEPER")
+    (results / "plots" / "bulk.log").write_text("BULK", encoding="utf-8")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+
+    # Fail only the probe, which is the sole find called with a './<top>' argument.
+    shim = tmp_path / "bin"
+    shim.mkdir()
+    (shim / "find").write_text(
+        "#!/bin/bash\n"
+        "# Only the keeper probe passes a subdirectory as $1; every other call\n"
+        '# passes ".", and failing those would abort before anything is packed.\n'
+        'case "$1" in ./?*) exit 3 ;; esac\n'
+        'exec /usr/bin/find "$@"\n',
+        encoding="utf-8",
+    )
+    (shim / "find").chmod(0o755)
+    env = dict(os.environ, PATH=f"{shim}:{os.environ['PATH']}")
+
+    _compress(results, env=env)
+
+    # The archive must exist, or the keeper survived because the script aborted
+    # before packing rather than because the probe failed safe.
+    assert (results / "workspace.tar.zst").is_file()
+    assert (results / "plots" / "latency.png").read_bytes() == b"KEEPER"
+
+
+def _listing_shims(tmp_path: Path, decompress_rc: int, listing: str) -> dict:
+    """PATH shims that break the listing pipeline (``zstd -dc | tar tf -``) while
+    leaving compression itself working."""
+    shim = tmp_path / "bin"
+    shim.mkdir(exist_ok=True)
+    (shim / "zstd").write_text(
+        f'#!/bin/bash\nif [ "$1" = "-dc" ]; then exit {decompress_rc}; fi\n'
+        'exec /usr/bin/zstd "$@"\n',
+        encoding="utf-8",
+    )
+    (shim / "tar").write_text(
+        f'#!/bin/bash\nif [ "$1" = "tf" ]; then printf %s {listing!r}; exit 0; fi\n'
+        'exec /usr/bin/tar "$@"\n',
+        encoding="utf-8",
+    )
+    for name in ("zstd", "tar"):
+        (shim / name).chmod(0o755)
+    return dict(os.environ, PATH=f"{shim}:{os.environ['PATH']}")
+
+
+def _packed(tmp_path: Path) -> Path:
+    results = tmp_path / "exp_1"
+    (results / "logs").mkdir(parents=True)
+    (results / "logs" / "stdout.log").write_text("BULK", encoding="utf-8")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+    return results
+
+
+def test_a_failed_decompress_does_not_become_an_empty_delete_list(tmp_path):
+    """Without pipefail a failing ``zstd -dc`` is invisible -- the pipeline's exit
+    status is tar's -- so the loop deletes against a listing that was never read."""
+    results = _packed(tmp_path)
+    env = _listing_shims(tmp_path, decompress_rc=7, listing="./logs/stdout.log\n")
+
+    done = _compress(results, expect_ok=False, env=env)
+
+    assert done.returncode != 0
+    assert (results / "logs" / "stdout.log").read_text() == "BULK"
+
+
+def test_an_empty_listing_aborts_before_deleting(tmp_path):
+    """An unreadable archive yields no members. Treating that as "nothing to delete"
+    would pass silently over a tree whose originals are still the only copy."""
+    results = _packed(tmp_path)
+    env = _listing_shims(tmp_path, decompress_rc=0, listing="")
+
+    done = _compress(results, expect_ok=False, env=env)
+
+    assert done.returncode != 0
+    assert (results / "logs" / "stdout.log").read_text() == "BULK"
+
+
+@pytest.mark.parametrize(
+    ("harness_settled", "wait_timeout", "expected"),
+    [(True, 3600, True), (False, 3600, False), (True, 0, False)],
+)
+def test_only_a_settled_pvc_is_compressed(harness_settled, wait_timeout, expected):
+    """Both halves gate the delete: a still-running harness writes files that land
+    in no archive, and wait_timeout 0 means nothing ever saw it finish."""
+    from llmdbenchmark.executor.context import ExecutionContext
+    from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
+
+    context = ExecutionContext(plan_dir=Path("/x"), workspace=Path("/x"))
+    context.harness_wait_timeout = wait_timeout
+
+    assert DeployHarnessStep._pvc_settled(context, harness_settled) is expected
+
+
+def test_awkwardly_named_keepers_are_not_deleted(tmp_path):
+    """Two name-identity traps that each deleted a keeper: ``--exclude-from`` read
+    ``plot[1].png`` as a glob so it did not match itself, and the delete loop's
+    ``read`` stripped a trailing space onto the neighbouring keeper's name."""
+    results = tmp_path / "exp_1"
+    results.mkdir()
+    (results / "plot[1].png").write_bytes(b"BRACKET")
+    (results / "latency.png").write_bytes(b"KEEPER")
+    (results / "latency.png ").write_text("BULK", encoding="utf-8")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+
+    _compress(results)
+
+    assert (results / "workspace.tar.zst").is_file()
+    assert (results / "plot[1].png").read_bytes() == b"BRACKET"
+    assert (results / "latency.png").read_bytes() == b"KEEPER"
+
+
+def test_a_linked_member_reads_through_to_its_target(tmp_path):
+    """tar stores a linked payload once and gives the other name a data-less entry,
+    so reading that name has to follow the link or the file looks absent."""
+    results = tmp_path / "exp_1"
+    results.mkdir()
+    (results / "a.json").write_text("SHARED", encoding="utf-8")
+    (results / "b.json").hardlink_to(results / "a.json")
+    (results / "c.json").symlink_to("a.json")
+    # Nested, so a relative target has to be resolved against its own directory
+    # rather than the result root.
+    (results / "sub").mkdir()
+    (results / "sub" / "d.json").write_text("NESTED", encoding="utf-8")
+    (results / "sub" / "e.json").symlink_to("d.json")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+
+    _compress(results)
+
+    from llmdbenchmark.utilities.archive import read_member
+
+    for name in ("a.json", "b.json", "c.json"):
+        assert read_member(results, name) == b"SHARED", name
+    for name in ("sub/d.json", "sub/e.json"):
+        assert read_member(results, name) == b"NESTED", name
+
+
+def test_a_parent_archive_is_not_read_as_this_result_sets(tmp_path):
+    """The FMA arms sit side by side under results/, so searching outside the set
+    would resolve one arm's file from a neighbour's archive and mislabel it."""
+    from llmdbenchmark.utilities.archive import read_member
+
+    results = tmp_path / "results"
+    arm = results / "exp_b"
+    arm.mkdir(parents=True)
+    (arm / "hpa.txt").write_text("HPA-B\n", encoding="utf-8")
+    (arm / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+    _compress(arm)
+
+    stray = results / "exp_a"
+    stray.mkdir()
+    (stray / "hpa.txt").write_text("HPA-A\n", encoding="utf-8")
+    (stray / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+    _compress(stray)
+    (results / "workspace.tar.zst").write_bytes(
+        (stray / "workspace.tar.zst").read_bytes()
+    )
+
+    assert read_member(arm, "hpa.txt") == b"HPA-B\n"
+    assert read_member(results / "exp_c", "hpa.txt") is None
+
+
+def test_a_newline_in_a_name_refuses_instead_of_deleting(tmp_path):
+    """`find` writes a newline raw, splitting one skip-list entry into two bogus
+    patterns, and `tar tf` escapes it -- so the delete loop can resolve one file's
+    escaped rendering onto a different real path and remove bytes no archive holds.
+    Refusing costs disk; compressing costs the only copy."""
+    results = tmp_path / "exp_1"
+    results.mkdir()
+    (results / "x\\nb.png").write_bytes(b"KEEPER")  # literal backslash-n
+    (results / "x\nb.png").write_bytes(b"other")  # real newline
+    (results / "bulk.log").write_text("BULK", encoding="utf-8")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+
+    assert _compress(results, expect_ok=False).returncode != 0
+
+    assert not (results / "workspace.tar.zst").exists()
+    assert (results / "x\\nb.png").read_bytes() == b"KEEPER"
+    assert (results / "bulk.log").read_text() == "BULK"
+
+
+def test_a_converter_exiting_does_not_kill_the_analysis_phase(tmp_path):
+    """The converters share a CLI entry point whose input check calls sys.exit, and
+    the driver fallback hands it a path that only exists inside the archive. A bare
+    `except Exception` misses SystemExit, so it would take the run down."""
+    results = tmp_path / "exp_1"
+    results.mkdir()
+    (results / "results.json").write_text(
+        json.dumps({"benchmarks": []}), encoding="utf-8"
+    )
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+    _compress(results)
+
+    from llmdbenchmark.analysis import run_analysis
+
+    # A string is the "converted nothing" signal; SystemExit escaping is not.
+    assert isinstance(run_analysis("guidellm", results, None), str)
+
+
+def test_the_remote_dir_is_quoted_and_the_fallback_backend_reads():
+    """Two holes with no other cover: the script interpolates a path straight into
+    `cd`, and the pure-Python backend is never chosen while the zstd CLI is present."""
+    from llmdbenchmark.utilities.archive import remote_compress_script
+
+    script = remote_compress_script("/requests/exp 1; rm -rf /tmp/PWNED")
+    assert "cd '/requests/exp 1; rm -rf /tmp/PWNED'" in script
+
+
+def test_the_archive_never_becomes_a_member_of_itself(tmp_path):
+    """The skip list is a snapshot, so an archive appearing after it was taken would
+    be packed into itself -- and the delete loop, trusting the verified member list,
+    would remove the one file holding everything."""
+    results = tmp_path / "exp_1"
+    (results / "logs").mkdir(parents=True)
+    (results / "logs" / "stdout.log").write_text("BULK", encoding="utf-8")
+    (results / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+
+    # A shim standing in for a concurrent run: create the archive after the snapshot.
+    shim = tmp_path / "bin"
+    shim.mkdir()
+    (shim / "tar").write_text(
+        "#!/bin/bash\n"
+        f'if [ "$1" = "cf" ]; then : > {results / "workspace.tar.zst"}; fi\n'
+        'exec /usr/bin/tar "$@"\n',
+        encoding="utf-8",
+    )
+    (shim / "tar").chmod(0o755)
+    env = dict(os.environ, PATH=f"{shim}:{os.environ['PATH']}")
+
+    _compress(results, env=env)
+
+    from llmdbenchmark.utilities.archive import read_member
+
+    assert read_member(results, "logs/stdout.log") == b"BULK"
+
+
+def test_a_glob_matches_the_same_set_plain_or_archived(tmp_path):
+    """fnmatch's `*` crosses `/` but Path.glob's does not, so the archive side would
+    fold in a nested file the plain side excludes -- the same glob answering
+    differently depending on whether the tree happens to be compressed."""
+    from llmdbenchmark.utilities.archive import read_members
+
+    def build(root: Path) -> None:
+        (root / "metrics" / "raw" / "sub").mkdir(parents=True)
+        (root / "metrics" / "raw" / "a_metrics.log").write_text("S1", encoding="utf-8")
+        (root / "metrics" / "raw" / "sub" / "b_metrics.log").write_text(
+            "S2", encoding="utf-8"
+        )
+        (root / "run_metadata.yaml").write_text("x: 1\n", encoding="utf-8")
+
+    plain = tmp_path / "plain"
+    archived = tmp_path / "archived"
+    build(plain)
+    build(archived)
+    _compress(archived)
+
+    pattern = "metrics/raw/*_metrics.log"
+    assert read_members(archived, pattern) == read_members(plain, pattern)
+    assert set(read_members(plain, pattern)) == {"metrics/raw/a_metrics.log"}
+
+
+@pytest.mark.parametrize(
+    ("settled", "driver_zstd", "pod_zstd", "expected", "probes"),
+    [
+        (True, True, True, True, 1),
+        (False, True, True, False, 0),
+        (True, False, True, False, 0),
+        (True, True, False, False, 1),
+    ],
+)
+def test_pvc_compression_needs_every_gate(
+    monkeypatch, settled, driver_zstd, pod_zstd, expected, probes
+):
+    """Guards an irreversible delete, so all four gates must hold -- and the pod
+    probe (a live `kubectl exec`) must not run once a cheaper gate has said no."""
+    from llmdbenchmark.executor.context import ExecutionContext
+    from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
+
+    calls = []
+    monkeypatch.setattr(
+        DeployHarnessStep,
+        "_pvc_has_zstd",
+        staticmethod(lambda *a: calls.append(a) or pod_zstd),
+    )
+    monkeypatch.setattr(
+        "llmdbenchmark.run.steps.step_07_deploy_harness.shutil.which",
+        lambda name: "/usr/bin/zstd" if driver_zstd else None,
+    )
+
+    warnings = []
+    context = ExecutionContext(plan_dir=Path("/x"), workspace=Path("/x"))
+    context.harness_wait_timeout = 3600
+    context.logger = SimpleNamespace(log_warning=warnings.append)
+
+    got = DeployHarnessStep._should_compress_on_pvc(None, context, "pod", "ns", settled)
+
+    assert got is expected
+    assert len(calls) == probes
+    # Exactly one reason, so a declined compression is never silent or doubly
+    # reported.
+    assert len(warnings) == (0 if expected else 1)

--- a/tests/test_pod_plot_modules.py
+++ b/tests/test_pod_plot_modules.py
@@ -1,0 +1,120 @@
+"""The plot modules must import with no llmdbenchmark package on sys.path.
+
+They are copied flat into /usr/local/bin in the image, so a package-qualified
+import that works on the driver would fail only in-pod, after a full benchmark.
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SOURCES = (
+    "llmdbenchmark/analysis/per_request_plots.py",
+    "llmdbenchmark/analysis/session_plots.py",
+    "llmdbenchmark/analysis/session_metrics.py",
+    "llmdbenchmark/analysis/scripts/generate_plots.py",
+)
+
+
+def _stage(tmp_path: Path) -> Path:
+    repo = Path(__file__).resolve().parent.parent
+    for source in SOURCES:
+        shutil.copy2(repo / source, tmp_path / Path(source).name)
+    return tmp_path
+
+
+# Editing sys.path is not enough: an editable install registers a sys.meta_path
+# finder at startup, so llmdbenchmark stays importable however the path is
+# filtered. Blocking it at the finder is what actually reproduces the pod, where
+# the package is absent entirely.
+_BLOCK_PACKAGE = """
+import sys
+
+class _Blocker:
+    def find_module(self, name, path=None):
+        return self.find_spec(name, path)
+
+    def find_spec(self, name, path=None, target=None):
+        if name == "llmdbenchmark" or name.startswith("llmdbenchmark."):
+            raise ImportError(f"blocked: {name}")
+        return None
+
+sys.meta_path.insert(0, _Blocker())
+sys.path.insert(0, ".")
+"""
+
+
+def test_plot_modules_import_flat(tmp_path):
+    _stage(tmp_path)
+
+    guard = subprocess.run(
+        [sys.executable, "-c", _BLOCK_PACKAGE + "import llmdbenchmark"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert guard.returncode != 0, (
+        "test cannot simulate the pod: llmdbenchmark leaked in"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", _BLOCK_PACKAGE + "import generate_plots"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# Skip, not fail: without matplotlib the plot modules no-op by design.
+@pytest.mark.skipif(
+    importlib.util.find_spec("matplotlib") is None, reason="needs matplotlib"
+)
+def test_generate_plots_writes_both_sets(tmp_path):
+    _stage(tmp_path)
+
+    results = tmp_path / "results"
+    results.mkdir()
+    requests = [
+        {
+            "start_time": 100.0 + i,
+            "end_time": 100.0 + i + 0.3,
+            "info": {
+                "output_token_times": [100.0 + i + 0.2 + j * 0.01 for j in range(6)],
+                "input_tokens": 64 + i,
+                "output_tokens": 6,
+            },
+        }
+        for i in range(10)
+    ]
+    import json
+
+    (results / "per_request_lifecycle_metrics.json").write_text(json.dumps(requests))
+    (
+        results / "benchmark_report_v0.2,_stage_0_session_lifecycle_metrics.json.yaml"
+    ).write_text(
+        "results:\n"
+        "  session_performance:\n"
+        "    sessions:\n"
+        "      session_rate: {mean: 2.0}\n"
+        "      session_duration: {mean: 5.0, p50: 5.0, p99: 9.0}\n"
+        "      total: 4\n"
+        "      failed: 1\n"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "generate_plots.py", str(results)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert list((results / "analysis" / "distributions").glob("*.png"))
+    assert list((results / "analysis" / "session").glob("*.png"))

--- a/tests/test_summary_extraction.py
+++ b/tests/test_summary_extraction.py
@@ -1,0 +1,95 @@
+"""Summary extraction: marker selection, no-marker passthrough, flat in-pod import."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from llmdbenchmark.analysis.summary import extract_summary
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "llmdbenchmark" / "analysis"
+
+# Editing sys.path is not enough: an editable install registers a sys.meta_path
+# finder at startup, so llmdbenchmark stays importable however the path is
+# filtered. Blocking it at the finder is what actually reproduces the pod, where
+# the package is absent entirely.
+_BLOCK_PACKAGE = """
+import sys
+
+class _Blocker:
+    def find_module(self, name, path=None):
+        return self.find_spec(name, path)
+
+    def find_spec(self, name, path=None, target=None):
+        if name == "llmdbenchmark" or name.startswith("llmdbenchmark."):
+            raise ImportError(f"blocked: {name}")
+        return None
+
+sys.meta_path.insert(0, _Blocker())
+sys.path.insert(0, ".")
+"""
+
+
+def test_extracts_from_last_marker(tmp_path):
+    (tmp_path / "stdout.log").write_text(
+        "noise\nResult ==\nstale\nResult ==\nkeep me\n", encoding="utf-8"
+    )
+
+    written = extract_summary(tmp_path, "Result ==")
+
+    assert written == tmp_path / "analysis" / "summary.txt"
+    # A retried run logs the marker twice; only the final block is the result.
+    assert written.read_text(encoding="utf-8") == "Result ==\nkeep me\n"
+
+
+def test_no_marker_keeps_whole_log(tmp_path):
+    (tmp_path / "stdout.log").write_text("line one\nline two\n", encoding="utf-8")
+
+    written = extract_summary(tmp_path, None)
+
+    assert written.read_text(encoding="utf-8") == "line one\nline two\n"
+
+
+def test_missing_marker_and_missing_log(tmp_path):
+    (tmp_path / "stdout.log").write_text("nothing of interest\n", encoding="utf-8")
+    assert extract_summary(tmp_path, "Result ==") is None
+    assert not (tmp_path / "analysis").exists()
+
+    assert extract_summary(tmp_path / "absent", "Result ==") is None
+
+
+def test_entry_point_imports_flat(tmp_path):
+    """The pod ships summary.py next to the script, with no llmdbenchmark package."""
+    results = tmp_path / "results"
+    results.mkdir()
+    (results / "stdout.log").write_text("noise\nResult ==\ntail\n", encoding="utf-8")
+
+    guard = subprocess.run(
+        [sys.executable, "-c", _BLOCK_PACKAGE + "import llmdbenchmark"],
+        capture_output=True,
+        text=True,
+        cwd=str(SCRIPTS_DIR),
+    )
+    assert guard.returncode != 0, (
+        "test cannot simulate the pod: llmdbenchmark leaked in"
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _BLOCK_PACKAGE
+            + "sys.argv = ['extract_summary.py', sys.argv[1], 'Result ==']\n"
+            + "exec(open('scripts/extract_summary.py').read())",
+            str(results),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(SCRIPTS_DIR),
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert (results / "analysis" / "summary.txt").read_text(
+        encoding="utf-8"
+    ) == "Result ==\ntail\n"

--- a/tests/test_summary_extraction.py
+++ b/tests/test_summary_extraction.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 from llmdbenchmark.analysis.summary import extract_summary
 
@@ -93,3 +96,30 @@ def test_entry_point_imports_flat(tmp_path):
     assert (results / "analysis" / "summary.txt").read_text(
         encoding="utf-8"
     ) == "Result ==\ntail\n"
+
+
+def test_extracts_from_an_archived_stdout_log(tmp_path):
+    """Logs are archived, so a driver-side call on a collected tree has to read
+    stdout.log back out of the archive rather than report nothing to summarise."""
+    from llmdbenchmark.utilities.archive import remote_compress_script
+
+    if shutil.which("zstd") is None:
+        pytest.skip("needs the zstd CLI")
+
+    results = tmp_path / "exp_1"
+    results.mkdir()
+    (results / "stdout.log").write_text("boot\nResult ==\nthroughput: 42\n")
+    (results / "benchmark_report_v0.2,_a.yaml").write_text("y: 1\n")
+
+    script = remote_compress_script(str(results), level=1)
+    assert (
+        subprocess.run(
+            ["bash", "-c", script], capture_output=True, check=False
+        ).returncode
+        == 0
+    )
+    assert not (results / "stdout.log").exists()
+
+    written = extract_summary(results, "Result ==")
+    assert written is not None
+    assert written.read_text(encoding="utf-8") == "Result ==\nthroughput: 42\n"

--- a/util/dump_result_file.sh
+++ b/util/dump_result_file.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Print one result file, whether the run left it plain or inside its archive.
+#
+# The CI dump steps used `[ -f "$f" ] && cat "$f"`, which reads as "absent" for an
+# archived file -- and the fallback branch is the success path, so a compressed run
+# degrades to "no <file>" with a green check. Logs are archived, so that is now the
+# normal case rather than an edge one.
+#
+# Usage: dump_result_file.sh [--tail N] [--glob] <results_dir> <relative_path>
+#
+#   --glob   treat <relative_path> as a shell pattern and print the first match,
+#            for the logs whose names carry a pod suffix.
+#   --tail N print only the last N lines.
+set -uo pipefail
+
+tail_lines=""
+use_glob=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tail) tail_lines="${2-}"; shift 2 ;;
+    --glob) use_glob=1; shift ;;
+    --) shift; break ;;
+    -*) echo "unknown option: $1" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+results_dir="${1-}"
+relative="${2-}"
+
+if [[ -z "$relative" ]]; then
+  echo "usage: dump_result_file.sh [--tail N] [--glob] <results_dir> <relative_path>" >&2
+  exit 2
+fi
+
+emit() {
+  if [[ -n "$tail_lines" ]]; then
+    tail -n "$tail_lines"
+  else
+    cat
+  fi
+}
+
+# An empty results dir is the caller's normal "nothing found" state, not an error:
+# the discovery step upstream initialises exp="" and the dump steps run under
+# `if: always()`, so exiting nonzero here would paint a red X per dump step on top
+# of whatever actually failed, which is exactly what those dumps exist to show.
+if [[ -z "$results_dir" || ! -d "$results_dir" ]]; then
+  echo "no $relative (no results directory)"
+  exit 0
+fi
+
+if ((use_glob)); then
+  # Nullglob so a non-match leaves the array empty rather than the literal pattern.
+  shopt -s nullglob
+  matches=("$results_dir"/$relative)
+  shopt -u nullglob
+  if ((${#matches[@]})); then
+    emit < "${matches[0]}"
+    exit 0
+  fi
+elif [[ -f "$results_dir/$relative" ]]; then
+  emit < "$results_dir/$relative"
+  exit 0
+fi
+
+# The archive the PVC script wrote inside this result set, keyed relative to it.
+# The member is addressed by its full path, never by basename: several treatments
+# have a file by the same name, so basename-matching would attribute one arm's
+# state to another.
+archive="$results_dir/workspace.tar.zst"
+if [[ -f "$archive" ]]; then
+  if ! command -v zstd >/dev/null 2>&1; then
+    echo "cannot read $archive: zstd not installed" >&2
+  else
+    # Escape unconditionally: an exact path carrying a '.' or '+' would otherwise
+    # reach grep -E as a wildcard and can match a different member. '/' is not an
+    # ERE metacharacter, so escaping it only earns a "stray \ before /" warning.
+    want="$(printf '%s' "$relative" | sed -e 's/[].[^$*+?(){}|\\]/\\&/g')"
+    if ((use_glob)); then
+      # Only '*' is meaningful in these patterns, and it must not cross a '/'.
+      want="${want//\\\*/[^/]*}"
+    fi
+    member="$(zstd -dc "$archive" 2>/dev/null | tar -tf - 2>/dev/null \
+      | grep -m1 -x -E "(\./)?${want}")" || true
+    if [[ -n "$member" ]]; then
+      zstd -dc "$archive" | tar -xOf - "$member" | emit && exit 0
+    fi
+  fi
+fi
+
+echo "no $relative for $(basename -- "$results_dir")"

--- a/workload/README.md
+++ b/workload/README.md
@@ -1069,6 +1069,8 @@ All flags for the `run` subcommand:
 | `--step` | | string | (all) | Run specific step(s) only (e.g. `--step 4-6`) |
 | `--dry-run` | `-n` | flag | false | Log commands without executing |
 | `--namespace` | `-p` | string | (from plan) | Kubernetes namespace |
+| `--compress` / `--no-compress` | | flag | true | Compress each result set on the PVC before collection (benchmark reports, `run_metadata.yaml`, `experiment-summary.yaml` and plots stay plain) |
+| `--compress-level` | | int | `10` | zstd compression level |
 
 ---
 


### PR DESCRIPTION
Tackling a pet-peeve of mine. I've been running _long_ experiments for a while, and, especially with `--monitoring` they generate a lot of raw data, data that has a very high compress-ratio.

This commits:

A. Move everything possible to be computed in-pod (helps with flaky connections as well)
B. Compress the output on PVC, with some notable exceptions. This also helps with copying stuff locally for analysis.