### PR TITLE
feat: prefer inference-perf's native BR0.2 partial over hand-derived aggregate

### DIFF
--- a/benchmark-report/llmd_benchmark_report/native_to_br0_2.py
+++ b/benchmark-report/llmd_benchmark_report/native_to_br0_2.py
@@ -1803,6 +1803,30 @@ def import_eval_containers(results_file: str) -> BenchmarkReportV02:
     return load_benchmark_report(br_dict)
 
 
+def _find_inference_perf_partial(results_file: str, stage: int) -> dict | None:
+    """Return the sibling BR0.2 partial for this stage, if inference-perf wrote one.
+
+    inference-perf >= v0.7.0 (kubernetes-sigs/inference-perf#461) drops
+    ``inference-perf.partial.stage_<N>.yaml`` next to each
+    ``stage_<N>_lifecycle_metrics.json``, carrying ``results.request_performance
+    .aggregate`` and ``run.{uid,eid,time}`` computed from the same request
+    lifecycle metrics this module otherwise re-derives by hand. Preferring the
+    partial when present retires that duplicate ~700-line mapping (llm-d/
+    llm-d-benchmark#1891); older harness images with no partial fall back to
+    the native derivation below unchanged.
+    """
+    partial_path = os.path.join(
+        os.path.dirname(results_file), f"inference-perf.partial.stage_{stage}.yaml"
+    )
+    if not os.path.isfile(partial_path):
+        return None
+    try:
+        return import_yaml(partial_path)
+    except (OSError, yaml.YAMLError) as e:
+        sys.stderr.write(f"Failed to read inference-perf partial {partial_path}: {e}\n")
+        return None
+
+
 def import_inference_perf(results_file: str) -> BenchmarkReportV02:
     """Import data from a Inference Perf run as a BenchmarkReportV02.
 
@@ -1943,6 +1967,48 @@ def import_inference_perf(results_file: str) -> BenchmarkReportV02:
         },
     )
 
+    partial = _find_inference_perf_partial(results_file, stage)
+    if partial is not None:
+        # Only uid/eid/time: version and results are this function's own
+        # concern (it must keep returning a v0.2 report regardless of the
+        # v0.2.1 version the partial itself declares), and nothing else in
+        # `run` (cid/pid/user/description/keywords) is inference-perf's to
+        # set. Present partial fields win over the envelope's placeholders
+        # (run.uid is explicitly "Initial UID, may be updated"; run.time
+        # here is this stage's own wall-clock window, more precise than the
+        # overall-harness window every stage would otherwise share).
+        run_from_partial = {
+            k: v
+            for k, v in (get_nested(partial, ["run"], {}) or {}).items()
+            if k in ("uid", "eid", "time")
+        }
+        if run_from_partial:
+            update_dict(br_dict, {"run": run_from_partial})
+        aggregate = get_nested(partial, ["results", "request_performance", "aggregate"])
+    else:
+        aggregate = _build_inference_perf_aggregate_native(results)
+
+    update_dict(
+        br_dict,
+        {
+            "results": {
+                "request_performance": {"aggregate": aggregate},
+            },
+        },
+    )
+
+    return load_benchmark_report(br_dict)
+
+
+def _build_inference_perf_aggregate_native(results: dict) -> dict:
+    """Derive results.request_performance.aggregate from native inference-perf
+    lifecycle metrics.
+
+    Fallback path for harness images built from an inference-perf release
+    that predates the BR0.2 partial (kubernetes-sigs/inference-perf#461,
+    llm-d/llm-d-benchmark#1891) -- import_inference_perf prefers the partial
+    when a sibling one is found next to ``results_file``.
+    """
     total_reqs = get_nested(results, ["load_summary", "count"])
     failures = get_nested(results, ["failures", "count"])
     if total_reqs == failures:
@@ -2629,16 +2695,7 @@ def import_inference_perf(results_file: str) -> BenchmarkReportV02:
             if aggregate["requests"].get(opt, {}).get("mean") is None:
                 aggregate["requests"].pop(opt, None)
 
-    update_dict(
-        br_dict,
-        {
-            "results": {
-                "request_performance": {"aggregate": aggregate},
-            },
-        },
-    )
-
-    return load_benchmark_report(br_dict)
+    return aggregate
 
 
 def import_inference_perf_session(results_file: str) -> BenchmarkReportV02:

--- a/tests/test_inference_perf_br_partial.py
+++ b/tests/test_inference_perf_br_partial.py
@@ -1,0 +1,181 @@
+"""Tests for #1891: prefer inference-perf's native BR0.2 partial over the
+hand-derived aggregate mapping when a sibling partial is present.
+
+inference-perf >= v0.7.0 (kubernetes-sigs/inference-perf#461) writes
+``inference-perf.partial.stage_<N>.yaml`` next to each
+``stage_<N>_lifecycle_metrics.json``, carrying ``results.request_performance
+.aggregate`` and ``run.{uid,eid,time}`` computed from the same request
+lifecycle metrics ``import_inference_perf`` otherwise re-derives by hand
+(~700 lines in ``_build_inference_perf_aggregate_native``). These tests pin:
+
+- the partial's aggregate is used verbatim instead of the native derivation,
+  and agrees field-for-field with what the native derivation produces on the
+  same underlying data;
+- the partial's run.uid/eid/time win over the envelope's placeholders;
+- older harness images with no partial keep working via the native fallback;
+- partial lookup is stage-scoped (stage 0's partial never leaks into stage 1).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from llmd_benchmark_report.native_to_br0_2 import import_inference_perf
+
+FIXTURES = Path(__file__).parent / "fixtures"
+NATIVE_FIXTURE = FIXTURES / "inference_perf_stage_lifecycle_metrics.json"
+
+
+def _write_stage(tmp_path: Path, stage: int) -> Path:
+    """Copy the native lifecycle fixture into tmp_path as stage_<N>_lifecycle_metrics.json."""
+    dest = tmp_path / f"stage_{stage}_lifecycle_metrics.json"
+    shutil.copyfile(NATIVE_FIXTURE, dest)
+    return dest
+
+
+def _write_partial(tmp_path: Path, stage: int, partial: dict) -> Path:
+    dest = tmp_path / f"inference-perf.partial.stage_{stage}.yaml"
+    dest.write_text(yaml.safe_dump(partial, sort_keys=False), encoding="utf-8")
+    return dest
+
+
+def _partial_for(aggregate: dict, *, uid: str, eid: str | None = None) -> dict:
+    run: dict = {
+        "uid": uid,
+        "time": {
+            "start": "2026-05-20T14:30:12.123+00:00",
+            "end": "2026-05-20T14:30:17.456+00:00",
+            "duration": "PT5.333S",
+        },
+    }
+    if eid is not None:
+        run["eid"] = eid
+    return {
+        "version": "0.2.1",
+        "run": run,
+        "results": {"request_performance": {"aggregate": aggregate}},
+    }
+
+
+class TestPartialPreferredOverNativeDerivation:
+    def test_no_partial_falls_back_to_native_derivation(self, tmp_path: Path) -> None:
+        """Older harness images (no partial file) keep working unchanged."""
+        results_file = _write_stage(tmp_path, 0)
+
+        report = import_inference_perf(str(results_file))
+
+        aggregate = report.dump()["results"]["request_performance"]["aggregate"]
+        assert aggregate["requests"]["total"] == 79
+
+    def test_partial_aggregate_agrees_with_native_derivation(
+        self, tmp_path: Path
+    ) -> None:
+        """The partial-sourced and natively-derived reports must agree
+        field-for-field on the same underlying run -- the whole point of the
+        partial is that it's computed from the same request lifecycle data."""
+        results_file = _write_stage(tmp_path, 0)
+        native_aggregate = import_inference_perf(str(results_file)).dump()["results"][
+            "request_performance"
+        ]["aggregate"]
+
+        _write_partial(
+            tmp_path,
+            0,
+            _partial_for(native_aggregate, uid="inference-perf-stage-0-aaaa1111"),
+        )
+        partial_aggregate = import_inference_perf(str(results_file)).dump()["results"][
+            "request_performance"
+        ]["aggregate"]
+
+        assert partial_aggregate == native_aggregate
+
+    def test_partial_aggregate_is_actually_used_not_silently_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        """A distinct partial aggregate must show up verbatim in the report --
+        proving the partial path runs instead of the native derivation, not
+        just alongside it."""
+        results_file = _write_stage(tmp_path, 0)
+        distinct_aggregate = {
+            "requests": {"total": 12345, "failures": 0},
+        }
+        _write_partial(
+            tmp_path,
+            0,
+            _partial_for(distinct_aggregate, uid="inference-perf-stage-0-bbbb2222"),
+        )
+
+        report = import_inference_perf(str(results_file))
+
+        aggregate = report.dump()["results"]["request_performance"]["aggregate"]
+        assert aggregate["requests"]["total"] == 12345
+        # The native fixture's own count (79) must not leak through.
+        assert aggregate["requests"]["total"] != 79
+
+    def test_partial_run_identity_wins_over_envelope_placeholders(
+        self, tmp_path: Path
+    ) -> None:
+        results_file = _write_stage(tmp_path, 0)
+        _write_partial(
+            tmp_path,
+            0,
+            _partial_for(
+                {"requests": {"total": 1, "failures": 0}},
+                uid="inference-perf-stage-0-cccc3333",
+                eid="inference-perf-experiment-dddd4444",
+            ),
+        )
+
+        report = import_inference_perf(str(results_file))
+
+        assert report.run.uid == "inference-perf-stage-0-cccc3333"
+        assert report.run.eid == "inference-perf-experiment-dddd4444"
+        assert report.run.time.duration == "PT5.333S"
+
+    def test_partial_lookup_is_scoped_to_its_own_stage(self, tmp_path: Path) -> None:
+        """Stage 0's partial must never leak into stage 1's report."""
+        stage0_file = _write_stage(tmp_path, 0)
+        stage1_file = _write_stage(tmp_path, 1)
+        _write_partial(
+            tmp_path,
+            0,
+            _partial_for(
+                {"requests": {"total": 111, "failures": 0}},
+                uid="inference-perf-stage-0-eeee5555",
+            ),
+        )
+        # No partial written for stage 1: it must fall back to native.
+
+        report0 = import_inference_perf(str(stage0_file))
+        report1 = import_inference_perf(str(stage1_file))
+
+        assert (
+            report0.dump()["results"]["request_performance"]["aggregate"]["requests"][
+                "total"
+            ]
+            == 111
+        )
+        assert (
+            report1.dump()["results"]["request_performance"]["aggregate"]["requests"][
+                "total"
+            ]
+            == 79
+        )
+        assert report1.run.uid != "inference-perf-stage-0-eeee5555"
+
+    def test_malformed_partial_falls_back_to_native_derivation(
+        self, tmp_path: Path
+    ) -> None:
+        """A partial that fails to parse must not crash the conversion --
+        fall back to the native derivation, matching the no-partial case."""
+        results_file = _write_stage(tmp_path, 0)
+        partial_path = tmp_path / "inference-perf.partial.stage_0.yaml"
+        partial_path.write_text("not: valid: yaml: [", encoding="utf-8")
+
+        report = import_inference_perf(str(results_file))
+
+        aggregate = report.dump()["results"]["request_performance"]["aggregate"]
+        assert aggregate["requests"]["total"] == 79


### PR DESCRIPTION
Fixes #1891

Co-Authored-By: Claude Sonnet

inference-perf >= v0.7.0 (kubernetes-sigs/inference-perf#461) writes
inference-perf.partial.stage_<N>.yaml next to each stage_<N>_lifecycle_
metrics.json, carrying results.request_performance.aggregate and
run.{uid,eid,time} computed from the same request lifecycle metrics
import_inference_perf otherwise re-derives by hand in ~700 lines
(native_to_br0_2.py, previously inline in the function). Two
implementations of one mapping drift -- #1744 (missing input_token_rate)
was an instance of exactly that.

- Add _find_inference_perf_partial: looks for the sibling partial next to
  results_file and returns its parsed contents, or None (missing or
  unparseable) so the native path is unaffected.
- When a partial is found, take only run.uid/eid/time (present fields win
  over the envelope's placeholders -- run.uid is explicitly "Initial UID,
  may be updated"; run.time here is the stage's own wall-clock window,
  more precise than the overall-harness window every stage previously
  shared) and results.request_performance.aggregate verbatim. Nothing
  else in the partial (version, scenario, stack) touches the envelope
  import_inference_perf already composes.
- Extract the existing native aggregate construction, unchanged, into
  _build_inference_perf_aggregate_native as the fallback for harness
  images built from an inference-perf release that predates the partial.

What still runs the native derivation, unchanged: results.session_performance
(import_inference_perf_session -- no partial yet, kubernetes-sigs/
inference-perf#718) and the v0.2.1 multimodal additions in
native_to_br0_2_1.py (request_size, multimodal, media rates --
kubernetes-sigs/inference-perf#719).

Added tests/test_inference_perf_br_partial.py: the partial-sourced and
natively-derived reports agree field-for-field on the same run, a
distinct partial aggregate is actually used (not silently ignored),
partial lookup is scoped to its own stage, and both the no-partial and
malformed-partial cases fall back to the native derivation.
