### PR TITLE
fix: skip the Kubernetes template set on nok8s stacks

### DIFF
--- a/llmdbenchmark/parser/render_plans.py
+++ b/llmdbenchmark/parser/render_plans.py
@@ -47,6 +47,15 @@ class RenderPlans:
     # Prefix for partial/macro files (not rendered directly)
     PARTIAL_PREFIX = "_"
 
+    # Substring marking a template as nok8s-specific (e.g. 34_nok8s-containers.yaml.j2).
+    # On a nok8s stack, only these are ever read back (see step_05_nok8s_deploy.py
+    # and step_06_nok8s_teardown.py): everything else is a Kubernetes manifest --
+    # PVCs, RBAC, the harness pod, helmfiles, HTTPRoute, PodMonitor -- that nok8s
+    # never applies. Rendering them anyway produced 30+ dead files per stack and
+    # version-resolver warnings for tools (helm, skopeo) the nok8s path itself
+    # tells users are unnecessary (docs/nok8s.md) (#1704).
+    NOK8S_TEMPLATE_INFIX = "nok8s"
+
     # Default namespace when "auto" is specified (matches original bash: llmdbench)
     DEFAULT_NAMESPACE = "llmdbench"
 
@@ -2305,6 +2314,15 @@ class RenderPlans:
 
         for template_info in templates:
             filename = template_info["filename"]
+
+            # nok8s applies no Kubernetes manifests, so only its own
+            # templates (31-34_nok8s-*) are relevant -- see NOK8S_TEMPLATE_INFIX.
+            if is_nok8s and self.NOK8S_TEMPLATE_INFIX not in filename:
+                self.logger.log_info(
+                    f"Skipped (not applicable to nok8s): {filename}", emoji="⏭️"
+                )
+                continue
+
             content = template_info["content"]
 
             try:

--- a/tests/test_nok8s_plan.py
+++ b/tests/test_nok8s_plan.py
@@ -89,6 +89,24 @@ def test_nok8s_scenario_renders_templates_and_flags(tmp_path: Path) -> None:
     assert kinds == ["envoy", "epp", "vllm"]
 
 
+def test_nok8s_scenario_skips_the_kubernetes_template_set(tmp_path: Path) -> None:
+    """nok8s applies no Kubernetes manifests, so the k8s-only templates
+    (PVCs, RBAC, the harness pod, helmfiles, HTTPRoute, PodMonitor, ...)
+    must not be rendered to disk at all -- they were previously written with
+    real content that nothing ever applies (#1704)."""
+    stack = _stack_dir(_render(tmp_path))
+
+    filenames = {p.name for p in stack.iterdir()}
+
+    assert filenames == {
+        "31_nok8s-epp-config.yaml",
+        "32_nok8s-epp-endpoints.yaml",
+        "33_nok8s-envoy.yaml",
+        "34_nok8s-containers.yaml",
+        "config.yaml",
+    }
+
+
 def test_should_skip_selects_by_method() -> None:
     from llmdbenchmark.standup.steps.step_05_nok8s_deploy import NoK8sDeployStep
     from llmdbenchmark.run.steps.step_07_deploy_harness_local import (


### PR DESCRIPTION
_load_templates() rendered every non-partial template unconditionally, so a nok8s stack still got the full Kubernetes manifest set written to disk -- PVCs, RBAC, the harness pod, helmfiles, HTTPRoute, PodMonitor -- 36 files per stack, none of which nok8s ever applies (only step_05_nok8s_deploy.py/step_06_nok8s_teardown.py read back the four 31-34_nok8s-* templates).

Skip any non-nok8s-named template when is_nok8s is set, at the per-stack render loop rather than the (globally cached) template loader, so a mixed k8s/nok8s scenario renders correctly per stack. k8s stacks are unaffected: is_nok8s is false, so every template still renders exactly as before.

Fixes #1704 (the remaining half after #1758 fixed the false helm/skopeo warnings)