### PR TITLE
feat(ci): support multiple harness/workload pairs per standup in nightly benchmark workflow

### DIFF
--- a/.github/workflows/reusable-ci-nightly-benchmark.yaml
+++ b/.github/workflows/reusable-ci-nightly-benchmark.yaml
@@ -142,12 +142,12 @@ on:
         default: 'false'
         type: 'string'
       harness:
-        description: 'Harness to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "eval-containers", "nop")'
+        description: 'Comma-separated list of harnesses to be used during "run" operation ("inference-perf", "guidellm", "inferencemax", "vllm-benchmark", "eval-containers", "nop"). Paired positionally with "workload"; each pair is run against the same standup.'
         required: false
         default: 'inference-perf'
         type: 'string'
       workload:
-        description: 'Workload profile to be used during "run" operation (check list under "workload/profiles")'
+        description: 'Comma-separated list of workload profiles to be used during "run" operation (check list under "workload/profiles"). Paired positionally with "harness"; must have the same number of entries.'
         required: false
         default: 'sanity_random.yaml'
         type: 'string'
@@ -927,11 +927,32 @@ jobs:
 
       - name: Set harness executable
         id: prereqs_set_harness_executable
-        if: env.LLMDBENCH_CICD_HARNESS == 'nop' && env.LLMDBENCH_CICD_SCENARIO_DIR == 'cicd'
+        # "harness" can be a comma-separated list; the executable set here applies to every pair
+        if: contains(format(',{0},', env.LLMDBENCH_CICD_HARNESS), ',nop,') && env.LLMDBENCH_CICD_SCENARIO_DIR == 'cicd'
         run: |
             export LLMDBENCH_CICD_SCENARIO_FILE="$LLMDBENCH_CICD_BENCHMARK_PATH/config/scenarios/$LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO.yaml"
             echo " ### Setting harness executable to \"llm-d-benchmark.py\" in \"$LLMDBENCH_CICD_SCENARIO_FILE\""
             yq -i '.scenario[0].harness.executable = "llm-d-benchmark.py"' $LLMDBENCH_CICD_SCENARIO_FILE
