### PR TITLE
Auto-mint prometheus-auth Secret for generic KEDA bearer-secret auth

### DIFF
--- a/llmdbenchmark/standup/keda_prometheus_auth.py
+++ b/llmdbenchmark/standup/keda_prometheus_auth.py
@@ -113,7 +113,9 @@ def create_prometheus_auth_secret(
     target_namespace: str,
     prom_ca_cert: str | None,
     sa_name: str = "wva-prometheus-auth",
+    secret_name: str = "prometheus-auth",
     ta_template_stem: str = "21_keda-triggerauthentication",
+    apply_trigger_auth: bool = True,
     errors: list | None = None,
     token_duration: str = "24h",
 ) -> None:
@@ -131,8 +133,13 @@ def create_prometheus_auth_secret(
         prom_ca_cert: PEM-encoded CA certificate for Prometheus (optional).
         sa_name: ServiceAccount name to mint the token from
             (default: "wva-prometheus-auth").
+        secret_name: Name of the Secret to create (default: "prometheus-auth").
         ta_template_stem: Template filename stem to locate the TA YAML
             (default: "21_keda-triggerauthentication").
+        apply_trigger_auth: Whether to also locate and apply the TA YAML found
+            via ta_template_stem (default: True). Callers that apply their own
+            TriggerAuthentication CR (e.g. the generic KEDA bearer-secret path)
+            should pass False to avoid a duplicate/conflicting apply.
         errors: List to append error messages to (optional).
         token_duration: Requested lifetime of the issued token
             (default: "24h"). Use Kubernetes duration format (e.g., "1h", "24h", "168h").
@@ -176,7 +183,7 @@ def create_prometheus_auth_secret(
         "create",
         "secret",
         "generic",
-        "prometheus-auth",
+        secret_name,
         f"--from-file=ca.crt={cert_path}",
         f"--from-literal=bearerToken={bearer_token}",
         "--dry-run=client",
@@ -187,7 +194,7 @@ def create_prometheus_auth_secret(
         check=False,
     )
     if secret_result.success and secret_result.stdout.strip():
-        secret_yaml_path = tmp_dir / "prometheus-auth-secret.yaml"
+        secret_yaml_path = tmp_dir / f"{secret_name}-secret.yaml"
         secret_yaml_path.write_text(secret_result.stdout, encoding="utf-8")
         apply_result = cmd.kube(
             "apply",
@@ -199,14 +206,17 @@ def create_prometheus_auth_secret(
         )
         if not apply_result.success:
             errors.append(
-                f"Failed to apply prometheus-auth Secret in ns/{target_namespace}: "
+                f"Failed to apply {secret_name} Secret in ns/{target_namespace}: "
                 f"{apply_result.stderr}"
             )
     else:
         errors.append(
-            f"Failed to generate prometheus-auth Secret for ns/{target_namespace}: "
+            f"Failed to generate {secret_name} Secret for ns/{target_namespace}: "
             f"{secret_result.stderr}"
         )
+        return
+
+    if not apply_trigger_auth:
         return
 
     ta_yaml = _find_yaml(stack_path, ta_template_stem)

--- a/llmdbenchmark/standup/lib/keda.py
+++ b/llmdbenchmark/standup/lib/keda.py
@@ -13,6 +13,7 @@ import yaml
 
 from llmdbenchmark.executor.command import CommandExecutor
 from llmdbenchmark.executor.context import ExecutionContext
+from llmdbenchmark.standup.keda_prometheus_auth import create_prometheus_auth_secret
 
 
 def stacks_enabling_keda(
@@ -40,12 +41,14 @@ def install_keda_for_namespace(
     stack_path: Path,
     namespace: str,
     errors: list,
+    prom_ca_cert: str | None = None,
 ) -> None:
     """Apply TriggerAuthentication (bearer-secret only) then the ScaledObjects template.
 
     For authMode=none, only the ScaledObjects template is applied.
-    For authMode=bearer-secret, the TriggerAuthentication (template 32) is applied
-    first so KEDA can resolve auth before the ScaledObject triggers fire.
+    For authMode=bearer-secret, the bearer token Secret is minted (when
+    prom_ca_cert is available) and the TriggerAuthentication (template 27a) is
+    applied first so KEDA can resolve auth before the ScaledObject triggers fire.
     """
     cfg_file = stack_path / "config.yaml"
     try:
@@ -54,9 +57,32 @@ def install_keda_for_namespace(
     except (OSError, yaml.YAMLError):
         return
 
-    auth_mode = cfg.get("keda", {}).get("prometheus", {}).get("authMode", "none")
+    prometheus_cfg = cfg.get("keda", {}).get("prometheus", {})
+    auth_mode = prometheus_cfg.get("authMode", "none")
 
     if auth_mode == "bearer-secret":
+        secret_name = prometheus_cfg.get("secretName", "prometheus-auth")
+        sa_name = prometheus_cfg.get("saName", "wva-prometheus-auth")
+
+        if prom_ca_cert:
+            create_prometheus_auth_secret(
+                cmd=cmd,
+                context=context,
+                stack_path=stack_path,
+                target_namespace=namespace,
+                prom_ca_cert=prom_ca_cert,
+                sa_name=sa_name,
+                secret_name=secret_name,
+                apply_trigger_auth=False,
+                errors=errors,
+            )
+        else:
+            context.logger.log_warning(
+                f"No Prometheus CA cert available; cannot auto-create "
+                f"secret/{secret_name} in ns/{namespace}. Create it manually or "
+                "KEDA bearer-secret auth will fail."
+            )
+
         ta_yaml = _find_yaml(stack_path, "27a_keda-triggerauthentication")
         if ta_yaml and _has_yaml_content(ta_yaml):
             result = cmd.kube("apply", "-f", str(ta_yaml), "-n", namespace, check=False)

--- a/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
+++ b/llmdbenchmark/standup/steps/step_03_workload_monitoring.py
@@ -678,6 +678,24 @@ class WorkloadMonitoringStep(Step):
 
         keda_sat_mod.verify_keda_installed(cmd, context)
 
+        # Only mint a Prometheus CA cert (needed for the auto-created bearer
+        # token Secret) when at least one stack actually uses bearer-secret
+        # auth -- authMode=none stacks don't need it.
+        needs_bearer_secret = any(
+            cfg.get("keda", {}).get("prometheus", {}).get("authMode") == "bearer-secret"
+            for _, cfg in pairs
+        )
+        prom_ca_cert = None
+        if needs_bearer_secret:
+            prom_ca_cert = keda_sat_mod.extract_prometheus_ca_cert(cmd, context.logger)
+            if not prom_ca_cert:
+                context.logger.log_warning(
+                    "Could not extract a Prometheus CA cert for generic KEDA "
+                    "bearer-secret auth. The prometheus-auth Secret will not be "
+                    "auto-created -- create it manually or KEDA metric queries "
+                    "will fail."
+                )
+
         seen_namespaces: set[str] = set()
         for stack_path, cfg in pairs:
             ns = cfg.get("namespace", {}).get("name", "")
@@ -693,4 +711,5 @@ class WorkloadMonitoringStep(Step):
                 stack_path=stack_path,
                 namespace=ns,
                 errors=errors,
+                prom_ca_cert=prom_ca_cert,
             )

--- a/tests/test_standup_keda.py
+++ b/tests/test_standup_keda.py
@@ -12,6 +12,7 @@ from llmdbenchmark.standup.lib.keda import (
     install_keda_for_namespace,
     stacks_enabling_keda,
 )
+from llmdbenchmark.standup.steps import step_03_workload_monitoring
 from llmdbenchmark.standup.steps.step_03_workload_monitoring import (
     WorkloadMonitoringStep,
 )
@@ -58,6 +59,25 @@ class _StubCmd:
 class _StubContext:
     logger: _StubLogger = field(default_factory=_StubLogger)
     dry_run: bool = False
+
+
+@dataclass
+class _TokenMintingStubCmd:
+    """Stub that returns a usable token/secret payload for the mint-secret path.
+
+    Plain _StubCmd returns empty stdout, which create_prometheus_auth_secret
+    treats as a mint failure -- these tests need a token/secret manifest.
+    """
+
+    kube_calls: list[tuple] = field(default_factory=list)
+
+    def kube(self, *args: str, **_: Any) -> _StubResult:
+        self.kube_calls.append(args)
+        if args[:2] == ("create", "token"):
+            return _StubResult(success=True, stdout="fake-bearer-token\n")
+        if args[:3] == ("create", "secret", "generic"):
+            return _StubResult(success=True, stdout="apiVersion: v1\nkind: Secret\n")
+        return _StubResult(success=True)
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +246,85 @@ class TestInstallKedaForNamespace:
         )
         assert ta_idx < so_idx
 
+    def test_bearer_secret_with_ca_cert_mints_secret_before_ta(
+        self, tmp_path: Path
+    ) -> None:
+        """authMode=bearer-secret + prom_ca_cert: mints token/Secret before applying TA."""
+        stack = _write_stack(
+            tmp_path,
+            "s1",
+            cfg={
+                "keda": {
+                    "prometheus": {
+                        "authMode": "bearer-secret",
+                        "secretName": "my-secret",
+                    },
+                    "scaledObjects": [{"name": "x"}],
+                },
+            },
+        )
+        _write_ta_template(stack, "test-ns", "my-secret")
+        _write_so_template(stack)
+        cmd = _TokenMintingStubCmd()
+        ctx = _StubContext()
+        errors: list = []
+
+        install_keda_for_namespace(
+            cmd, ctx, stack, "test-ns", errors, prom_ca_cert="FAKE-CA-CERT"
+        )
+
+        assert errors == []
+        token_calls = [a for a in cmd.kube_calls if a[:2] == ("create", "token")]
+        assert token_calls and token_calls[0][2] == "wva-prometheus-auth"
+
+        secret_calls = [
+            a for a in cmd.kube_calls if a[:3] == ("create", "secret", "generic")
+        ]
+        assert secret_calls and secret_calls[0][3] == "my-secret"
+
+        applied = [a for a in cmd.kube_calls if a[0] == "apply"]
+        assert len(applied) == 3  # minted Secret, TA, ScaledObjects
+        paths_applied = [a[2] for a in applied]
+        secret_idx = next(
+            i for i, p in enumerate(paths_applied) if "my-secret-secret" in p
+        )
+        ta_idx = next(i for i, p in enumerate(paths_applied) if "27a_keda" in p)
+        so_idx = next(
+            i for i, p in enumerate(paths_applied) if "27_keda-scaledobjects" in p
+        )
+        assert secret_idx < ta_idx < so_idx
+
+    def test_bearer_secret_without_ca_cert_warns_and_skips_mint(
+        self, tmp_path: Path
+    ) -> None:
+        """authMode=bearer-secret with no prom_ca_cert: warns, still applies TA + SO."""
+        stack = _write_stack(
+            tmp_path,
+            "s1",
+            cfg={
+                "keda": {
+                    "prometheus": {
+                        "authMode": "bearer-secret",
+                        "secretName": "my-secret",
+                    },
+                    "scaledObjects": [{"name": "x"}],
+                },
+            },
+        )
+        _write_ta_template(stack, "test-ns", "my-secret")
+        _write_so_template(stack)
+        cmd = _StubCmd()
+        ctx = _StubContext()
+        errors: list = []
+
+        install_keda_for_namespace(cmd, ctx, stack, "test-ns", errors)
+
+        assert errors == []
+        assert not any(a[:2] == ("create", "token") for a in cmd.kube_calls)
+        assert any("WARN" in m and "my-secret" in m for m in ctx.logger.messages)
+        applied = [a for a in cmd.kube_calls if a[0] == "apply"]
+        assert len(applied) == 2  # TA + ScaledObjects only
+
     def test_bearer_secret_missing_ta_template_warns(self, tmp_path: Path) -> None:
         """Missing TA template logs a warning but does not append an error."""
         stack = _write_stack(
@@ -384,6 +483,71 @@ class TestInstallKedaIfEnabled:
         assert len(crd_checks) == 1, (
             f"Expected KEDA CRD check; kube_calls={cmd.kube_calls}"
         )
+
+    def test_none_auth_stack_does_not_extract_ca_cert(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """authMode=none stacks never trigger the CA-cert lookup."""
+        stack = _write_stack(
+            tmp_path,
+            "s1",
+            cfg={
+                "keda": {
+                    "prometheus": {"authMode": "none"},
+                    "scaledObjects": [{"name": "x"}],
+                },
+                "namespace": {"name": "ns1"},
+            },
+        )
+        _write_so_template(stack)
+        calls: list = []
+        monkeypatch.setattr(
+            step_03_workload_monitoring.keda_sat_mod,
+            "extract_prometheus_ca_cert",
+            lambda *a, **k: calls.append((a, k)) or "SHOULD-NOT-BE-CALLED",
+        )
+        step = WorkloadMonitoringStep()
+        ctx = _FullStubContext(rendered_stacks=[stack])
+        cmd = _StubCmd()
+
+        step._install_keda_if_enabled(cmd, ctx, [])
+
+        assert calls == []
+
+    def test_bearer_secret_stack_extracts_and_threads_ca_cert(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """authMode=bearer-secret: CA cert is extracted and reaches the mint call."""
+        stack = _write_stack(
+            tmp_path,
+            "s1",
+            cfg={
+                "keda": {
+                    "prometheus": {
+                        "authMode": "bearer-secret",
+                        "secretName": "my-secret",
+                    },
+                    "scaledObjects": [{"name": "x"}],
+                },
+                "namespace": {"name": "ns1"},
+            },
+        )
+        _write_ta_template(stack, "ns1", "my-secret")
+        _write_so_template(stack)
+        monkeypatch.setattr(
+            step_03_workload_monitoring.keda_sat_mod,
+            "extract_prometheus_ca_cert",
+            lambda *a, **k: "FAKE-CA-CERT",
+        )
+        step = WorkloadMonitoringStep()
+        ctx = _FullStubContext(rendered_stacks=[stack])
+        cmd = _TokenMintingStubCmd()
+        errors: list = []
+
+        step._install_keda_if_enabled(cmd, ctx, errors)
+
+        assert errors == []
+        assert any(a[:2] == ("create", "token") for a in cmd.kube_calls)
 
     def test_keda_crd_missing_logs_warning(self, tmp_path: Path) -> None:
         """A missing KEDA CRD logs a warning but does not abort or append an error."""


### PR DESCRIPTION
## Summary
- The generic KEDA path (`keda.scaledObjects` + `keda.prometheus.authMode: bearer-secret`) applies the `TriggerAuthentication` CR but never created the Secret it references, so `ScaledObject`s got stuck failing with `bearer token=<empty> is required when bearer auth is enabled` until someone manually minted a token/Secret per namespace.
- WVA and EPP+KEDA-saturation already automate this via `create_prometheus_auth_secret`; this wires the same mechanism into `install_keda_for_namespace` so it mints the Secret (using `keda.prometheus.secretName`/`saName`) before applying the TriggerAuthentication, gated on the Prometheus CA cert being extractable. Falls back to a warning (not a hard failure) when the cert can't be extracted, matching the WVA/EPP-KEDA behavior.
- `create_prometheus_auth_secret` gained `secret_name` (was hardcoded to `"prometheus-auth"`) and `apply_trigger_auth` (so the generic path, which applies its own TA, doesn't get a duplicate apply) parameters — both default to prior behavior, so existing WVA/EPP-KEDA call sites are unaffected.

## Test plan
- [x] `tests/test_standup_keda.py` (21 tests, new coverage for: Secret minted before TA/ScaledObjects apply, graceful warn-and-skip with no CA cert, CA-cert extraction gated only when a bearer-secret stack is present) — all passing
- [x] Verified end-to-end against a live OpenShift namespace using the affected cluster-config overlay (`llm-d-autoscaling` repo's `ocp/model-sim-qwen3-32b.yaml` + `token-aware.yaml.j2`): manually minted the Secret with the same commands this change now automates, and the `ScaledObject`s transitioned to `Ready` with working HPAs.
