### PR TITLE
Splice the connector into the guide path

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -881,19 +881,19 @@ jobs:
           #
           if [[ ! -z $LLMDBENCH_CICD_CONNECTOR ]]; then
             echo "### Setting \"CONNECTOR\" to \"$LLMDBENCH_CICD_CONNECTOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
-            lkcmd="yq -i \".scenario[0].kustomize.guideVariableOverrides.CONNECTOR = \\\"$LLMDBENCH_CICD_CONNECTOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+            lkcmd="yq -i '.scenario[0].kustomize.guideVariableOverrides.CONNECTOR = strenv(LLMDBENCH_CICD_CONNECTOR)' \"$LLMDBENCH_CICD_SCENARIO_FILE\""
             echo -n "; $lkcmd" >> "$LLMDBENCH_CICD_CMD_LOG"
-            eval $lkcmd
-            cat $LLMDBENCH_CICD_SCENARIO_FILE | yq '.scenario[0].kustomize.guideVariableOverrides.CONNECTOR'
+            yq -i '.scenario[0].kustomize.guideVariableOverrides.CONNECTOR = strenv(LLMDBENCH_CICD_CONNECTOR)' "$LLMDBENCH_CICD_SCENARIO_FILE"
+            cat "$LLMDBENCH_CICD_SCENARIO_FILE" | yq '.scenario[0].kustomize.guideVariableOverrides.CONNECTOR'
             # First-class connector: the deploy step splices this between backend and
             # infra provider (amd/vllm -> amd/vllm/moriio) so the connector overlay
             # (and its image override) is actually applied. Without it acceleratorBackend
             # alone resolves to the vanilla base overlay.
             echo "### Setting kustomize.connector to \"$LLMDBENCH_CICD_CONNECTOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
-            lkcmd="yq -i \".scenario[0].kustomize.connector = \\\"$LLMDBENCH_CICD_CONNECTOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+            lkcmd="yq -i '.scenario[0].kustomize.connector = strenv(LLMDBENCH_CICD_CONNECTOR)' \"$LLMDBENCH_CICD_SCENARIO_FILE\""
             echo -n "; $lkcmd" >> "$LLMDBENCH_CICD_CMD_LOG"
-            eval $lkcmd
-            cat $LLMDBENCH_CICD_SCENARIO_FILE | yq '.scenario[0].kustomize.connector'
+            yq -i '.scenario[0].kustomize.connector = strenv(LLMDBENCH_CICD_CONNECTOR)' "$LLMDBENCH_CICD_SCENARIO_FILE"
+            cat "$LLMDBENCH_CICD_SCENARIO_FILE" | yq '.scenario[0].kustomize.connector'
           fi
           if [[ ! -z $LLMDBENCH_CICD_OFFLOADING_TARGET ]]; then
             echo "### Setting \"VARIANT\" to \"$LLMDBENCH_CICD_OFFLOADING_TARGET\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""

--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -885,6 +885,15 @@ jobs:
             echo -n "; $lkcmd" >> "$LLMDBENCH_CICD_CMD_LOG"
             eval $lkcmd
             cat $LLMDBENCH_CICD_SCENARIO_FILE | yq '.scenario[0].kustomize.guideVariableOverrides.CONNECTOR'
+            # First-class connector: the deploy step splices this between backend and
+            # infra provider (amd/vllm -> amd/vllm/moriio) so the connector overlay
+            # (and its image override) is actually applied. Without it acceleratorBackend
+            # alone resolves to the vanilla base overlay.
+            echo "### Setting kustomize.connector to \"$LLMDBENCH_CICD_CONNECTOR\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
+            lkcmd="yq -i \".scenario[0].kustomize.connector = \\\"$LLMDBENCH_CICD_CONNECTOR\\\"\" $LLMDBENCH_CICD_SCENARIO_FILE"
+            echo -n "; $lkcmd" >> "$LLMDBENCH_CICD_CMD_LOG"
+            eval $lkcmd
+            cat $LLMDBENCH_CICD_SCENARIO_FILE | yq '.scenario[0].kustomize.connector'
           fi
           if [[ ! -z $LLMDBENCH_CICD_OFFLOADING_TARGET ]]; then
             echo "### Setting \"VARIANT\" to \"$LLMDBENCH_CICD_OFFLOADING_TARGET\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""

--- a/llmdbenchmark/kustomize/variable_resolver.py
+++ b/llmdbenchmark/kustomize/variable_resolver.py
@@ -9,9 +9,35 @@ from pathlib import Path
 _VAR_RE = re.compile(r"\$\{(\w+)\}")
 _RELATIVE_GUIDE_PATH = re.compile(r"(?<!\S)(guides/\S+)")
 
+# The overlay selector the guide README ships by default. Every consumer that
+# needs a fallback backend must reference this rather than re-typing the
+# literal, so the default lives in exactly one place.
+DEFAULT_ACCEL_BACKEND = "gpu/vllm"
+
 
 class GuideVariableResolver:
     """Replace ``${VAR}`` placeholders and resolve relative ``guides/...`` paths."""
