### PR TITLE
Pin FMA+KEDA workloads to a target node for benchmarking

### DIFF
--- a/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
+++ b/config/scenarios/cicd/ocp-keda-fma-hotstart.yaml
@@ -108,9 +108,12 @@ scenario:
       # type and all free, labels it, and pins the LauncherPopulationPolicy +
       # requester Deployment to it; launcherCount/replicas are sized to that
       # node's GPU count. Standup fails if no fully-free single-type GPU node.
+      # Node/label/taint come from the shared top-level `nodePinning` block
+      # (config/templates/values/defaults.yaml) so they are set in ONE place.
+      # Uncomment nodeLabel/nodeLabelValue/nodeName here only to override it
+      # for this scenario alone.
       launcherNodeSelection:
         enabled: true
-        nodeLabel: fma-hotstart
 
       # HOT-START CHANGE #1: Deploy all replicas at standup for parallel model loading
       # Initially set to maxReplicas so all launcher pods load models simultaneously

--- a/config/templates/jinja/24_fma-deployment.yaml.j2
+++ b/config/templates/jinja/24_fma-deployment.yaml.j2
@@ -4,7 +4,17 @@
    fma-deployment.yaml.j2
 
    Fast Model Actuation Deployment.
+
+   Node pinning resolves from the shared `nodePinning` block (defaults.yaml)
+   unless the scenario sets the fma.* equivalent, which wins.
    ============================================================================ #}
+{% set _np = nodePinning | default({}) %}
+{% set _np_on = _np.enabled | default(false) %}
+{% set _lns = fma.launcherNodeSelection | default({}) %}
+{% set _pin_on = _lns.enabled | default(false) or _np_on %}
+{% set _pin_label = _lns.nodeLabel | default('', true) or (_np.nodeLabel if _np_on else '') or 'fma-hotstart' %}
+{% set _pin_value = _lns.nodeLabelValue | default('', true) or (_np.nodeLabelValue if _np_on else '') or 'true' %}
+{% set _pin_tolerations = fma.tolerations | default([], true) or (_np.tolerations | default([], true) if _np_on else []) %}
 
 apiVersion: fma.llm-d.ai/v1alpha1
 kind: InferenceServerConfig
@@ -84,6 +94,12 @@ spec:
       serviceAccountName: fma-launcher
 {% if fma.launcher.runtimeClassName is defined and fma.launcher.runtimeClassName %}
       runtimeClassName: {{ fma.launcher.runtimeClassName }}
+{% endif %}
+{% if _pin_tolerations %}
+      # Launcher pods are created by the FMA controller from this podTemplate,
+      # so a taint on the target node has to be tolerated here.
+      tolerations:
+{{ _pin_tolerations | toyaml | indent(8, first=True) }}
 {% endif %}
       containers:
         - name: inference-server
@@ -173,9 +189,9 @@ spec:
     labelSelector:
       matchLabels:
         nvidia.com/gpu.present: "true"
-{% if fma.launcherNodeSelection is defined and fma.launcherNodeSelection.enabled | default(false) %}
+{% if _pin_on %}
         # Pin launchers to the single GPU node step_06 selected + labeled.
-        {{ fma.launcherNodeSelection.nodeLabel | default('fma-hotstart') }}: "true"
+        {{ _pin_label }}: "{{ _pin_value }}"
 {% endif %}
       # Skip unhealthy nodes
       matchExpressions:
@@ -216,11 +232,15 @@ spec:
         dual-pods.llm-d.ai/admin-port: "8081"
         dual-pods.llm-d.ai/inference-server-config: fma-{{ model_id_label }}
     spec:
-{% if fma.launcherNodeSelection is defined and fma.launcherNodeSelection.enabled | default(false) %}
+{% if _pin_on %}
       # Pin the requester to the single GPU node step_06 selected + labeled.
       # ANDed with the nodeAffinity below (which stays load-bearing for WVA).
       nodeSelector:
