### PR TITLE
Flag stale data in FMA benchmark summary tables

### DIFF
--- a/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-keda.yaml
@@ -307,6 +307,41 @@ jobs:
           [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_KEDA_WARMSTART_DIR/" || true
           [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_KEDA_HOTSTART_DIR/" || true
 
+          # Each column's date is resolved independently as "newest folder present",
+          # so a failed pass silently falls back to an earlier run's data. Match on
+          # github_run_id (stamped in by the upload), not the date -- a run crossing
+          # midnight UTC is still current.
+          STALE=""
+          check_provenance() {
+            # $1 = column label, $2 = downloaded dir, $3 = resolved date
+            if [ -z "$3" ]; then
+              echo "| $1 | — | ❌ no data in bucket |" >> "$GITHUB_STEP_SUMMARY"
+              STALE="yes"
+              return
+            fi
+            if grep -rqs "github_run_id: \"${{ github.run_id }}\"" "$2"; then
+              echo "| $1 | $3 | ✅ this run |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| $1 | $3 | ⚠️ from an earlier run |" >> "$GITHUB_STEP_SUMMARY"
+              STALE="yes"
+            fi
+          }
+
+          echo "### Data provenance" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Column | Data date | Source |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          check_provenance "Baseline (EPP+KEDA, no FMA)" "$BASELINE_DIR" "$BL_DATE"
+          check_provenance "EPP+KEDA with FMA Warm Start" "$FMA_KEDA_WARMSTART_DIR" "$FW_WARMSTART_DATE"
+          check_provenance "EPP+KEDA with FMA Hot Start" "$FMA_KEDA_HOTSTART_DIR" "$FW_HOTSTART_DATE"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$STALE" ]; then
+            echo "> [!WARNING]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> At least one column is missing or carried over from an earlier run," >> "$GITHUB_STEP_SUMMARY"
+            echo "> so the columns below are not a like-for-like comparison." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           python3 "$GITHUB_WORKSPACE/llmdbenchmark/analysis/scripts/fma_comparison_table.py" \
             --baseline-dir "$BASELINE_DIR" \
             --warmstart-dir "$FMA_KEDA_WARMSTART_DIR" \

--- a/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
+++ b/.github/workflows/ci-benchmark-ocp-fma-wva.yaml
@@ -310,6 +310,41 @@ jobs:
           [ -n "$FW_WARMSTART_DATE" ] && gcloud storage cp -r "${FW_WARMSTART_PREFIX}${FW_WARMSTART_DATE}" "$FMA_WVA_WARMSTART_DIR/" || true
           [ -n "$FW_HOTSTART_DATE" ] && gcloud storage cp -r "${FW_HOTSTART_PREFIX}${FW_HOTSTART_DATE}" "$FMA_WVA_HOTSTART_DIR/" || true
 
+          # Each column's date is resolved independently as "newest folder present",
+          # so a failed pass silently falls back to an earlier run's data. Match on
+          # github_run_id (stamped in by the upload), not the date -- a run crossing
+          # midnight UTC is still current.
+          STALE=""
+          check_provenance() {
+            # $1 = column label, $2 = downloaded dir, $3 = resolved date
+            if [ -z "$3" ]; then
+              echo "| $1 | — | ❌ no data in bucket |" >> "$GITHUB_STEP_SUMMARY"
+              STALE="yes"
+              return
+            fi
+            if grep -rqs "github_run_id: \"${{ github.run_id }}\"" "$2"; then
+              echo "| $1 | $3 | ✅ this run |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| $1 | $3 | ⚠️ from an earlier run |" >> "$GITHUB_STEP_SUMMARY"
+              STALE="yes"
+            fi
+          }
+
+          echo "### Data provenance" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Column | Data date | Source |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          check_provenance "Baseline (WVA without FMA)" "$BASELINE_DIR" "$BL_DATE"
+          check_provenance "WVA with FMA Warm Start" "$FMA_WVA_WARMSTART_DIR" "$FW_WARMSTART_DATE"
+          check_provenance "WVA with FMA Hot Start" "$FMA_WVA_HOTSTART_DIR" "$FW_HOTSTART_DATE"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$STALE" ]; then
+            echo "> [!WARNING]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> At least one column is missing or carried over from an earlier run," >> "$GITHUB_STEP_SUMMARY"
+            echo "> so the columns below are not a like-for-like comparison." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           python3 "$GITHUB_WORKSPACE/llmdbenchmark/analysis/scripts/fma_comparison_table.py" \
             --baseline-dir "$BASELINE_DIR" \
             --warmstart-dir "$FMA_WVA_WARMSTART_DIR" \


### PR DESCRIPTION
### Summary

The display-results summary tables can silently report data from an earlier run. This adds a provenance check that verifies each column came from the current workflow run, and surfaces the result in the step summary.


### Problem

`latest_date_under()` selects benchmark data by listing the GCS prefix and taking the newest YYYY-MM-DD/ folder:

```
gcloud storage ls "$1" 2>/dev/null | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}/$' | sort | tail -1
```

Nothing ties that folder to the current run, and each of the three columns resolves independently. So when one pass fails standup — or uploads nothing — that column falls back to whatever date last succeeded, while the others are fresh. The resulting table mixes runs but renders identically to a clean one.

Two things let it pass unnoticed:

- The upload is gcloud storage cp -r ... || true, and a missing results directory only echoes a message. Neither fails the job.
- display-results has if: always() with set +e, so it renders regardless of upstream failures.

The resolved dates are printed, but they go to the step log rather than the step summary, and nothing compares them. A real nightly hit this: hotstart failed at standup with Decode pods not ready, and the comparison table still rendered three columns.

### Change

After the downloads, each column is checked against `github_run_id` — the field the upload step already stamps into run_metadata.yaml — and the verdict is written to `$GITHUB_STEP_SUMMARY` above the results:

| Column | Data date | Source |
|---|---|---|
| Baseline (EPP+KEDA, no FMA) | 2026-08-26 | ✅ this run |
| EPP+KEDA with FMA Warm Start | 2026-08-20 | ⚠️ from an earlier run |
| EPP+KEDA with FMA Hot Start | — | ❌ no data in bucket |


If any column is stale or missing, a > `[!WARNING]` block precedes the results table noting the columns aren't a like-for-like comparison.

Matching on the run ID rather than the date is deliberate: a nightly that starts before midnight UTC and uploads after would fail a date comparison while being entirely current.