### PR TITLE
feat: Allow the Ability to Quiet Sspects of Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ llmdbenchmark --version
 | `--non-admin` / `-i` | `LLMDBENCH_NON_ADMIN` | Skip admin-only steps |
 | `--dry-run` / `-n` | `LLMDBENCH_DRY_RUN` | Generate YAML without applying to cluster |
 | `--verbose` / `-v` | `LLMDBENCH_VERBOSE` | Enable debug logging |
+| `--quiet-plan` / `--no-quiet-plan` | `LLMDBENCH_QUIET_PLAN` | Suppress the per-file plan-rendering narration on the console -- the `Rendered: <file>` lines, image overrides and per-stack banners -- replacing it with a one-line summary of what was rendered and where. **On by default** for `standup`, `smoketest`, `teardown`, `run` and `experiment`, where the render is an implicit prelude; **off by default** for `plan`, whose output it is. The detail is never lost: it is written to `<workspace>/logs/` at `DEBUG` either way. `--verbose` overrides this and always shows the full narration. See [Quieting the plan-rendering output](#quieting-the-plan-rendering-output). |
 | `--run-description TEXT` | `LLMDBENCH_DESCRIPTION_TEXT` | Human-readable label for the run, recorded as `run.description` in the benchmark report. Defaults to `<model> [<experiment id>]`. Also settable as `description.text` under a scenario's `common:` (or top-level `shared:`) block, or per treatment in an experiment. |
 | `--run-keywords LIST` | `LLMDBENCH_DESCRIPTION_KEYWORDS` | Comma-separated tags recorded as `run.keywords`. Never auto-populated; omitted entirely when unset. Also settable as `description.keywords` in the same places. |
 | `--cluster-config FILE` / `--cc` | | YAML of cluster-specific overrides (storage class, service account, ...), deep-merged on top of the scenario. Not committed -- each user keeps their own. See [openshift-setup.md](docs/openshift-setup.md). |
@@ -562,6 +563,45 @@ llmdbenchmark standup -p override-ns           # CLI wins over env var
 
 Boolean env vars accept `1`, `true`, or `yes` (case-insensitive). Active `LLMDBENCH_*` overrides are logged at startup for debugging.
 
+### Quieting the plan-rendering output
+
+`standup`, `smoketest`, `teardown`, `run` and `experiment` all render the plan
+before they do anything else. That render narrates itself in detail -- one line
+per template, plus image overrides and per-stack banners -- which for a typical
+scenario is 40+ lines *per stack*, enough to push the phase output you are
+actually watching off the screen.
+
+By default those commands now print a two-line summary instead:
+
+```text
+✅ Plan rendered: 40 manifest(s) across 1 stack(s) -> /.../workspace/plan
+📝 Per-file render detail suppressed (--no-quiet-plan or -v to show; always recorded in /.../workspace/logs)
+```
+
+`plan` is the exception -- the render narration *is* that command's output, so
+it stays verbose by default.
+
+Nothing is thrown away. The suppressed lines are demoted to `DEBUG`, not
+dropped, so they are still written to `<workspace>/logs/llmdbenchmark-stdout.log`.
+Warnings and errors from the render are never quieted.
+
+```bash
+# full narration on a lifecycle command (one-off)
+llmdbenchmark standup --spec gpu --no-quiet-plan
+
+# ... or for a whole shell / CI job
+export LLMDBENCH_QUIET_PLAN=false
+
+# just the summary from `plan`, when you only want the files on disk
+llmdbenchmark plan --spec gpu --quiet-plan
+
+# --verbose always wins and shows everything
+llmdbenchmark -v standup --spec gpu
+```
+
+Precedence: `--quiet-plan` / `--no-quiet-plan` > `LLMDBENCH_QUIET_PLAN` >
+per-command default, with `--verbose` overriding all three.
+
 ## Architecture
 
 The tool operates in three phases, each composed of numbered steps executed by a shared [`StepExecutor`](llmdbenchmark/executor/README.md) framework.
@@ -687,7 +727,7 @@ llmdbenchmark/                Python package
     run/                      Run phase (see run/README.md)
         steps/                Step implementations (00-11)
 
-    logging/                  Structured logger with emoji support (see logging/README.md)
+    logging/                  Structured logger with emoji support, plus the QuietLogger console-quieting proxy (see logging/README.md)
     exceptions/               Error hierarchy (Template, Configuration, Execution)
     utilities/                Shared helpers (see utilities/README.md)
         cluster.py            Kubernetes connection, platform detection

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -17,9 +17,10 @@ from pathlib import Path
 import yaml as _yaml
 
 from llmdbenchmark import __version__, __package_name__, __package_home__
-from llmdbenchmark.interface.env import env, env_bool
+from llmdbenchmark.interface.env import env, env_bool, env_bool_optional
 from llmdbenchmark.config import config
 from llmdbenchmark.logging.logger import get_logger
+from llmdbenchmark.logging.quiet import plan_logger
 from llmdbenchmark.utilities.os.filesystem import (
     create_workspace,
     create_sub_dir_workload,
@@ -70,6 +71,7 @@ def setup_workspace(
     log_dir: Path,
     verbose: bool = False,
     dry_run: bool = False,
+    quiet_plan: bool = False,
 ) -> None:
     """Set workspace paths and runtime flags on the global config singleton."""
     config.workspace = workspace_path
@@ -77,6 +79,7 @@ def setup_workspace(
     config.log_dir = log_dir
     config.verbose = verbose
     config.dry_run = dry_run
+    config.quiet_plan = quiet_plan
 
 
 def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
@@ -104,23 +107,30 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
             logger.log_error(f"Invalid specification: {e}")
             sys.exit(1)
 
-        logger.log_info(
+        # Everything from here to the end of the Helm pre-render is the
+        # plan-rendering prelude. On every command but `plan` it is a means
+        # to an end, so it narrates through a logger that demotes INFO to
+        # DEBUG -- console stays clean, workspace logs keep the detail.
+        render_logger = plan_logger(logger, config.quiet_plan)
+
+        render_logger.log_info(
             "Specification file rendered and validated successfully.",
             emoji="✅",
         )
 
-        logger.log_debug(
+        render_logger.log_debug(
             "Using specification file to fully render templates into complete system stack plans."
         )
 
-        version_resolver = VersionResolver(logger=logger, dry_run=args.dry_run)
+        version_resolver = VersionResolver(logger=render_logger, dry_run=args.dry_run)
         cluster_resource_resolver = ClusterResourceResolver(
-            logger=logger,
+            logger=render_logger,
             dry_run=args.dry_run,
             kubeconfig=getattr(args, "kubeconfig", None),
         )
 
         render_plan_errors = RenderPlans(
+            logger=render_logger,
             template_dir=specification_as_dict["template_dir"]["path"],
             defaults_file=specification_as_dict["values_file"]["path"],
             scenarios_file=specification_as_dict["scenario_file"]["path"],
@@ -164,7 +174,9 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
         # This enables kustomize overlays and full manifest inspection.
         # Runs even in dry-run mode - helmfile template is purely local
         # and does not touch the cluster.
-        _render_helm_manifests(config.plan_dir, logger)
+        _render_helm_manifests(config.plan_dir, render_logger)
+
+        _log_plan_summary(logger, render_plan_errors, config.plan_dir)
 
     if args.command == Command.STANDUP.value:
         _execute_standup(args, logger, render_plan_errors)
@@ -177,6 +189,39 @@ def dispatch_cli(args: argparse.Namespace, logger: logging.Logger) -> None:
 
     if args.command == Command.RUN.value:
         _execute_run(args, logger, render_plan_errors)
+
+
+def _log_plan_summary(logger, render_result, plan_dir: Path) -> None:
+    """Emit the one-line replacement for the suppressed render narration.
+
+    Under ``--quiet-plan`` the forty-odd "Rendered: <file>" lines are gone
+    from the console, so the user still needs to be told that a plan was
+    produced and where it landed. Skipped when not quieting -- the detailed
+    lines already say all of this.
+    """
+    if not config.quiet_plan:
+        return
+
+    stack_dirs = list(getattr(render_result, "rendered_paths", []) or [])
+    # config.yaml is the resolved-values dump RenderPlans writes alongside
+    # the templates, not a manifest -- counting it would make this line
+    # disagree with the "Success: N" tally it stands in for.
+    manifests = sum(
+        len([f for f in d.glob("*.yaml") if f.name != "config.yaml"])
+        for d in stack_dirs
+    )
+    stacks = len(stack_dirs) or len(getattr(render_result, "stacks", {}) or {})
+
+    logger.log_info(
+        f"Plan rendered: {manifests} manifest(s) across {stacks} stack(s) "
+        f"-> {plan_dir}",
+        emoji="\u2705",
+    )
+    logger.log_info(
+        "Per-file render detail suppressed (--no-quiet-plan or -v to show; "
+        f"always recorded in {config.log_dir})",
+        emoji="\U0001f4dd",
+    )
 
 
 def _render_helm_manifests(plan_dir: Path, logger) -> None:
@@ -1413,14 +1458,17 @@ def _render_plans_for_experiment(args, logger, setup_overrides=None):
         base_dir=args.base_dir,
     ).eval()
 
-    version_resolver = VersionResolver(logger=logger, dry_run=args.dry_run)
+    render_logger = plan_logger(logger, config.quiet_plan)
+
+    version_resolver = VersionResolver(logger=render_logger, dry_run=args.dry_run)
     cluster_resource_resolver = ClusterResourceResolver(
-        logger=logger,
+        logger=render_logger,
         dry_run=args.dry_run,
         kubeconfig=getattr(args, "kubeconfig", None),
     )
 
     render_plan_errors = RenderPlans(
+        logger=render_logger,
         template_dir=specification_as_dict["template_dir"]["path"],
         defaults_file=specification_as_dict["values_file"]["path"],
         scenarios_file=specification_as_dict["scenario_file"]["path"],
@@ -1449,6 +1497,8 @@ def _render_plans_for_experiment(args, logger, setup_overrides=None):
     if render_plan_errors.has_errors:
         error_dump = json.dumps(render_plan_errors.to_dict(), indent=2)
         raise PhaseError(f"Rendering failed with setup overrides:\n{error_dump}")
+
+    _log_plan_summary(logger, render_plan_errors, config.plan_dir)
 
     return render_plan_errors
 
@@ -1919,6 +1969,32 @@ def _extract_workspace_from_scenario(
     return None
 
 
+def _resolve_quiet_plan(args: argparse.Namespace) -> bool:
+    """Decide whether to quiet the plan-rendering narration on the console.
+
+    Precedence: ``--quiet-plan`` / ``--no-quiet-plan`` > ``LLMDBENCH_QUIET_PLAN``
+    > per-command default. The default is "quiet everywhere except ``plan``":
+    on ``plan`` the render narration is the deliverable, everywhere else it
+    buries the phase output the user is actually watching.
+
+    ``--verbose`` always wins and turns quieting off -- it puts the console
+    handler at DEBUG, which would print the demoted lines anyway, so wrapping
+    would only strip the blank-line separators.
+    """
+    if getattr(args, "verbose", False):
+        return False
+
+    explicit = getattr(args, "quiet_plan", None)
+    if explicit is not None:
+        return bool(explicit)
+
+    from_env = env_bool_optional("LLMDBENCH_QUIET_PLAN")
+    if from_env is not None:
+        return from_env
+
+    return getattr(args, "command", None) != Command.PLAN.value
+
+
 def cli() -> None:
     """Parse arguments, set up workspace and logging, and dispatch the subcommand."""
 
@@ -2042,6 +2118,21 @@ def cli() -> None:
     )
 
     benchmark_parser.add_argument(
+        "--quiet-plan",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Suppress the per-file plan-rendering narration on the console "
+        "(the 'Rendered: <file>' lines, image overrides and per-stack "
+        "banners), replacing it with a one-line summary. The detail is still "
+        "written to <workspace>/logs at DEBUG. Default: on for standup, "
+        "smoketest, teardown, run and experiment -- where the render is an "
+        "implicit prelude -- and off for `plan`, whose output it is. "
+        "--no-quiet-plan restores the full narration, and --verbose always "
+        "shows it. "
+        "Env: LLMDBENCH_QUIET_PLAN.",
+    )
+
+    benchmark_parser.add_argument(
         "--telemetry-enabled",
         action="store_true",
         help="Enable telemetry reporting.",
@@ -2137,6 +2228,7 @@ def cli() -> None:
         args.wva = env_bool("LLMDBENCH_WVA")
     if hasattr(args, "epp_keda_saturation") and not args.epp_keda_saturation:
         args.epp_keda_saturation = env_bool("LLMDBENCH_EPP_KEDA_SATURATION")
+    args.quiet_plan = _resolve_quiet_plan(args)
     if not args.specification_file:
         parser.error(
             "the following arguments are required: --specification_file/--spec"
@@ -2207,6 +2299,7 @@ def cli() -> None:
         log_dir=absolute_workspace_log_dir,
         verbose=args.verbose,
         dry_run=args.dry_run,
+        quiet_plan=args.quiet_plan,
     )
 
     logger = get_logger(config.log_dir, config.verbose, __name__)

--- a/llmdbenchmark/config.py
+++ b/llmdbenchmark/config.py
@@ -18,6 +18,11 @@ class WorkspaceConfig:
     log_dir: Optional[Path] = None
     verbose: bool = False
     dry_run: bool = False
+    # Suppress the plan-rendering narration on the console (it still
+    # lands in the workspace logs at DEBUG). Resolved per subcommand in
+    # cli.py: on by default everywhere except `plan`, where the render
+    # narration IS the output. See llmdbenchmark/logging/quiet.py.
+    quiet_plan: bool = False
     telemetry_enabled: bool = False
     telemetry_provider: str = "http"
     telemetry_endpoint: Optional[str] = None

--- a/llmdbenchmark/interface/env.py
+++ b/llmdbenchmark/interface/env.py
@@ -36,3 +36,15 @@ def env_float(name: str, default: float | None = None) -> float | None:
         return float(val)
     except ValueError:
         return default
+
+
+def env_bool_optional(name: str) -> bool | None:
+    """Return env var as boolean, or ``None`` when unset.
+
+    For tri-state flags where "unset" is distinct from "explicitly false"
+    and the default is decided later (e.g. per subcommand).
+    """
+    val = os.environ.get(name)
+    if val is None:
+        return None
+    return val.strip().lower() in ("1", "true", "yes")

--- a/llmdbenchmark/logging/README.md
+++ b/llmdbenchmark/logging/README.md
@@ -7,7 +7,8 @@ Logging utilities with emoji formatting, stream separation, per-instance file ou
 ```
 logging/
 ├── __init__.py    -- Empty package marker
-└── logger.py      -- LLMDBenchmarkLogger class and get_logger() factory
+├── logger.py      -- LLMDBenchmarkLogger class and get_logger() factory
+└── quiet.py       -- QuietLogger proxy that demotes INFO to DEBUG
 ```
 
 ## LLMDBenchmarkLogger
@@ -80,3 +81,33 @@ def get_logger(
 Factory function that creates a configured logger. If `log_name` is not provided, generates one from `{username}-{YYYYMMDD-HHMMSS-mmm}`.
 
 Raises `ConfigurationError` if `log_dir` is `None` or if file handler creation fails.
+
+## QuietLogger
+
+`quiet.py` provides a proxy that wraps an `LLMDBenchmarkLogger` and demotes its
+INFO output to DEBUG. The console handler then drops those lines (unless
+`--verbose` puts it at DEBUG), while every file handler still records them --
+so the detail survives in `<workspace>/logs/` for a post-mortem.
+
+```python
+from llmdbenchmark.logging.quiet import plan_logger
+
+render_logger = plan_logger(logger, config.quiet_plan)
+```
+
+| Method | Behavior |
+|--------|----------|
+| `log_info` | Demoted to `log_debug` (emoji preserved) |
+| `log_plain_console` | Demoted to `log_debug` |
+| `log_plain` | Demoted to `log_debug` -- it writes straight to every handler stream, so it would otherwise bypass level filtering |
+| `line_break` | No-op -- blank separators around removed sections are just gaps |
+| `log_warning` / `log_error` / `log_debug` / anything else | Delegated unchanged via `__getattr__` |
+
+Warnings and errors are never suppressed: a display preference must not hide a
+render failure.
+
+Its one caller today is the plan-rendering pipeline, which narrates ~40 lines
+per stack. That is the whole point of `llmdbenchmark plan`, but on `standup` /
+`smoketest` / `teardown` / `run` / `experiment` the render is an implicit
+prelude, so `cli._resolve_quiet_plan` turns quieting on there by default. See
+`--quiet-plan` in the root README.

--- a/llmdbenchmark/logging/quiet.py
+++ b/llmdbenchmark/logging/quiet.py
@@ -1,0 +1,59 @@
+"""Console-quieting proxy around :class:`LLMDBenchmarkLogger`.
+
+The plan-rendering pipeline (``RenderSpecification`` -> ``VersionResolver`` /
+``ClusterResourceResolver`` -> ``RenderPlans`` -> Helm pre-render) narrates
+itself at INFO: one line per rendered template, per image override, per stack.
+That is the whole point of ``llmdbenchmark plan``, but on ``standup`` /
+``smoketest`` / ``teardown`` / ``run`` / ``experiment`` the render is an
+implicit prelude, and forty-odd lines of it push the output the user actually
+cares about off the screen.
+
+Wrapping the logger in :class:`QuietLogger` demotes those INFO lines to DEBUG.
+The console handler drops them (unless ``--verbose``), while every file
+handler keeps them at DEBUG -- so the full render narration is still in
+``<workspace>/logs/`` for a post-mortem. Warnings and errors are delegated
+untouched: a render problem must never be silenced.
+"""
+
+
+class QuietLogger:
+    """Proxy that demotes INFO output to DEBUG, passing everything else through.
+
+    Only the "chatty" methods are overridden. Any other attribute --
+    ``log_warning``, ``log_error``, ``log_debug``, ``set_indent``, ``logger``
+    -- resolves on the wrapped instance via ``__getattr__``, so this is a
+    drop-in substitute for ``LLMDBenchmarkLogger`` anywhere a ``logger=``
+    argument is accepted.
+    """
+
+    def __init__(self, logger):
+        self._logger = logger
+
+    @property
+    def wrapped(self):
+        """The underlying logger, for callers that need the un-quieted one."""
+        return self._logger
+
+    def log_info(self, msg, emoji=None):
+        """Demote to DEBUG: file handlers keep it, console drops it."""
+        self._logger.log_debug(msg, emoji=emoji)
+
+    def log_plain_console(self, msg, emoji=None):
+        """Demote to DEBUG -- the console half of this call is the noise."""
+        self._logger.log_debug(msg, emoji=emoji)
+
+    def log_plain(self, msg):
+        """Demote to DEBUG. ``log_plain`` writes straight to every stream,
+        which would bypass the level filtering this proxy exists to apply."""
+        self._logger.log_debug(str(msg))
+
+    def line_break(self):
+        """No-op. Blank separators around suppressed sections are just gaps."""
+
+    def __getattr__(self, name):
+        return getattr(self._logger, name)
+
+
+def plan_logger(logger, quiet: bool):
+    """Return *logger*, wrapped in :class:`QuietLogger` when *quiet* is set."""
+    return QuietLogger(logger) if quiet else logger


### PR DESCRIPTION
# Summary

- Adds `--quiet-plan` / `--no-quiet-plan`  arguments (default to `quiet-plan`) for logging; 
- Adds `export LLMDBENCH_QUIET_PLAN=false` or `export LLMDBENCH_QUIET_PLAN=true` for CICD env configuration on the fly
- Currently is implemented in the `plan` phase, by default we will log success of entire rendering, and any failures that occur. To gain the verbose rendering plan as before, utilize `--no-quiet-plan`
