### PR TITLE
fix: Update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,6 @@
 !llmdbenchmark/standup/preprocess/
 !build/
 !util/
-
+!benchmark-report/
 # Exclude Python cache directories
 **/__pycache__/

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,6 @@
 !build/
 !util/
 !benchmark-report/
+!llm_d_stack_discovery/
 # Exclude Python cache directories
 **/__pycache__/


### PR DESCRIPTION
# Summary

A recent rearrangement of dir structure broke docker builds. This fixes that by updating the ignore list.