+
+      - name: Validate harness/workload pairs
+        id: prereqs_validate_harness_workload_pairs
+        run: |
+          IFS=',' read -r -a harness_list <<< "$LLMDBENCH_CICD_HARNESS"
+          IFS=',' read -r -a workload_list <<< "$LLMDBENCH_CICD_WORKLOAD"
+          if [[ ${#harness_list[@]} -ne ${#workload_list[@]} ]]; then
+            echo "### ERROR: \"harness\" (${#harness_list[@]} entries: \"$LLMDBENCH_CICD_HARNESS\") and \"workload\" (${#workload_list[@]} entries: \"$LLMDBENCH_CICD_WORKLOAD\") must have the same number of comma-separated entries"
+            exit 1
+          fi
+          for i in "${!harness_list[@]}"; do
+            harness=$(echo "${harness_list[$i]}" | xargs)
+            workload=$(echo "${workload_list[$i]}" | xargs)
+            if [[ -z $harness || -z $workload ]]; then
+              echo "### ERROR: pair $i has an empty harness (\"$harness\") or workload (\"$workload\") entry"
+              exit 1
+            fi
+            echo "### Pair $i: harness \"$harness\", workload \"$workload\""
+          done
+        shell: bash
 
       - name: List images from kustomize manifest
         id: prereqs_list_images_from_kustomize_manifests
@@ -1192,9 +1213,18 @@ jobs:
           elif [[ "$LLMDBENCH_CICD_TARGET" == "cks" && "${{ inputs.standup_method }}" == "fma" ]]; then
             echo "Temporarily unable to test \"fma\" on \"cks\" clusters"
           else
-            LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD run $LLMDBENCH_EXTRA_RUN_OPERATION_CMD --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --methods $LLMDBENCH_CICD_METHOD --harness $LLMDBENCH_CICD_HARNESS --workload $LLMDBENCH_CICD_WORKLOAD"
-            echo "### $(cat "$LLMDBENCH_CICD_CMD_LOG"); $LLMDBENCH_CMD ###"
-            eval $LLMDBENCH_CMD
+            # "harness" and "workload" are positionally-paired comma-separated lists, so multiple
+            # harness/workload combinations can be exercised against a single standup
+            IFS=',' read -r -a harness_list <<< "$LLMDBENCH_CICD_HARNESS"
+            IFS=',' read -r -a workload_list <<< "$LLMDBENCH_CICD_WORKLOAD"
+            for i in "${!harness_list[@]}"; do
+              harness=$(echo "${harness_list[$i]}" | xargs)
+              workload=$(echo "${workload_list[$i]}" | xargs)
+              echo "### Running pair $((i+1))/${#harness_list[@]}: harness \"$harness\", workload \"$workload\""
+              LLMDBENCH_CMD="llmdbenchmark --spec $LLMDBENCH_CICD_SCENARIO_DIR/$LLMDBENCH_CICD_SCENARIO $LLMDBENCH_EXTRA_CMD run $LLMDBENCH_EXTRA_RUN_OPERATION_CMD --namespace $LLMDBENCH_CICD_NS --gateway-class $LLMDBENCH_CICD_GATEWAY_CLASS --methods $LLMDBENCH_CICD_METHOD --harness $harness --workload $workload"
+              echo "### $(cat "$LLMDBENCH_CICD_CMD_LOG"); $LLMDBENCH_CMD ###"
+              eval $LLMDBENCH_CMD
+            done
           fi
         shell: bash
 
@@ -1302,6 +1332,7 @@ jobs:
                [ "${{ steps.prereq_install_llmdbenchmark.outcome }}" = "failure" ] || \
                [ "${{ steps.prereqs_apply_overrides_to_llmdbenchmark_scenarios.outcome }}" = "failure" ] || \
                [ "${{ steps.prereqs_set_harness_executable.outcome }}" = "failure" ] || \
+               [ "${{ steps.prereqs_validate_harness_workload_pairs.outcome }}" = "failure" ] || \
                [ "${{ steps.prereqs_apply_overrides_to_kustomize_manifests.outcome }}" = "failure" ] || \
                [ "${{ steps.prereqs_setup_extrac_cli_parms_llmdbenchmark.outcome }}" = "failure" ]; then
             CATEGORY="prereqs"


### PR DESCRIPTION
# Summary

Allows the reusable nightly benchmark workflow to run multiple harness/workload combinations against a single standup, instead of requiring one full standup/teardown cycle per harness.

The harness and workload inputs now accept positionally-paired, comma-separated lists:

```
harness:  'inference-perf,guidellm'
workload: 'sanity_random.yaml,multi-turn.yaml'
```

This stands the stack up once, then runs `--harness inference-perf --workload sanity_random.yaml` followed by `--harness guidellm --workload multi-turn.yaml`, then tears down as usual.

Changes

- Inputs (harness, workload): descriptions updated to document the paired-list format. Defaults unchanged.
- Run step: now loops over the pairs sequentially against the same standup. Fail-fast: the first failing pair stops the step, and the existing on-failure steps (harness pod logs, teardown, debug info) behave as before. 
- New Validate harness/workload pairs step: fails the job before standup if the two lists have different entry counts or contain an empty entry (e.g. 'a,,b'), so malformed inputs cost seconds instead of a full standup. Wired into Detect failure category as prereqs.

Backward compatibility

A single value is a one-element list, so all existing callers and cron configs work unchanged. No caller workflow modifications needed. Whitespace around commas is trimmed; a trailing comma is tolerated.

Notes / follow-ups

- Workload profiles are harness-specific (workload/profiles/<harness>/); each workload in the list must exist for its paired harness. An incompatible pair currently fails at run time ("Profile not found"). A pre-standup existence check could be added to the validation step as a follow-up. But to be honest I'm not sure if that really is needed here...
