### PR TITLE
fix(keda): fix bearer-secret ServiceAccount naming and creation order

### DIFF
--- a/config/templates/jinja/23_wva-namespace.yaml.j2
+++ b/config/templates/jinja/23_wva-namespace.yaml.j2
@@ -20,6 +20,7 @@
 {% set epp_keda_enabled = eppKedaSaturation is defined and eppKedaSaturation.enabled | default(false) %}
 {% if wva_enabled or epp_keda_enabled %}
 {% set target_ns = wva.namespace | default(eppKedaSaturation.namespace, true) | default(namespace.name, true) %}
+{% set sa_name = "wva-prometheus-auth" if wva_enabled else "keda-prometheus-auth" %}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -30,7 +31,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: wva-prometheus-auth
+  name: {{ sa_name }}
   namespace: {{ target_ns }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -43,6 +44,6 @@ roleRef:
   name: allow-thanos-querier-api-access
 subjects:
 - kind: ServiceAccount
-  name: wva-prometheus-auth
+  name: {{ sa_name }}
   namespace: {{ target_ns }}
 {% endif %}

--- a/llmdbenchmark/standup/keda_prometheus_auth.py
+++ b/llmdbenchmark/standup/keda_prometheus_auth.py
@@ -112,7 +112,7 @@ def create_prometheus_auth_secret(
     stack_path: Path,
     target_namespace: str,
     prom_ca_cert: str | None,
-    sa_name: str = "wva-prometheus-auth",
+    sa_name: str = "keda-prometheus-auth",
     secret_name: str = "prometheus-auth",
     ta_template_stem: str = "21_keda-triggerauthentication",
     apply_trigger_auth: bool = True,
@@ -132,7 +132,7 @@ def create_prometheus_auth_secret(
         target_namespace: Kubernetes namespace for the Secret and TA.
         prom_ca_cert: PEM-encoded CA certificate for Prometheus (optional).
         sa_name: ServiceAccount name to mint the token from
-            (default: "wva-prometheus-auth").
+            (default: "keda-prometheus-auth").
         secret_name: Name of the Secret to create (default: "prometheus-auth").
         ta_template_stem: Template filename stem to locate the TA YAML
             (default: "21_keda-triggerauthentication").

--- a/llmdbenchmark/standup/keda_saturation.py
+++ b/llmdbenchmark/standup/keda_saturation.py
@@ -97,7 +97,7 @@ def install_epp_keda_saturation_for_namespace(
         stack_path,
         epp_keda_namespace,
         prom_ca_cert,
-        sa_name="wva-prometheus-auth",
+        sa_name="keda-prometheus-auth",
         ta_template_stem="21_keda-triggerauthentication",
         errors=errors,
     )

--- a/llmdbenchmark/standup/lib/keda.py
+++ b/llmdbenchmark/standup/lib/keda.py
@@ -62,7 +62,7 @@ def install_keda_for_namespace(
 
     if auth_mode == "bearer-secret":
         secret_name = prometheus_cfg.get("secretName", "prometheus-auth")
-        sa_name = prometheus_cfg.get("saName", "wva-prometheus-auth")
+        sa_name = prometheus_cfg.get("saName", "keda-prometheus-auth")
 
         if prom_ca_cert:
             create_prometheus_auth_secret(

--- a/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+++ b/llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from collections.abc import Mapping
 import json
 import re
+import tempfile
 
 import yaml
 
@@ -272,6 +273,7 @@ class AdminPrerequisitesStep(Step):
 
         self._apply_namespace_yaml(cmd, context, errors)
         self._apply_openshift_sccs(cmd, context, plan_config)
+        self._ensure_keda_prometheus_service_accounts(cmd, context, errors)
 
         if errors:
             for err in errors:
@@ -801,6 +803,73 @@ class AdminPrerequisitesStep(Step):
             result = cmd.kube("apply", "-f", str(ns_yaml))
             if not result.success:
                 errors.append(f"Failed to create namespace resources: {result.stderr}")
+
+    def _ensure_keda_prometheus_service_accounts(
+        self, cmd: CommandExecutor, context: ExecutionContext, errors: list
+    ):
+        """Pre-create the ServiceAccount for the generic bearer-secret KEDA path.
+
+        Stacks with ``keda.prometheus.authMode: bearer-secret`` mint a bearer
+        token from this ServiceAccount in step_03 (workload_monitoring), but
+        cluster-config overlays declare the ServiceAccount itself via
+        ``extraObjects`` on the ModelService Helm chart, which only installs
+        in step_09 -- six steps later. Creating it here, idempotently, closes
+        that gap. The ClusterRoleBinding granting it Thanos Querier access is
+        left to the chart's extraObjects -- nothing consumes it before
+        step_09.
+        """
+        if context.dry_run:
+            return
+
+        seen: set[tuple[str, str]] = set()
+        for stack_path in context.rendered_stacks or []:
+            cfg = self._load_stack_config(stack_path)
+            keda_cfg = cfg.get("keda", {}) or {}
+            if not keda_cfg.get("scaledObjects"):
+                continue
+            prometheus_cfg = keda_cfg.get("prometheus", {}) or {}
+            if prometheus_cfg.get("authMode") != "bearer-secret":
+                continue
+            namespace = cfg.get("namespace", {}).get("name", "")
+            sa_name = prometheus_cfg.get("saName", "keda-prometheus-auth")
+            if not namespace or (namespace, sa_name) in seen:
+                continue
+            seen.add((namespace, sa_name))
+
+            render = cmd.kube(
+                "create",
+                "serviceaccount",
+                sa_name,
+                "--dry-run=client",
+                "-o",
+                "yaml",
+                "-n",
+                namespace,
+                check=False,
+            )
+            if not render.success or not render.stdout.strip():
+                errors.append(
+                    f"Failed to render ServiceAccount/{sa_name} for "
+                    f"ns/{namespace}: {render.stderr}"
+                )
+                continue
+
+            tmp_dir = Path(tempfile.mkdtemp())
+            sa_yaml = tmp_dir / f"{sa_name}-serviceaccount.yaml"
+            sa_yaml.write_text(render.stdout, encoding="utf-8")
+            apply_result = cmd.kube(
+                "apply", "-f", str(sa_yaml), "-n", namespace, check=False
+            )
+            if not apply_result.success:
+                errors.append(
+                    f"Failed to apply ServiceAccount/{sa_name} in "
+                    f"ns/{namespace}: {apply_result.stderr}"
+                )
+            else:
+                cmd.logger.log_info(
+                    f"✅ ServiceAccount/{sa_name} ready in ns/{namespace} "
+                    "(KEDA bearer-secret auth)"
+                )
 
     def _apply_openshift_sccs(
         self, cmd: CommandExecutor, context: ExecutionContext, plan_config: dict

--- a/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
+++ b/llmdbenchmark/teardown/steps/step_01_uninstall_helm.py
@@ -708,7 +708,7 @@ class UninstallHelmStep(Step):
 
             # Delete per-namespace resources (ServiceAccount, Secret, TriggerAuthentication).
             for kind, name in (
-                ("serviceaccount", "wva-prometheus-auth"),
+                ("serviceaccount", "keda-prometheus-auth"),
                 ("secret", "prometheus-auth"),
                 ("triggerauthentication", "prometheus-auth"),
             ):

--- a/tests/test_admin_prerequisites_keda_sa.py
+++ b/tests/test_admin_prerequisites_keda_sa.py
@@ -1,0 +1,180 @@
+"""Tests for the keda-prometheus-auth ServiceAccount pre-creation in step_02.
+
+This closes an ordering gap: stacks using ``keda.prometheus.authMode:
+bearer-secret`` mint a bearer token from a ServiceAccount in step_03
+(workload_monitoring), but cluster-config overlays only create that
+ServiceAccount via Helm ``extraObjects`` in step_09 (deploy_modelservice) --
+six steps later. See llmdbenchmark/standup/steps/step_02_admin_prerequisites.py
+(_ensure_keda_prometheus_service_accounts).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import yaml
+
+from llmdbenchmark.standup.steps.step_02_admin_prerequisites import (
+    AdminPrerequisitesStep,
+)
+
+
+@dataclass
+class _Result:
+    success: bool = True
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _Cmd:
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+    logger: MagicMock = field(default_factory=MagicMock)
+
+    def kube(self, *args: str, **_: Any) -> _Result:
+        self.calls.append(tuple(args))
+        if args[:2] == ("create", "serviceaccount"):
+            sa_name = args[2]
+            namespace = args[args.index("-n") + 1]
+            return _Result(
+                stdout=(
+                    "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n"
+                    f"  name: {sa_name}\n  namespace: {namespace}\n"
+                )
+            )
+        return _Result(success=True)
+
+
+@dataclass
+class _FailApplyCmd(_Cmd):
+    def kube(self, *args: str, **_: Any) -> _Result:
+        self.calls.append(tuple(args))
+        if args[:2] == ("create", "serviceaccount"):
+            return super().kube(*args)
+        if args[0] == "apply":
+            return _Result(success=False, stderr="forbidden")
+        return _Result(success=True)
+
+
+def _context(rendered_stacks: list[Path], dry_run: bool = False) -> MagicMock:
+    context = MagicMock()
+    context.rendered_stacks = rendered_stacks
+    context.dry_run = dry_run
+    return context
+
+
+def _write_stack(tmp_path: Path, name: str, cfg: dict) -> Path:
+    stack_dir = tmp_path / name
+    stack_dir.mkdir(parents=True)
+    (stack_dir / "config.yaml").write_text(yaml.safe_dump(cfg))
+    return stack_dir
+
+
+def _bearer_secret_cfg(namespace: str, sa_name: str | None = None) -> dict:
+    prometheus_cfg: dict[str, Any] = {"authMode": "bearer-secret"}
+    if sa_name:
+        prometheus_cfg["saName"] = sa_name
+    return {
+        "namespace": {"name": namespace},
+        "keda": {
+            "scaledObjects": [{"name": "so1"}],
+            "prometheus": prometheus_cfg,
+        },
+    }
+
+
+class TestEnsureKedaPrometheusServiceAccounts:
+    def test_creates_sa_for_bearer_secret_stack(self, tmp_path: Path) -> None:
+        stack = _write_stack(tmp_path, "s1", _bearer_secret_cfg("ns1"))
+        step = AdminPrerequisitesStep()
+        cmd = _Cmd()
+        errors: list = []
+
+        step._ensure_keda_prometheus_service_accounts(cmd, _context([stack]), errors)
+
+        assert errors == []
+        create_calls = [c for c in cmd.calls if c[:2] == ("create", "serviceaccount")]
+        assert create_calls and create_calls[0][2] == "keda-prometheus-auth"
+        applied = [c for c in cmd.calls if c[0] == "apply"]
+        assert len(applied) == 1
+
+    def test_respects_custom_sa_name(self, tmp_path: Path) -> None:
+        stack = _write_stack(
+            tmp_path, "s1", _bearer_secret_cfg("ns1", sa_name="my-custom-sa")
+        )
+        step = AdminPrerequisitesStep()
+        cmd = _Cmd()
+        errors: list = []
+
+        step._ensure_keda_prometheus_service_accounts(cmd, _context([stack]), errors)
+
+        create_calls = [c for c in cmd.calls if c[:2] == ("create", "serviceaccount")]
+        assert create_calls[0][2] == "my-custom-sa"
+
+    def test_skips_when_auth_mode_is_none(self, tmp_path: Path) -> None:
+        cfg = _bearer_secret_cfg("ns1")
+        cfg["keda"]["prometheus"]["authMode"] = "none"
+        stack = _write_stack(tmp_path, "s1", cfg)
+        step = AdminPrerequisitesStep()
+        cmd = _Cmd()
+        errors: list = []
+
+        step._ensure_keda_prometheus_service_accounts(cmd, _context([stack]), errors)
+
+        assert cmd.calls == []
+        assert errors == []
+
+    def test_skips_when_no_scaled_objects(self, tmp_path: Path) -> None:
+        stack = _write_stack(
+            tmp_path,
+            "s1",
+            {
+                "namespace": {"name": "ns1"},
+                "keda": {"prometheus": {"authMode": "bearer-secret"}},
+            },
+        )
+        step = AdminPrerequisitesStep()
+        cmd = _Cmd()
+        errors: list = []
+
+        step._ensure_keda_prometheus_service_accounts(cmd, _context([stack]), errors)
+
+        assert cmd.calls == []
+
+    def test_dedups_across_stacks_sharing_namespace(self, tmp_path: Path) -> None:
+        s1 = _write_stack(tmp_path, "s1", _bearer_secret_cfg("ns1"))
+        s2 = _write_stack(tmp_path, "s2", _bearer_secret_cfg("ns1"))
+        step = AdminPrerequisitesStep()
+        cmd = _Cmd()
+        errors: list = []
+
+        step._ensure_keda_prometheus_service_accounts(cmd, _context([s1, s2]), errors)
+
+        create_calls = [c for c in cmd.calls if c[:2] == ("create", "serviceaccount")]
+        assert len(create_calls) == 1
+
+    def test_dry_run_is_noop(self, tmp_path: Path) -> None:
+        stack = _write_stack(tmp_path, "s1", _bearer_secret_cfg("ns1"))
+        step = AdminPrerequisitesStep()
+        cmd = _Cmd()
+        errors: list = []
+
+        step._ensure_keda_prometheus_service_accounts(
+            cmd, _context([stack], dry_run=True), errors
+        )
+
+        assert cmd.calls == []
+
+    def test_apply_failure_appends_error(self, tmp_path: Path) -> None:
+        stack = _write_stack(tmp_path, "s1", _bearer_secret_cfg("ns1"))
+        step = AdminPrerequisitesStep()
+        cmd = _FailApplyCmd()
+        errors: list = []
+
+        step._ensure_keda_prometheus_service_accounts(cmd, _context([stack]), errors)
+
+        assert len(errors) == 1
+        assert "forbidden" in errors[0]

--- a/tests/test_standup_keda.py
+++ b/tests/test_standup_keda.py
@@ -275,7 +275,7 @@ class TestInstallKedaForNamespace:
 
         assert errors == []
         token_calls = [a for a in cmd.kube_calls if a[:2] == ("create", "token")]
-        assert token_calls and token_calls[0][2] == "wva-prometheus-auth"
+        assert token_calls and token_calls[0][2] == "keda-prometheus-auth"
 
         secret_calls = [
             a for a in cmd.kube_calls if a[:3] == ("create", "secret", "generic")


### PR DESCRIPTION
## Summary
- Rename the `wva-prometheus-auth` ServiceAccount default to `keda-prometheus-auth` for the two auth paths that have nothing to do with the WVA controller: the generic `keda.prometheus.authMode: bearer-secret` path (`lib/keda.py`) and the EPP+KEDA-saturation path (`keda_saturation.py`). The real WVA-controller path (`wva.py`) keeps `wva-prometheus-auth` since it legitimately owns that ServiceAccount. The shared namespace template (`23_wva-namespace.yaml.j2`) now picks the SA name based on which mode is enabled.
- Pre-create the ServiceAccount for the generic bearer-secret KEDA path in `step_02` (admin_prerequisites), before `step_03` (workload_monitoring) mints a bearer token from it. Cluster-config overlays typically declare this ServiceAccount via Helm `extraObjects` on the ModelService chart, which only installs in `step_09` — six steps after `step_03` needs it — so every standup using this auth mode failed with `serviceaccounts "..." not found`.

## Test plan
- [x] `pytest tests/test_standup_keda.py tests/test_teardown_wva.py tests/test_teardown_gaie_epp_cleanup.py tests/test_admin_prerequisites_gateway_crds.py tests/test_admin_prerequisites_keda_sa.py` — all pass (added `test_admin_prerequisites_keda_sa.py` covering the new step_02 pre-creation logic: create, custom `saName`, `authMode: none` skip, no-`scaledObjects` skip, dedup across stacks, dry-run no-op, apply-failure error propagation)
- [x] Verified end-to-end against a live OpenShift cluster: standup previously failed at `step_03` with `serviceaccounts "wva-prometheus-auth" not found` for a `keda.prometheus.authMode: bearer-secret` stack; after this fix `step_02` creates the ServiceAccount and `step_03` mints the token successfully