### PR TITLE
fix: FMA+KEDA WLP model upped to 32b with inference-perf harness rather than nop

### DIFF
--- a/config/scenarios/guides/fast-model-actuation-keda.yaml
+++ b/config/scenarios/guides/fast-model-actuation-keda.yaml
@@ -29,17 +29,17 @@ scenario:
       # guide's manifests, so these values do NOT drive the deployment. They
       # MUST, however, match the model the guide actually serves -- the
       # post-standup smoketest validates the /v1/models endpoint against
-      # model.name (the guide serves Qwen/Qwen3-0.6B via its InferenceServerConfig).
+      # model.name (the guide serves Qwen/Qwen3-32B via its InferenceServerConfig).
       # -----------------------------------------------------------------------
       model:
-        name: Qwen/Qwen3-0.6B
-        shortName: qwen-qwen3-0-6b
-        path: models/Qwen/Qwen3-0.6B
-        huggingfaceId: Qwen/Qwen3-0.6B
-        size: 10Gi
+        name: Qwen/Qwen3-32B
+        shortName: qwen-qwen3-32b
+        path: models/Qwen/Qwen3-32B
+        huggingfaceId: Qwen/Qwen3-32B
+        size: 100Gi
         maxModelLen: 16000
         blockSize: 64
-        gpuMemoryUtilization: 0.9
+        gpuMemoryUtilization: 0.95
 
     # =======================================================================
     # KUSTOMIZE DEPLOY METHOD -- pre-enabled. This block defines the ENTIRE
@@ -60,8 +60,8 @@ scenario:
       guideVariableOverrides: {}   # override/fill the guide README's ${VAR}
 
     harness:
-      name: nop
-      experimentProfile: nop.yaml
+      name: inference-perf
+      experimentProfile: shared_prefix_synthetic_heavy.yaml
       executable: llm-d-benchmark.py
 
     workDir: "~/data/fast-model-actuation-keda"


### PR DESCRIPTION
Related: https://github.com/llm-d/llm-d-benchmark/pull/1824