### PR TITLE
 feat(standup): add --no-pvc so standup succeeds on clusters without PVC provisioning

### DIFF
--- a/config/scenarios/cicd/gke.yaml
+++ b/config/scenarios/cicd/gke.yaml
@@ -44,7 +44,7 @@ scenario:
         customCommand: |
           export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
           export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-          vllm serve /model-cache/$MODEL_PATH \
+          vllm serve $MODEL_SERVE_REF \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_INFERENCE_PORT \
@@ -80,7 +80,7 @@ scenario:
           customCommand: |
             export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
             export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_METRICS_PORT \
@@ -100,7 +100,7 @@ scenario:
           customCommand: |
             export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
             export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_INFERENCE_PORT \

--- a/config/scenarios/examples/multi-model-optimized-baseline.yaml
+++ b/config/scenarios/examples/multi-model-optimized-baseline.yaml
@@ -363,7 +363,7 @@ shared:
         # so this one command string is correct for every model.
         customCommand: |
           ${accelerator.runtimePreamble}
-          vllm serve /model-cache/$MODEL_PATH \
+          vllm serve $MODEL_SERVE_REF \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_METRICS_PORT \

--- a/config/scenarios/experimental/kimi-k3-h100.yaml
+++ b/config/scenarios/experimental/kimi-k3-h100.yaml
@@ -305,7 +305,7 @@ scenario:
             sleep 3
           done
 
-          exec vllm serve /model-cache/$MODEL_PATH \
+          exec vllm serve $MODEL_SERVE_REF \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_INFERENCE_PORT \

--- a/config/scenarios/guides/agentic-serving.yaml
+++ b/config/scenarios/guides/agentic-serving.yaml
@@ -232,7 +232,7 @@ scenario:
           customCommand: |
             export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
             export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_METRICS_PORT \

--- a/config/scenarios/guides/flow-control.yaml
+++ b/config/scenarios/guides/flow-control.yaml
@@ -281,7 +281,7 @@ scenario:
           customCommand: |
             export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
             export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_METRICS_PORT \

--- a/config/scenarios/guides/multimodal-serving-aggregation.yaml
+++ b/config/scenarios/guides/multimodal-serving-aggregation.yaml
@@ -301,7 +301,7 @@ scenario:
           customCommand: |
             export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
             export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_METRICS_PORT \

--- a/config/scenarios/guides/optimized-baseline.yaml
+++ b/config/scenarios/guides/optimized-baseline.yaml
@@ -278,7 +278,7 @@ scenario:
         vllm:
           customCommand: |
             ${accelerator.runtimePreamble}
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_METRICS_PORT \

--- a/config/scenarios/guides/pd-disaggregation.yaml
+++ b/config/scenarios/guides/pd-disaggregation.yaml
@@ -315,7 +315,7 @@ scenario:
           customCommand: |
             ${accelerator.runtimePreamble}
             . /shared-config/llmdbench_env.sh
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_INFERENCE_PORT \
@@ -406,7 +406,7 @@ scenario:
           customCommand: |
             ${accelerator.runtimePreamble}
             . /shared-config/llmdbench_env.sh
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_METRICS_PORT \

--- a/config/scenarios/guides/precise-prefix-cache-routing.yaml
+++ b/config/scenarios/guides/precise-prefix-cache-routing.yaml
@@ -322,7 +322,7 @@ scenario:
           customCommand: |
             ${accelerator.runtimePreamble}
             . /shared-config/llmdbench_env.sh
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_INFERENCE_PORT \

--- a/config/scenarios/guides/predicted-latency-routing.yaml
+++ b/config/scenarios/guides/predicted-latency-routing.yaml
@@ -257,7 +257,7 @@ scenario:
           customCommand: |
             export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
             export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
-            vllm serve /model-cache/$MODEL_PATH \
+            vllm serve $MODEL_SERVE_REF \
             --host 0.0.0.0 \
             --served-model-name $MODEL_NAME \
             --port $VLLM_METRICS_PORT \

--- a/config/scenarios/guides/tiered-prefix-cache.yaml
+++ b/config/scenarios/guides/tiered-prefix-cache.yaml
@@ -298,7 +298,7 @@ scenario:
           export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
           export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
           . /shared-config/llmdbench_env.sh
-          vllm serve /model-cache/$MODEL_PATH \
+          vllm serve $MODEL_SERVE_REF \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_METRICS_PORT \

--- a/config/scenarios/guides/wide-ep-lws.yaml
+++ b/config/scenarios/guides/wide-ep-lws.yaml
@@ -332,7 +332,7 @@ scenario:
           export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
           export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
           . /shared-config/llmdbench_env.sh
-          vllm serve /model-cache/$MODEL_PATH \
+          vllm serve $MODEL_SERVE_REF \
           --host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_INFERENCE_PORT \
@@ -460,7 +460,7 @@ scenario:
           export LD_LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | sed ':a; N; $!ba; s/\n/:/g'):${LD_LIBRARY_PATH}
           export LIBRARY_PATH=$(find / -name libcuda.so.1 -printf '%h\n' 2>/dev/null | head -1):${LIBRARY_PATH}
           . /shared-config/llmdbench_env.sh
-          vllm serve /model-cache/$MODEL_PATH \
+          vllm serve $MODEL_SERVE_REF \
           -host 0.0.0.0 \
           --served-model-name $MODEL_NAME \
           --port $VLLM_METRICS_PORT \

--- a/config/templates/jinja/14_standalone-deployment_yaml.j2
+++ b/config/templates/jinja/14_standalone-deployment_yaml.j2
@@ -295,6 +295,8 @@ spec:
           value: "{{ model.name }}"
         - name: MODEL_PATH
           value: "{{ model.path }}"
