### PR TITLE
fix(kustomize): read connector from guideVariableOverrides.CONNECTOR

### DIFF
--- a/llmdbenchmark/kustomize/variable_resolver.py
+++ b/llmdbenchmark/kustomize/variable_resolver.py
@@ -32,11 +32,24 @@ class GuideVariableResolver:
         ``acceleratorBackend`` alone is ``{accelerator}/{backend}`` (e.g.
         ``amd/vllm``). To route the deploy at a connector-specific overlay such
         as ``amd/vllm/moriio/<infra>`` (and thus its image override) instead of
-        the vanilla base, ``kustomize.connector`` is spliced between backend and
-        infra provider here.
+        the vanilla base, the connector is spliced between backend and infra
+        provider here.
+
+        The connector is read from ``kustomize.guideVariableOverrides.CONNECTOR``
+        -- the same value the CI workflow writes for the guide README's
+        ``${CONNECTOR}`` substitution -- falling back to the legacy first-class
+        ``kustomize.connector`` key, which that workflow (and older scenarios)
+        still set. Either knob is authoritative; both carry the same value.
         """
         backend = kust_config.get("acceleratorBackend", DEFAULT_ACCEL_BACKEND)
-        connector = str(kust_config.get("connector", "") or "").strip().strip("/")
+        # guideVariableOverrides may be absent or an explicit YAML null, so
+        # coalesce to an empty mapping before indexing into it.
+        overrides = kust_config.get("guideVariableOverrides") or {}
+        connector = (
+            str(overrides.get("CONNECTOR") or kust_config.get("connector") or "")
+            .strip()
+            .strip("/")
+        )
         return f"{backend}/{connector}" if connector else backend
 
     def __init__(

--- a/tests/test_effective_backend_connector.py
+++ b/tests/test_effective_backend_connector.py
@@ -1,0 +1,69 @@
+"""Tests for connector folding in `GuideVariableResolver.effective_backend`.
+
+The modelserver overlay is routed at `modelserver/{acceleratorBackend}/{connector}/{infra}`.
+The connector is read from `kustomize.guideVariableOverrides.CONNECTOR` -- the
+same value the CI workflow writes for the guide README's `${CONNECTOR}`
+substitution -- falling back to the legacy first-class `kustomize.connector`
+key that the workflow (and older scenarios) still set.
+"""
+
+from __future__ import annotations
+
+from llmdbenchmark.kustomize.variable_resolver import GuideVariableResolver
+
+
+def test_connector_override_is_spliced():
+    kust = {
+        "acceleratorBackend": "amd/vllm",
+        "guideVariableOverrides": {"CONNECTOR": "moriio"},
+    }
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm/moriio"
+
+
+def test_falls_back_to_legacy_first_class_connector():
+    kust = {"acceleratorBackend": "amd/vllm", "connector": "moriio"}
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm/moriio"
+
+
+def test_override_takes_precedence_over_legacy_key():
+    kust = {
+        "acceleratorBackend": "amd/vllm",
+        "connector": "nixlv2",
+        "guideVariableOverrides": {"CONNECTOR": "moriio"},
+    }
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm/moriio"
+
+
+def test_null_guide_variable_overrides_does_not_crash():
+    kust = {"acceleratorBackend": "amd/vllm", "guideVariableOverrides": None}
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm"
+
+
+def test_null_overrides_falls_back_to_legacy_key():
+    kust = {
+        "acceleratorBackend": "amd/vllm",
+        "guideVariableOverrides": None,
+        "connector": "moriio",
+    }
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm/moriio"
+
+
+def test_no_connector_returns_bare_backend():
+    kust = {"acceleratorBackend": "amd/vllm"}
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm"
+
+
+def test_empty_override_connector_is_ignored():
+    kust = {
+        "acceleratorBackend": "amd/vllm",
+        "guideVariableOverrides": {"CONNECTOR": ""},
+    }
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm"
+
+
+def test_connector_surrounding_slashes_are_trimmed():
+    kust = {
+        "acceleratorBackend": "amd/vllm",
+        "guideVariableOverrides": {"CONNECTOR": "/moriio/"},
+    }
+    assert GuideVariableResolver.effective_backend(kust) == "amd/vllm/moriio"


### PR DESCRIPTION
The modelserver overlay is routed at
modelserver/{acceleratorBackend}/{connector}/{infra}. effective_backend previously read the connector only from the first-class kustomize.connector key, which the nightly workflow sets via a splice added in #1892. The llm-d-infra copy of that workflow lagged the splice, so kustomize.connector was unset and the deploy resolved to the vanilla base overlay (e.g. modelserver/amd/vllm/amd-ci instead of .../amd/vllm/moriio/amd-ci).

Read the connector from guideVariableOverrides.CONNECTOR instead -- the same value the workflow already writes for the guide README's ${CONNECTOR} substitution -- so a single knob drives both and the routing no longer depends on the drifted infra workflow.