### PR TITLE
Remove stray schedule trigger from reusable benchmark workflow

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -247,9 +247,6 @@ on:
 #    branches:
 #      - main
 
-  schedule:
-    - cron: '0 0 * * *'  # Daily at midnight UTC
-
 jobs:
   ensure-nightly-build-image:
     name: Ensure Nightly Build Image


### PR DESCRIPTION
Closes #1889 
## Problem

`reusable-ci-nightly-benchmark.yaml` is a `workflow_call` only engine, invoked by the eight `ci-nightly-benchmark-*` callers. It should never run on its own.

But `schedule:` is indented two spaces, the same level as `workflow_call:` which makes it a **sibling trigger**, not part of the call definition:

```yaml
on:
  workflow_call:
    inputs:
      ...
    outputs:
      ...
#  push:
#    branches:
#      - main

  schedule:                                     # <-- 2 spaces = second trigger
    - cron: '0 0 * * *'  # Daily at midnight UTC
```

So the engine also fires by itself every day at 00:00 UTC, with no caller.

## Note for reviewers
If a generic nightly run *is* wanted, the right shape is a new thin caller alongside the existing eight, it would get real inputs and a name that the cluster-detection grep can match. Happy to follow up with that if so.