-        {{ fma.launcherNodeSelection.nodeLabel | default('fma-hotstart') }}: "true"
+        {{ _pin_label }}: "{{ _pin_value }}"
+{% endif %}
+{% if _pin_tolerations %}
+      tolerations:
+{{ _pin_tolerations | toyaml | indent(8, first=True) }}
 {% endif %}
       {# Pick a resolved accelerator type from decode/prefill/standalone
          (cluster_resource_resolver.py rewrites `labelValue: auto` into the

--- a/config/templates/values/defaults.yaml
+++ b/config/templates/values/defaults.yaml
@@ -1525,6 +1525,43 @@ kustomize:
 
 # ============================================================================
 # FMA DEPLOYMENT CONFIGURATION
+# ============================================================================
+# Single-node pinning (benchmark isolation)
+#
+# ONE place to name the reserved node and its taint. Set these three values
+# and every workload that reads them lands on that node -- no per-scenario
+# edits. Consumed by:
+#   - FMA launchers + requester (24_fma-deployment.yaml.j2)
+#   - EPP                       (12_router-values.yaml.j2)
+#
+# `enabled: false` leaves every consumer untouched, so this is inert until
+# you fill it in. A scenario can still override any consumer individually
+# (fma.tolerations, router.epp.affinity) -- an explicit per-scenario value
+# always wins over these defaults.
+#
+# The harness and data-access pods are deliberately NOT pinned: with a taint
+# on the node they cannot land there, which is what keeps load generation off
+# the measurement node.
+# ============================================================================
+nodePinning:
+  enabled: false
+  # Node to pin to. Also used as fma.launcherNodeSelection.nodeName, which
+  # skips FMA's free-GPU/CPU auto-scan (that scan ignores taints and could
+  # otherwise pick a node whose pods never schedule).
+  nodeName: ""
+  # Label the node already carries, used for pod placement. EPP has no
+  # nodeSelector in the router chart, so this becomes a nodeAffinity term
+  # there and a nodeSelector for the FMA requester/launchers.
+  nodeLabel: ""
+  nodeLabelValue: ""
+  # Taints to tolerate. A label places a pod; only a matching toleration lets
+  # it schedule on a tainted node. Standard corev1.Toleration entries, e.g.
+  #   - key: reserved
+  #     operator: Equal
+  #     value: my-workload
+  #     effect: NoSchedule
+  tolerations: []
+
 # For Fast Model Actuation
 # ============================================================================
 fma:
@@ -1538,7 +1575,19 @@ fma:
   # (used by cicd/ocp-wva-fma-hotstart).
   launcherNodeSelection:
     enabled: false
-    nodeLabel: fma-hotstart
+    # Empty so an inherited nodePinning value is not masked by a default; the
+    # effective fallback when neither is set is still fma-hotstart=true.
+    nodeLabel: ""
+    nodeLabelValue: ""
+    # Pin to this node instead of auto-selecting one. Required when the target
+    # node is tainted: the auto-scan reads allocatable/committed resources and
+    # does not consider taints, so it can pick a node whose pods never schedule.
+    nodeName: ""
+
+  # Tolerations applied to the FMA launcher pods and the requester Deployment.
+  # Needed when the target node carries a taint -- a nodeSelector alone places
+  # a pod, but only a matching toleration lets it schedule there.
+  tolerations: []
 
   # Deployment naming
   deployment:

--- a/docs/upstream-versions.md
+++ b/docs/upstream-versions.md
@@ -8,8 +8,8 @@
 > `auto` Helm/image versions are resolved against live registries at
 > generation time via the existing `VersionResolver`.
 
-- Generated at: `2026-08-22 19:37:58` (UTC)
-- Generated against git ref: `8bc9f1ddd873a24f1657d6cca2e0d0fb6947dd36`
+- Generated at: `2026-09-03 17:42:14` (UTC)
+- Generated against git ref: `9d0129aa252bc3d054002a50aa6ca80f0d18ac49`
 
 ## System Tool Dependencies
 
@@ -25,12 +25,13 @@ whatever the host's package manager provides.
 | **helm** | `v3.19.0` | version | `install.sh` line 81 (`tool_version_for`) | [helm/helm](https://github.com/helm/helm) |
 | **helm-diff** | `v3.13.0` | plugin (version) | `install.sh` line 82 (`tool_version_for`) | [databus23/helm-diff](https://github.com/databus23/helm-diff) |
 | **helmfile** | `1.5.1` | version | `install.sh` line 80 (`tool_version_for`) | [helmfile/helmfile](https://github.com/helmfile/helmfile) |
-| **jq** | `1.8.2` | version | `install.sh` line 87 (`tool_version_for`) | [jqlang/jq](https://github.com/jqlang/jq) |
-| **kustomize** | `v5.8.1` | version | `install.sh` line 84 (`tool_version_for`) | [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) |
-| **llm-d-planner (git)** | `v0.1.0` | commit SHA | `install.sh` line 984 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
-| **oc** | `4.18.0` | version | `install.sh` line 83 (`tool_version_for`) | [openshift/oc](https://github.com/openshift/oc) |
-| **skopeo** | `1.20.1` | version | `install.sh` line 86 (`tool_version_for`) | [containers/skopeo](https://github.com/containers/skopeo) |
+| **jq** | `1.8.2` | version | `install.sh` line 90 (`tool_version_for`) | [jqlang/jq](https://github.com/jqlang/jq) |
+| **kustomize** | `v5.8.1` | version | `install.sh` line 87 (`tool_version_for`) | [kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize) |
+| **llm-d-planner (git)** | `v0.1.0` | commit SHA | `install.sh` line 1021 (`PLANNER_GIT`) | [llm-d-incubation/llm-d-planner](https://github.com/llm-d-incubation/llm-d-planner) |
+| **oc** | `4.18.0` | version | `install.sh` line 86 (`tool_version_for`) | [openshift/oc](https://github.com/openshift/oc) |
+| **skopeo** | `1.20.1` | version | `install.sh` line 89 (`tool_version_for`) | [containers/skopeo](https://github.com/containers/skopeo) |
 | **yq** | `v4.53.6` | version | `install.sh` line 79 (`tool_version_for`) | [mikefarah/yq](https://github.com/mikefarah/yq) |
+| **zstd** | `system-provided` | system-provided | `install.sh`: `command -v` check (no pin) | (unknown) |
 
 
 ## Helm Chart Dependencies
@@ -59,7 +60,7 @@ generation (and plan) time.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **benchmark** | `v0.8.0` | tag | `config/templates/values/defaults.yaml` line 380 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
+| **benchmark** | `nightly` | tag | `config/templates/values/defaults.yaml` line 380 (`images.benchmark`) | [llm-d/llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) (`ghcr.io/llm-d/llm-d-benchmark`) |
 | **python** | `3.10` | tag | `config/templates/values/defaults.yaml` line 428 (`images.python`) | [Docker Hub: python](https://hub.docker.com/_/python) (`python`) |
 | **routerEndpointPicker** | `v0.10.0` | tag | `config/templates/values/defaults.yaml` line 405 (`images.routerEndpointPicker`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-endpoint-picker`) |
 | **routingSidecar** | `v0.10.0` | tag | `config/templates/values/defaults.yaml` line 411 (`images.routingSidecar`) | [llm-d/llm-d-router](https://github.com/llm-d/llm-d-router) (`ghcr.io/llm-d/llm-d-router-disagg-sidecar`) |
@@ -83,6 +84,7 @@ captured in the snapshot table below.
 | **Jinja2** | `(unpinned)` | (unpinned) | `pyproject.toml` line 8 | [Jinja2 (PyPI)](https://pypi.org/project/jinja2/) |
 | **kubernetes** | `==35.0.0` | constraint | `pyproject.toml` line 11 | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
 | **kubernetes-asyncio** | `(unpinned)` | (unpinned) | `pyproject.toml` line 13 | [kubernetes-asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
+| **llmd-benchmark-report** | `>=0.2.1,<0.3` | constraint | `pyproject.toml` line 20 | [llmd-benchmark-report (PyPI)](https://pypi.org/project/llmd-benchmark-report/) |
 | **packaging** | `(unpinned)` | (unpinned) | `pyproject.toml` line 10 | [packaging (PyPI)](https://pypi.org/project/packaging/) |
 | **pydantic** | `>=2.0` | constraint | `pyproject.toml` line 17 | [pydantic (PyPI)](https://pypi.org/project/pydantic/) |
 | **pykube-ng** | `(unpinned)` | (unpinned) | `pyproject.toml` line 12 | [pykube-ng (PyPI)](https://pypi.org/project/pykube-ng/) |
@@ -102,20 +104,20 @@ annotated with their `pyproject.toml` line.
 
 | Dependency | Current Pin | Pin Type | File Location | Upstream Repo |
 |---|---|---|---|---|
-| **aiohappyeyeballs** | `2.7.1` | version | (transitive in `.venv`) | [aiohappyeyeballs (PyPI)](https://pypi.org/project/aiohappyeyeballs/) |
+| **aiohappyeyeballs** | `2.6.2` | version | (transitive in `.venv`) | [aiohappyeyeballs (PyPI)](https://pypi.org/project/aiohappyeyeballs/) |
 | **aiohttp** | `3.14.1` | version | (transitive in `.venv`) | [aiohttp (PyPI)](https://pypi.org/project/aiohttp/) |
 | **aiosignal** | `1.4.0` | version | (transitive in `.venv`) | [aiosignal (PyPI)](https://pypi.org/project/aiosignal/) |
 | **annotated-doc** | `0.0.4` | version | (transitive in `.venv`) | [annotated-doc (PyPI)](https://pypi.org/project/annotated-doc/) |
 | **annotated-types** | `0.7.0` | version | (transitive in `.venv`) | [annotated-types (PyPI)](https://pypi.org/project/annotated-types/) |
-| **anyio** | `4.14.2` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
+| **anyio** | `4.14.1` | version | (transitive in `.venv`) | [anyio (PyPI)](https://pypi.org/project/anyio/) |
 | **attrs** | `26.1.0` | version | (transitive in `.venv`) | [attrs (PyPI)](https://pypi.org/project/attrs/) |
 | **binaryornot** | `0.6.0` | version | (transitive in `.venv`) | [binaryornot (PyPI)](https://pypi.org/project/binaryornot/) |
 | **boxsdk** | `3.14.0` | version | (transitive in `.venv`) | [boxsdk (PyPI)](https://pypi.org/project/boxsdk/) |
 | **certifi** | `2026.6.17` | version | (transitive in `.venv`) | [certifi (PyPI)](https://pypi.org/project/certifi/) |
-| **cffi** | `2.1.0` | version | (transitive in `.venv`) | [cffi (PyPI)](https://pypi.org/project/cffi/) |
+| **cffi** | `2.0.0` | version | (transitive in `.venv`) | [cffi (PyPI)](https://pypi.org/project/cffi/) |
 | **cfgv** | `3.5.0` | version | (transitive in `.venv`) | [cfgv (PyPI)](https://pypi.org/project/cfgv/) |
 | **chardet** | `6.0.0.post1` | version | (transitive in `.venv`) | [chardet (PyPI)](https://pypi.org/project/chardet/) |
-| **charset-normalizer** | `3.4.9` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
+| **charset-normalizer** | `3.4.7` | version | (transitive in `.venv`) | [charset-normalizer (PyPI)](https://pypi.org/project/charset-normalizer/) |
 | **click** | `8.4.2` | version | (transitive in `.venv`) | [click (PyPI)](https://pypi.org/project/click/) |
 | **cryptography** | `49.0.0` | version | (transitive in `.venv`) | [cryptography (PyPI)](https://pypi.org/project/cryptography/) |
 | **detect_secrets** | `38ba7e335083e0a4db8c53e9be414795b27891e9` | commit SHA | (transitive in `.venv`) | [detect_secrets (PyPI)](https://pypi.org/project/detect-secrets/) |
@@ -123,16 +125,16 @@ annotated with their `pyproject.toml` line.
 | **distro** | `1.9.0` | version | (transitive in `.venv`) | [distro (PyPI)](https://pypi.org/project/distro/) |
 | **durationpy** | `0.10` | version | (transitive in `.venv`) | [durationpy (PyPI)](https://pypi.org/project/durationpy/) |
 | **execnet** | `2.1.2` | version | (transitive in `.venv`) | [execnet (PyPI)](https://pypi.org/project/execnet/) |
-| **fastapi** | `0.139.0` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
-| **filelock** | `3.29.7` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
+| **fastapi** | `0.138.2` | version | (transitive in `.venv`) | [fastapi (PyPI)](https://pypi.org/project/fastapi/) |
+| **filelock** | `3.29.4` | version | (transitive in `.venv`) | [filelock (PyPI)](https://pypi.org/project/filelock/) |
 | **frozenlist** | `1.8.0` | version | (transitive in `.venv`) | [frozenlist (PyPI)](https://pypi.org/project/frozenlist/) |
 | **fsspec** | `2026.6.0` | version | (transitive in `.venv`) | [fsspec (PyPI)](https://pypi.org/project/fsspec/) |
 | **gitdb** | `4.0.12` | version | (transitive in `.venv`) | [gitdb (PyPI)](https://pypi.org/project/gitdb/) |
-| **GitPython** | `3.1.51` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
+| **GitPython** | `3.1.50` | version | `pyproject.toml` line 14 (direct) | [GitPython (PyPI)](https://pypi.org/project/gitpython/) |
 | **google-api-core** | `2.31.0` | version | (transitive in `.venv`) | [google-api-core (PyPI)](https://pypi.org/project/google-api-core/) |
-| **google-auth** | `2.56.0` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
+| **google-auth** | `2.55.1` | version | `pyproject.toml` line 18 (direct) | [google-auth (PyPI)](https://pypi.org/project/google-auth/) |
 | **google-cloud-core** | `2.6.0` | version | (transitive in `.venv`) | [google-cloud-core (PyPI)](https://pypi.org/project/google-cloud-core/) |
-| **google-cloud-storage** | `3.13.0` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
+| **google-cloud-storage** | `3.12.0` | version | `pyproject.toml` line 19 (direct) | [google-cloud-storage (PyPI)](https://pypi.org/project/google-cloud-storage/) |
 | **google-crc32c** | `1.8.0` | version | (transitive in `.venv`) | [google-crc32c (PyPI)](https://pypi.org/project/google-crc32c/) |
 | **google-resumable-media** | `2.10.0` | version | (transitive in `.venv`) | [google-resumable-media (PyPI)](https://pypi.org/project/google-resumable-media/) |
 | **googleapis-common-protos** | `1.75.0` | version | (transitive in `.venv`) | [googleapis-common-protos (PyPI)](https://pypi.org/project/googleapis-common-protos/) |
@@ -141,7 +143,7 @@ annotated with their `pyproject.toml` line.
 | **httpcore** | `1.0.9` | version | (transitive in `.venv`) | [httpcore (PyPI)](https://pypi.org/project/httpcore/) |
 | **httptools** | `0.8.0` | version | (transitive in `.venv`) | [httptools (PyPI)](https://pypi.org/project/httptools/) |
 | **httpx** | `0.28.1` | version | (transitive in `.venv`) | [httpx (PyPI)](https://pypi.org/project/httpx/) |
-| **huggingface_hub** | `1.23.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
+| **huggingface_hub** | `1.21.0` | version | `pyproject.toml` line 15 (direct) | [huggingface_hub (PyPI)](https://pypi.org/project/huggingface-hub/) |
 | **identify** | `2.6.19` | version | (transitive in `.venv`) | [identify (PyPI)](https://pypi.org/project/identify/) |
 | **idna** | `3.18` | version | (transitive in `.venv`) | [idna (PyPI)](https://pypi.org/project/idna/) |
 | **iniconfig** | `2.3.0` | version | (transitive in `.venv`) | [iniconfig (PyPI)](https://pypi.org/project/iniconfig/) |
@@ -150,6 +152,7 @@ annotated with their `pyproject.toml` line.
 | **kubernetes** | `35.0.0` | version | `pyproject.toml` line 11 (direct) | [kubernetes (PyPI)](https://pypi.org/project/kubernetes/) |
 | **kubernetes_asyncio** | `36.1.0` | version | (transitive in `.venv`) | [kubernetes_asyncio (PyPI)](https://pypi.org/project/kubernetes-asyncio/) |
 | **llm-optimizer** | `bb82d22e8863b762e856be66e831d551d27576b1` | commit SHA | (transitive in `.venv`) | [llm-optimizer (PyPI)](https://pypi.org/project/llm-optimizer/) |
+| **llmd_benchmark_report** | `editable` | editable | (transitive in `.venv`) | [llmd_benchmark_report (PyPI)](https://pypi.org/project/llmd-benchmark-report/) |
 | **llmdbenchmark** | `editable` | editable | (transitive in `.venv`) | [llmdbenchmark (PyPI)](https://pypi.org/project/llmdbenchmark/) |
 | **markdown-it-py** | `4.2.0` | version | (transitive in `.venv`) | [markdown-it-py (PyPI)](https://pypi.org/project/markdown-it-py/) |
 | **MarkupSafe** | `3.0.3` | version | (transitive in `.venv`) | [MarkupSafe (PyPI)](https://pypi.org/project/markupsafe/) |
@@ -160,7 +163,7 @@ annotated with their `pyproject.toml` line.
 | **nvidia-ml-py3** | `7.352.0` | version | (transitive in `.venv`) | [nvidia-ml-py3 (PyPI)](https://pypi.org/project/nvidia-ml-py3/) |
 | **oauthlib** | `3.3.1` | version | (transitive in `.venv`) | [oauthlib (PyPI)](https://pypi.org/project/oauthlib/) |
 | **ollama** | `0.6.2` | version | (transitive in `.venv`) | [ollama (PyPI)](https://pypi.org/project/ollama/) |
-| **openai** | `2.45.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
+| **openai** | `2.44.0` | version | (transitive in `.venv`) | [openai (PyPI)](https://pypi.org/project/openai/) |
 | **packaging** | `26.2` | version | `pyproject.toml` line 10 (direct) | [packaging (PyPI)](https://pypi.org/project/packaging/) |
 | **pandas** | `3.0.3` | version | (transitive in `.venv`) | [pandas (PyPI)](https://pypi.org/project/pandas/) |
 | **planner** | `9def3abea1720bce19823a4b5ae3ff2015ae77f1` | commit SHA | (transitive in `.venv`) | [planner (PyPI)](https://pypi.org/project/planner/) |
@@ -168,11 +171,11 @@ annotated with their `pyproject.toml` line.
 | **pluggy** | `1.6.0` | version | (transitive in `.venv`) | [pluggy (PyPI)](https://pypi.org/project/pluggy/) |
 | **pre_commit** | `4.6.0` | version | (transitive in `.venv`) | [pre_commit (PyPI)](https://pypi.org/project/pre-commit/) |
 | **propcache** | `0.5.2` | version | (transitive in `.venv`) | [propcache (PyPI)](https://pypi.org/project/propcache/) |
-| **proto-plus** | `1.28.1` | version | (transitive in `.venv`) | [proto-plus (PyPI)](https://pypi.org/project/proto-plus/) |
+| **proto-plus** | `1.28.0` | version | (transitive in `.venv`) | [proto-plus (PyPI)](https://pypi.org/project/proto-plus/) |
 | **protobuf** | `7.35.1` | version | (transitive in `.venv`) | [protobuf (PyPI)](https://pypi.org/project/protobuf/) |
 | **psutil** | `7.2.2` | version | (transitive in `.venv`) | [psutil (PyPI)](https://pypi.org/project/psutil/) |
 | **psycopg2-binary** | `2.9.12` | version | (transitive in `.venv`) | [psycopg2-binary (PyPI)](https://pypi.org/project/psycopg2-binary/) |
-| **pyasn1** | `0.6.4` | version | (transitive in `.venv`) | [pyasn1 (PyPI)](https://pypi.org/project/pyasn1/) |
+| **pyasn1** | `0.6.3` | version | (transitive in `.venv`) | [pyasn1 (PyPI)](https://pypi.org/project/pyasn1/) |
 | **pyasn1_modules** | `0.4.2` | version | (transitive in `.venv`) | [pyasn1_modules (PyPI)](https://pypi.org/project/pyasn1-modules/) |
 | **pycparser** | `3.0` | version | (transitive in `.venv`) | [pycparser (PyPI)](https://pypi.org/project/pycparser/) |
 | **pydantic** | `2.13.4` | version | `pyproject.toml` line 17 (direct) | [pydantic (PyPI)](https://pypi.org/project/pydantic/) |
@@ -184,11 +187,11 @@ annotated with their `pyproject.toml` line.
 | **pytest** | `9.1.1` | version | (transitive in `.venv`) | [pytest (PyPI)](https://pypi.org/project/pytest/) |
 | **pytest-xdist** | `3.8.0` | version | (transitive in `.venv`) | [pytest-xdist (PyPI)](https://pypi.org/project/pytest-xdist/) |
 | **python-dateutil** | `2.9.0.post0` | version | (transitive in `.venv`) | [python-dateutil (PyPI)](https://pypi.org/project/python-dateutil/) |
-| **python-discovery** | `1.4.4` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
+| **python-discovery** | `1.4.2` | version | (transitive in `.venv`) | [python-discovery (PyPI)](https://pypi.org/project/python-discovery/) |
 | **python-dotenv** | `1.2.2` | version | (transitive in `.venv`) | [python-dotenv (PyPI)](https://pypi.org/project/python-dotenv/) |
 | **python-multipart** | `0.0.32` | version | (transitive in `.venv`) | [python-multipart (PyPI)](https://pypi.org/project/python-multipart/) |
 | **PyYAML** | `6.0.3` | version | `pyproject.toml` line 7 (direct) | [PyYAML (PyPI)](https://pypi.org/project/pyyaml/) |
-| **regex** | `2026.7.10` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
+| **regex** | `2026.6.28` | version | (transitive in `.venv`) | [regex (PyPI)](https://pypi.org/project/regex/) |
 | **requests** | `2.34.2` | version | `pyproject.toml` line 9 (direct) | [requests (PyPI)](https://pypi.org/project/requests/) |
 | **requests-oauthlib** | `2.0.0` | version | (transitive in `.venv`) | [requests-oauthlib (PyPI)](https://pypi.org/project/requests-oauthlib/) |
 | **requests-toolbelt** | `1.0.0` | version | (transitive in `.venv`) | [requests-toolbelt (PyPI)](https://pypi.org/project/requests-toolbelt/) |
@@ -202,18 +205,18 @@ annotated with their `pyproject.toml` line.
 | **starlette** | `1.3.1` | version | (transitive in `.venv`) | [starlette (PyPI)](https://pypi.org/project/starlette/) |
 | **tabulate** | `0.10.0` | version | (transitive in `.venv`) | [tabulate (PyPI)](https://pypi.org/project/tabulate/) |
 | **tokenizers** | `0.22.2` | version | (transitive in `.venv`) | [tokenizers (PyPI)](https://pypi.org/project/tokenizers/) |
-| **tqdm** | `4.68.4` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
-| **transformers** | `5.13.1` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
-| **typer** | `0.26.8` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
+| **tqdm** | `4.68.3` | version | (transitive in `.venv`) | [tqdm (PyPI)](https://pypi.org/project/tqdm/) |
+| **transformers** | `5.12.1` | version | `pyproject.toml` line 16 (direct) | [transformers (PyPI)](https://pypi.org/project/transformers/) |
+| **typer** | `0.25.1` | version | (transitive in `.venv`) | [typer (PyPI)](https://pypi.org/project/typer/) |
 | **typing-inspection** | `0.4.2` | version | (transitive in `.venv`) | [typing-inspection (PyPI)](https://pypi.org/project/typing-inspection/) |
-| **typing_extensions** | `4.16.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
+| **typing_extensions** | `4.15.0` | version | (transitive in `.venv`) | [typing_extensions (PyPI)](https://pypi.org/project/typing-extensions/) |
 | **urllib3** | `2.7.0` | version | (transitive in `.venv`) | [urllib3 (PyPI)](https://pypi.org/project/urllib3/) |
 | **uvicorn** | `0.48.0` | version | (transitive in `.venv`) | [uvicorn (PyPI)](https://pypi.org/project/uvicorn/) |
 | **uvloop** | `0.22.1` | version | (transitive in `.venv`) | [uvloop (PyPI)](https://pypi.org/project/uvloop/) |
-| **virtualenv** | `21.6.1` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
+| **virtualenv** | `21.5.1` | version | (transitive in `.venv`) | [virtualenv (PyPI)](https://pypi.org/project/virtualenv/) |
 | **watchfiles** | `1.2.0` | version | (transitive in `.venv`) | [watchfiles (PyPI)](https://pypi.org/project/watchfiles/) |
 | **websocket-client** | `1.9.0` | version | (transitive in `.venv`) | [websocket-client (PyPI)](https://pypi.org/project/websocket-client/) |
-| **websockets** | `16.1` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
+| **websockets** | `16.0` | version | (transitive in `.venv`) | [websockets (PyPI)](https://pypi.org/project/websockets/) |
 | **yarl** | `1.24.2` | version | (transitive in `.venv`) | [yarl (PyPI)](https://pypi.org/project/yarl/) |
 
 </details>

--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -1656,7 +1656,51 @@ class RenderPlans:
                 existing = provider_block.get(gw_class) or {}
                 provider_block[gw_class] = self.deep_merge(provider_config, existing)
 
+        self._apply_epp_node_pinning(values, epp)
+
         return values
+
+    def _apply_epp_node_pinning(self, values: dict, epp: dict) -> None:
+        """Pin EPP to the shared ``nodePinning`` node, if one is configured.
+
+        Lets a single `nodePinning` block place EPP alongside the FMA
+        workloads instead of every scenario repeating the affinity by hand.
+        The router chart has no ``nodeSelector`` for EPP -- only ``affinity``
+        and ``tolerations`` -- so node selection becomes a nodeAffinity term.
+        A scenario that sets either key explicitly wins.
+        """
+        pinning = values.get("nodePinning") or {}
+        if not pinning.get("enabled", False):
+            return
+
+        label = str(pinning.get("nodeLabel") or "")
+        label_value = str(pinning.get("nodeLabelValue") or "")
+        tolerations = pinning.get("tolerations") or []
+
+        if label and not epp.get("affinity"):
+            epp["affinity"] = {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": label,
+                                        "operator": "In",
+                                        "values": [label_value],
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+            self.logger.log_info(
+                f"Pinned EPP to nodes with {label}={label_value} (nodePinning)"
+            )
+
+        if tolerations and not epp.get("tolerations"):
+            epp["tolerations"] = deepcopy(tolerations)
 
     def _resolve_inference_pool_host(self, values: dict) -> dict:
         """Auto-populate destinationRule.host from model_id_label when not set.

--- a/llmdbenchmark/standup/steps/step_06_fma_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_fma_deploy.py
@@ -272,17 +272,50 @@ class FMADeployStep(Step):
         """The fma.launcherNodeSelection block, or {} (guards an explicit null)."""
         return (plan_config.get("fma", {}) or {}).get("launcherNodeSelection", {}) or {}
 
+    @staticmethod
+    def _node_pinning(plan_config: dict) -> dict:
+        """The shared `nodePinning` block, or {} when disabled/absent.
+
+        Lets one top-level block drive FMA + EPP placement so a scenario does
+        not repeat the node name, label, and tolerations. The per-scenario
+        `fma.launcherNodeSelection` / `fma.tolerations` keys still win.
+        """
+        pinning = plan_config.get("nodePinning") or {}
+        return pinning if pinning.get("enabled", False) else {}
+
     @classmethod
     def _launcher_node_selection_enabled(cls, plan_config: dict) -> bool:
-        """True when fma.launcherNodeSelection.enabled is set for this stack."""
-        return bool(cls._launcher_node_selection(plan_config).get("enabled", False))
+        """True when either the per-scenario block or `nodePinning` opts in."""
+        if cls._launcher_node_selection(plan_config).get("enabled", False):
+            return True
+        return bool(cls._node_pinning(plan_config))
 
     @classmethod
     def _node_label(cls, plan_config: dict) -> str:
         """The node label key to use. `or` guards an explicit null/empty value
         (the .get default only applies to a MISSING key, not an explicit null)."""
         return (
-            cls._launcher_node_selection(plan_config).get("nodeLabel") or "fma-hotstart"
+            cls._launcher_node_selection(plan_config).get("nodeLabel")
+            or cls._node_pinning(plan_config).get("nodeLabel")
+            or "fma-hotstart"
+        )
+
+    @classmethod
+    def _node_label_value(cls, plan_config: dict) -> str:
+        """The node label value to match. Defaults to "true" for back-compat."""
+        return str(
+            cls._launcher_node_selection(plan_config).get("nodeLabelValue")
+            or cls._node_pinning(plan_config).get("nodeLabelValue")
+            or "true"
+        )
+
+    @classmethod
+    def _target_node_name(cls, plan_config: dict) -> str:
+        """Explicit node to pin to, or "" to auto-select one."""
+        return str(
+            cls._launcher_node_selection(plan_config).get("nodeName")
+            or cls._node_pinning(plan_config).get("nodeName")
+            or ""
         )
 
     def _select_and_label_gpu_node(
@@ -316,6 +349,17 @@ class FMADeployStep(Step):
         ``None`` if no node qualified (fatal error appended, standup fails).
         """
         node_label = self._node_label(plan_config)
+        target_node = self._target_node_name(plan_config)
+
+        # Explicit node: skip candidate scanning entirely. Required for a
+        # tainted node -- the scan below ranks on free GPU/CPU and ignores
+        # taints, so it can pick a node whose pods never schedule. The node is
+        # assumed to be pre-labeled (by a cluster admin), so nothing is
+        # relabeled here; we only read its free GPU count for sizing.
+        if target_node:
+            return self._free_gpus_on_node(
+                context, cmd, target_node, node_label, plan_config, errors
+            )
 
         # In dry-run, `kube` short-circuits to empty stdout; force the read so
         # node selection can actually inspect the cluster. Skip entirely if the
@@ -415,11 +459,12 @@ class FMADeployStep(Step):
         # labeled. `<key>-` removes the key; `-l <key>=true` restricts to nodes
         # that have it (no-op when none). Not fatal -- labeling the chosen node
         # below is what matters.
+        node_label_value = self._node_label_value(plan_config)
         clear_result = cmd.kube(
             "label",
             "nodes",
             "-l",
-            f"{node_label}=true",
+            f"{node_label}={node_label_value}",
             f"{node_label}-",
             check=False,
         )
@@ -433,14 +478,14 @@ class FMADeployStep(Step):
             "label",
             "node",
             node_name,
-            f"{node_label}=true",
+            f"{node_label}={node_label_value}",
             "--overwrite",
             check=False,
         )
         if not label_result.success:
             errors.append(
-                f"Failed to label GPU node {node_name} with {node_label}=true: "
-                f"{label_result.stderr}"
+                f"Failed to label GPU node {node_name} with "
+                f"{node_label}={node_label_value}: {label_result.stderr}"
             )
             return None
 
@@ -448,9 +493,82 @@ class FMADeployStep(Step):
             f"    | Selected {'dedicated ' if is_dedicated else ''}GPU node "
             f"{node_name} ({gpu_count} free {product} GPU(s); {free_cpu_m}m free "
             f"CPU{'' if is_dedicated else ', shared with other GPU workloads'}) "
-            f"for FMA launchers; labeled {node_label}=true"
+            f"for FMA launchers; labeled {node_label}={node_label_value}"
         )
         return gpu_count
+
+    def _free_gpus_on_node(
+        self,
+        context: ExecutionContext,
+        cmd: CommandExecutor,
+        node_name: str,
+        node_label: str,
+        plan_config: dict,
+        errors: list[str],
+    ) -> int | None:
+        """Free GPU count on an explicitly requested node, or None on failure.
+
+        Validates the node exists, carries the expected selection label, and
+        has free GPUs. Does NOT label or otherwise mutate the node -- an
+        explicitly named node is assumed to be prepared (labeled, tainted) by
+        whoever owns the cluster.
+        """
+        expected_value = self._node_label_value(plan_config)
+        result = cmd.kube(
+            "get", "node", node_name, "-o", "json", check=False, force=True
+        )
+        if not result.success or not (result.stdout or "").strip():
+            errors.append(
+                f"fma.launcherNodeSelection.nodeName='{node_name}' was requested "
+                f"but reading that node failed: "
+                f"{result.stderr or 'no output from get node'}"
+            )
+            return None
+        try:
+            node = json.loads(result.stdout)
+        except (ValueError, json.JSONDecodeError) as exc:
+            errors.append(f"Failed to parse `get node {node_name} -o json`: {exc}")
+            return None
+
+        labels = (node.get("metadata") or {}).get("labels") or {}
+        actual = labels.get(node_label)
+        if actual != expected_value:
+            errors.append(
+                f"Node '{node_name}' does not carry the expected selection label "
+                f"{node_label}={expected_value} (found "
+                f"{node_label}={actual if actual is not None else '<absent>'}). "
+                "The rendered launchers/requester select on that label, so they "
+                "would never schedule. Ask whoever owns the node to apply it, or "
+                "align fma.launcherNodeSelection.nodeLabel/nodeLabelValue."
+            )
+            return None
+
+        committed = self._committed_resources_by_node(cmd, errors)
+        if committed is None:
+            return None
+        allocatable = (node.get("status") or {}).get("allocatable") or {}
+        alloc_gpu = int(allocatable.get("nvidia.com/gpu") or 0)
+        free_gpu = alloc_gpu - committed.get(node_name, {}).get("gpu", 0)
+        if free_gpu <= 0:
+            errors.append(
+                f"Node '{node_name}' has no free GPUs ({alloc_gpu} allocatable, "
+                f"{committed.get(node_name, {}).get('gpu', 0)} already requested)."
+            )
+            return None
+
+        taints = (node.get("spec") or {}).get("taints") or []
+        if taints and not (plan_config.get("fma", {}) or {}).get("tolerations"):
+            context.logger.log_warning(
+                f"    | Node '{node_name}' carries {len(taints)} taint(s) but "
+                "fma.tolerations is empty -- launchers/requester will stay "
+                "Pending. Set fma.tolerations to match the node's taints."
+            )
+
+        context.logger.log_info(
+            f"    | Using requested GPU node {node_name} ({free_gpu} free "
+            f"GPU(s); label {node_label}={expected_value} already present)"
+        )
+        return free_gpu
 
     @staticmethod
     def _cpu_to_millicores(value) -> int:

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -261,30 +261,38 @@ class UninstallHelmStep(Step):
         def _lns(cfg):
             return (cfg.get("fma", {}) or {}).get("launcherNodeSelection", {}) or {}
 
+        # Only clean up labels standup itself applied. A stack that pins via
+        # `nodeName` targets a node prepared by whoever owns the cluster, so
+        # stripping its label here would break every later run against it.
         node_labels = {
-            (_lns(cfg).get("nodeLabel") or "fma-hotstart")
+            (
+                _lns(cfg).get("nodeLabel") or "fma-hotstart",
+                str(_lns(cfg).get("nodeLabelValue") or "true"),
+            )
             for cfg in map(self._load_stack_config, context.rendered_stacks or [])
-            if _lns(cfg).get("enabled", False)
+            if _lns(cfg).get("enabled", False) and not (_lns(cfg).get("nodeName") or "")
         }
-        for node_label in node_labels:
-            # `<key>-` removes the label; `-l <key>=true` restricts to nodes
+        for node_label, node_label_value in node_labels:
+            # `<key>-` removes the label; `-l <key>=<value>` restricts to nodes
             # that carry it, so this is a no-op (not an error) when none do.
             result = cmd.kube(
                 "label",
                 "nodes",
                 "-l",
-                f"{node_label}=true",
+                f"{node_label}={node_label_value}",
                 f"{node_label}-",
                 check=False,
             )
             if result.success:
                 context.logger.log_info(
-                    f"  Removed FMA launcher node label {node_label}=true",
+                    f"  Removed FMA launcher node label "
+                    f"{node_label}={node_label_value}",
                     emoji="🗑️",
                 )
             else:
                 context.logger.log_warning(
-                    f"  Could not remove node label {node_label}=true: {result.stderr}"
+                    f"  Could not remove node label "
+                    f"{node_label}={node_label_value}: {result.stderr}"
                 )
 
     def _collect_model_labels(self, context: ExecutionContext) -> list[str]:


### PR DESCRIPTION
Confines an FMA+KEDA benchmark to a single node — including a tainted, admin-reserved one — so load generation and other tenants can't perturb the measurements.

Node name, label, and tolerations are set in one place: the new top-level nodePinning block in `config/templates/values/defaults.yaml`. Filling it in places the FMA launchers, the FMA requester, and EPP on that node; no per-scenario edits. The block is inert while enabled: false.

```
nodePinning:
  enabled: true
  nodeName: <node>
  nodeLabel: <key>
  nodeLabelValue: <value>
  tolerations:
    - key: <taint-key>
      operator: Equal
      value: <taint-value>
      effect: NoSchedule
```

FMA launchers and requester

- nodeName pins to a named node instead of auto-selecting. Required for a tainted node: the auto-scan ranks on free GPU/CPU and does not consider taints, so it can pick a node whose pods never schedule. A named node is validated (exists, carries the selection label, has free GPUs) but never labeled or otherwise mutated — it is assumed prepared by whoever owns the cluster. A node with taints but no fma.tolerations warns rather than failing silently.
- nodeLabelValue makes the selection label value configurable; previously hardcoded to 'true'.
- fma.tolerations is applied to both the launcher podTemplate (launcher pods are created by the FMA controller from it) and the requester Deployment.
- Teardown no longer strips the selection label when nodeName is set, which would otherwise break subsequent runs against an admin-prepared node.

EPP

`_apply_epp_node_pinning()` in `render_plans.py` injects EPP's placement from the same block. The router chart exposes affinity and tolerations for EPP but no nodeSelector, so node selection becomes a nodeAffinity term there while the FMA requester uses nodeSelector — different syntax, same effect. Adding router.epp.nodeSelector would be silently ignored, which is why this is done in the renderer rather than left to scenario authors.