### PR TITLE
feat: Add tensor-parallel + eager knobs to FMA launcher

### DIFF
--- a/config/templates/jinja/24_fma-deployment.yaml.j2
+++ b/config/templates/jinja/24_fma-deployment.yaml.j2
@@ -47,7 +47,7 @@ spec:
    feeds the derived Helm release name elsewhere, and a path mangles that
    into an invalid (leading-dash) release name. #}
 {% set _fma_model_arg = (fma.modelMountPath + '/' + model.path) if (fma.launcher.loadModelFromLocalDir | default(false)) else model.name %}
-    options: "--model {{ _fma_model_arg }} --enable-sleep-mode --no-enable-prefix-caching --load-format auto{% if (model.gpuMemoryUtilization | default(0.95) | float) > 0 %} --gpu-memory-utilization {{ model.gpuMemoryUtilization | default(0.95) }}{% endif %} --max-model-len {{ model.maxModelLen }}{% if fma.launcher.kvCacheMemory is defined and fma.launcher.kvCacheMemory %} --kv-cache-memory {{ fma.launcher.kvCacheMemory }}{% endif %} --tensor-parallel-size 1"
+    options: "--model {{ _fma_model_arg }} --enable-sleep-mode --no-enable-prefix-caching --load-format auto{% if (model.gpuMemoryUtilization | default(0.95) | float) > 0 %} --gpu-memory-utilization {{ model.gpuMemoryUtilization | default(0.95) }}{% endif %} --max-model-len {{ model.maxModelLen }}{% if fma.launcher.kvCacheMemory is defined and fma.launcher.kvCacheMemory %} --kv-cache-memory {{ fma.launcher.kvCacheMemory }}{% endif %} --tensor-parallel-size {{ fma.launcher.tensorParallelSize | default(1) }}{% if fma.launcher.enforceEager | default(false) %} --enforce-eager{% endif %}"
     port: 8000
 ---
 apiVersion: fma.llm-d.ai/v1alpha1
@@ -131,12 +131,25 @@ spec:
           # double-book (N launchers + N requesters = 2N GPU requests on an
           # N-GPU node), leaving requesters Pending with Insufficient nvidia.com/gpu.
           volumeMounts:
+{% if (fma.launcher.tensorParallelSize | default(1) | int) > 1 %}
+          # TP>1: vLLM tensor-parallel workers exchange over a shared-memory
+          # message queue; the pod default 64Mi /dev/shm crashes NCCL/multiproc
+          # at init, so give the launcher a real in-memory /dev/shm.
+          - name: dshm
+            mountPath: /dev/shm
+{% endif %}
 {% if fma.mountModelVolume %}
           - name: model-cache
             mountPath: {{ fma.modelMountPath }}
             readOnly: False
 {% endif %}
       volumes:
+{% if (fma.launcher.tensorParallelSize | default(1) | int) > 1 %}
+      - name: dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 16Gi
+{% endif %}
 {% if fma.mountModelVolume %}
       - name: model-cache
         persistentVolumeClaim:

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1589,6 +1589,21 @@ fma:
     # -- it feeds the derived Helm release name, and a path mangles that
     # into an invalid (leading-dash) release name.
     loadModelFromLocalDir: false
+    # Tensor parallelism for models that do not fit on a single GPU (e.g.
+    # Qwen3-32B on an 80GB H100). > 1 feeds --tensor-parallel-size and, since
+    # TP workers exchange over a shared-memory message queue, provisions a
+    # 16Gi in-memory /dev/shm on the launcher (the pod default 64Mi crashes
+    # NCCL at init). Pair with fma.requester.limitsGPU so the requester
+    # reserves matching GPUs. Default 1 leaves single-GPU runs unchanged (#1853).
+    tensorParallelSize: 1
+    # Opt-in: skip torch.compile + CUDA-graph capture on the launcher's vLLM
+    # child. Binds faster on cold boot at the cost of steady-state serving
+    # performance -- every request then runs unoptimized kernels (and small/
+    # low-concurrency requests also pay per-step kernel-launch overhead that
+    # graph replay would have avoided). Off by default so serving deployments
+    # keep the optimized path; useful for actuation-timing runs, where boot
+    # latency matters and serving throughput is not measured.
+    enforceEager: false
     image:
       repository: ghcr.io/llm-d-incubation/llm-d-fast-model-actuation/launcher
       tag: v0.6.4

