### PR TITLE
Fix EPP log processing and cluster-state capture diagnostics

### DIFF
--- a/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
+++ b/llmdbenchmark/run/steps/step_09a_capture_cluster_state.py
@@ -9,8 +9,10 @@ Runs AFTER step_09_collect_results so the local results dir already exists
 and won't trip step_09's "skip if results dir non-empty" gate.
 """
 
+import json
 import time
 from pathlib import Path
+from urllib.parse import quote
 
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.executor.step import Phase, Step, StepResult
@@ -44,6 +46,27 @@ def _kube_logs_with_retry(cmd, *args, attempts: int = 3, backoff: float = 2.0):
         if i < attempts - 1:
             time.sleep(backoff)
     return last
+
+
+def _prometheus_api_status(stdout: str) -> tuple[str, str]:
+    """Return (status, error_detail) from a Prometheus/Thanos API response.
+
+    Status is "" for an absent or unparseable body, so callers fail closed.
+    """
+    if not stdout or not stdout.strip():
+        return "", ""
+    try:
+        body = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return "", ""
+    if not isinstance(body, dict):
+        return "", ""
+    status = str(body.get("status") or "")
+    error = str(body.get("error") or "")
+    error_type = str(body.get("errorType") or "")
+    if error and error_type:
+        error = f"{error_type}: {error}"
+    return status, error
 
 
 _FMA_GUIDE_STACK_NAME = "fast-model-actuation"
@@ -222,31 +245,36 @@ class CaptureClusterStateStep(Step):
         # 5. WVA controller logs — every reconcile loop logs the OPTIMIZED
         # replica count it computed. Capped to keep the upload reasonable;
         # bump --tail if we ever need full forensic depth.
-        result = _kube_logs_with_retry(
-            cmd,
-            "deployment/wva-controller-manager",
-            "--namespace",
-            wva_ns,
-            "--tail=50000",
-        )
-        if (
-            result.success
-            and result.stdout
-            and not _is_kubelet_log_sentinel(result.stdout)
-        ):
-            (out_dir / "wva-controller.log").write_text(result.stdout, encoding="utf-8")
-            captured.append("wva-controller.log")
-        elif result.success and result.stdout:
-            (out_dir / "wva-controller.kubelet-error").write_text(
-                result.stdout, encoding="utf-8"
+        # WVA paths only -- KEDA-only scenarios never deploy this Deployment,
+        # so fetching it there is a guaranteed NotFound on every run.
+        if wva_enabled:
+            result = _kube_logs_with_retry(
+                cmd,
+                "deployment/wva-controller-manager",
+                "--namespace",
+                wva_ns,
+                "--tail=50000",
             )
-            warnings.append(
-                "logs wva-controller-manager: kubelet sentinel after retries"
-            )
-        else:
-            warnings.append(
-                f"logs wva-controller-manager failed: {result.stderr[:200]}"
-            )
+            if (
+                result.success
+                and result.stdout
+                and not _is_kubelet_log_sentinel(result.stdout)
+            ):
+                (out_dir / "wva-controller.log").write_text(
+                    result.stdout, encoding="utf-8"
+                )
+                captured.append("wva-controller.log")
+            elif result.success and result.stdout:
+                (out_dir / "wva-controller.kubelet-error").write_text(
+                    result.stdout, encoding="utf-8"
+                )
+                warnings.append(
+                    "logs wva-controller-manager: kubelet sentinel after retries"
+                )
+            else:
+                warnings.append(
+                    f"logs wva-controller-manager failed: {result.stderr[:200]}"
+                )
 
         # 5b. Dual-pods-controller log — its klog lines anchor each FMA actuation
         # (wake / create_instance / launcher-create), the signal the hit-rate
@@ -300,10 +328,26 @@ class CaptureClusterStateStep(Step):
         # "Skipping pod that doesn't match any scale target" even when the
         # pod has the right metadata. Compare baseline-vs-FMA captures of
         # this file to isolate which side of the chain breaks.
-        thanos_proxy = (
-            "/api/v1/namespaces/openshift-monitoring/services/"
-            "thanos-querier:web/proxy/api/v1/query"
+        # Via the route, not the apiserver service proxy: that proxy does not
+        # forward credentials, so Thanos answers 401. Needs `get
+        # prometheuses/api` in openshift-monitoring.
+        thanos_host = ""
+        route_result = cmd.kube(
+            "get",
+            "route",
+            "thanos-querier",
+            "--namespace",
+            "openshift-monitoring",
+            "-o",
+            "jsonpath={.spec.host}",
+            check=False,
         )
+        if route_result.success:
+            thanos_host = route_result.stdout.strip().strip("'\"")
+        token = ""
+        token_result = cmd.kube("whoami", "-t", check=False)
+        if token_result.success:
+            token = token_result.stdout.strip()
         thanos_queries = [
             (
                 "vllm-cache-with-variant",
@@ -317,20 +361,42 @@ class CaptureClusterStateStep(Step):
             ),
             ("epp-pool-queue-size", "inference_pool_average_queue_size"),
         ]
-        for label, query in thanos_queries:
-            result = cmd.kube(
-                "get", "--raw", f"{thanos_proxy}?query={query}", check=False
+        if not thanos_host or not token:
+            warnings.append(
+                "thanos queries skipped: could not resolve "
+                f"{'route' if not thanos_host else 'token'}"
             )
-            if result.success:
-                (out_dir / f"thanos-{label}.json").write_text(
-                    result.stdout, encoding="utf-8"
+        else:
+            for label, query in thanos_queries:
+                # PromQL carries {}, "", =~ and : -- all of which must be
+                # percent-encoded to survive as a single query parameter.
+                url = (
+                    f"https://{thanos_host}/api/v1/query?query={quote(query, safe='')}"
                 )
-                captured.append(f"thanos-{label}.json")
-            else:
-                (out_dir / f"thanos-{label}.error").write_text(
-                    result.stderr, encoding="utf-8"
+                # Token via stdin (`@-`), never on the command line: execute()
+                # logs the command string and keeps it on CommandResult.
+                result = cmd.execute(
+                    f'curl -sS -k -H @- "{url}"',
+                    check=False,
+                    stdin=f"Authorization: Bearer {token}",
                 )
-                warnings.append(f"thanos query '{label}' failed: {result.stderr[:200]}")
+                # Gate on the API's status field: errors come back in the body,
+                # and curl without -f exits 0 on a 4xx.
+                api_status, api_error = _prometheus_api_status(result.stdout)
+                if result.success and api_status == "success":
+                    (out_dir / f"thanos-{label}.json").write_text(
+                        result.stdout, encoding="utf-8"
+                    )
+                    captured.append(f"thanos-{label}.json")
+                else:
+                    detail = (
+                        api_error or result.stderr or result.stdout or "(no output)"
+                    )
+                    (out_dir / f"thanos-{label}.error").write_text(
+                        result.stdout or result.stderr or "(no output)",
+                        encoding="utf-8",
+                    )
+                    warnings.append(f"thanos query '{label}' failed: {detail[:200]}")
 
         # 9. Pod logs for controllers and serving pods. Iterate over every pod
         # in deploy_ns (and the WVA ns if it differs) and dump --tail=5000 per container.

--- a/llmdbenchmark/smoketests/base.py
+++ b/llmdbenchmark/smoketests/base.py
@@ -1886,6 +1886,15 @@ class BaseSmoketest:
         report: SmoketestReport,
         service_test_passed: bool,
     ):
+        # epponly/none deploy no Gateway, so no route exists to fetch --
+        # looking one up there is a guaranteed warning on every run.
+        gateway_class = _nested_get(plan_config, "gateway", "className") or ""
+        if gateway_class in ("epponly", "none"):
+            context.logger.log_info(
+                f"gateway.className={gateway_class} -- no OpenShift route to test"
+            )
+            return
+
         release = _nested_get(plan_config, "release") or ""
         route_name = f"{release}-inference-gateway-route"
 

--- a/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
+++ b/llmdbenchmark/standup/steps/step_09_deploy_modelservice.py
@@ -805,13 +805,15 @@ class DeployModelserviceStep(Step):
         fma_enabled = plan_config.get("fma", {}).get("enabled", False)
         hpa_name = f"{model_id_label}-{'fma' if fma_enabled else 'decode'}-saturation"
 
-        for label, resource_name in (
-            ("ScaledObject", hpa_name + "-saturation"),
-            ("HPA", "keda-hpa-" + hpa_name + "-saturation"),
+        # hpa_name already ends in -saturation, and the resource type has to be
+        # a literal: deriving it from the name yielded `oc get qwen` / `keda`.
+        for label, kind, resource_name in (
+            ("ScaledObject", "scaledobjects.keda.sh", hpa_name),
+            ("HPA", "hpa", f"keda-hpa-{hpa_name}"),
         ):
             result = cmd.kube(
                 "get",
-                resource_name.split("-")[0].lower(),
+                kind,
                 resource_name,
                 "-n",
                 epp_keda_ns,

--- a/llmdbenchmark/standup/steps/step_10_smoketest.py
+++ b/llmdbenchmark/standup/steps/step_10_smoketest.py
@@ -508,6 +508,15 @@ class SmoketestStep(Step):
         errors: list,
     ):
         """Test the OpenShift route endpoint."""
+        # epponly/none deploy no Gateway, so no route exists to fetch --
+        # looking one up there is a guaranteed warning on every run.
+        gateway_class = plan_config.get("gateway", {}).get("className", "")
+        if gateway_class in ("epponly", "none"):
+            _context.logger.log_info(
+                f"gateway.className={gateway_class} -- no OpenShift route to test"
+            )
+            return
+
         release = self._require_config(plan_config, "release")
         route_name = f"{release}-inference-gateway-route"
 

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -695,8 +695,11 @@ def capture_infrastructure_logs(
                     script = Path(script_str)
             if script.exists():
                 context.logger.log_info("Processing EPP logs...")
+                # The script resolves <dir>/logs/epp_pods.log; results_dir does
+                # not always contain logs/, so it would silently exit 0.
+                epp_target = log_dir.parent if log_dir.name == "logs" else results_dir
                 result = subprocess.run(
-                    ["python3", str(script), str(results_dir), "--visualize"],
+                    ["python3", str(script), str(epp_target), "--visualize"],
                     capture_output=True,
                     text=True,
                     timeout=120,
@@ -704,8 +707,19 @@ def capture_infrastructure_logs(
                 if result.returncode == 0:
                     context.logger.log_info("EPP log processing complete")
                 else:
+                    # Summarise from the tail: a traceback's exception is on the
+                    # last line, the head is just the frame list.
+                    detail = (result.stderr or result.stdout or "").strip()
+                    summary = detail.splitlines()[-1] if detail else "(no output)"
                     context.logger.log_warning(
-                        f"EPP log processing failed (non-fatal): {result.stderr[:200]}"
+                        f"EPP log processing failed (non-fatal, rc="
+                        f"{result.returncode}): {summary[:300]}"
                     )
+                    if detail:
+                        context.logger.log_debug(
+                            f"EPP log processing stderr:\n{detail}"
+                        )
         except Exception as e:
-            context.logger.log_warning(f"EPP log processing failed (non-fatal): {e}")
+            context.logger.log_warning(
+                f"EPP log processing failed (non-fatal): {type(e).__name__}: {e}"
+            )

--- a/workload/harnesses/process_epp_logs.py
+++ b/workload/harnesses/process_epp_logs.py
@@ -19,7 +19,7 @@ import re
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 # Optional matplotlib for visualization
@@ -82,9 +82,19 @@ class ScoringSnapshot:
 PREFIX_RE = re.compile(r"^\[pod/([^/]+)/([^\]]+)\]\s*")
 
 
-def parse_timestamp(ts_str: str) -> Optional[datetime]:
-    """Parse an ISO 8601 timestamp, truncating nanoseconds to microseconds."""
+def parse_timestamp(ts_str: Any) -> Optional[datetime]:
+    """Parse an ISO 8601 string or float/int epoch, truncating ns to µs.
+
+    The EPP emits ``ts`` as a float, so string-only handling raises TypeError.
+    """
     if not ts_str:
+        return None
+    if isinstance(ts_str, (int, float)) and not isinstance(ts_str, bool):
+        try:
+            return datetime.fromtimestamp(ts_str, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if not isinstance(ts_str, str):
         return None
     # Handle nanosecond timestamps by truncating to 6 decimal places
     ts_str = re.sub(r"(\.\d{6})\d+", r"\1", ts_str)


### PR DESCRIPTION
### Summary

Four post-run diagnostic failures, all non-fatal but noisy, and two of them meant a diagnostic had never produced output. 

### Fixes

- EPP log processing never worked. The EPP emits its `ts` field as a float epoch (`1787000226.5217133`), but `parse_timestamp` was written for strings, so re.sub raised TypeError on every line. Now accepts `float/int` epochs as well as ISO strings.

- Wrong directory passed to that script. The caller passed `results_dir`, but the script resolves `<dir>/logs/epp_pods.log` and the logs are written to `log_dir` — a separate parameter. When they diverged the script found nothing and exited 0, so the failure was invisible. Now derived from `log_dir`.

- Errors were truncated from the wrong end. `stderr[:200]` keeps a traceback's frame list; the exception is on the last line. That's why both local and CI logs cut off mid-frame with no cause visible. Now summarises from the tail, includes the exit code, and logs the full text at debug level.

- wva-controller-manager not found on every KEDA run. `wva_enabled` was already computed but only gated the whole-step skip; the controller-log fetch ran unconditionally. Now gated, so KEDA-only scenarios stop emitting a guaranteed NotFound.

- Five thanos query `... BadRequest warnings`. These turned out to be a real bug in three layers. -v=6 revealed the hidden cause — Client sent an HTTP request to an HTTPS server — since port web (`9091`) serves TLS. Adding an `https: scheme` prefix fixed that but exposed a 401: the apiserver service proxy doesn't forward credentials to the backend, so that route can't work at all. Switched to the thanos-querier route with a bearer token; all five queries now return success, with the two EPP queries returning 32 series of real data. PromQL is also percent-encoded now ({, }, ", =~, : were interpolated raw) — a genuine defect, though not the cause.

The token is passed via curl -H @- on stdin, not inline: CommandExecutor.execute() writes the command string to a run log and retains it on CommandResult, so an inline token would be persisted to disk.
