### PR TITLE
feat(run): add --no-pvc and --no-cleanup for clusters without PVC provisioning

### DIFF
--- a/config/templates/jinja/20_harness_pod.yaml.j2
+++ b/config/templates/jinja/20_harness_pod.yaml.j2
@@ -186,8 +186,12 @@ spec:
       mountPath: /workspace/harnesses
   volumes:
   - name: results
+{% if no_pvc | default(false) %}
+    emptyDir: {}
+{% else %}
     persistentVolumeClaim:
       claimName: {{ storage.workloadPvc.name }}
+{% endif %}
 {% for profile_harness in profile_mounts %}
   - name: {{ profile_harness }}-profiles
     configMap:

--- a/docs/run.md
+++ b/docs/run.md
@@ -134,6 +134,7 @@ The following table displays a comprehensive list of environment variables (and 
 | LLMDBENCH_HARNESS_CPU_MEM                      | How many CPUs should be requested for `pod` `llmdbench-${LLMDBENCH_HARNESS_NAME}-launcher` | Default=`32Gi` |
 | LLMDBENCH_HARNESS_PVC_NAME                     | The `pvc` where experimental results will be stored | Default=`workload-pvc`. Can be overriden with CLI parameter `-k/--pvc`      |
 | LLMDBENCH_HARNESS_PVC_SIZE                     | The size of the `pvc` where experimental results will be stored | Default=`20Gi` |
+| LLMDBENCH_NO_PVC                               | Run without the workload PVC/data-access pod (`--no-pvc`); harness pods use an emptyDir and results are copied from the pods into the workspace | Default=(empty). Can be overriden with CLI parameter `--no-pvc` |
 | LLMDBENCH_HARNESS_SKIP_RUN                     | Skip the execution of the experiment, and only collect data already on the `pvc` | Default=(empty) |
 | LLMDBENCH_HARNESS_LOAD_PARALLELISM             | Controls the number harness pods which will be created to generate load (all pods execute the same workload profile) | Default=`1`, can be overriden with ` -j/--parallelism` |
 | LLMDBENCH_HARNESS_ENVVARS_TO_YAML              | List all environment variables to be added to all harness pods | Default=`LLMDBENCH_RUN_EXPERIMENT`, can be overriden with `-g/--envvarspod` |

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1397,7 +1397,8 @@ def _execute_run(args, logger, render_plan_errors):
                     logger.log_info(
                         f"      [{i}/{parallelism}] {local_path.name} ({file_count} files)"
                     )
-    logger.log_info(f"  Local results: {results_dir}")
+    logger.log_info(f"  Local results:  {results_dir}")
+    logger.log_info(f"  Local analysis: {context.run_analysis_dir()}")
     # The PVC/data-access-pod hint is Kubernetes-only; nok8s writes results
     # straight to the local dir shown above.
     # --no-pvc: there is no PVC or data-access pod to point at.

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1164,6 +1164,7 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         ),
         pvc_bind_timeout=int(getattr(args, "pvc_bind_timeout", 240) or 240),
         no_pvc=getattr(args, "no_pvc", False),
+        no_cleanup=getattr(args, "no_cleanup", False),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
@@ -1399,6 +1400,11 @@ def _execute_run(args, logger, render_plan_errors):
                     )
     logger.log_info(f"  Local results:  {results_dir}")
     logger.log_info(f"  Local analysis: {context.run_analysis_dir()}")
+    if context.no_cleanup and not context.container_only:
+        logger.log_info(
+            "  Pods:           kept (--no-cleanup); inspect with kubectl, "
+            "the next run cleans them up"
+        )
     # The PVC/data-access-pod hint is Kubernetes-only; nok8s writes results
     # straight to the local dir shown above.
     # --no-pvc: there is no PVC or data-access pod to point at.
@@ -1899,6 +1905,7 @@ def _log_env_overrides(logger, args):
         ),
         "LLMDBENCH_PVC_BIND_TIMEOUT": ("pvc_bind_timeout", "--pvc-bind-timeout"),
         "LLMDBENCH_NO_PVC": ("no_pvc", "--no-pvc"),
+        "LLMDBENCH_NO_CLEANUP": ("no_cleanup", "--no-cleanup"),
         "LLMDBENCH_FMA_TEARDOWN_TIMEOUT": (
             "fma_teardown_timeout",
             "--fma-teardown-timeout",

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1167,6 +1167,17 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
+    # Announce PVC-less mode up front so nobody hunts for a missing
+    # workload PVC / data-access pod that was deliberately never created.
+    if context.no_pvc:
+        logger.log_info(
+            "Running in PVC-less mode (--no-pvc): no workload PVC or "
+            "data-access pod will be created. Harness pods write results "
+            "to an ephemeral emptyDir, and results are copied directly "
+            "from the pods into the workspace before pod deletion.",
+            emoji="📦",
+        )
+
     # --list-endpoints: detect endpoints (step 03 only), print a copy-paste
     # table with per-stack routing URLs, and exit without deploying any
     # harness pods. Useful for discovering what's live in a multi-stack
@@ -1336,6 +1347,8 @@ def _execute_run(args, logger, render_plan_errors):
     run_config_file = getattr(args, "run_config", None)
     is_run_only = bool(endpoint_url or run_config_file)
     mode = "run-only" if is_run_only else "full"
+    if context.no_pvc:
+        mode += " (pvc-less)"
     if context.generate_config_only:
         mode = "generate-config"
     harness = context.harness_name or "inference-perf"

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1387,7 +1387,8 @@ def _execute_run(args, logger, render_plan_errors):
     logger.log_info(f"  Local results: {results_dir}")
     # The PVC/data-access-pod hint is Kubernetes-only; nok8s writes results
     # straight to the local dir shown above.
-    if not context.container_only:
+    # --no-pvc: there is no PVC or data-access pod to point at.
+    if not context.container_only and not context.no_pvc:
         kube_bin = "oc" if context.is_openshift else "kubectl"
         logger.log_info(
             f"  PVC results:   {kube_bin} exec -n {namespace} "

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -1163,6 +1163,7 @@ def _do_run(args, logger, render_plan_errors, experiment_file_override=None):
             getattr(args, "data_access_timeout", 120) or 120
         ),
         pvc_bind_timeout=int(getattr(args, "pvc_bind_timeout", 240) or 240),
+        no_pvc=getattr(args, "no_pvc", False),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
     )
 
@@ -1882,6 +1883,7 @@ def _log_env_overrides(logger, args):
             "--modelservice-deploy-timeout",
         ),
         "LLMDBENCH_PVC_BIND_TIMEOUT": ("pvc_bind_timeout", "--pvc-bind-timeout"),