--- a/tests/test_fma_launcher_tensor_parallel.py
+++ b/tests/test_fma_launcher_tensor_parallel.py
@@ -1,0 +1,129 @@
+"""Regression coverage for #1853: the FMA launcher should support tensor
+parallelism (TP>1) for models that do not fit on a single GPU.
+
+``fma.launcher.tensorParallelSize`` (default 1) feeds ``--tensor-parallel-size``
+on the InferenceServerConfig's vLLM options, and, because TP workers exchange
+over a shared-memory message queue, provisions a 16Gi in-memory ``/dev/shm``
+emptyDir on the LauncherConfig pod when it is > 1 (the pod default 64Mi crashes
+NCCL at init). ``fma.launcher.enforceEager`` (default off) appends
+``--enforce-eager``. Both default so single-GPU runs render exactly as before.
+"""
+
+from __future__ import annotations
+
+import yaml
+from jinja2 import Environment
+
+from llmdbenchmark.parser.render_plans import RenderPlans
+
+_TEMPLATE_PATH = "config/templates/jinja/24_fma-deployment.yaml.j2"
+
+
+def _render(values: dict) -> list[dict]:
+    env = Environment(
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=False,
+    )
+    env.filters["toyaml"] = RenderPlans._toyaml_filter
+    with open(_TEMPLATE_PATH, encoding="utf-8") as fh:
+        template = env.from_string(fh.read())
+    out = template.render(**values)
+    return [yaml.safe_load(doc) for doc in out.split("\n---\n") if doc.strip()]
+
+
+def _base_values(tensor_parallel_size: int = 1, enforce_eager: bool = False) -> dict:
+    return {
+        "model_id_label": "qwen3-32b-abc123",
+        "model": {
+            "name": "Qwen/Qwen3-32B",
+            "path": "models/Qwen/Qwen3-32B",
+            "maxModelLen": 32768,
+            "gpuMemoryUtilization": 0.95,
+        },
+        "namespace": {"name": "bench"},
+        "labels": {"inferenceServing": "true"},
+        "huggingface": {"enabled": False},
+        "scenarioName": "test-scenario",
+        "fma": {
+            "enabled": True,
+            "modelMountPath": "/model-cache",
+            "modelPvcName": "model-pvc",
+            "mountModelVolume": True,
+            "launcher": {
+                "loadModelFromLocalDir": False,
+                "tensorParallelSize": tensor_parallel_size,
+                "enforceEager": enforce_eager,
+                "maxInstances": 4,
+                "image": {
+                    "repository": "example.com/launcher",
+                    "tag": "v0.6.4",
+                    "pullPolicy": "IfNotPresent",
+                },
+                "podTemplate": {"metadata": {}},
+                "customPreprocessCommands": [],
+            },
+            "launcherConfigurator": {"port": 8001},
+            "requester": {
+                "image": {"repository": "example.com/requester", "tag": "v0.6.4"},
+                "probePort": 8080,
+                "spiPort": 8081,
+                "limitsGPU": 2,
+                "limitsCPU": "1",
+                "limitsMemory": "250Mi",
+                "replicas": 0,
+            },
+        },
+    }
+
+
+def _options(docs: list[dict]) -> str:
+    isc = next(d for d in docs if d and d.get("kind") == "InferenceServerConfig")
+    return isc["spec"]["modelServerConfig"]["options"]
+
+
+def _launcher_pod_spec(docs: list[dict]) -> dict:
+    lc = next(d for d in docs if d and d.get("kind") == "LauncherConfig")
+    return lc["spec"]["podTemplate"]["spec"]
+
+
+class TestFmaLauncherTensorParallel:
+    def test_default_tp_is_one(self):
+        docs = _render(_base_values())
+        assert "--tensor-parallel-size 1" in _options(docs)
+
+    def test_tp_greater_than_one_sets_flag(self):
+        docs = _render(_base_values(tensor_parallel_size=2))
+        assert "--tensor-parallel-size 2" in _options(docs)
+
+    def test_default_tp_renders_no_dshm(self):
+        spec = _launcher_pod_spec(_render(_base_values()))
+        volume_names = {v["name"] for v in spec.get("volumes", [])}
+        mount_names = {
+            m["name"]
+            for c in spec.get("containers", [])
+            for m in c.get("volumeMounts", [])
+        }
+        assert "dshm" not in volume_names
+        assert "dshm" not in mount_names
+
+    def test_tp_greater_than_one_provisions_dshm(self):
+        spec = _launcher_pod_spec(_render(_base_values(tensor_parallel_size=2)))
+        dshm_vol = next(v for v in spec["volumes"] if v["name"] == "dshm")
+        assert dshm_vol["emptyDir"]["medium"] == "Memory"
+        assert dshm_vol["emptyDir"]["sizeLimit"] == "16Gi"
+        dshm_mount = next(
+            m
+            for c in spec["containers"]
+            for m in c.get("volumeMounts", [])
+            if m["name"] == "dshm"
+        )
+        assert dshm_mount["mountPath"] == "/dev/shm"
+
+    def test_enforce_eager_default_off(self):
+        assert "--enforce-eager" not in _options(_render(_base_values()))
+
+    def test_enforce_eager_opt_in_appends_flag(self):
+        docs = _render(_base_values(enforce_eager=True))
+        assert "--enforce-eager" in _options(docs)


### PR DESCRIPTION
## Summary

The FMA launcher hardcoded `--tensor-parallel-size 1`, so models that do not fit on a single GPU (e.g. Qwen3-32B on an 80GB H100) could not be served through the launcher path. This adds two opt-in launcher knobs and defaults both so single-GPU launchers render exactly as before.

- `fma.launcher.tensorParallelSize` (default `1`): values `> 1` feed `--tensor-parallel-size` on the launcher's vLLM options **and** provision a 16Gi in-memory `/dev/shm` `emptyDir` on the LauncherConfig pod. TP workers exchange over a shared-memory message queue, and the pod default 64Mi `/dev/shm` crashes NCCL at init, so the volume is required whenever TP > 1. Pair with `fma.requester.limitsGPU` (e.g. `2` for TP=2).
- `fma.launcher.enforceEager` (default `false`): appends `--enforce-eager`, skipping torch.compile + CUDA-graph capture for faster cold boot at the cost of steady-state serving performance.

## Testing

Test-only regression coverage over the rendered `24_fma-deployment.yaml.j2` template (`tests/test_fma_launcher_tensor_parallel.py`): the default renders `--tensor-parallel-size 1` with no `dshm` volume/mount, TP=2 renders the flag plus a `medium: Memory`, `sizeLimit: 16Gi` `/dev/shm`, and `enforceEager` toggles `--enforce-eager` off/on. No live cluster run.

Closes #1853