+        - name: MODEL_SERVE_REF
+          value: "{{ model_serve_ref('standalone') }}"
         - name: VLLM_WORKER_MULTIPROC_METHOD
           value: "{{ standalone.vllm.workerMultiprocMethod }}"
         - name: VLLM_LOGGING_LEVEL

--- a/config/templates/jinja/_macros.j2
+++ b/config/templates/jinja/_macros.j2
@@ -79,6 +79,26 @@
 {"enable_kv_cache_events":true,"publisher":"{{ publisher }}","endpoint":"tcp://{{ service_name }}.{{ ns }}.svc.cluster.local:{{ port }}","topic":"{{ topic_prefix }}@$(POD_IP):$(VLLM_INFERENCE_PORT)@{{ model.name }}"}
 {%- endmacro %}
 
+{# What this stack's default command serves -- the single source of truth
+   for the vLLM serve target, also exported to pods as $MODEL_SERVE_REF so
+   custom commands stay dual-mode (PVC vs hf) without hardcoding paths.
+   - standalone: always the model ID. The ID resolves through the HF hub
+     cache (HF_HOME), NOT the staged PVC copy at <modelMountPath>/<path>;
+     see #1822 for the cost of that split. Kept as-is here to preserve
+     existing behavior -- switching mounted standalone to the staged path
+     is a separate, deliberate change.
+   - modelservice + uriProtocol=hf: the HF id (runtime fetch by the chart).
+   - modelservice otherwise: the staged PVC copy at <cacheBase>/<path>. #}
+{% macro model_serve_ref(stack='modelservice') -%}
+{%- if stack == 'standalone' -%}
+{{ model.name }}
+{%- elif modelservice is defined and modelservice.uriProtocol is defined and modelservice.uriProtocol == 'hf' -%}
+{{ model.huggingfaceId | default(model.name) }}
+{%- else -%}
+{{ model.cacheBase }}/{{ model.path }}
+{%- endif -%}
+{%- endmacro %}
+
 {# Macro to build vLLM serve command with templated arguments #}
 {% macro build_vllm_command(mode='decode') -%}
 {% if mode == 'decode' -%}
@@ -135,9 +155,7 @@
 {% set proxy_disabled = (routing is defined and routing.proxy is defined and routing.proxy.enabled is defined and not routing.proxy.enabled) -%}
 {% set use_inference_port = proxy_disabled or mode == 'prefill' -%}
 {% set port_var = '$VLLM_INFERENCE_PORT' if use_inference_port else '$VLLM_METRICS_PORT' -%}
-{% set use_hf_id = (modelservice is defined and modelservice.uriProtocol is defined and modelservice.uriProtocol == 'hf') -%}
-{% set model_ref = model.huggingfaceId | default(model.name) if use_hf_id else model.cacheBase ~ '/' ~ model.path -%}
-{{ preprocess_script }} {{ preprocess_sep }} vllm serve {{ model_ref }} \
+{{ preprocess_script }} {{ preprocess_sep }} vllm serve {{ model_serve_ref() }} \
   --host {{ vllmCommon.host }} \
   --served-model-name {{ model.name }} \
   --port {{ port_var }} \
@@ -212,6 +230,11 @@
 {# arbitrary -- any non-empty value works.                              #}
 - name: USER
   value: "llm-d"
+{# The mode-correct vLLM serve target (see model_serve_ref) -- custom
+   commands use $MODEL_SERVE_REF instead of hardcoding /model-cache paths
+   so they work in both PVC and hf modes. #}
+- name: MODEL_SERVE_REF
+  value: "{{ model_serve_ref() }}"
 {# Only emit HF_HOME when the modelservice chart will NOT. With
    modelservice.uriProtocol == 'hf' (mirrors 13_ms-values.yaml.j2) the
    chart mounts an hf:// cache and injects its own HF_HOME=/model-cache;
@@ -377,7 +400,7 @@
 {% set has_disable_uvicorn = vllmCommon.flags.disableUvicornAccessLog | default(false) -%}
 {% set has_no_prefix_caching = vllmCommon.flags.noPrefixCaching | default(false) -%}
 {% set has_enable_prefix_caching = vllmCommon.flags.enablePrefixCaching | default(false) -%}
-{{ preprocess_script }}; vllm serve {{ model.name }} \
+{{ preprocess_script }}; vllm serve {{ model_serve_ref('standalone') }} \
   --host {{ vllmCommon.host | default('0.0.0.0') }} \
   --served-model-name {{ model.name }} \
   --port $VLLM_INFERENCE_PORT \

--- a/docs/standup.md
+++ b/docs/standup.md
@@ -295,6 +295,8 @@ The scenario parameters can be roughly categorized in four groups:
 | LLMDBENCH_VLLM_COMMON_INITIAL_DELAY_PROBE    |                                                                         |                                                                                                                                          |
 | LLMDBENCH_VLLM_COMMON_POD_SCHEDULER          |                                                                         |                                                                                                                                          |
 
+On clusters where users cannot provision PersistentVolumeClaims, pass `standup --no-pvc` to avoid creating the model and workload PVCs altogether. See [Standing up without PVCs](../llmdbenchmark/standup/README.md#standing-up-without-pvcs---no-pvc) for details.
+
 - "Standalone"-specific VLLM parameters
 
 | Variable                                                | Meaning                                    | Note                                           |

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -623,7 +623,19 @@ def _do_standup(args, logger, render_plan_errors):
         llmd_repo_path=getattr(args, "llmd_repo_path", None),
         kustomize_skip_infra=not getattr(args, "full_infra", False),
         stack_filter=_parse_stack_filter(getattr(args, "stack", None)),
+        no_pvc=getattr(args, "no_pvc", False),
     )
+
+    # Announce PVC-less standup up front, mirroring the run phase.
+    if context.no_pvc:
+        logger.log_info(
+            "Running standup in PVC-less mode (--no-pvc): no model PVC, "
+            "workload PVC, or data-access pod will be created. Model "
+            "weights are fetched at runtime by the serving pods. Pair "
+            "with 'run --no-pvc' -- a plain 'run' would create the "
+            "workload PVC on demand.",
+            emoji="\U0001f4e6",
+        )
 
     _check_model_access(context, all_stacks_info, logger)
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -2532,6 +2532,29 @@ def _deep_merge_dicts(base: dict, override: dict) -> dict:
     return result
 
 
+def _no_pvc_standup_overrides(args) -> dict:
+    """Synthetic global overrides for ``standup --no-pvc``.
+
+    Redirects model-weight storage away from PVCs pre-render, so step 04
+    and every template do the right thing with no special-casing: the
+    modelservice chart fetches weights at runtime (hf://) and the
+    standalone deployment omits its model-cache PVC volume (the template
+    already gates that volume on standalone.mountModelVolume).
+
+    Standup-only: run --no-pvc deploys no serving pods, so redirecting
+    model storage there would be pure noise. An explicit user --set of
+    the same path wins (merge-order contract at the call site).
+    """
+    if getattr(args, "command", "") != Command.STANDUP.value:
+        return {}
+    if not getattr(args, "no_pvc", False):
+        return {}
+    return {
+        "modelservice": {"uriProtocol": "hf"},
+        "standalone": {"mountModelVolume": False},
+    }
+
+
 def _build_setup_overrides_by_stack(args, logger) -> dict[str, dict]:
     """Combine ``--cluster-config`` and ``--set`` into selector buckets.
 
@@ -2565,6 +2588,22 @@ def _build_setup_overrides_by_stack(args, logger) -> dict[str, dict]:
     if description_overrides:
         by_selector[GLOBAL_SELECTOR] = _deep_merge_dicts(
             {"description": description_overrides},
+            by_selector.get(GLOBAL_SELECTOR, {}),
+        )
+
+    # standup --no-pvc: model storage must not use a PVC. Synthetic global
+    # override, same precedence contract as above (explicit --set wins).
+    no_pvc_overrides = _no_pvc_standup_overrides(args)
+    if no_pvc_overrides:
+        logger.log_warning(
+            "--no-pvc: forcing modelservice.uriProtocol=hf and "
+            "standalone.mountModelVolume=false -- serving pods fetch model "
+            "weights from HuggingFace at startup (slower cold starts; "
+            "results are comparable only to other hf-loading runs). An "
+            "explicit --set of the same key overrides this."
+        )
+        by_selector[GLOBAL_SELECTOR] = _deep_merge_dicts(
+            no_pvc_overrides,
             by_selector.get(GLOBAL_SELECTOR, {}),
         )
 

--- a/llmdbenchmark/cli.py
+++ b/llmdbenchmark/cli.py
@@ -2549,6 +2549,10 @@ def _no_pvc_standup_overrides(args) -> dict:
         return {}
     if not getattr(args, "no_pvc", False):
         return {}
+    # hf is currently the only PVC-free modelservice protocol in practice
+    # (13_ms-values.yaml.j2 renders anything != 'hf' as pvc://), so forcing
+    # it unconditionally is safe. If s3/oci rendering lands later, make
+    # this conditional on the resolved protocol instead of clobbering it.
     return {
         "modelservice": {"uriProtocol": "hf"},
         "standalone": {"mountModelVolume": False},

--- a/llmdbenchmark/interface/README.md
+++ b/llmdbenchmark/interface/README.md
@@ -83,6 +83,7 @@ Provisions model infrastructure from a specification. Implicitly generates a pla
 | `--gateway-deploy-timeout` | `LLMDBENCH_GATEWAY_DEPLOY_TIMEOUT` | Seconds to wait for gateway infrastructure pods to deploy during standup with modelservice. |
 | `--modelservice-deploy-timeout` | `LLMDBENCH_MODELSERVICE_DEPLOY_TIMEOUT` | Seconds to wait for decode, prefill and inference pool pods to deploy during standup with modelservice (Generic timeout for Step 9). |
 | `--pvc-bind-timeout` | `LLMDBENCH_PVC_BIND_TIMEOUT` | Seconds to wait for each PVC (workload, model, extra) to reach the Bound phase during standup. Fails fast on missing default StorageClass instead of masking as a downstream pod/job timeout. Default: 240 (some dynamic provisioners take 1-3 minutes per volume). |
+| `--no-pvc` | `LLMDBENCH_NO_PVC` | Stand up without creating any PVCs: model weights fetched at runtime (uriProtocol forced to hf, standalone model mount disabled, with a warning); workload PVC/data-access pod not created. Pair with run --no-pvc. hostPath scenarios fail fast |
 | `--data-access-timeout` | `LLMDBENCH_DATA_ACCESS_TIMEOUT` | Seconds to wait for the harness data-access pod to become Ready. On a `WaitForFirstConsumer` StorageClass the unspent `--pvc-bind-timeout` is added to this budget, since the volume is only provisioned once that pod schedules. Default: 120. |
 
 ### smoketest (`smoketest.py`)

--- a/llmdbenchmark/interface/standup.py
+++ b/llmdbenchmark/interface/standup.py
@@ -2,7 +2,7 @@
 
 import argparse
 from llmdbenchmark.interface.commands import Command
-from llmdbenchmark.interface.env import env, env_int
+from llmdbenchmark.interface.env import env, env_bool, env_int
 
 
 def add_subcommands(
@@ -156,6 +156,18 @@ def add_subcommands(
         "default StorageClass on the cluster) fails fast instead of "
         "masquerading as a downstream pod/job timeout. Default: 240 "
         "(some dynamic provisioners take 1-3 minutes per volume).",
+    )
+    standup_parser.add_argument(
+        "--no-pvc",
+        action="store_true",
+        default=env_bool("LLMDBENCH_NO_PVC"),
+        help="Stand up without creating any PVCs, for clusters where users "
+        "cannot provision them. Model weights are fetched at runtime "
+        "(modelservice.uriProtocol is forced to 'hf'; standalone model-PVC "
+        "mount disabled) with a warning, and the workload PVC / "
+        "data-access pod are not created -- pair with 'run --no-pvc'. "
+        "Scenarios with storage.hostPath.enabled fail fast (explicit "
+        "conflict) (env: LLMDBENCH_NO_PVC). Default: off.",
     )
     standup_parser.add_argument(
         "--pod-restart-budget",

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -139,7 +139,7 @@ Steps are registered in `steps/__init__.py` via `get_run_steps()`:
 |------|------|-------------|
 | 00 | `RunPreflightStep` | Validate cluster connectivity, harness namespace, output destination |
 | 01 | `RunCleanupPreviousStep` | Delete leftover harness pods/configmaps from previous runs |
-| 02 | `HarnessNamespaceStep` | Prepare harness namespace (PVC, data access pod) |
+| 02 | `HarnessNamespaceStep` | Prepare harness namespace (PVC + data-access pod in PVC mode) |
 | 03 | `DetectEndpointStep` | Auto-detect model-serving endpoint (standalone service, gateway, or `-U` override) |
 | 04 | `VerifyModelStep` | Verify model is served at endpoint via `/v1/models` |
 | 05 | `RenderProfilesStep` | Render workload profile templates with runtime values; handle experiment treatments |

--- a/llmdbenchmark/run/README.md
+++ b/llmdbenchmark/run/README.md
@@ -289,6 +289,8 @@ they are lost when the pod is deleted (there is no PVC to recover from);
 on-PVC zstd pre-compression does not apply; `emptyDir` usage counts
 against the node's ephemeral storage instead of a provisioned volume.
 
+For a fully PVC-less flow, stand the stack up with `standup --no-pvc` as well.
+
 ### Upload results to cloud storage
 
 ```bash

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -38,6 +38,9 @@ On clusters where users cannot provision PersistentVolumeClaims, pass
   creates PV/PVC objects and contradicts the flag.
 - Guide/kustomize deployments that declare their own PVCs inside guide
   manifests are out of scope for this flag.
+- Note: the `plan` subcommand previews the un-switched scenario (`--no-pvc`
+  overrides apply at standup render time only), so a plan preview may show
+  `uriProtocol: pvc` even when the standup will force `hf`.
 
 ## Deployment Methods
 

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -12,7 +12,7 @@ Steps are registered in `steps/__init__.py` via `get_standup_steps()` and execut
 | 02 | `AdminPrerequisitesStep` | global | Install cluster-level admin prerequisites (CRDs, gateways, LeaderWorkerSet, SCCs) |
 | 03 | `WorkloadMonitoringStep` | global | Validate cluster resources and configure workload monitoring (PodMonitors). Installs WVA controller once per `wva.namespace` across all rendered stacks. |
 | 04 | `ModelNamespaceStep` | global | Prepare the model namespace. Creates one shared model PVC (idempotent across stacks) and one download Job per stack with `modelservice.uriProtocol: pvc` (or standalone). Jobs are launched in parallel (phase 1) and waited on in turn (phase 2), so total wall time ~ slowest model. Every stack's weights live in a distinct `model.path` subdirectory on the shared PVC. |
-| 05 | `HarnessNamespaceStep` | global | Prepare the harness namespace (scenario-wide workload PVC, data access pod, secrets) |
+| 05 | `HarnessNamespaceStep` | global | Prepare the harness namespace (namespace, secrets, preprocess ConfigMap; workload PVC + data-access pod only in PVC mode) |
 | 06 | `FMADeployStep` | global | Deploy FMA controllers |
 | 06 | `StandaloneDeployStep` | global | Deploy vLLM as standalone Kubernetes Deployments and Services |
 | 08 | `DeploySetupStep` | global | Set up Helm repos and deploy gateway infrastructure for modelservice mode |

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -21,6 +21,24 @@ Steps are registered in `steps/__init__.py` via `get_standup_steps()` and execut
 
 Note: Step 01 is intentionally absent (reserved). Steps 10 and 11 (smoketest and inference test) were moved to the `llmdbenchmark.smoketests` module and now run as a separate phase after standup.
 
+## Standing up without PVCs (`--no-pvc`)
+
+On clusters where users cannot provision PersistentVolumeClaims, pass
+`--no-pvc` (env: `LLMDBENCH_NO_PVC=1`):
+
+- Model weights are fetched at runtime: `modelservice.uriProtocol` is
+  forced to `hf` and standalone's model-PVC mount is disabled, with a
+  warning (an explicit `--set` of the same key wins). Serving pods pull
+  from HuggingFace at startup — slower cold starts, and results are
+  comparable only to other hf-loading runs.
+- The workload PVC and data-access pod are not created; pair the standup
+  with `run --no-pvc` (a plain `run` would create the workload PVC on
+  demand).
+- Scenarios with `storage.hostPath.enabled: true` fail fast — hostPath
+  creates PV/PVC objects and contradicts the flag.
+- Guide/kustomize deployments that declare their own PVCs inside guide
+  manifests are out of scope for this flag.
+
 ## Deployment Methods
 
 Steps 06-09 handle two mutually exclusive deployment methods:

--- a/llmdbenchmark/standup/README.md
+++ b/llmdbenchmark/standup/README.md
@@ -36,6 +36,10 @@ On clusters where users cannot provision PersistentVolumeClaims, pass
   demand).
 - Scenarios with `storage.hostPath.enabled: true` fail fast — hostPath
   creates PV/PVC objects and contradicts the flag.
+- Scenario `customCommand`s should serve `$MODEL_SERVE_REF` (exported to
+  every serving pod) instead of hardcoding `/model-cache/...` paths -- it
+  resolves to the staged PVC path in PVC mode and the HF model ID in hf
+  mode, so the same scenario works under both.
 - Guide/kustomize deployments that declare their own PVCs inside guide
   manifests are out of scope for this flag.
 - Note: the `plan` subcommand previews the un-switched scenario (`--no-pvc`

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -56,6 +56,18 @@ class ModelNamespaceStep(Step):
                     errors=errors,
                 )
 
+        conflict = self._check_no_pvc_hostpath_conflict(context)
+        if conflict:
+            errors.append(conflict)
+            context.logger.log_error(f"    {conflict}")
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=False,
+                message="--no-pvc / hostPath conflict",
+                errors=errors,
+            )
+
         # PVC and download are per-stack: only needed for "pvc" protocol or
         # standalone mode - S3/OCI/hf protocols fetch at runtime and skip
         # PVC creation entirely, deferring to the modelservice chart (hf
@@ -159,6 +171,30 @@ class ModelNamespaceStep(Step):
             success=True,
             message=f"Model namespace prepared (ns={context.namespace})",
         )
+
+    def _check_no_pvc_hostpath_conflict(self, context) -> str | None:
+        """--no-pvc contradicts explicit hostPath storage: hostPath still
+        creates PV/PVC objects, and it is a deliberate scenario choice --
+        neither silently overriding it nor silently creating PVC objects
+        would honor the user's intent. Fail fast with the fix spelled out."""
+        if not context.no_pvc:
+            return None
+        for stack_path in context.rendered_stacks or []:
+            stack_cfg = self._load_stack_config(stack_path)
+            enabled = (
+                (stack_cfg or {})
+                .get("storage", {})
+                .get("hostPath", {})
+                .get("enabled", False)
+            )
+            if enabled:
+                return (
+                    f"--no-pvc conflicts with storage.hostPath.enabled=true "
+                    f"(stack '{stack_path.name}'): hostPath creates PV/PVC "
+                    f"objects. Disable hostPath in the scenario or drop "
+                    f"--no-pvc."
+                )
+        return None
 
     @staticmethod
     def _parse_size_to_gib(raw: str | None) -> float:

--- a/llmdbenchmark/standup/steps/step_04_model_namespace.py
+++ b/llmdbenchmark/standup/steps/step_04_model_namespace.py
@@ -44,18 +44,6 @@ class ModelNamespaceStep(Step):
         if context.is_openshift and context.namespace:
             self._extract_openshift_uid_range(cmd, context)
 
-        if not context.dry_run:
-            sc_error = self._validate_storage_class(cmd, context)
-            if sc_error:
-                errors.append(sc_error)
-                return StepResult(
-                    step_number=self.number,
-                    step_name=self.name,
-                    success=False,
-                    message="Storage class validation failed",
-                    errors=errors,
-                )
-
         conflict = self._check_no_pvc_hostpath_conflict(context)
         if conflict:
             errors.append(conflict)
@@ -67,6 +55,19 @@ class ModelNamespaceStep(Step):
                 message="--no-pvc / hostPath conflict",
                 errors=errors,
             )
+
+        # --no-pvc: no standup PVCs exist to validate a StorageClass for.
+        if not context.dry_run and not context.no_pvc:
+            sc_error = self._validate_storage_class(cmd, context)
+            if sc_error:
+                errors.append(sc_error)
+                return StepResult(
+                    step_number=self.number,
+                    step_name=self.name,
+                    success=False,
+                    message="Storage class validation failed",
+                    errors=errors,
+                )
 
         # PVC and download are per-stack: only needed for "pvc" protocol or
         # standalone mode - S3/OCI/hf protocols fetch at runtime and skip
@@ -284,8 +285,11 @@ class ModelNamespaceStep(Step):
 
         uri_protocol = self._require_config(plan_config, "modelservice", "uriProtocol")
         standalone_enabled = plan_config.get("standalone", {}).get("enabled", False)
+        standalone_mounts = plan_config.get("standalone", {}).get(
+            "mountModelVolume", True
+        )
 
-        return uri_protocol == "pvc" or standalone_enabled
+        return uri_protocol == "pvc" or (standalone_enabled and standalone_mounts)
 
     @staticmethod
     def _is_hostpath_enabled(plan_config: dict | None) -> bool:

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -1,4 +1,4 @@
-"""Step 05 -- Prepare the harness namespace (PVC, data access pod, secrets)."""
+"""Step 05 -- Prepare the harness namespace (secrets/ConfigMap; PVC + data-access pod in PVC mode)."""
 
 from pathlib import Path
 
@@ -16,7 +16,9 @@ class HarnessNamespaceStep(Step):
         super().__init__(
             number=5,
             name="harness_namespace",
-            description="Prepare harness namespace (PVC, data access pod)",
+            description=(
+                "Prepare harness namespace (PVC + data-access pod in PVC mode)"
+            ),
             phase=Phase.STANDUP,
             per_stack=False,
         )

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -66,6 +66,9 @@ class HarnessNamespaceStep(Step):
         self._create_preprocesses_configmap(cmd, context, configmap_namespaces, errors)
 
         if context.no_pvc:
+            context.logger.log_info(
+                "\u2139\ufe0f  Skipped workload PVC + data-access pod (--no-pvc)"
+            )
             if errors:
                 for err in errors:
                     context.logger.log_error(f"    {err}")

--- a/llmdbenchmark/standup/steps/step_05_harness_namespace.py
+++ b/llmdbenchmark/standup/steps/step_05_harness_namespace.py
@@ -57,6 +57,33 @@ class HarnessNamespaceStep(Step):
                 "HF token not configured -- skipping secret creation"
             )
 
+        model_ns = context.require_namespace()
+        configmap_namespaces = [harness_ns]
+        if model_ns != harness_ns:
+            configmap_namespaces.append(model_ns)
+        self._create_preprocesses_configmap(cmd, context, configmap_namespaces, errors)
+
+        if context.no_pvc:
+            if errors:
+                for err in errors:
+                    context.logger.log_error(f"    {err}")
+                return StepResult(
+                    step_number=self.number,
+                    step_name=self.name,
+                    success=False,
+                    message="Harness namespace preparation had errors",
+                    errors=errors,
+                )
+            return StepResult(
+                step_number=self.number,
+                step_name=self.name,
+                success=True,
+                message=(
+                    f"Harness namespace prepared (ns={harness_ns}; --no-pvc: "
+                    f"workload PVC and data-access pod skipped)"
+                ),
+            )
+
         bind_deferred = False
         pvc_yaml = self._find_rendered_yaml(context, "01_pvc_workload-pvc")
         if pvc_yaml:
@@ -153,12 +180,6 @@ class HarnessNamespaceStep(Step):
             result = cmd.kube("apply", "-f", str(svc_yaml))
             if not result.success:
                 errors.append(f"Failed to create data access service: {result.stderr}")
-
-        model_ns = context.require_namespace()
-        configmap_namespaces = [harness_ns]
-        if model_ns != harness_ns:
-            configmap_namespaces.append(model_ns)
-        self._create_preprocesses_configmap(cmd, context, configmap_namespaces, errors)
 
         timeout = context.harness_data_access_timeout
         if bind_deferred:

--- a/tests/test_model_serve_ref.py
+++ b/tests/test_model_serve_ref.py
@@ -1,0 +1,91 @@
+"""model_serve_ref(): the single source of truth for what vLLM serves.
+
+Semantics ("what this stack's default command would serve"), keyed on the
+consuming stack -- NOT global config, since the plan renders every template
+for every scenario and a standalone-enabled scenario must not perturb the
+modelservice render:
+- stack='standalone'                  -> model ID (HF hub resolution; see
+                                         #1822 for why the staged PVC copy
+                                         is a separate concern)
+- stack='modelservice', uriProtocol hf -> HF id (huggingfaceId, then name)
+- stack='modelservice', otherwise      -> <cacheBase>/<path> (staged copy)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment
+
+_JINJA_DIR = Path(__file__).resolve().parent.parent / "config" / "templates" / "jinja"
+_MACROS = (_JINJA_DIR / "_macros.j2").read_text(encoding="utf-8")
+
+
+def _render_ref(values: dict[str, Any], call: str = "model_serve_ref()") -> str:
+    env = Environment()
+    template = env.from_string(_MACROS + "\n{{ " + call + " }}")
+    return template.render(**values).strip().splitlines()[-1].strip()
+
+
+_BASE = {
+    "model": {
+        "name": "Qwen/Qwen3-32B",
+        "path": "models/Qwen/Qwen3-32B",
+        "cacheBase": "/model-cache",
+    },
+}
+
+
+def test_standalone_stack_serves_model_id() -> None:
+    """The standalone ref is the ID regardless of global protocol config."""
+    values = dict(_BASE)
+    values["modelservice"] = {"uriProtocol": "pvc"}
+    assert _render_ref(values, "model_serve_ref('standalone')") == "Qwen/Qwen3-32B"
+
+
+def test_modelservice_ref_ignores_standalone_enabled() -> None:
+    """A standalone-enabled scenario must not perturb the modelservice
+    render -- the plan renders all templates for every scenario."""
+    values = dict(_BASE)
+    values["standalone"] = {"enabled": True}
+    values["modelservice"] = {"uriProtocol": "pvc"}
+    assert _render_ref(values) == "/model-cache/models/Qwen/Qwen3-32B"
+
+
+def test_modelservice_hf_serves_huggingface_id() -> None:
+    values = dict(_BASE)
+    values["model"] = dict(_BASE["model"], huggingfaceId="Qwen/Qwen3-32B-FP8")
+    values["modelservice"] = {"uriProtocol": "hf"}
+    assert _render_ref(values) == "Qwen/Qwen3-32B-FP8"
+
+
+def test_modelservice_hf_falls_back_to_model_name() -> None:
+    values = dict(_BASE)
+    values["modelservice"] = {"uriProtocol": "hf"}
+    assert _render_ref(values) == "Qwen/Qwen3-32B"
+
+
+def test_modelservice_pvc_serves_cache_path() -> None:
+    values = dict(_BASE)
+    values["modelservice"] = {"uriProtocol": "pvc"}
+    assert _render_ref(values) == "/model-cache/models/Qwen/Qwen3-32B"
+
+
+def test_serve_ref_env_emitted_for_both_stacks() -> None:
+    """Long-term guard that both serving pod specs export MODEL_SERVE_REF
+    (the render-diff harness proved the initial emission; this keeps it).
+    modelservice pods get it via build_ms_env_vars (decode + prefill share
+    the macro); standalone pods via their deployment template."""
+    standalone = (_JINJA_DIR / "14_standalone-deployment_yaml.j2").read_text(
+        encoding="utf-8"
+    )
+    assert "MODEL_SERVE_REF" in _MACROS
+    assert "model_serve_ref('standalone')" in standalone
+
+
+def test_default_commands_use_the_macro() -> None:
+    """Both default-command branches must serve via model_serve_ref() so the
+    env var and the defaults can never drift apart."""
+    assert "vllm serve {{ model_serve_ref() }}" in _MACROS
+    assert "vllm serve {{ model_serve_ref('standalone') }}" in _MACROS

--- a/tests/test_standup_no_pvc.py
+++ b/tests/test_standup_no_pvc.py
@@ -53,3 +53,36 @@ def test_no_pvc_overrides_empty_for_run() -> None:
     assert (
         _no_pvc_standup_overrides(argparse.Namespace(command="run", no_pvc=True)) == {}
     )
+
+
+def test_step04_rejects_hostpath_with_no_pvc(tmp_path) -> None:
+    import yaml as _yaml
+
+    from llmdbenchmark.standup.steps.step_04_model_namespace import (
+        ModelNamespaceStep,
+    )
+    from llmdbenchmark.executor.context import ExecutionContext
+
+    class _Logger:
+        def log_info(self, *a, **k): ...
+        def log_warning(self, *a, **k): ...
+        def log_error(self, *a, **k): ...
+
+    stack = tmp_path / "plan" / "stack01"
+    stack.mkdir(parents=True)
+    (stack / "config.yaml").write_text(
+        _yaml.dump({"storage": {"hostPath": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+    context = ExecutionContext(
+        plan_dir=tmp_path / "plan",
+        workspace=tmp_path,
+        logger=_Logger(),
+        namespace="model-ns",
+        no_pvc=True,
+        rendered_stacks=[stack],
+        dry_run=True,
+    )
+    result = ModelNamespaceStep()._check_no_pvc_hostpath_conflict(context)
+    assert result is not None
+    assert "hostPath" in result and "--no-pvc" in result

--- a/tests/test_standup_no_pvc.py
+++ b/tests/test_standup_no_pvc.py
@@ -138,3 +138,84 @@ def test_step05_no_pvc_skips_pvc_and_data_access(tmp_path) -> None:
     assert any(c[0] == "apply" for c in cmd.kube_calls)
     assert cmd.pvc_waits == 0
     assert cmd.pod_waits == 0
+
+
+def test_requires_pvc_download_standalone_respects_mount_flag() -> None:
+    """--no-pvc sets standalone.mountModelVolume=false but not
+    standalone.enabled -- _requires_pvc_download must honor the mount
+    flag so standalone stacks don't still get a model PVC + download job
+    while the deployment template omits the model-cache volume mount."""
+    from llmdbenchmark.standup.steps.step_04_model_namespace import (
+        ModelNamespaceStep,
+    )
+
+    step = ModelNamespaceStep()
+
+    no_pvc_cfg = {
+        "standalone": {"enabled": True, "mountModelVolume": False},
+        "modelservice": {"uriProtocol": "hf"},
+    }
+    assert step._requires_pvc_download(no_pvc_cfg) is False
+
+    default_cfg = {
+        "standalone": {"enabled": True},
+        "modelservice": {"uriProtocol": "hf"},
+    }
+    assert step._requires_pvc_download(default_cfg) is True
+
+
+def test_step04_no_pvc_skips_storage_class_validation(tmp_path, monkeypatch) -> None:
+    """--no-pvc: no standup PVCs exist, so validating a StorageClass
+    against the cluster (which PVC-restricted users often cannot list)
+    must not happen."""
+    import yaml as _yaml
+
+    from llmdbenchmark.executor.command import CommandResult
+    from llmdbenchmark.executor.context import ExecutionContext
+    from llmdbenchmark.standup.steps.step_04_model_namespace import (
+        ModelNamespaceStep,
+    )
+
+    class _Logger:
+        def log_info(self, *a, **k): ...
+        def log_warning(self, *a, **k): ...
+        def log_error(self, *a, **k): ...
+
+    class _Cmd:
+        def kube(self, *args, **kwargs) -> CommandResult:
+            return CommandResult(command=" ".join(str(a) for a in args), exit_code=0)
+
+    stack = tmp_path / "plan" / "stack01"
+    stack.mkdir(parents=True)
+    (stack / "config.yaml").write_text(
+        _yaml.dump(
+            {
+                "modelservice": {"uriProtocol": "hf"},
+                "control": {"contextSecretName": "ctx-secret"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    context = ExecutionContext(
+        plan_dir=tmp_path / "plan",
+        workspace=tmp_path,
+        logger=_Logger(),
+        namespace="model-ns",
+        no_pvc=True,
+        rendered_stacks=[stack],
+        dry_run=False,
+    )
+    context.cmd = _Cmd()
+
+    def _must_not_be_called(self, cmd, context):
+        raise AssertionError(
+            "_validate_storage_class must not be called under --no-pvc"
+        )
+
+    monkeypatch.setattr(
+        ModelNamespaceStep, "_validate_storage_class", _must_not_be_called
+    )
+
+    result = ModelNamespaceStep().execute(context)
+    assert result.success

--- a/tests/test_standup_no_pvc.py
+++ b/tests/test_standup_no_pvc.py
@@ -1,0 +1,27 @@
+"""standup --no-pvc: flag plumbing, overrides, and step gates."""
+
+from __future__ import annotations
+
+import argparse
+
+from llmdbenchmark.interface import standup as standup_interface
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    standup_interface.add_subcommands(subparsers, parents=[])
+    return parser.parse_args(argv)
+
+
+def test_standup_no_pvc_defaults_false() -> None:
+    assert _parse(["standup"]).no_pvc is False
+
+
+def test_standup_no_pvc_parses_true() -> None:
+    assert _parse(["standup", "--no-pvc"]).no_pvc is True
+
+
+def test_standup_no_pvc_env_var(monkeypatch) -> None:
+    monkeypatch.setenv("LLMDBENCH_NO_PVC", "1")
+    assert _parse(["standup"]).no_pvc is True

--- a/tests/test_standup_no_pvc.py
+++ b/tests/test_standup_no_pvc.py
@@ -86,3 +86,55 @@ def test_step04_rejects_hostpath_with_no_pvc(tmp_path) -> None:
     result = ModelNamespaceStep()._check_no_pvc_hostpath_conflict(context)
     assert result is not None
     assert "hostPath" in result and "--no-pvc" in result
+
+
+def test_step05_no_pvc_skips_pvc_and_data_access(tmp_path) -> None:
+    from llmdbenchmark.executor.command import CommandResult
+    from llmdbenchmark.executor.context import ExecutionContext
+    from llmdbenchmark.standup.steps.step_05_harness_namespace import (
+        HarnessNamespaceStep,
+    )
+
+    class _Logger:
+        def log_info(self, *a, **k): ...
+        def log_warning(self, *a, **k): ...
+        def log_error(self, *a, **k): ...
+
+    class _Cmd:
+        def __init__(self):
+            self.kube_calls: list[tuple] = []
+            self.pvc_waits = 0
+            self.pod_waits = 0
+
+        def kube(self, *args, **kwargs) -> CommandResult:
+            self.kube_calls.append(args)
+            if args[:2] == ("get", "namespace"):
+                return CommandResult(command="get ns", exit_code=1)
+            return CommandResult(command=" ".join(str(a) for a in args), exit_code=0)
+
+        def wait_for_pvc(self, **k) -> CommandResult:
+            self.pvc_waits += 1
+            return CommandResult(command="wait pvc", exit_code=0)
+
+        def wait_for_pods(self, **k) -> CommandResult:
+            self.pod_waits += 1
+            return CommandResult(command="wait pods", exit_code=0)
+
+    context = ExecutionContext(
+        plan_dir=tmp_path,
+        workspace=tmp_path,
+        logger=_Logger(),
+        namespace="bench",
+        harness_namespace="bench",
+        no_pvc=True,
+    )
+    cmd = _Cmd()
+    context.cmd = cmd
+
+    result = HarnessNamespaceStep().execute(context)
+    assert result.success
+    assert "--no-pvc" in result.message or "PVC" in result.message
+    # Namespace apply happened; no PVC bind wait, no data-access pod wait.
+    assert any(c[0] == "apply" for c in cmd.kube_calls)
+    assert cmd.pvc_waits == 0
+    assert cmd.pod_waits == 0

--- a/tests/test_standup_no_pvc.py
+++ b/tests/test_standup_no_pvc.py
@@ -25,3 +25,31 @@ def test_standup_no_pvc_parses_true() -> None:
 def test_standup_no_pvc_env_var(monkeypatch) -> None:
     monkeypatch.setenv("LLMDBENCH_NO_PVC", "1")
     assert _parse(["standup"]).no_pvc is True
+
+
+def test_no_pvc_overrides_for_standup() -> None:
+    from llmdbenchmark.cli import _no_pvc_standup_overrides
+
+    args = argparse.Namespace(command="standup", no_pvc=True)
+    assert _no_pvc_standup_overrides(args) == {
+        "modelservice": {"uriProtocol": "hf"},
+        "standalone": {"mountModelVolume": False},
+    }
+
+
+def test_no_pvc_overrides_empty_without_flag() -> None:
+    from llmdbenchmark.cli import _no_pvc_standup_overrides
+
+    assert (
+        _no_pvc_standup_overrides(argparse.Namespace(command="standup", no_pvc=False))
+        == {}
+    )
+
+
+def test_no_pvc_overrides_empty_for_run() -> None:
+    """run --no-pvc must NOT redirect model storage -- run deploys nothing."""
+    from llmdbenchmark.cli import _no_pvc_standup_overrides
+
+    assert (
+        _no_pvc_standup_overrides(argparse.Namespace(command="run", no_pvc=True)) == {}
+    )


### PR DESCRIPTION
# Summary

- This PR closes the gap: standup <cmds> `--no-pvc` (env `LLMDBENCH_NO_PVC`, shared with run) brings up a fully serving stack creating zero PVC-dependent objects.

- Model weights download method auto-switch: when `--no-pvc` is set, AKA `modelservice.uriProtocol` is forced to `hf` and `standalone.mountModelVolume` to false via global overrides through the existing `--set` merge
- Harness prep gated: `step 05` always creates the namespace, HF-token secret, and preprocess ConfigMap, and creates the workload PVC + data-access pod/service only in PVC mode 
- Pairing: a startup announcement notes that run `--no-pvc` is the matching invocation (a plain run would create the workload PVC on demand). `experiment` is deliberately unchanged since having to `redownload` the model to ephemeral storage on combinatoric testing wouldn't be logical...