### PR TITLE
fix: silence false-positive "conection" typo flags

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -49,6 +49,7 @@ datas = "datas"
 queston = "queston"
 decod = "decod"
 resurces = "resurces"
+conection = "conection"
 
 # Pre-existing typos in codebase (to be fixed separately)
 analagous = "analagous"


### PR DESCRIPTION
The nightly typos scan (#1850) flagged 9 occurrences of "conection" across docs/nok8s.md, cli_overrides.py, and test_cli_set_overrides.py. Every one is a deliberate misspelling used as the worked example for the nok8s.connection fuzzy-typo-detection feature itself (find_typo_leaves) -- not a mistake. "Fixing" the source would break the documented example and the tests that assert on it (they expect the override path "nok8s.conection" to be flagged as a near-miss of "nok8s.connection").

Add it to _typos.toml's existing "Deliberate typos asserted on by the CLI-override tests" allowlist, alongside queston/decod/resurces. Verified with `typos .`: 18 matches before, 0 after.

Fixes #1850