+        "LLMDBENCH_NO_PVC": ("no_pvc", "--no-pvc"),
         "LLMDBENCH_FMA_TEARDOWN_TIMEOUT": (
             "fma_teardown_timeout",
             "--fma-teardown-timeout",

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -190,6 +190,12 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
     # by a post-run sentinel + sleep -- before the pod is deleted.
     no_pvc: bool = False
 
+    # --no-cleanup: leave harness pods and their ConfigMaps in place after
+    # the run (skip step 06's phase-5 pod deletion and step 11), so users
+    # can inspect logs, exec in, or re-copy results. The next run's step 01
+    # removes leftovers by label.
+    no_cleanup: bool = False
+
     # Teardown timeouts
     fma_teardown_timeout: int = 120
 

--- a/llmdbenchmark/executor/context.py
+++ b/llmdbenchmark/executor/context.py
@@ -184,6 +184,12 @@ class ExecutionContext:  # pylint: disable=too-many-instance-attributes
 
     pvc_bind_timeout: int = 240
 
+    # --no-pvc: run the harness without the workload PVC / data-access pod
+    # (for clusters where users cannot provision PVCs). Results live in each
+    # harness pod's emptyDir and are copied from the pod itself -- kept alive
+    # by a post-run sentinel + sleep -- before the pod is deleted.
+    no_pvc: bool = False
+
     # Teardown timeouts
     fma_teardown_timeout: int = 120
 

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -128,6 +128,7 @@ Executes benchmark experiments against deployed infrastructure.
 | `--generate-config` | -- | Generate run config and exit |
 | `--data-access-timeout` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready. |
 | `--no-pvc` | `LLMDBENCH_NO_PVC` | Run without the workload PVC/data-access pod; results are copied straight from the harness pods into the workspace (for clusters where users cannot provision PVCs) |
+| `--no-cleanup` | `LLMDBENCH_NO_CLEANUP` | Leave harness pods and ConfigMaps in place after the run for inspection (logs, exec, re-copy); the next run removes leftovers. Pairs well with `--no-pvc`, whose kept pods stay asleep with results still in their emptyDir |
 
 ### teardown (`teardown.py`)
 

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -127,6 +127,7 @@ Executes benchmark experiments against deployed infrastructure.
 | `-c` / `--config` | -- | Run config YAML file (run-only mode) |
 | `--generate-config` | -- | Generate run config and exit |
 | `--data-access-timeout` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready. |
+| `--no-pvc` | `LLMDBENCH_NO_PVC` | Run without the workload PVC/data-access pod; results are copied straight from the harness pods into the workspace (for clusters where users cannot provision PVCs) |
 
 ### teardown (`teardown.py`)
 

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -244,6 +244,17 @@ def add_subcommands(
         "to both full run and run-only (existing-stack) modes "
         "(env: LLMDBENCH_NO_PVC). Default: off.",
     )
+    run_parser.add_argument(
+        "--no-cleanup",
+        action="store_true",
+        default=env_bool("LLMDBENCH_NO_CLEANUP"),
+        help="Leave harness pods and their ConfigMaps in place after the "
+        "run instead of deleting them, so you can inspect logs, exec into "
+        "the pods, or re-copy results. Especially useful with --no-pvc, "
+        "where kept pods stay asleep with results still in their emptyDir. "
+        "Leftovers are removed automatically by the next run's cleanup "
+        "step (env: LLMDBENCH_NO_CLEANUP). Default: off.",
+    )
 
     # Monitoring
     run_parser.add_argument(

--- a/llmdbenchmark/interface/run.py
+++ b/llmdbenchmark/interface/run.py
@@ -232,6 +232,18 @@ def add_subcommands(
         "240. A PVC that never binds fails fast rather than masquerading "
         "as a downstream pod/job timeout.",
     )
+    run_parser.add_argument(
+        "--no-pvc",
+        action="store_true",
+        default=env_bool("LLMDBENCH_NO_PVC"),
+        help="Run without the workload PVC and data-access pod, for "
+        "clusters where users cannot provision PVCs. Harness pods write "
+        "results to an ephemeral emptyDir volume, stay alive after the "
+        "benchmark finishes, and results are copied directly from each "
+        "pod into the local workspace before the pod is deleted. Applies "
+        "to both full run and run-only (existing-stack) modes "
+        "(env: LLMDBENCH_NO_PVC). Default: off.",
+    )
 
     # Monitoring
     run_parser.add_argument(

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -129,6 +129,7 @@ llmdbenchmark --spec guides/inference-scheduling run -p <NS> -z
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` | Kubeconfig path |
 | `--data-access-timeout N` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready (default: 120). |
 | `--no-pvc` | `LLMDBENCH_NO_PVC` | Run without the workload PVC/data-access pod; results are copied straight from the harness pods into the workspace (for clusters where users cannot provision PVCs) |
+| `--no-cleanup` | `LLMDBENCH_NO_CLEANUP` | Leave harness pods and ConfigMaps in place after the run for inspection (logs, exec, re-copy); the next run removes leftovers. Pairs well with `--no-pvc`, whose kept pods stay asleep with results still in their emptyDir |
 
 ## Step Details
 

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -128,6 +128,7 @@ llmdbenchmark --spec guides/inference-scheduling run -p <NS> -z
 | `-s STEPS` | | Step filter (e.g., `0,1,6` or `2-8`) |
 | `-k FILE` | `LLMDBENCH_KUBECONFIG` | Kubeconfig path |
 | `--data-access-timeout N` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready (default: 120). |
+| `--no-pvc` | `LLMDBENCH_NO_PVC` | Run without the workload PVC/data-access pod; results are copied straight from the harness pods into the workspace (for clusters where users cannot provision PVCs) |
 
 ## Step Details
 
@@ -267,6 +268,25 @@ logs/
   pod_status.txt          -- Pod status snapshot
 epp_metrics/              -- EPP analysis output (if available)
 ```
+
+### Running without a PVC (`--no-pvc`)
+
+On clusters where users cannot provision PersistentVolumeClaims, pass
+`--no-pvc` (env: `LLMDBENCH_NO_PVC=1`). It works in both full `run` and
+run-only (`--endpoint-url` / `--config`) modes:
+
+- The workload PVC and data-access pod are never created (step 02 is
+  skipped).
+- Harness pods mount an `emptyDir` at `/requests` instead of the PVC.
+- Each pod stays alive after the benchmark (it writes its exit code to
+  `/requests/.llmdbench_harness_done` and sleeps) so results can be copied
+  out of the `emptyDir` with `kubectl cp` (or the `--fast-collect` tar
+  stream) into `workspace/results` before the pod is deleted.
+
+Trade-offs: results are ephemeral until collected -- if collection fails,
+they are lost when the pod is deleted (there is no PVC to recover from);
+on-PVC zstd pre-compression does not apply; `emptyDir` usage counts
+against the node's ephemeral storage instead of a provisioned volume.
 
 ### Upload results to cloud storage
 

--- a/llmdbenchmark/run/steps/step_02_harness_namespace.py
+++ b/llmdbenchmark/run/steps/step_02_harness_namespace.py
@@ -34,7 +34,13 @@ class HarnessNamespaceStep(_HarnessNamespaceStep):
 
         Also skipped for nok8s: the harness runs as a local container writing
         to a host bind-mount, so no k8s namespace/PVC/data-access pod exists.
+
+        Also skipped for --no-pvc: the whole point of that mode is that the
+        user cannot provision PVCs -- harness pods use an emptyDir and step
+        06's collection copies results straight from the pods.
         """
+        if context.no_pvc:
+            return True
         if "nok8s" in (context.deployed_methods or []):
             return True
         return context.harness_skip_run

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -690,12 +690,26 @@ class DeployHarnessStep(Step):
                 and not context.dry_run
                 and not context.harness_debug
             ):
-                delete_pods_by_names(
-                    spec.cmd,
-                    treatment_pod_names,
-                    spec.harness_ns,
-                    context,
-                )
+                if context.no_cleanup:
+                    # Safe across retries: each attempt's pods carry a unique
+                    # treatment label value, so leftovers never match the next
+                    # attempt's wait selector. Next run's step 01 removes them.
+                    kube_bin = "oc" if context.is_openshift else "kubectl"
+                    context.logger.log_info(
+                        f"--no-cleanup: leaving {len(treatment_pod_names)} "
+                        f"pod(s) in namespace '{spec.harness_ns}': "
+                        f"{', '.join(treatment_pod_names)}. Delete with: "
+                        f"{kube_bin} delete pod -n {spec.harness_ns} "
+                        f"-l app={spec.pod_label} (the next run also cleans "
+                        f"them up automatically)."
+                    )
+                else:
+                    delete_pods_by_names(
+                        spec.cmd,
+                        treatment_pod_names,
+                        spec.harness_ns,
+                        context,
+                    )
 
             # Result validation gate (opt-in): fail the attempt if the
             # harness reported failed sessions, even when every phase above

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -1042,6 +1042,69 @@ class DeployHarnessStep(Step):
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _copy_dir_from_pod(
+        cmd,
+        source_pod: str,
+        namespace: str,
+        remote_dir: str,
+        local_path: Path,
+        context: ExecutionContext,
+        fast_collect: bool,
+        dir_compressed: bool,
+    ) -> CommandResult:
+        """Copy one remote results directory from ``source_pod`` to ``local_path``.
+
+        ``fast_collect`` swaps ``kubectl cp`` for a gzip'd ``exec | tar``
+        stream -- same files, much faster for large trees. The stream is
+        retried because dropped apiserver exec streams (``tar: Unexpected
+        EOF``) are transient, and extractall overwrites so a partial
+        extraction from a failed attempt is harmless.
+        """
+        if not fast_collect:
+            return cmd.kube(
+                "cp",
+                "--retries=5",
+                f"{source_pod}:{remote_dir}",
+                str(local_path),
+                namespace=namespace,
+                check=False,
+            )
+        tar_flags = "cf" if dir_compressed else "cz"
+        # Auto-detected binary + kubeconfig/context/namespace flags.
+        kube_argv = [
+            cmd._kube_bin,
+            *cmd._kubeconfig_args(),
+            "--namespace",
+            namespace,
+            "exec",
+            source_pod,
+            "--",
+            "tar",
+            tar_flags,
+            "-C",
+            remote_dir,
+            ".",
+        ]
+        max_attempts = 5
+        cp_result = CommandResult(command=" ".join(kube_argv), exit_code=1)
+        for cp_attempt in range(1, max_attempts + 1):
+            cp_result = DeployHarnessStep._fast_collect_stream(
+                kube_argv,
+                local_path,
+                mode="r|" if dir_compressed else "r|gz",
+            )
+            if cp_result.success:
+                break
+            context.logger.log_warning(
+                f"FAST_COLLECT pipeline attempt {cp_attempt}/{max_attempts} "
+                f"failed for {remote_dir} (exit={cp_result.exit_code}): "
+                f"{(cp_result.stderr or cp_result.stdout)[:300]}"
+            )
+            if cp_attempt < max_attempts:
+                time.sleep(min(5 * cp_attempt, 30))
+        return cp_result
+
+    @staticmethod
     def _collect_treatment_results_discovery(
         cmd,
         experiment_id: str,
@@ -1149,64 +1212,25 @@ class DeployHarnessStep(Step):
                 context,
             )
 
-            if FAST_COLLECT:
-                remote_dir = f"{results_dir_prefix}/{dir_name}"
-                tar_flags = "cf" if dir_compressed else "cz"
-                # Auto-detected binary + kubeconfig/context/namespace flags.
-                kube_argv = [
-                    cmd._kube_bin,
-                    *cmd._kubeconfig_args(),
-                    "--namespace",
-                    namespace,
-                    "exec",
-                    data_pod,
-                    "--",
-                    "tar",
-                    tar_flags,
-                    "-C",
-                    remote_dir,
-                    ".",
-                ]
-                # Retry the whole stream: dropped apiserver exec streams
-                # (``tar: Unexpected EOF``) are transient; extractall overwrites
-                # so a partial extraction from a failed attempt is harmless.
-                max_attempts = 5
-                cp_result = CommandResult(command=" ".join(kube_argv), exit_code=1)
-                for cp_attempt in range(1, max_attempts + 1):
-                    cp_result = DeployHarnessStep._fast_collect_stream(
-                        kube_argv,
-                        local_path,
-                        mode="r|" if dir_compressed else "r|gz",
-                    )
-                    if cp_result.success:
-                        break
-                    context.logger.log_warning(
-                        f"FAST_COLLECT pipeline attempt {cp_attempt}/{max_attempts} "
-                        f"failed for {dir_name} (exit={cp_result.exit_code}): "
-                        f"{(cp_result.stderr or cp_result.stdout)[:300]}"
-                    )
-                    if cp_attempt < max_attempts:
-                        time.sleep(min(5 * cp_attempt, 30))
-                if not cp_result.success:
-                    context.logger.log_error(
-                        f"FAST_COLLECT pipeline failed for {dir_name} after "
-                        f"{max_attempts} attempt(s) "
-                        f"(exit={cp_result.exit_code}): "
-                        f"{(cp_result.stderr or cp_result.stdout)[:500]}"
-                    )
-                else:
-                    context.logger.log_info(
-                        f"FAST Collected {remote_dir} to {local_path}"
-                    )
-            else:
-                remote_path = f"{data_pod}:{results_dir_prefix}/{dir_name}"
-                cp_result = cmd.kube(
-                    "cp",
-                    "--retries=5",
-                    remote_path,
-                    str(local_path),
-                    namespace=namespace,
-                    check=False,
+            cp_result = DeployHarnessStep._copy_dir_from_pod(
+                cmd,
+                data_pod,
+                namespace,
+                f"{results_dir_prefix}/{dir_name}",
+                local_path,
+                context,
+                fast_collect=FAST_COLLECT,
+                dir_compressed=dir_compressed,
+            )
+            if FAST_COLLECT and not cp_result.success:
+                context.logger.log_error(
+                    f"FAST_COLLECT pipeline failed for {dir_name} after "
+                    f"5 attempt(s) (exit={cp_result.exit_code}): "
+                    f"{(cp_result.stderr or cp_result.stdout)[:500]}"
+                )
+            elif FAST_COLLECT:
+                context.logger.log_info(
+                    f"FAST Collected {results_dir_prefix}/{dir_name} to {local_path}"
                 )
 
             if cp_result.success:

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -32,8 +32,10 @@ from llmdbenchmark.executor.step import Step, StepResult, Phase
 from llmdbenchmark.executor.context import ExecutionContext, is_fma_only_mode
 from llmdbenchmark.utilities.kube_helpers import (
     DATA_ACCESS_LABEL,
+    HARNESS_DONE_SENTINEL,
     find_data_access_pod,
     wait_for_pods_by_selector,
+    wait_for_harness_sentinels,
     collect_pod_results,
     sync_analysis_dir,
     delete_pods_by_names,
@@ -438,6 +440,10 @@ class DeployHarnessStep(Step):
                         treatment_group=spec.group or "",
                         concurrent_with=",".join(spec.siblings),
                     )
+                    if context.no_pvc:
+                        harness_command = self._no_pvc_keepalive_command(
+                            harness_command, spec.results_dir_prefix
+                        )
 
                 # Build template values by merging plan_config with runtime values
                 template_values = dict(spec.plan_config) if spec.plan_config else {}
@@ -588,15 +594,39 @@ class DeployHarnessStep(Step):
                 and not context.harness_debug
                 and spec.timeout != 0
             ):
-                wait_errors = wait_for_pods_by_selector(
-                    spec.cmd,
-                    f"app={spec.pod_label},{TREATMENT_LABEL}={treatment_label_value}",
-                    spec.harness_ns,
-                    spec.timeout,
-                    context,
-                )
+                if context.no_pvc:
+                    # emptyDir pods sleep after finishing, so pod phase can't
+                    # signal completion -- poll for the sentinel instead.
+                    wait_errors = wait_for_harness_sentinels(
+                        spec.cmd,
+                        treatment_pod_names,
+                        spec.harness_ns,
+                        f"{spec.results_dir_prefix}/{HARNESS_DONE_SENTINEL}",
+                        spec.timeout,
+                        context,
+                    )
+                else:
+                    wait_errors = wait_for_pods_by_selector(
+                        spec.cmd,
+                        f"app={spec.pod_label},{TREATMENT_LABEL}={treatment_label_value}",
+                        spec.harness_ns,
+                        spec.timeout,
+                        context,
+                    )
                 if wait_errors:
                     treatment_errors.extend(wait_errors)
+            elif (
+                not no_pods
+                and context.no_pvc
+                and spec.timeout == 0
+                and not context.dry_run
+                and not context.harness_debug
+            ):
+                context.logger.log_warning(
+                    "--no-pvc with wait timeout 0: not waiting for the harness. "
+                    "Results live only in the pod's emptyDir and are deleted "
+                    "with the pod, so collection will likely find nothing."
+                )
 
             # Phase 3: collect this treatment's results
             if not no_pods and not context.dry_run and not context.harness_debug:
@@ -1519,6 +1549,20 @@ class DeployHarnessStep(Step):
         if not value or not isinstance(value, str):
             return value
         return base64.b64encode(value.encode("utf-8")).decode("utf-8")
+
+    @staticmethod
+    def _no_pvc_keepalive_command(
+        harness_command: str, results_dir_prefix: str
+    ) -> str:
+        """Wrap the harness command so the pod outlives the benchmark.
+
+        With --no-pvc the results live in the pod's emptyDir, which is only
+        reachable while the pod runs. Record the harness exit code in a
+        sentinel file (polled by wait_for_harness_sentinels) and sleep so
+        phase 3 can copy the results out before phase 5 deletes the pod.
+        """
+        sentinel = f"{results_dir_prefix}/{HARNESS_DONE_SENTINEL}"
+        return f"({harness_command}); echo $? > {sentinel}; sleep infinity"
 
     @staticmethod
     def _build_harness_command(

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -1284,6 +1284,18 @@ class DeployHarnessStep(Step):
         local_results_dir = context.run_results_dir()
         local_analysis_dir = context.run_analysis_dir()
 
+        copy_method = (
+            "a gzip'd 'exec | tar' stream (--fast-collect)"
+            if context.harness_fast_collect
+            else "'kubectl cp --retries=5'"
+        )
+        context.logger.log_info(
+            f"--no-pvc: collecting results for {experiment_id} from "
+            f"{len(pod_names)} harness pod(s) -- copying each pod's emptyDir "
+            f"({results_dir_prefix}) to {local_results_dir} via {copy_method} "
+            f"before the pods are deleted..."
+        )
+
         for pod_name in pod_names:
             ls_result = cmd.kube(
                 "exec",
@@ -1318,6 +1330,10 @@ class DeployHarnessStep(Step):
                 local_path = local_results_dir / dir_name
                 local_path.mkdir(parents=True, exist_ok=True)
 
+                context.logger.log_info(
+                    f"Copying {results_dir_prefix}/{dir_name} from pod "
+                    f"'{pod_name}' via {copy_method}..."
+                )
                 cp_result = DeployHarnessStep._copy_dir_from_pod(
                     cmd,
                     pod_name,
@@ -1329,17 +1345,12 @@ class DeployHarnessStep(Step):
                     dir_compressed=False,
                 )
                 if cp_result.success:
-                    file_count = sum(
-                        1 for f in local_path.rglob("*") if f.is_file()
-                    )
+                    file_count = sum(1 for f in local_path.rglob("*") if f.is_file())
                     context.logger.log_info(
                         f"Collected {file_count} file(s) for {dir_name} "
                         f"from pod '{pod_name}'"
                     )
-                    if (
-                        not context.harness_debug
-                        and context.harness_wait_timeout != 0
-                    ):
+                    if not context.harness_debug and context.harness_wait_timeout != 0:
                         sync_analysis_dir(local_path, local_analysis_dir, dir_name)
                 else:
                     errors.append(
@@ -1673,9 +1684,7 @@ class DeployHarnessStep(Step):
         return base64.b64encode(value.encode("utf-8")).decode("utf-8")
 
     @staticmethod
-    def _no_pvc_keepalive_command(
-        harness_command: str, results_dir_prefix: str
-    ) -> str:
+    def _no_pvc_keepalive_command(harness_command: str, results_dir_prefix: str) -> str:
         """Wrap the harness command so the pod outlives the benchmark.
 
         With --no-pvc the results live in the pod's emptyDir, which is only

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -630,14 +630,26 @@ class DeployHarnessStep(Step):
 
             # Phase 3: collect this treatment's results
             if not no_pods and not context.dry_run and not context.harness_debug:
-                collect_errors = self._collect_treatment_results_discovery(
-                    spec.cmd,
-                    experiment_id,
-                    spec.harness_ns,
-                    spec.results_dir_prefix,
-                    context,
-                    harness_settled=not treatment_errors,
-                )
+                if context.no_pvc:
+                    # No data-access pod exists; copy from the (still
+                    # sleeping) harness pods before phase 5 deletes them.
+                    collect_errors = self._collect_treatment_results_from_pods(
+                        spec.cmd,
+                        experiment_id,
+                        spec.harness_ns,
+                        spec.results_dir_prefix,
+                        treatment_pod_names,
+                        context,
+                    )
+                else:
+                    collect_errors = self._collect_treatment_results_discovery(
+                        spec.cmd,
+                        experiment_id,
+                        spec.harness_ns,
+                        spec.results_dir_prefix,
+                        context,
+                        harness_settled=not treatment_errors,
+                    )
                 if collect_errors:
                     treatment_errors.extend(collect_errors)
 
@@ -1248,6 +1260,92 @@ class DeployHarnessStep(Step):
             else:
                 errors.append(f"Failed to copy {dir_name}: {cp_result.stderr[:200]}")
 
+        return errors
+
+    @staticmethod
+    def _collect_treatment_results_from_pods(
+        cmd,
+        experiment_id: str,
+        namespace: str,
+        results_dir_prefix: str,
+        pod_names: list[str],
+        context: ExecutionContext,
+    ) -> list[str]:
+        """Collect results directly from each harness pod (--no-pvc mode).
+
+        There is no workload PVC and no data-access pod: each harness pod's
+        results live in its own emptyDir, reachable only while the pod is
+        alive (it sleeps after writing its completion sentinel). List the
+        result directories inside every pod and copy the ones matching this
+        experiment before phase 5 deletes the pods -- deletion destroys the
+        emptyDir, so a failure here is unrecoverable and must be loud.
+        """
+        errors: list[str] = []
+        local_results_dir = context.run_results_dir()
+        local_analysis_dir = context.run_analysis_dir()
+
+        for pod_name in pod_names:
+            ls_result = cmd.kube(
+                "exec",
+                pod_name,
+                "--",
+                "ls",
+                "-1",
+                results_dir_prefix,
+                namespace=namespace,
+                check=False,
+            )
+            if not ls_result.success:
+                errors.append(
+                    f"Could not list results in pod '{pod_name}' -- its "
+                    f"emptyDir results cannot be recovered after pod "
+                    f"deletion: {ls_result.stderr[:200]}"
+                )
+                continue
+
+            all_dirs = [
+                d.strip() for d in ls_result.stdout.strip().split("\n") if d.strip()
+            ]
+            matching_dirs = [d for d in all_dirs if experiment_id in d]
+            if not matching_dirs:
+                context.logger.log_warning(
+                    f"No result directories found for experiment "
+                    f"{experiment_id} in pod '{pod_name}' (found: {all_dirs[:5]})"
+                )
+                continue
+
+            for dir_name in matching_dirs:
+                local_path = local_results_dir / dir_name
+                local_path.mkdir(parents=True, exist_ok=True)
+
+                cp_result = DeployHarnessStep._copy_dir_from_pod(
+                    cmd,
+                    pod_name,
+                    namespace,
+                    f"{results_dir_prefix}/{dir_name}",
+                    local_path,
+                    context,
+                    fast_collect=context.harness_fast_collect,
+                    dir_compressed=False,
+                )
+                if cp_result.success:
+                    file_count = sum(
+                        1 for f in local_path.rglob("*") if f.is_file()
+                    )
+                    context.logger.log_info(
+                        f"Collected {file_count} file(s) for {dir_name} "
+                        f"from pod '{pod_name}'"
+                    )
+                    if (
+                        not context.harness_debug
+                        and context.harness_wait_timeout != 0
+                    ):
+                        sync_analysis_dir(local_path, local_analysis_dir, dir_name)
+                else:
+                    errors.append(
+                        f"Failed to copy {dir_name} from pod '{pod_name}': "
+                        f"{cp_result.stderr[:200]}"
+                    )
         return errors
 
     @staticmethod

--- a/llmdbenchmark/run/steps/step_07_deploy_harness.py
+++ b/llmdbenchmark/run/steps/step_07_deploy_harness.py
@@ -463,6 +463,7 @@ class DeployHarnessStep(Step):
                         "cluster_type": context.platform_type,
                         "profile_mounts": spec.profile_mounts,
                         "treatment_label_value": treatment_label_value,
+                        "no_pvc": context.no_pvc,
                     }
                 )
 

--- a/llmdbenchmark/run/steps/step_09_collect_results.py
+++ b/llmdbenchmark/run/steps/step_09_collect_results.py
@@ -20,8 +20,12 @@ class CollectResultsStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip if results are already local (nok8s bind-mount, or step 06)."""
+        """Skip if results are already local (nok8s bind-mount, --no-pvc, or step 06)."""
         if "nok8s" in (context.deployed_methods or []):
+            return True
+        # --no-pvc: results were copied from the harness pods in step 06 and
+        # there is no data-access pod to fall back on.
+        if context.no_pvc:
             return True
         results_dir = context.run_results_dir()
         if results_dir.exists() and any(results_dir.iterdir()):

--- a/llmdbenchmark/run/steps/step_11_cleanup_post.py
+++ b/llmdbenchmark/run/steps/step_11_cleanup_post.py
@@ -23,8 +23,14 @@ class RunCleanupPostStep(Step):
         )
 
     def should_skip(self, context: ExecutionContext) -> bool:
-        """Skip cleanup in debug mode, or for nok8s (no cluster resources)."""
+        """Skip cleanup in debug mode, for nok8s, or under --no-cleanup.
+
+        --no-cleanup keeps the ConfigMaps too: the kept pods still project
+        them, and the next run recreates/replaces them anyway.
+        """
         if "nok8s" in (context.deployed_methods or []):
+            return True
+        if context.no_cleanup:
             return True
         return context.harness_debug
 

--- a/llmdbenchmark/utilities/kube_helpers.py
+++ b/llmdbenchmark/utilities/kube_helpers.py
@@ -26,6 +26,11 @@ CRASH_STATES = _CRASH_STATES
 
 DATA_ACCESS_LABEL = "role=llm-d-benchmark-data-access"
 
+#: Written by --no-pvc harness pods (as ``echo $? > <prefix>/<sentinel>``)
+#: once the benchmark finishes, while the pod itself keeps sleeping so its
+#: emptyDir stays reachable for collection.
+HARNESS_DONE_SENTINEL = ".llmdbench_harness_done"
+
 # Retry budget for locating the data-access pod. Deliberately generous relative
 # to what it guards: ~14s of polling against a wave of results that cost hours of
 # GPU time and cannot be regenerated once the harness pods are deleted.
@@ -314,6 +319,89 @@ def wait_for_pods_by_selector(
     if not errors:
         context.logger.log_info("All pods completed successfully")
 
+    return errors
+
+
+def wait_for_harness_sentinels(
+    cmd,
+    pod_names: list[str],
+    namespace: str,
+    sentinel_path: str,
+    timeout: int,
+    context: ExecutionContext,
+) -> list[str]:
+    """Wait for --no-pvc harness pods to write their completion sentinel.
+
+    Under ``--no-pvc`` the harness command ends with
+    ``echo $? > <sentinel>; sleep infinity`` so the pod stays Running and
+    its emptyDir remains reachable for collection. Pod phase therefore
+    cannot signal completion; the sentinel file does. A pod that reaches a
+    terminal phase before writing the sentinel crashed -- its emptyDir is
+    already gone, so fail it fast instead of burning the whole timeout.
+
+    Returns a list of error strings (empty when every pod's harness
+    finished with exit code 0).
+    """
+    import time as _time
+
+    errors: list[str] = []
+    poll = 5
+    waited = 0
+    # pod -> None (pending) | "<exit code>" | "terminal:<phase>"
+    status: dict[str, str | None] = {name: None for name in pod_names}
+
+    context.logger.log_info(
+        f"Waiting for {len(pod_names)} pod(s) to write {sentinel_path} "
+        f"(timeout={timeout}s)..."
+    )
+    while any(v is None for v in status.values()):
+        for pod in [p for p, v in status.items() if v is None]:
+            result = cmd.kube(
+                "exec",
+                pod,
+                "--",
+                "cat",
+                sentinel_path,
+                namespace=namespace,
+                check=False,
+            )
+            if result.success and result.stdout.strip():
+                status[pod] = result.stdout.strip().splitlines()[0]
+                continue
+            phase_result = cmd.kube(
+                "get",
+                "pod",
+                pod,
+                "--namespace",
+                namespace,
+                "-o",
+                "jsonpath={.status.phase}",
+                check=False,
+            )
+            phase = phase_result.stdout.strip() if phase_result.success else ""
+            if phase in ("Succeeded", "Failed"):
+                status[pod] = f"terminal:{phase}"
+        if all(v is not None for v in status.values()) or waited >= timeout:
+            break
+        _time.sleep(poll)
+        waited += poll
+
+    for pod, state in status.items():
+        if state is None:
+            errors.append(
+                f"Pod '{pod}' did not write {sentinel_path} within {timeout}s"
+            )
+        elif state.startswith("terminal:"):
+            errors.append(
+                f"Pod '{pod}' reached phase {state.split(':', 1)[1]} before "
+                f"writing {sentinel_path} -- the harness container exited "
+                f"unexpectedly and its emptyDir results are lost"
+            )
+        elif state != "0":
+            errors.append(f"Pod '{pod}' harness exited with code {state}")
+
+    if not errors:
+        context.logger.log_info("All pods wrote their completion sentinel")
     return errors
 
 

--- a/tests/test_harness_pod_template_scripts.py
+++ b/tests/test_harness_pod_template_scripts.py
@@ -208,3 +208,24 @@ def test_harness_pod_tolerates_a_missing_description_block() -> None:
 
     assert env["LLMDBENCH_DESCRIPTION_TEXT"] == ""
     assert env["LLMDBENCH_DESCRIPTION_KEYWORDS"] == ""
+
+
+def test_harness_pod_mounts_pvc_by_default() -> None:
+    pod = _render_pod(_template_values())
+    results_vol = next(v for v in pod["spec"]["volumes"] if v["name"] == "results")
+    assert results_vol["persistentVolumeClaim"]["claimName"] == "workload-pvc"
+    assert "emptyDir" not in results_vol
+
+
+def test_harness_pod_uses_emptydir_with_no_pvc() -> None:
+    """--no-pvc swaps the results volume for an emptyDir; the mount at
+    /requests is unchanged so nothing inside the pod notices."""
+    values = _template_values()
+    values["no_pvc"] = True
+    pod = _render_pod(values)
+    results_vol = next(v for v in pod["spec"]["volumes"] if v["name"] == "results")
+    assert results_vol["emptyDir"] == {}
+    assert "persistentVolumeClaim" not in results_vol
+    container = pod["spec"]["containers"][0]
+    mounts = {m["name"]: m["mountPath"] for m in container["volumeMounts"]}
+    assert mounts["results"] == "/requests"

--- a/tests/test_no_cleanup.py
+++ b/tests/test_no_cleanup.py
@@ -1,0 +1,47 @@
+"""Tests for the --no-cleanup flag (keep harness pods after the run)."""
+
+from __future__ import annotations
+
+import argparse
+
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.interface import run as run_interface
+from llmdbenchmark.run.steps.step_11_cleanup_post import RunCleanupPostStep
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    run_interface.add_subcommands(subparsers, parents=[])
+    return parser.parse_args(argv)
+
+
+def test_no_cleanup_flag_defaults_false() -> None:
+    args = _parse(["run"])
+    assert args.no_cleanup is False
+
+
+def test_no_cleanup_flag_parses_true() -> None:
+    args = _parse(["run", "--no-cleanup"])
+    assert args.no_cleanup is True
+
+
+def test_no_cleanup_env_var_sets_default(monkeypatch) -> None:
+    monkeypatch.setenv("LLMDBENCH_NO_CLEANUP", "1")
+    args = _parse(["run"])
+    assert args.no_cleanup is True
+
+
+def test_context_no_cleanup_defaults_false(tmp_path) -> None:
+    context = ExecutionContext(plan_dir=tmp_path, workspace=tmp_path)
+    assert context.no_cleanup is False
+
+
+def test_cleanup_post_step_skips_with_no_cleanup(tmp_path) -> None:
+    context = ExecutionContext(plan_dir=tmp_path, workspace=tmp_path, no_cleanup=True)
+    assert RunCleanupPostStep().should_skip(context) is True
+
+
+def test_cleanup_post_step_runs_by_default(tmp_path) -> None:
+    context = ExecutionContext(plan_dir=tmp_path, workspace=tmp_path)
+    assert RunCleanupPostStep().should_skip(context) is False

--- a/tests/test_no_pvc_flag.py
+++ b/tests/test_no_pvc_flag.py
@@ -1,0 +1,47 @@
+"""Tests for the --no-pvc flag plumbing (CLI parser + ExecutionContext)."""
+
+from __future__ import annotations
+
+import argparse
+
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.interface import run as run_interface
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    run_interface.add_subcommands(subparsers, parents=[])
+    return parser.parse_args(argv)
+
+
+def test_no_pvc_flag_defaults_false() -> None:
+    args = _parse(["run"])
+    assert args.no_pvc is False
+
+
+def test_no_pvc_flag_parses_true() -> None:
+    args = _parse(["run", "--no-pvc"])
+    assert args.no_pvc is True
+
+
+def test_no_pvc_env_var_sets_default(monkeypatch) -> None:
+    monkeypatch.setenv("LLMDBENCH_NO_PVC", "1")
+    args = _parse(["run"])
+    assert args.no_pvc is True
+
+
+def test_cli_flag_beats_unset_env(monkeypatch) -> None:
+    monkeypatch.delenv("LLMDBENCH_NO_PVC", raising=False)
+    args = _parse(["run", "--no-pvc"])
+    assert args.no_pvc is True
+
+
+def test_context_no_pvc_defaults_false(tmp_path) -> None:
+    context = ExecutionContext(plan_dir=tmp_path, workspace=tmp_path)
+    assert context.no_pvc is False
+
+
+def test_context_accepts_no_pvc(tmp_path) -> None:
+    context = ExecutionContext(plan_dir=tmp_path, workspace=tmp_path, no_pvc=True)
+    assert context.no_pvc is True

--- a/tests/test_no_pvc_steps.py
+++ b/tests/test_no_pvc_steps.py
@@ -161,3 +161,64 @@ def test_copy_dir_from_pod_uses_kubectl_cp_with_retries(tmp_path) -> None:
         str(tmp_path / "exp-1_1"),
     )
     assert kwargs == {"namespace": "ns", "check": False}
+
+
+def test_collect_from_pods_copies_matching_dirs(tmp_path) -> None:
+    context = ExecutionContext(
+        plan_dir=tmp_path,
+        workspace=tmp_path,
+        logger=_FakeLogger(),
+        # 0 skips the analysis sync (same condition the PVC path uses), so
+        # this test only exercises discovery + copy.
+        harness_wait_timeout=0,
+    )
+    cmd = _FakeCmd(
+        [
+            # ls in pod: one matching dir, one unrelated dir
+            _Result(success=True, stdout="exp-1_1\nother-exp_1\n"),
+            # cp of the matching dir
+            _Result(success=True),
+        ]
+    )
+    errors = DeployHarnessStep._collect_treatment_results_from_pods(
+        cmd, "exp-1", "ns", "/requests", ["harness-pod-1"], context
+    )
+    assert errors == []
+    ls_args, ls_kwargs = cmd.calls[0]
+    assert ls_args == ("exec", "harness-pod-1", "--", "ls", "-1", "/requests")
+    assert ls_kwargs == {"namespace": "ns", "check": False}
+    cp_args, _ = cmd.calls[1]
+    assert cp_args[2] == "harness-pod-1:/requests/exp-1_1"
+    # Unrelated dir was not copied.
+    assert len(cmd.calls) == 2
+
+
+def test_collect_from_pods_reports_ls_failure(tmp_path) -> None:
+    context = ExecutionContext(
+        plan_dir=tmp_path, workspace=tmp_path, logger=_FakeLogger(),
+        harness_wait_timeout=0,
+    )
+    cmd = _FakeCmd([_Result(success=False, stderr="pod gone")])
+    errors = DeployHarnessStep._collect_treatment_results_from_pods(
+        cmd, "exp-1", "ns", "/requests", ["harness-pod-1"], context
+    )
+    assert len(errors) == 1
+    assert "harness-pod-1" in errors[0]
+
+
+def test_collect_from_pods_reports_cp_failure(tmp_path) -> None:
+    context = ExecutionContext(
+        plan_dir=tmp_path, workspace=tmp_path, logger=_FakeLogger(),
+        harness_wait_timeout=0,
+    )
+    cmd = _FakeCmd(
+        [
+            _Result(success=True, stdout="exp-1_1\n"),
+            _Result(success=False, stderr="connection reset"),
+        ]
+    )
+    errors = DeployHarnessStep._collect_treatment_results_from_pods(
+        cmd, "exp-1", "ns", "/requests", ["harness-pod-1"], context
+    )
+    assert len(errors) == 1
+    assert "exp-1_1" in errors[0]

--- a/tests/test_no_pvc_steps.py
+++ b/tests/test_no_pvc_steps.py
@@ -1,0 +1,30 @@
+"""--no-pvc: run steps that create or read the workload PVC must skip."""
+
+from __future__ import annotations
+
+from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.run.steps.step_02_harness_namespace import (
+    HarnessNamespaceStep,
+)
+from llmdbenchmark.run.steps.step_09_collect_results import CollectResultsStep
+
+
+def _context(tmp_path, **kwargs) -> ExecutionContext:
+    return ExecutionContext(plan_dir=tmp_path, workspace=tmp_path, **kwargs)
+
+
+def test_harness_namespace_step_skips_with_no_pvc(tmp_path) -> None:
+    assert HarnessNamespaceStep().should_skip(_context(tmp_path, no_pvc=True))
+
+
+def test_harness_namespace_step_runs_by_default(tmp_path) -> None:
+    assert not HarnessNamespaceStep().should_skip(_context(tmp_path))
+
+
+def test_collect_results_step_skips_with_no_pvc(tmp_path) -> None:
+    assert CollectResultsStep().should_skip(_context(tmp_path, no_pvc=True))
+
+
+def test_collect_results_step_runs_by_default(tmp_path) -> None:
+    # Empty results dir + k8s mode: the fallback collector should run.
+    assert not CollectResultsStep().should_skip(_context(tmp_path))

--- a/tests/test_no_pvc_steps.py
+++ b/tests/test_no_pvc_steps.py
@@ -138,3 +138,26 @@ def test_sentinel_wait_times_out(tmp_path, monkeypatch) -> None:
     )
     assert len(errors) == 1
     assert "did not write" in errors[0]
+
+
+def test_copy_dir_from_pod_uses_kubectl_cp_with_retries(tmp_path) -> None:
+    cmd = _FakeCmd([_Result(success=True)])
+    result = DeployHarnessStep._copy_dir_from_pod(
+        cmd,
+        "harness-pod-1",
+        "ns",
+        "/requests/exp-1_1",
+        tmp_path / "exp-1_1",
+        _wait_context(tmp_path),
+        fast_collect=False,
+        dir_compressed=False,
+    )
+    assert result.success
+    args, kwargs = cmd.calls[0]
+    assert args == (
+        "cp",
+        "--retries=5",
+        "harness-pod-1:/requests/exp-1_1",
+        str(tmp_path / "exp-1_1"),
+    )
+    assert kwargs == {"namespace": "ns", "check": False}

--- a/tests/test_no_pvc_steps.py
+++ b/tests/test_no_pvc_steps.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import time
+
 from llmdbenchmark.executor.context import ExecutionContext
 from llmdbenchmark.run.steps.step_02_harness_namespace import (
     HarnessNamespaceStep,
 )
+from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
 from llmdbenchmark.run.steps.step_09_collect_results import CollectResultsStep
+from llmdbenchmark.utilities.kube_helpers import (
+    HARNESS_DONE_SENTINEL,
+    wait_for_harness_sentinels,
+)
 
 
 def _context(tmp_path, **kwargs) -> ExecutionContext:
@@ -28,15 +35,6 @@ def test_collect_results_step_skips_with_no_pvc(tmp_path) -> None:
 def test_collect_results_step_runs_by_default(tmp_path) -> None:
     # Empty results dir + k8s mode: the fallback collector should run.
     assert not CollectResultsStep().should_skip(_context(tmp_path))
-
-
-import time
-
-from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
-from llmdbenchmark.utilities.kube_helpers import (
-    HARNESS_DONE_SENTINEL,
-    wait_for_harness_sentinels,
-)
 
 
 class _Result:
@@ -76,9 +74,7 @@ class _FakeCmd:
 
 
 def _wait_context(tmp_path):
-    return ExecutionContext(
-        plan_dir=tmp_path, workspace=tmp_path, logger=_FakeLogger()
-    )
+    return ExecutionContext(plan_dir=tmp_path, workspace=tmp_path, logger=_FakeLogger())
 
 
 def test_keepalive_command_wraps_and_sleeps() -> None:
@@ -94,7 +90,11 @@ def test_keepalive_command_wraps_and_sleeps() -> None:
 def test_sentinel_wait_success(tmp_path) -> None:
     cmd = _FakeCmd([_Result(success=True, stdout="0\n")])
     errors = wait_for_harness_sentinels(
-        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 60,
+        cmd,
+        ["pod-a"],
+        "ns",
+        f"/requests/{HARNESS_DONE_SENTINEL}",
+        60,
         _wait_context(tmp_path),
     )
     assert errors == []
@@ -103,7 +103,11 @@ def test_sentinel_wait_success(tmp_path) -> None:
 def test_sentinel_wait_nonzero_exit_is_an_error(tmp_path) -> None:
     cmd = _FakeCmd([_Result(success=True, stdout="2\n")])
     errors = wait_for_harness_sentinels(
-        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 60,
+        cmd,
+        ["pod-a"],
+        "ns",
+        f"/requests/{HARNESS_DONE_SENTINEL}",
+        60,
         _wait_context(tmp_path),
     )
     assert len(errors) == 1
@@ -119,7 +123,11 @@ def test_sentinel_wait_terminal_pod_fails_fast(tmp_path) -> None:
         ]
     )
     errors = wait_for_harness_sentinels(
-        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 600,
+        cmd,
+        ["pod-a"],
+        "ns",
+        f"/requests/{HARNESS_DONE_SENTINEL}",
+        600,
         _wait_context(tmp_path),
     )
     assert len(errors) == 1
@@ -133,7 +141,11 @@ def test_sentinel_wait_times_out(tmp_path, monkeypatch) -> None:
         [_Result(success=False), _Result(success=True, stdout="Running")] * 50
     )
     errors = wait_for_harness_sentinels(
-        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 10,
+        cmd,
+        ["pod-a"],
+        "ns",
+        f"/requests/{HARNESS_DONE_SENTINEL}",
+        10,
         _wait_context(tmp_path),
     )
     assert len(errors) == 1
@@ -195,7 +207,9 @@ def test_collect_from_pods_copies_matching_dirs(tmp_path) -> None:
 
 def test_collect_from_pods_reports_ls_failure(tmp_path) -> None:
     context = ExecutionContext(
-        plan_dir=tmp_path, workspace=tmp_path, logger=_FakeLogger(),
+        plan_dir=tmp_path,
+        workspace=tmp_path,
+        logger=_FakeLogger(),
         harness_wait_timeout=0,
     )
     cmd = _FakeCmd([_Result(success=False, stderr="pod gone")])
@@ -208,7 +222,9 @@ def test_collect_from_pods_reports_ls_failure(tmp_path) -> None:
 
 def test_collect_from_pods_reports_cp_failure(tmp_path) -> None:
     context = ExecutionContext(
-        plan_dir=tmp_path, workspace=tmp_path, logger=_FakeLogger(),
+        plan_dir=tmp_path,
+        workspace=tmp_path,
+        logger=_FakeLogger(),
         harness_wait_timeout=0,
     )
     cmd = _FakeCmd(

--- a/tests/test_no_pvc_steps.py
+++ b/tests/test_no_pvc_steps.py
@@ -28,3 +28,113 @@ def test_collect_results_step_skips_with_no_pvc(tmp_path) -> None:
 def test_collect_results_step_runs_by_default(tmp_path) -> None:
     # Empty results dir + k8s mode: the fallback collector should run.
     assert not CollectResultsStep().should_skip(_context(tmp_path))
+
+
+import time
+
+from llmdbenchmark.run.steps.step_07_deploy_harness import DeployHarnessStep
+from llmdbenchmark.utilities.kube_helpers import (
+    HARNESS_DONE_SENTINEL,
+    wait_for_harness_sentinels,
+)
+
+
+class _Result:
+    def __init__(self, success: bool = True, stdout: str = "", stderr: str = ""):
+        self.success = success
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = 0 if success else 1
+
+
+class _FakeLogger:
+    def __init__(self):
+        self.messages: list[str] = []
+
+    def log_info(self, msg, **kwargs):
+        self.messages.append(msg)
+
+    def log_warning(self, msg, **kwargs):
+        self.messages.append(msg)
+
+    def log_error(self, msg, **kwargs):
+        self.messages.append(msg)
+
+
+class _FakeCmd:
+    """Replays scripted results; records every kube() call."""
+
+    def __init__(self, results: list[_Result]):
+        self._results = list(results)
+        self.calls: list[tuple] = []
+
+    def kube(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self._results:
+            return self._results.pop(0)
+        return _Result(success=False, stderr="script exhausted")
+
+
+def _wait_context(tmp_path):
+    return ExecutionContext(
+        plan_dir=tmp_path, workspace=tmp_path, logger=_FakeLogger()
+    )
+
+
+def test_keepalive_command_wraps_and_sleeps() -> None:
+    wrapped = DeployHarnessStep._no_pvc_keepalive_command(
+        "export A=1; llm-d-benchmark.sh", "/requests"
+    )
+    assert wrapped == (
+        "(export A=1; llm-d-benchmark.sh); "
+        "echo $? > /requests/.llmdbench_harness_done; sleep infinity"
+    )
+
+
+def test_sentinel_wait_success(tmp_path) -> None:
+    cmd = _FakeCmd([_Result(success=True, stdout="0\n")])
+    errors = wait_for_harness_sentinels(
+        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 60,
+        _wait_context(tmp_path),
+    )
+    assert errors == []
+
+
+def test_sentinel_wait_nonzero_exit_is_an_error(tmp_path) -> None:
+    cmd = _FakeCmd([_Result(success=True, stdout="2\n")])
+    errors = wait_for_harness_sentinels(
+        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 60,
+        _wait_context(tmp_path),
+    )
+    assert len(errors) == 1
+    assert "exited with code 2" in errors[0]
+
+
+def test_sentinel_wait_terminal_pod_fails_fast(tmp_path) -> None:
+    # exec fails (no sentinel), pod phase is Failed -> crash before sentinel.
+    cmd = _FakeCmd(
+        [
+            _Result(success=False, stderr="error"),
+            _Result(success=True, stdout="Failed"),
+        ]
+    )
+    errors = wait_for_harness_sentinels(
+        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 600,
+        _wait_context(tmp_path),
+    )
+    assert len(errors) == 1
+    assert "Failed" in errors[0]
+
+
+def test_sentinel_wait_times_out(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(time, "sleep", lambda _s: None)
+    # Pod stays Running and never writes the sentinel.
+    cmd = _FakeCmd(
+        [_Result(success=False), _Result(success=True, stdout="Running")] * 50
+    )
+    errors = wait_for_harness_sentinels(
+        cmd, ["pod-a"], "ns", f"/requests/{HARNESS_DONE_SENTINEL}", 10,
+        _wait_context(tmp_path),
+    )
+    assert len(errors) == 1
+    assert "did not write" in errors[0]


### PR DESCRIPTION
# Summary

Users on clusters where PVCs can't be provisioned currently can't benchmark at all. The `run` phase unconditionally creates a `workload-pvc` and `data-access` pod for results. This PR makes both optional by supplying a `none pvc` mode.

- `--no-pvc` (env `LLMDBENCH_NO_PVC`) works in full run and run-only modes:
  - Skips the workload PVC + data-access pod entirely (run steps 02/09)
  - Harness pods mount an emptyDir at /requests; the harness command is wrapped to record its exit code to a sentinel (/requests/.llmdbench_harness_done) and sleep, keeping the volume reachable
  - Wait polls the sentinel instead of pod phase; results are copied per-pod (kubectl cp --retries=5 or --fast-collect tar stream) into workspace/results before pod deletion
  - Mode is announced at startup and in the summary banner (Mode: run-only (pvc-less)), with per-directory copy-progress logging

- `--no-cleanup` (env `LLMDBENCH_NO_CLEANUP`) leaves harness pods and ConfigMaps in place after the run for log inspection, exec, or manual result recovery (with `--no-pvc`, kept pods stay asleep with results intact). The next run's cleanup step sweeps leftovers by label...unique per-attempt labels keep stale pods invisible to retries.

- Default (PVC) behavior is unchanged.