+
+    @staticmethod
+    def effective_backend(kust_config: dict) -> str:
+        """Return the modelserver overlay selector for a ``kustomize`` config.
+
+        This is the single source of truth for how the connector is folded
+        into the backend selector; both the standup deploy step and the
+        teardown step call it so they can never drift.
+
+        The guide README's modelserver apply is
+        ``modelserver/gpu/vllm/${INFRA_PROVIDER}``, which :meth:`resolve`
+        rewrites to ``modelserver/{acceleratorBackend}/${INFRA_PROVIDER}``.
+        ``acceleratorBackend`` alone is ``{accelerator}/{backend}`` (e.g.
+        ``amd/vllm``). To route the deploy at a connector-specific overlay such
+        as ``amd/vllm/moriio/<infra>`` (and thus its image override) instead of
+        the vanilla base, ``kustomize.connector`` is spliced between backend and
+        infra provider here.
+        """
+        backend = kust_config.get("acceleratorBackend", DEFAULT_ACCEL_BACKEND)
+        connector = str(kust_config.get("connector", "") or "").strip().strip("/")
+        return f"{backend}/{connector}" if connector else backend
 
     def __init__(
         self,
@@ -19,7 +45,7 @@ class GuideVariableResolver:
         namespace: str,
         gaie_version: str,
         repo_path: str,
-        accelerator_backend: str = "gpu/vllm",
+        accelerator_backend: str = DEFAULT_ACCEL_BACKEND,
         variable_overrides: dict[str, str] | None = None,
         readme_variables: dict[str, str] | None = None,
         router_chart_version: str = "v0",
@@ -58,6 +84,11 @@ class GuideVariableResolver:
         # REPO_ROOT below.
         if variable_overrides:
             self._variables.update(variable_overrides)
+
+    @property
+    def accelerator_backend(self) -> str:
+        """The effective overlay selector this resolver rewrites paths to."""
+        return self._accelerator_backend
 
     def resolve(self, command: str) -> str:
         """Return *command* with all placeholders resolved and paths absolutised."""
@@ -108,8 +139,9 @@ class GuideVariableResolver:
 
     def _apply_accelerator_backend(self, text: str) -> str:
         """Swap the default ``gpu/vllm`` backend for the configured one."""
-        if self._accelerator_backend == "gpu/vllm":
+        if self._accelerator_backend == DEFAULT_ACCEL_BACKEND:
             return text
         return text.replace(
-            "modelserver/gpu/vllm", f"modelserver/{self._accelerator_backend}"
+            f"modelserver/{DEFAULT_ACCEL_BACKEND}",
+            f"modelserver/{self._accelerator_backend}",
         )

--- a/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
+++ b/llmdbenchmark/standup/steps/step_06_kustomize_deploy.py
@@ -17,7 +17,10 @@ from llmdbenchmark.kustomize.readme_parser import (
     DeployMode,
     parse_guide_readme,
 )
-from llmdbenchmark.kustomize.variable_resolver import GuideVariableResolver
+from llmdbenchmark.kustomize.variable_resolver import (
+    DEFAULT_ACCEL_BACKEND,
+    GuideVariableResolver,
+)
 
 
 class KustomizeDeployStep(Step):
@@ -71,7 +74,7 @@ class KustomizeDeployStep(Step):
         # to v0 (the published llm-d-router-* chart version) when the
         # scenario doesn't pin one.
         router_chart_version = kust_config.get("routerChartVersion", "") or "v0"
-        accel_backend = kust_config.get("acceleratorBackend", "gpu/vllm")
+        accel_backend = GuideVariableResolver.effective_backend(kust_config)
         monitoring = kust_config.get("monitoring", False)
         overlay_path = kust_config.get("overlayPath", "")
         patches = kust_config.get("patches", [])
@@ -741,7 +744,9 @@ class KustomizeDeployStep(Step):
             "harness_namespace": harness_ns,
             "deploy_methods": ",".join(context.deployed_methods),
             "guide_name": guide_name,
-            "accelerator_backend": kust_cfg.get("acceleratorBackend", "gpu/vllm"),
+            "accelerator_backend": kust_cfg.get(
+                "acceleratorBackend", DEFAULT_ACCEL_BACKEND
+            ),
             "model_name": model_cfg.get("name", ""),
             "gaie_version": kust_cfg.get("gaieVersion", ""),
         }

--- a/llmdbenchmark/teardown/steps/step_05_kustomize_teardown.py
+++ b/llmdbenchmark/teardown/steps/step_05_kustomize_teardown.py
@@ -55,7 +55,10 @@ class KustomizeTeardownStep(Step):
         # teardown commands reference the same chart, so we need to
         # resolve the same variable as during deploy.
         router_chart_version = kust_config.get("routerChartVersion", "") or "v0"
-        accel_backend = kust_config.get("acceleratorBackend", "gpu/vllm")
+        # Fold the connector into the overlay selector so teardown resolves the
+        # same modelserver path the deploy step used. Shared derivation — deploy
+        # and teardown cannot drift.
+        accel_backend = GuideVariableResolver.effective_backend(kust_config)
         monitoring = kust_config.get("monitoring", False)
 
         if not guide_name or not repo_path:


### PR DESCRIPTION
The guide README's modelserver apply is ``modelserver/gpu/vllm/${INFRA_PROVIDER}``, which the resolver rewrites to ``modelserver/{acceleratorBackend}/${INFRA_PROVIDER}``. ``acceleratorBackend`` alone is ``{accelerator}/{backend}`` (e.g. ``amd/vllm``). To support connector-specific overlay such as ``amd/vllm/moriio/<infra>``the connector needs to be spliced between backend and infra provider.