### PR TITLE
fix(scenarios): correct typo in NCCL_EXCLUDE_IB_HCA interface name

### DIFF
--- a/config/scenarios/guides/pd-disaggregation.yaml
+++ b/config/scenarios/guides/pd-disaggregation.yaml
@@ -362,7 +362,7 @@ scenario:
         # -----------------------------------------------------------------------
         extraEnvVars:
           - name: NCCL_EXCLUDE_IB_HCA
-            value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+            value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
           - name: NVSHMEM_DEBUG
             value: "none"
           - name: NCCL_DEBUG
@@ -453,7 +453,7 @@ scenario:
         # -----------------------------------------------------------------------
         extraEnvVars:
           - name: NCCL_EXCLUDE_IB_HCA
-            value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+            value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
           - name: NVSHMEM_DEBUG
             value: "none"
           - name: NCCL_DEBUG

--- a/config/scenarios/guides/wide-ep-lws.yaml
+++ b/config/scenarios/guides/wide-ep-lws.yaml
@@ -413,7 +413,7 @@ scenario:
         - name: NVIDIA_GDRCOPY
           value: "enabled"
         - name: NCCL_EXCLUDE_IB_HCA
-          value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+          value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
         - name: NVSHMEM_DEBUG
           value: "INFO"
         - name: HF_HUB_DISABLE_XET
@@ -551,7 +551,7 @@ scenario:
         - name: NVIDIA_GDRCOPY
           value: "enabled"
         - name: NCCL_EXCLUDE_IB_HCA
-          value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+          value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
         - name: NVSHMEM_DEBUG
           value: "INFO"
         - name: HF_HUB_DISABLE_XET


### PR DESCRIPTION
Fixes: #1849 
Fix an extra character typo in the `NCCL_EXCLUDE_IB_HCA` environment variable where `mlxl5_7` was set instead of `mlx5_7`.
