### PR TITLE
fix: embed metrics into 0.2.1 benchmark reports

### DIFF
--- a/llmdbenchmark/analysis/metrics_embed.py
+++ b/llmdbenchmark/analysis/metrics_embed.py
@@ -86,7 +86,7 @@ def embed_metrics(
         _say("No metrics summary -- skipping report metrics embedding")
         return 0
 
-    reports = sorted(results_dir.glob("benchmark_report_v0.2,_*.yaml"))
+    reports = sorted(results_dir.glob("benchmark_report_v0.2*,_*.yaml"))
     if not reports:
         return 0
 


### PR DESCRIPTION
The report glob was pinned to "v0.2,", so a v0.2.1 report -- emitted alongside the v0.2 one -- never received the time series and carried no observability block at all.